### PR TITLE
[refactor] drop backend alias and update imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 ## 📁 Основные файлы и структура
 
-- **backend/diabetes/** — основной пакет, логика бота
+- **services/api/app/diabetes/** — основной пакет, логика бота
     - **common_handlers.py** — общие обработчики и роутинг
     - **onboarding_handlers.py** — сценарий регистрации и стартовые команды
     - **profile_handlers.py** — управление профилем пользователя
@@ -19,14 +19,14 @@
     - **db.py, models.py** — работа с БД
     - **functions.py** — расчёты и парсинг
     - **gpt_client.py** — работа с OpenAI
-- **backend/requirements.txt** — зависимости Python
+- **services/api/app/requirements.txt** — зависимости Python
 - **setup.sh** — автоматическая установка окружения
 - **infra/docker/Dockerfile.api** — для контейнеризации и Codex
 - **infra/docker/docker-compose.yml** — пример конфигурации Docker Compose
 - **infra/env/.env.example** — шаблон для переменных окружения
 - **tests/** — директория для автотестов (по мере развития)
   
-Все обработчики располагаются в отдельных файлах с суффиксом `_handlers.py` в каталоге `backend/diabetes/`. Добавляя новый функционал, создавайте новый модуль или дополняйте существующий, придерживаясь тематического разделения.
+Все обработчики располагаются в отдельных файлах с суффиксом `_handlers.py` в каталоге `services/api/app/diabetes/`. Добавляя новый функционал, создавайте новый модуль или дополняйте существующий, придерживаясь тематического разделения.
 
 ---
 
@@ -43,7 +43,7 @@
     cp infra/env/.env.example .env
     # Впишите свои значения в .env
     source venv/bin/activate
-    python backend/bot.py
+    python services/api/app/bot.py
     ```
 
 3. Для Docker/Codex:
@@ -63,8 +63,8 @@
     ```
 - **Линтинг**: PEP8-стиль
     ```bash
-    pip install -r backend/requirements-dev.txt
-    ruff backend/diabetes tests
+    pip install -r services/api/app/requirements-dev.txt
+    ruff services/api/app tests
     ```
 
 ---
@@ -79,15 +79,15 @@
 ## ⚡ Примеры задач для Codex/разработки
 
 - **Рефакторинг:**
-  _Refactor backend/diabetes/handlers.py, split into smaller modules for readability and maintainability. Add type hints and docstrings._
+  _Refactor services/api/app/diabetes/handlers.py, split into smaller modules for readability and maintainability. Add type hints and docstrings._
 - **Покрытие тестами:**
-  _Add pytest unit tests for backend/diabetes/functions.py, cover all calculation logic._
+  _Add pytest unit tests for services/api/app/diabetes/functions.py, cover all calculation logic._
 - **CI и линтинг:**
-  _Run ruff on backend/diabetes/ and tests/, fix all style issues. Add a pre-commit hook if needed._
+  _Run ruff on services/api/app/ and tests/, fix all style issues. Add a pre-commit hook if needed._
 - **Документация:**
   _Generate and update code documentation. Add docstrings to all public functions._
 - **Безопасность:**
-  _Audit backend/diabetes/db.py for ORM or SQL security issues. Implement parameterized queries if needed._
+  _Audit services/api/app/diabetes/db.py for ORM or SQL security issues. Implement parameterized queries if needed._
 - **Docker:**  
   _Check that infra/docker/Dockerfile.api builds and runs with .env, update README.md with Docker instructions._
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,15 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libpq-dev gcc nodejs npm && \
     rm -rf /var/lib/apt/lists/*
 
-COPY backend/requirements.txt backend/requirements.txt
-RUN pip install --upgrade pip && pip install -r backend/requirements.txt
+COPY services/api/app/requirements.txt requirements.txt
+RUN pip install --upgrade pip && pip install -r requirements.txt
 
 COPY . .
 
 # Копируйте .env при деплое или используйте секреты Docker Compose!
 # COPY .env .env
 
-# WebApp UI обслуживается FastAPI-приложением backend.main.
+# WebApp UI обслуживается FastAPI-приложением services.api.app.main.
 # WEBAPP_URL должен указывать на публичный HTTPS-адрес.
 ENV UVICORN_WORKERS=1
 CMD ["bash", "./start.sh"]

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@
 
 ### Структура
 
-- `backend/diabetes/` — основной пакет
+- `services/api/app/diabetes/` — основной пакет
   - `common_handlers.py` — общие обработчики и роутинг
   - `onboarding_handlers.py` — регистрация и стартовые команды
   - `profile_handlers.py` — профиль пользователя
   - `reporting_handlers.py` — дневник и отчётность
   - `dose_handlers.py` — расчёт доз инсулина
   - новые файлы `*_handlers.py` — для прочих сценариев
-- `backend/main.py` — FastAPI‑приложение: отдаёт WebApp и REST API
+- `services/api/app/main.py` — FastAPI‑приложение: отдаёт WebApp и REST API
 - `webapp/ui` — исходники фронтенда (React + Vite, собирается в `dist/`)
 
-Новые обработчики добавляйте в каталог `backend/diabetes/`, создавая отдельные модули с суффиксом `_handlers.py` и группируя их по доменам.
+Новые обработчики добавляйте в каталог `services/api/app/diabetes/`, создавая отдельные модули с суффиксом `_handlers.py` и группируя их по доменам.
 
 ### Доступные команды
 
@@ -59,7 +59,7 @@
    ```
 3. **Установите зависимости и соберите фронтенд:**
    ```bash
-   pip install -r backend/requirements.txt
+   pip install -r services/api/app/requirements.txt
 
    (cd webapp/ui && npm ci)
 
@@ -79,14 +79,14 @@
 
 6. **Запустите сервер:**
    ```bash
-   python backend/main.py
+   python services/api/app/main.py
    ```
 
 ### Запуск WebApp
 
 В каталоге `webapp/ui` расположен React‑SPA (Vite), исходники лежат в `src/`,
 а результат сборки — в `dist/`. Все команды `npm` запускаются из этого каталога.
-Файл `backend/main.py` отдаёт содержимое
+Файл `services/api/app/main.py` отдаёт содержимое
 каталога `webapp/ui/dist` и предоставляет REST API (`/api/timezone`,
 `/api/profile`, `/api/reminders`).
 
@@ -108,7 +108,7 @@
 
 2. **Запустите FastAPI‑приложение:**
    ```bash
-    uvicorn backend.main:app --host 0.0.0.0 --port 8000
+    uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000
    ```
    Количество воркеров можно настроить переменной окружения `UVICORN_WORKERS`.
 
@@ -136,7 +136,7 @@ ngrok http 8000
 ## Сервисный запуск
 
 В каталоге `docs/deploy/` лежат примерные конфигурации для запуска приложения как службы.
-Они выполняют `uvicorn backend.main:app --workers 4` и автоматически перезапускаются при сбое.
+Они выполняют `uvicorn services.api.app.main:app --workers 4` и автоматически перезапускаются при сбое.
 
 - `docs/deploy/diabetes-assistant.service` — unit‑файл для **systemd**. Скопируйте его в `/etc/systemd/system/`, отредактируйте пути и пользователя, затем выполните `sudo systemctl enable --now diabetes-assistant`.
 - `docs/deploy/supervisord.conf` — секция для **supervisord**. Добавьте её в конфигурацию и перезапустите менеджер процессов.
@@ -148,7 +148,7 @@ ngrok http 8000
 Для проверки качества кода:
 
 ```bash
-pip install -r backend/requirements-dev.txt
-ruff backend/diabetes tests
+pip install -r services/api/app/requirements-dev.txt
+ruff services/api/app/diabetes tests
 pytest tests/
 ```

--- a/backend
+++ b/backend
@@ -1,1 +1,0 @@
-services/api/app

--- a/docs/deploy/diabetes-assistant.service
+++ b/docs/deploy/diabetes-assistant.service
@@ -7,7 +7,7 @@ Type=simple
 User=www-data
 WorkingDirectory=/opt/diabetes-assistant
 EnvironmentFile=/opt/diabetes-assistant/.env
-ExecStart=/usr/bin/env uvicorn backend.main:app --host 0.0.0.0 --port 8000 --workers 4
+ExecStart=/usr/bin/env uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000 --workers 4
 Restart=on-failure
 RestartSec=5
 

--- a/docs/deploy/supervisord.conf
+++ b/docs/deploy/supervisord.conf
@@ -1,6 +1,6 @@
 [program:diabetes-webapp]
 directory=/opt/diabetes-assistant
-command=uvicorn backend.main:app --host 0.0.0.0 --port 8000 --workers 4
+command=uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000 --workers 4
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,2 +1,2 @@
 line-length = 120
-extend-exclude = ["backend/diabetes/handlers.py", "backend/alembic"]
+extend-exclude = ["services/api/app/diabetes/handlers.py", "services/api/alembic"]

--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -7,7 +7,7 @@ import os
 import sys
 from dotenv import load_dotenv
 from services.api.app.diabetes.models import metadata
-from backend.config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
+from services.api.app.config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
 
 # Загрузка переменных окружения
 load_dotenv(".env")

--- a/services/api/app/bot.py
+++ b/services/api/app/bot.py
@@ -3,9 +3,9 @@
 Bot entry point and configuration.
 """
 
-from diabetes.handlers.common_handlers import register_handlers
-from backend.services import init_db
-from backend.config import LOG_LEVEL, TELEGRAM_TOKEN
+from services.api.app.diabetes.handlers.common_handlers import register_handlers
+from services.api.app.services import init_db
+from services.api.app.config import LOG_LEVEL, TELEGRAM_TOKEN
 from telegram import BotCommand
 from telegram.ext import Application, ContextTypes
 from sqlalchemy.exc import SQLAlchemyError

--- a/services/api/app/diabetes/config.py
+++ b/services/api/app/diabetes/config.py
@@ -1,4 +1,4 @@
-from backend import config as _config
+from services.api.app import config as _config
 
 __all__ = [name for name in dir(_config) if not name.startswith("_")]
 

--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -5,7 +5,7 @@ import re
 
 from openai import OpenAIError
 
-from diabetes.services.gpt_client import _get_client
+from services.api.app.diabetes.services.gpt_client import _get_client
 
 # gpt_command_parser.py  ← замените весь блок SYSTEM_PROMPT
 SYSTEM_PROMPT = (

--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -6,9 +6,9 @@ import logging
 
 from telegram.ext import ContextTypes
 
-from diabetes.services.db import SessionLocal, Alert, Profile, run_db
-from diabetes.handlers.common_handlers import commit_session
-from diabetes.utils.helpers import get_coords_and_link
+from services.api.app.diabetes.services.db import SessionLocal, Alert, Profile, run_db
+from services.api.app.diabetes.handlers.common_handlers import commit_session
+from services.api.app.diabetes.utils.helpers import get_coords_and_link
 
 logger = logging.getLogger(__name__)
 

--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -20,8 +20,8 @@ from telegram.ext import (
 )
 from sqlalchemy.exc import SQLAlchemyError
 
-from diabetes.services.db import Entry, SessionLocal
-from diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.services.db import Entry, SessionLocal
+from services.api.app.diabetes.utils.ui import menu_keyboard
 
 logger = logging.getLogger(__name__)
 

--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -21,16 +21,16 @@ from telegram.ext import (
     filters,
 )
 
-from diabetes.services.db import SessionLocal, User, Entry, Profile
-from diabetes.utils.functions import (
+from services.api.app.diabetes.services.db import SessionLocal, User, Entry, Profile
+from services.api.app.diabetes.utils.functions import (
     extract_nutrition_info,
     calc_bolus,
     PatientProfile,
     smart_input,
 )
-from diabetes.services.gpt_client import create_thread, send_message, _get_client
-from diabetes.gpt_command_parser import parse_command
-from diabetes.utils.ui import menu_keyboard, confirm_keyboard, dose_keyboard, sugar_keyboard
+from services.api.app.diabetes.services.gpt_client import create_thread, send_message, _get_client
+from services.api.app.diabetes.gpt_command_parser import parse_command
+from services.api.app.diabetes.utils.ui import menu_keyboard, confirm_keyboard, dose_keyboard, sugar_keyboard
 from .common_handlers import commit_session, menu_command
 from .alert_handlers import check_alert
 from .reporting_handlers import send_report, history_view, report_request, render_entry

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -27,10 +27,10 @@ from telegram.ext import (
     MessageHandler,
     filters,
 )
-from diabetes.handlers.callbackquery_no_warn_handler import CallbackQueryNoWarnHandler
+from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import CallbackQueryNoWarnHandler
 
-from diabetes.services.db import SessionLocal, User, Profile
-from diabetes.utils.ui import menu_keyboard, build_timezone_webapp_button
+from services.api.app.diabetes.services.db import SessionLocal, User, Profile
+from services.api.app.diabetes.utils.ui import menu_keyboard, build_timezone_webapp_button
 from .common_handlers import commit_session
 from zoneinfo import ZoneInfo
 
@@ -54,7 +54,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     with SessionLocal() as session:
         user = session.get(User, user_id)
         if not user:
-            from diabetes.services.gpt_client import create_thread
+            from services.api.app.diabetes.services.gpt_client import create_thread
 
             try:
                 thread_id = create_thread()

--- a/services/api/app/diabetes/handlers/profile_handlers.py
+++ b/services/api/app/diabetes/handlers/profile_handlers.py
@@ -10,14 +10,14 @@ from telegram.ext import (
     MessageHandler,
     filters,
 )
-from diabetes.handlers.callbackquery_no_warn_handler import CallbackQueryNoWarnHandler
+from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import CallbackQueryNoWarnHandler
 
-from diabetes.services.db import SessionLocal, Profile, Alert, Reminder, User
-from diabetes.handlers.alert_handlers import evaluate_sugar
-from diabetes.utils.ui import menu_keyboard, back_keyboard, build_timezone_webapp_button
-from backend.config import WEBAPP_URL
+from services.api.app.diabetes.services.db import SessionLocal, Profile, Alert, Reminder, User
+from services.api.app.diabetes.handlers.alert_handlers import evaluate_sugar
+from services.api.app.diabetes.utils.ui import menu_keyboard, back_keyboard, build_timezone_webapp_button
+from services.api.app.config import WEBAPP_URL
 from .common_handlers import commit_session
-import diabetes.handlers.reminder_handlers as reminder_handlers
+import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 from zoneinfo import ZoneInfo
 import json
 
@@ -375,7 +375,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     action = query.data.split(":", 1)[1] if ":" in query.data else None
 
     if action == "sos_contact":
-        from diabetes.handlers import sos_handlers
+        from services.api.app.diabetes.handlers import sos_handlers
 
         await sos_handlers.sos_contact_start(update.callback_query, context)
         return

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -9,7 +9,7 @@ import logging
 import json
 import re
 
-from diabetes.utils.helpers import parse_time_interval
+from services.api.app.diabetes.utils.helpers import parse_time_interval
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, WebAppInfo
 from telegram.ext import (
@@ -20,9 +20,9 @@ from telegram.ext import (
 )
 from telegram.error import BadRequest
 
-from diabetes.services.db import Reminder, ReminderLog, SessionLocal, User, run_db
+from services.api.app.diabetes.services.db import Reminder, ReminderLog, SessionLocal, User, run_db
 from .common_handlers import commit_session
-from backend.config import WEBAPP_URL
+from services.api.app.config import WEBAPP_URL
 
 logger = logging.getLogger(__name__)
 

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -18,10 +18,10 @@ from telegram import (
 )
 from telegram.ext import ContextTypes
 
-from diabetes.services.db import SessionLocal, Entry
-from diabetes.services.gpt_client import send_message, _get_client
-from diabetes.services.reporting import make_sugar_plot, generate_pdf_report
-from diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.services.db import SessionLocal, Entry
+from services.api.app.diabetes.services.gpt_client import send_message, _get_client
+from services.api.app.diabetes.services.reporting import make_sugar_plot, generate_pdf_report
+from services.api.app.diabetes.utils.ui import menu_keyboard
 
 LOW_SUGAR_THRESHOLD = 3.0
 HIGH_SUGAR_THRESHOLD = 13.0

--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -13,8 +13,8 @@ from telegram.ext import (
     filters,
 )
 
-from diabetes.services.db import SessionLocal, Profile
-from diabetes.utils.ui import back_keyboard, menu_keyboard
+from services.api.app.diabetes.services.db import SessionLocal, Profile
+from services.api.app.diabetes.utils.ui import back_keyboard, menu_keyboard
 from .common_handlers import commit_session
 from . import dose_handlers
 from .dose_handlers import _cancel_then

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -20,7 +20,7 @@ import asyncio
 import threading
 from typing import Any, Callable, TypeVar
 
-from backend import config
+from services.api.app import config
 
 DB_HOST = config.DB_HOST
 DB_PORT = config.DB_PORT

--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -6,8 +6,8 @@ import threading
 
 from openai import OpenAIError
 
-from backend.config import OPENAI_ASSISTANT_ID
-from diabetes.utils.openai_utils import get_openai_client
+from services.api.app.config import OPENAI_ASSISTANT_ID
+from services.api.app.diabetes.utils.openai_utils import get_openai_client
 
 logger = logging.getLogger(__name__)
 

--- a/services/api/app/diabetes/services/reporting.py
+++ b/services/api/app/diabetes/services/reporting.py
@@ -13,7 +13,7 @@ from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont, TTFError
 from reportlab.pdfgen import canvas
 
-from backend.config import FONT_DIR
+from services.api.app.config import FONT_DIR
 
 # Регистрация шрифтов для поддержки кириллицы и жирного начертания
 DEFAULT_FONT_DIR = '/usr/share/fonts/truetype/dejavu'

--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from openai import OpenAI
-from backend.config import OPENAI_API_KEY, OPENAI_ASSISTANT_ID, OPENAI_PROXY
+from services.api.app.config import OPENAI_API_KEY, OPENAI_ASSISTANT_ID, OPENAI_PROXY
 
 
 def get_openai_client() -> OpenAI:

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -4,7 +4,7 @@ UI-компоненты бота «Diabet Buddy».
 Здесь живут все клавиатуры (Reply и Inline) и их генераторы.
 Импортируйте объекты напрямую:
 
-    from diabetes.utils.ui import menu_keyboard, dose_keyboard, confirm_keyboard
+    from services.api.app.diabetes.utils.ui import menu_keyboard, dose_keyboard, confirm_keyboard
 """
 
 from telegram import (
@@ -14,7 +14,7 @@ from telegram import (
     KeyboardButton,
     WebAppInfo,
 )
-from backend.config import WEBAPP_URL
+from services.api.app.config import WEBAPP_URL
 
 __all__ = (
     "menu_keyboard",

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -117,4 +117,4 @@ if __name__ == "__main__":  # pragma: no cover
 
     workers = int(os.getenv("UVICORN_WORKERS", "1"))
     init_db()
-    uvicorn.run("backend.main:app", host="0.0.0.0", port=8000, workers=workers)
+    uvicorn.run("services.api.app.main:app", host="0.0.0.0", port=8000, workers=workers)

--- a/services/api/app/services/__init__.py
+++ b/services/api/app/services/__init__.py
@@ -1,4 +1,4 @@
-from diabetes.services.db import init_db
+from services.api.app.diabetes.services.db import init_db
 
 from .profile import save_profile, set_timezone
 from .reminders import list_reminders, save_reminder

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from diabetes.services.db import Profile, SessionLocal, User, run_db
-from backend.schemas.profile import ProfileSchema
+from services.api.app.diabetes.services.db import Profile, SessionLocal, User, run_db
+from services.api.app.schemas.profile import ProfileSchema
 
 
 async def set_timezone(telegram_id: int, tz: str) -> None:

--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -4,8 +4,8 @@ from typing import List
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from diabetes.services.db import Reminder, SessionLocal, run_db
-from backend.schemas.reminders import ReminderSchema
+from services.api.app.diabetes.services.db import Reminder, SessionLocal, run_db
+from services.api.app.schemas.reminders import ReminderSchema
 
 
 async def list_reminders(telegram_id: int) -> List[Reminder]:

--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ source venv/bin/activate
 
 echo "Установка Python-зависимостей…"
 pip install --upgrade pip
-pip install -r backend/requirements.txt
+pip install -r services/api/app/requirements.txt
 
 echo "Сборка фронтенда (npm ci && npm run build)…"
 pushd webapp/ui >/dev/null
@@ -26,4 +26,4 @@ fi
 
 echo "Установка завершена! Проверьте файл .env и заполните свои токены и пароли."
 echo "Фронтенд собран в webapp/ui/dist."
-echo "Для запуска API: source venv/bin/activate && python backend/main.py"
+echo "Для запуска API: source venv/bin/activate && python services/api/app/main.py"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,0 @@
-import sys
-from pathlib import Path
-
-# Ensure the backend package is importable
-backend_path = Path(__file__).resolve().parents[1] / "backend"
-if str(backend_path) not in sys.path:
-    sys.path.insert(0, str(backend_path))

--- a/tests/test_add_reminder_wizard.py
+++ b/tests/test_add_reminder_wizard.py
@@ -5,9 +5,9 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from diabetes.services.db import Base, User, Reminder
-import diabetes.handlers.reminder_handlers as handlers
-from diabetes.handlers.common_handlers import commit_session
+from services.api.app.diabetes.services.db import Base, User, Reminder
+import services.api.app.diabetes.handlers.reminder_handlers as handlers
+from services.api.app.diabetes.handlers.common_handlers import commit_session
 
 
 class DummyMessage:

--- a/tests/test_alert_stats.py
+++ b/tests/test_alert_stats.py
@@ -5,8 +5,8 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from diabetes.services.db import Base, Alert, User
-import diabetes.handlers.alert_handlers as alert_handlers
+from services.api.app.diabetes.services.db import Base, Alert, User
+import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
 
 
 class DummyMessage:

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -3,9 +3,9 @@ from types import SimpleNamespace
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from diabetes.services.db import Base, User, Profile, Alert
-import diabetes.handlers.alert_handlers as handlers
-from diabetes.handlers.common_handlers import commit_session
+from services.api.app.diabetes.services.db import Base, User, Profile, Alert
+import services.api.app.diabetes.handlers.alert_handlers as handlers
+from services.api.app.diabetes.handlers.common_handlers import commit_session
 
 
 class DummyJob:

--- a/tests/test_bot_db_error.py
+++ b/tests/test_bot_db_error.py
@@ -3,7 +3,7 @@ import pytest
 from sqlalchemy.exc import SQLAlchemyError
 import asyncio
 
-import bot
+import services.api.app.bot as bot
 
 
 def test_main_logs_db_error(monkeypatch, caplog):

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -14,9 +14,9 @@ def test_log_level_debug(monkeypatch):
     monkeypatch.setenv("LOG_LEVEL", "DEBUG")
 
     # Ensure fresh imports so that env vars are read
-    for mod in ["backend.config", "bot"]:
+    for mod in ["services.api.app.config", "services.api.app.bot"]:
         sys.modules.pop(mod, None)
-    bot = importlib.import_module("bot")
+    bot = importlib.import_module("services.api.app.bot")
 
     # Stub external interactions
     monkeypatch.setattr(bot, "init_db", lambda: None)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,14 +15,14 @@ def _reload(module: str):
 
 def test_import_config_without_db_password(monkeypatch):
     monkeypatch.delenv("DB_PASSWORD", raising=False)
-    _reload("backend.config")  # should not raise
+    _reload("services.api.app.config")  # should not raise
 
 
 def test_init_db_raises_when_no_password(monkeypatch):
     monkeypatch.delenv("DB_PASSWORD", raising=False)
     monkeypatch.setenv("SKIP_DOTENV", "1")
-    config = _reload("backend.config")
-    db = _reload("diabetes.services.db")
+    config = _reload("services.api.app.config")
+    db = _reload("services.api.app.diabetes.services.db")
     assert config.DB_PASSWORD is None
     with pytest.raises(ValueError):
         db.init_db()
@@ -32,7 +32,7 @@ def test_webapp_url_missing(monkeypatch, caplog):
     monkeypatch.delenv("WEBAPP_URL", raising=False)
     monkeypatch.setenv("SKIP_DOTENV", "1")
     with caplog.at_level(logging.WARNING):
-        config = _reload("backend.config")
+        config = _reload("services.api.app.config")
     assert config.WEBAPP_URL is None
     assert any("WEBAPP_URL is not set" in msg for msg in caplog.messages)
 
@@ -41,7 +41,7 @@ def test_webapp_url_requires_https(monkeypatch, caplog):
     monkeypatch.setenv("WEBAPP_URL", "http://example.com")
     monkeypatch.setenv("SKIP_DOTENV", "1")
     with caplog.at_level(logging.WARNING):
-        config = _reload("backend.config")
+        config = _reload("services.api.app.config")
     assert config.WEBAPP_URL is None
     assert any("Ignoring WEBAPP_URL" in msg and "not HTTPS" in msg for msg in caplog.messages)
 
@@ -51,7 +51,7 @@ def test_webapp_url_valid(monkeypatch, caplog):
     monkeypatch.setenv("WEBAPP_URL", url)
     monkeypatch.setenv("SKIP_DOTENV", "1")
     with caplog.at_level(logging.WARNING):
-        config = _reload("backend.config")
+        config = _reload("services.api.app.config")
     assert config.WEBAPP_URL == url
     assert not caplog.messages
 

--- a/tests/test_db_reinit.py
+++ b/tests/test_db_reinit.py
@@ -30,9 +30,9 @@ class DummyEngine:
 
 def test_init_db_recreates_engine_on_url_change(monkeypatch, attr, orig, new, url_attr):
     monkeypatch.setenv("SKIP_DOTENV", "1")
-    config = _reload("backend.config")
+    config = _reload("services.api.app.config")
     config.DB_PASSWORD = "pwd"
-    db = _reload("diabetes.services.db")
+    db = _reload("services.api.app.diabetes.services.db")
 
     created = []
 

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -6,8 +6,8 @@ from telegram.ext import MessageHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from diabetes.handlers import dose_handlers
+import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+from services.api.app.diabetes.handlers import dose_handlers
 
 
 class DummyMessage:

--- a/tests/test_dose_handlers_logging.py
+++ b/tests/test_dose_handlers_logging.py
@@ -1,6 +1,6 @@
 import logging
 
-from diabetes.handlers import dose_handlers
+from services.api.app.diabetes.handlers import dose_handlers
 
 
 def test_logging_truncates_content(caplog):

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -6,8 +6,8 @@ import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-import diabetes.handlers.dose_handlers as dose_handlers
+import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 
 
 class DummyMessage:

--- a/tests/test_dose_sugar_missing.py
+++ b/tests/test_dose_sugar_missing.py
@@ -7,8 +7,8 @@ from telegram.ext import ConversationHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from diabetes.handlers import dose_handlers
+import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+from services.api.app.diabetes.handlers import dose_handlers
 
 
 class DummyMessage:

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 os.environ.setdefault("DB_PASSWORD", "test")
-from diabetes.services.db import Base, User, Entry
+from services.api.app.diabetes.services.db import Base, User, Entry
 
 
 class DummyMessage:
@@ -47,9 +47,9 @@ class DummyBot:
 async def test_edit_dose(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import diabetes.handlers.common_handlers as common_handlers
-    import diabetes.handlers.dose_handlers as dose_handlers
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.common_handlers as common_handlers
+    import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)

--- a/tests/test_freeform_handler_unknown.py
+++ b/tests/test_freeform_handler_unknown.py
@@ -1,7 +1,7 @@
 import pytest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
-import diabetes.handlers.dose_handlers as handlers
+import services.api.app.diabetes.handlers.dose_handlers as handlers
 
 
 class DummyMessage:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from diabetes.utils.functions import (
+from services.api.app.diabetes.utils.functions import (
     PatientProfile,
     _safe_float,
     calc_bolus,

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 from openai import OpenAIError
 
-from diabetes.services import gpt_client
+from services.api.app.diabetes.services import gpt_client
 
 
 def test_get_client_thread_safe(monkeypatch):

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -7,8 +7,8 @@ import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-from diabetes.utils import openai_utils  # noqa: F401,E402
-from diabetes import gpt_command_parser  # noqa: E402
+from services.api.app.diabetes.utils import openai_utils  # noqa: F401,E402
+from services.api.app.diabetes import gpt_command_parser  # noqa: E402
 
 
 @pytest.mark.asyncio

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -32,8 +32,8 @@ class DummyQuery:
 async def test_callback_router_cancel_entry_sends_menu():
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
-    import diabetes.utils.openai_utils  # noqa: F401
-    import diabetes.handlers.common_handlers as handlers
+    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.common_handlers as handlers
 
     query = DummyQuery("cancel_entry")
     update = SimpleNamespace(callback_query=query)
@@ -53,8 +53,8 @@ async def test_callback_router_cancel_entry_sends_menu():
 async def test_callback_router_invalid_entry_id(caplog):
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
-    import diabetes.utils.openai_utils  # noqa: F401
-    import diabetes.handlers.common_handlers as handlers
+    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.common_handlers as handlers
 
     query = DummyQuery("del:abc")
     update = SimpleNamespace(callback_query=query)
@@ -71,8 +71,8 @@ async def test_callback_router_invalid_entry_id(caplog):
 async def test_callback_router_unknown_data(caplog):
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
-    import diabetes.utils.openai_utils  # noqa: F401
-    import diabetes.handlers.common_handlers as handlers
+    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.common_handlers as handlers
 
     query = DummyQuery("foo")
     update = SimpleNamespace(callback_query=query)
@@ -89,8 +89,8 @@ async def test_callback_router_unknown_data(caplog):
 async def test_callback_router_ignores_reminder_action():
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
-    import diabetes.utils.openai_utils  # noqa: F401
-    import diabetes.handlers.common_handlers as handlers
+    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.common_handlers as handlers
 
     query = DummyQuery("rem_toggle:1")
     update = SimpleNamespace(callback_query=query)

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -7,9 +7,9 @@ import json
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
 from telegram.ext import ConversationHandler
-import diabetes.handlers.profile_handlers as profile_handlers
-import diabetes.handlers.common_handlers as common_handlers
-import diabetes.handlers.reminder_handlers as reminder_handlers
+import services.api.app.diabetes.handlers.profile_handlers as profile_handlers
+import services.api.app.diabetes.handlers.common_handlers as common_handlers
+import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
 
 class DummyMessage:
@@ -44,7 +44,7 @@ async def test_profile_command_commit_failure(monkeypatch, caplog):
 
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
-    import diabetes.utils.openai_utils  # noqa: F401
+    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
 
     session = MagicMock()
     session.__enter__.return_value = session
@@ -75,7 +75,7 @@ async def test_callback_router_commit_failure(monkeypatch, caplog):
 
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
-    import diabetes.utils.openai_utils  # noqa: F401
+    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
 
     session = MagicMock()
     session.__enter__.return_value = session

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -2,7 +2,7 @@ import pytest
 from pathlib import Path
 from types import SimpleNamespace
 
-import diabetes.handlers.dose_handlers as handlers
+import services.api.app.diabetes.handlers.dose_handlers as handlers
 
 
 class DummyMessage:

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -2,7 +2,7 @@ import datetime
 from types import SimpleNamespace
 
 import pytest
-import diabetes.handlers.dose_handlers as handlers
+import services.api.app.diabetes.handlers.dose_handlers as handlers
 
 
 class DummyMessage:

--- a/tests/test_handlers_freeform_units.py
+++ b/tests/test_handlers_freeform_units.py
@@ -1,6 +1,6 @@
 import pytest
 from types import SimpleNamespace
-import diabetes.handlers.dose_handlers as handlers
+import services.api.app.diabetes.handlers.dose_handlers as handlers
 
 
 class DummyMessage:

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from telegram import InlineKeyboardMarkup
 
 os.environ.setdefault("DB_PASSWORD", "test")
-from diabetes.services.db import Base, User, Entry
+from services.api.app.diabetes.services.db import Base, User, Entry
 
 
 class DummyMessage:
@@ -49,10 +49,10 @@ class DummyBot:
 async def test_history_view_buttons(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import diabetes.handlers.reporting_handlers as reporting_handlers
-    import diabetes.handlers.common_handlers as common_handlers
-    import diabetes.handlers.dose_handlers as dose_handlers
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.reporting_handlers as reporting_handlers
+    import services.api.app.diabetes.handlers.common_handlers as common_handlers
+    import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 
     engine = create_engine(
         "sqlite:///:memory:",
@@ -124,9 +124,9 @@ async def test_history_view_buttons(monkeypatch):
 async def test_edit_flow(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import diabetes.handlers.common_handlers as common_handlers
-    import diabetes.handlers.dose_handlers as dose_handlers
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.common_handlers as common_handlers
+    import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 
     engine = create_engine(
         "sqlite:///:memory:",

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -3,8 +3,8 @@ from types import SimpleNamespace
 
 import pytest
 
-import diabetes.handlers.dose_handlers as dose_handlers
-import diabetes.handlers.common_handlers as common_handlers
+import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
+import services.api.app.diabetes.handlers.common_handlers as common_handlers
 
 
 class DummyMessage:
@@ -140,7 +140,7 @@ async def test_photo_flow_saves_entry(monkeypatch, tmp_path):
     assert context.user_data["pending_entry"]["sugar_before"] == 5.5
 
     monkeypatch.setattr(common_handlers, "SessionLocal", lambda: session)
-    import diabetes.handlers.alert_handlers as alert_handlers
+    import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
 
     async def noop(*a, **k):
         return None

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -6,9 +6,9 @@ from unittest.mock import MagicMock
 from telegram import InlineKeyboardMarkup
 from telegram.ext import ConversationHandler
 
-from diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.utils.ui import menu_keyboard
 
-from diabetes.services.db import Base, User, Profile
+from services.api.app.diabetes.services.db import Base, User, Profile
 
 
 class DummyMessage:
@@ -39,8 +39,8 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
     import os
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
-    import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import diabetes.handlers.profile_handlers as handlers
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.profile_handlers as handlers
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
@@ -98,8 +98,8 @@ async def test_profile_command_invalid_values(monkeypatch, args):
 
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
-    import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import diabetes.handlers.profile_handlers as handlers
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.profile_handlers as handlers
 
     commit_mock = MagicMock()
     session_local_mock = MagicMock()
@@ -123,8 +123,8 @@ async def test_profile_command_help_and_dialog(monkeypatch):
 
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
-    import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import diabetes.handlers.profile_handlers as handlers
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.profile_handlers as handlers
 
     # Test /profile help
     help_msg = DummyMessage()
@@ -150,8 +150,8 @@ async def test_profile_view_preserves_user_data(monkeypatch):
 
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
-    import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import diabetes.handlers.profile_handlers as handlers
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.profile_handlers as handlers
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -5,9 +5,9 @@ import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from diabetes.handlers import dose_handlers
-from diabetes.utils.ui import sugar_keyboard
+import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+from services.api.app.diabetes.handlers import dose_handlers
+from services.api.app.diabetes.utils.ui import sugar_keyboard
 
 
 class DummyMessage:

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -30,9 +30,9 @@ class DummyQuery:
 async def test_report_request_and_custom_flow(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import diabetes.handlers.reporting_handlers as reporting_handlers
-    import diabetes.handlers.dose_handlers as dose_handlers
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.reporting_handlers as reporting_handlers
+    import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 
     message = DummyMessage()
     update = SimpleNamespace(
@@ -78,8 +78,8 @@ async def test_report_request_and_custom_flow(monkeypatch):
 async def test_report_period_callback_week(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import diabetes.handlers.reporting_handlers as reporting_handlers
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.reporting_handlers as reporting_handlers
 
     called: dict[str, datetime.datetime | str] = {}
 

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -2,7 +2,7 @@ import pytest
 from pathlib import Path
 from types import SimpleNamespace
 
-import diabetes.handlers.dose_handlers as dose_handlers
+import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 
 
 class DummyMessage:

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -1,7 +1,7 @@
 import pytest
 from types import SimpleNamespace
 
-import diabetes.handlers.common_handlers as handlers
+import services.api.app.diabetes.handlers.common_handlers as handlers
 
 
 class DummyMessage:

--- a/tests/test_history_view_async.py
+++ b/tests/test_history_view_async.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from diabetes.handlers import reporting_handlers
+from services.api.app.diabetes.handlers import reporting_handlers
 
 
 class DummyMessage:

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -6,8 +6,8 @@ from telegram.ext import CommandHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from diabetes.handlers import dose_handlers
+import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+from services.api.app.diabetes.handlers import dose_handlers
 
 
 class DummyMessage:

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from diabetes.services.db import Base
+from services.api.app.diabetes.services.db import Base
 
 
 class DummyMessage:
@@ -29,9 +29,9 @@ async def test_onboarding_demo_photo_missing(monkeypatch, caplog):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 
-    import diabetes.handlers.common_handlers  # noqa: F401
-    import diabetes.handlers.onboarding_handlers as onboarding
-    import diabetes.services.gpt_client as gpt_client
+    import services.api.app.diabetes.handlers.common_handlers  # noqa: F401
+    import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
+    import services.api.app.diabetes.services.gpt_client as gpt_client
 
     monkeypatch.setattr(gpt_client, "create_thread", lambda: "tid")
 

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import sessionmaker
 
 from telegram.ext import ConversationHandler
 
-from diabetes.services.db import Base, User
+from services.api.app.diabetes.services.db import Base, User
 
 
 class DummyMessage:
@@ -48,8 +48,8 @@ async def test_onboarding_flow(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 
-    import diabetes.handlers.onboarding_handlers as onboarding
-    import diabetes.services.gpt_client as gpt_client
+    import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
+    import services.api.app.diabetes.services.gpt_client as gpt_client
 
     monkeypatch.setattr(gpt_client, "create_thread", lambda: "tid")
 

--- a/tests/test_parse_time_interval.py
+++ b/tests/test_parse_time_interval.py
@@ -2,7 +2,7 @@ from datetime import time, timedelta
 
 import pytest
 
-from diabetes.utils.helpers import INVALID_TIME_MSG, parse_time_interval
+from services.api.app.diabetes.utils.helpers import INVALID_TIME_MSG, parse_time_interval
 
 
 def test_parse_time_zero_padded():

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -6,8 +6,8 @@ from telegram.ext import MessageHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from diabetes.handlers import (
+import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+from services.api.app.diabetes.handlers import (
     dose_handlers,
     profile_handlers,
     onboarding_handlers,

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -5,9 +5,9 @@ import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from diabetes.handlers import dose_handlers, profile_handlers
-from diabetes.services.db import Base, Entry, User
+import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+from services.api.app.diabetes.handlers import dose_handlers, profile_handlers
+from services.api.app.diabetes.services.db import Base, Entry, User
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -3,11 +3,11 @@ from types import SimpleNamespace
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from diabetes.services.db import Base, User, Profile, Alert, Reminder
-import diabetes.handlers.profile_handlers as handlers
-from diabetes.handlers.common_handlers import commit_session
-import diabetes.handlers.reminder_handlers as reminder_handlers
-import diabetes.handlers.sos_handlers as sos_handlers
+from services.api.app.diabetes.services.db import Base, User, Profile, Alert, Reminder
+import services.api.app.diabetes.handlers.profile_handlers as handlers
+from services.api.app.diabetes.handlers.common_handlers import commit_session
+import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
+import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
 
 
 class DummyMessage:

--- a/tests/test_quick_input_help_button.py
+++ b/tests/test_quick_input_help_button.py
@@ -1,7 +1,7 @@
 import pytest
 from types import SimpleNamespace
 
-import diabetes.handlers.common_handlers as handlers
+import services.api.app.diabetes.handlers.common_handlers as handlers
 
 
 class DummyMessage:

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -7,17 +7,17 @@ from telegram.ext import (
     ConversationHandler,
     MessageHandler,
 )
-from diabetes.handlers.callbackquery_no_warn_handler import CallbackQueryNoWarnHandler
+from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import CallbackQueryNoWarnHandler
 
-from diabetes.handlers.common_handlers import register_handlers, callback_router, start_command
-from diabetes.handlers import security_handlers, reminder_handlers
+from services.api.app.diabetes.handlers.common_handlers import register_handlers, callback_router, start_command
+from services.api.app.diabetes.handlers import security_handlers, reminder_handlers
 
 
 def test_register_handlers_attaches_expected_handlers(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    from diabetes.handlers import dose_handlers, profile_handlers, reporting_handlers
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+    from services.api.app.diabetes.handlers import dose_handlers, profile_handlers, reporting_handlers
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
     register_handlers(app)

--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -5,9 +5,9 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from diabetes.services.db import Base, User, Reminder, Entry
-import diabetes.handlers.reminder_handlers as handlers
-from diabetes.handlers.common_handlers import commit_session
+from services.api.app.diabetes.services.db import Base, User, Reminder, Entry
+import services.api.app.diabetes.handlers.reminder_handlers as handlers
+from services.api.app.diabetes.handlers.common_handlers import commit_session
 
 
 class DummyMessage:

--- a/tests/test_reminder_limit_free_vs_pro.py
+++ b/tests/test_reminder_limit_free_vs_pro.py
@@ -5,8 +5,8 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-import diabetes.handlers.reminder_handlers as handlers
-from diabetes.services.db import Base, Reminder, User
+import services.api.app.diabetes.handlers.reminder_handlers as handlers
+from services.api.app.diabetes.services.db import Base, Reminder, User
 
 
 class DummyMessage:

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -5,11 +5,11 @@ from types import SimpleNamespace
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from diabetes.services.db import Base, User, Reminder, ReminderLog
-import diabetes.handlers.reminder_handlers as handlers
-import diabetes.handlers.common_handlers as common_handlers
-from diabetes.handlers.common_handlers import commit_session
-from diabetes.utils.helpers import parse_time_interval
+from services.api.app.diabetes.services.db import Base, User, Reminder, ReminderLog
+import services.api.app.diabetes.handlers.reminder_handlers as handlers
+import services.api.app.diabetes.handlers.common_handlers as common_handlers
+from services.api.app.diabetes.handlers.common_handlers import commit_session
+from services.api.app.diabetes.utils.helpers import parse_time_interval
 
 
 class DummyMessage:

--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -1,15 +1,15 @@
 import os
 import re
 from telegram.ext import ApplicationBuilder, MessageHandler
-from diabetes.utils.ui import menu_keyboard
-import diabetes.handlers.common_handlers as handlers
-import diabetes.handlers.reminder_handlers as reminder_handlers
+from services.api.app.diabetes.utils.ui import menu_keyboard
+import services.api.app.diabetes.handlers.common_handlers as handlers
+import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
 
 def test_reminders_button_matches_regex():
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import diabetes.utils.openai_utils as openai_utils  # noqa: F401
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
     button_texts = [btn.text for row in menu_keyboard.keyboard for btn in row]
     assert "⏰ Напоминания" in button_texts

--- a/tests/test_render_entry.py
+++ b/tests/test_render_entry.py
@@ -1,7 +1,7 @@
 import datetime
 from types import SimpleNamespace
 
-from diabetes.handlers.reporting_handlers import render_entry
+from services.api.app.diabetes.handlers.reporting_handlers import render_entry
 
 
 def make_entry(**kwargs):

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import sessionmaker
 
 os.environ.setdefault("DB_PASSWORD", "test")
 
-from diabetes.services.reporting import make_sugar_plot, generate_pdf_report
+from services.api.app.diabetes.services.reporting import make_sugar_plot, generate_pdf_report
 
 
 class DummyEntry:
@@ -140,8 +140,8 @@ async def test_send_report_uses_gpt(monkeypatch):
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst")
     os.environ.setdefault("DB_PASSWORD", "pwd")
 
-    import diabetes.handlers.reporting_handlers as handlers
-    from diabetes.services.db import Base, Entry, User
+    import services.api.app.diabetes.handlers.reporting_handlers as handlers
+    from services.api.app.diabetes.services.db import Base, Entry, User
 
     engine = create_engine(
         "sqlite:///:memory:",

--- a/tests/test_security_handlers.py
+++ b/tests/test_security_handlers.py
@@ -1,7 +1,7 @@
 import pytest
 from types import SimpleNamespace
 
-import diabetes.handlers.security_handlers as handlers
+import services.api.app.diabetes.handlers.security_handlers as handlers
 
 
 class DummyMessage:

--- a/tests/test_smart_input.py
+++ b/tests/test_smart_input.py
@@ -1,6 +1,6 @@
 import pytest
 
-from diabetes.utils.functions import smart_input
+from services.api.app.diabetes.utils.functions import smart_input
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -8,12 +8,12 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from telegram.ext import ApplicationBuilder, MessageHandler
 
-from diabetes.services.db import Base, User, Profile
-import diabetes.handlers.sos_handlers as sos_handlers
-import diabetes.handlers.alert_handlers as alert_handlers
-import diabetes.handlers.common_handlers as handlers
-from diabetes.handlers.common_handlers import commit_session
-from diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.services.db import Base, User, Profile
+import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
+import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
+import services.api.app.diabetes.handlers.common_handlers as handlers
+from services.api.app.diabetes.handlers.common_handlers import commit_session
+from services.api.app.diabetes.utils.ui import menu_keyboard
 
 
 class DummyMessage:
@@ -129,7 +129,7 @@ async def test_alert_skips_phone_contact(test_session, monkeypatch):
 async def test_sos_contact_menu_button_starts_conv(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import diabetes.utils.openai_utils as openai_utils  # noqa: F401
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
     button_texts = [btn.text for row in menu_keyboard.keyboard for btn in row]
     assert "🆘 SOS контакт" in button_texts

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -6,8 +6,8 @@ from telegram.ext import ConversationHandler, MessageHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from diabetes.handlers import dose_handlers
+import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+from services.api.app.diabetes.handlers import dose_handlers
 
 
 class DummyMessage:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,8 +10,8 @@ from reportlab.pdfbase.ttfonts import TTFont
 
 import pytest
 
-import diabetes.utils.helpers as utils
-from diabetes.utils.helpers import clean_markdown, parse_time_interval, split_text_by_width
+import services.api.app.diabetes.utils.helpers as utils
+from services.api.app.diabetes.utils.helpers import clean_markdown, parse_time_interval, split_text_by_width
 
 def test_clean_markdown():
     text = "**Жирный**\n# Заголовок\n* элемент\n1. Первый"

--- a/tests/test_webapp_server.py
+++ b/tests/test_webapp_server.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 from fastapi.staticfiles import StaticFiles
 
-import backend.main as server
+import services.api.app.main as server
 
 if not server.UI_DIR.exists():
     (server.UI_DIR / "assets").mkdir(parents=True)

--- a/tests/test_webapp_server_startup.py
+++ b/tests/test_webapp_server_startup.py
@@ -1,4 +1,4 @@
-"""Tests for backend server startup checks."""
+"""Tests for API server startup checks."""
 
 import importlib
 from pathlib import Path
@@ -6,8 +6,8 @@ from pathlib import Path
 import pytest
 
 
-def test_backend_import_without_ui(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Importing backend.main should succeed even if UI build is missing."""
+def test_app_import_without_ui(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Importing services.api.app.main should succeed even if UI build is missing."""
     ui_dir = (Path(__file__).resolve().parents[1] / "webapp" / "ui" / "dist").resolve()
     original_exists = Path.exists
 
@@ -17,5 +17,5 @@ def test_backend_import_without_ui(monkeypatch: pytest.MonkeyPatch) -> None:
         return original_exists(self)
 
     monkeypatch.setattr(Path, "exists", fake_exists)
-    importlib.reload(importlib.import_module("backend.main"))
+    importlib.reload(importlib.import_module("services.api.app.main"))
 

--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -1,7 +1,7 @@
 
 from fastapi.testclient import TestClient
 
-import backend.main as server
+import services.api.app.main as server
 
 
 def test_timezone_persist_and_validate(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- refactor code and tests to import modules via `services.api.app`
- remove legacy `backend` symlink and update configs/docs
- adjust lint paths and Docker build to match new layout

## Testing
- `ruff check services/api/app tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689ac0b9fdf4832a8d9a562de07ae6cb