### PR TITLE
[webapp] Remove unused @ux alias from Vite config

### DIFF
--- a/webapp/ui/vite.config.ts
+++ b/webapp/ui/vite.config.ts
@@ -12,7 +12,6 @@ export default defineConfig(async ({ mode }) => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),
-        '@ux': path.resolve(__dirname, '../ux-kit/src'), // ← сюда будет синкаться дизайн
       },
     },
     server: {


### PR DESCRIPTION
## Summary
- remove unused `@ux` alias from Vite config since the design kit is absent

## Testing
- `ruff check backend/diabetes tests`
- `pytest tests -q`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689aa23f0508832a8c43398c5bfa7332