### PR TITLE
[bot] Use API SDK for profile management

### DIFF
--- a/services/api/app/bot.py
+++ b/services/api/app/bot.py
@@ -4,11 +4,9 @@ Bot entry point and configuration.
 """
 
 from services.api.app.diabetes.handlers.common_handlers import register_handlers
-from services.api.app.services import init_db
 from services.api.app.config import LOG_LEVEL, TELEGRAM_TOKEN
 from telegram import BotCommand
 from telegram.ext import Application, ContextTypes
-from sqlalchemy.exc import SQLAlchemyError
 import logging
 import os
 import sys
@@ -52,14 +50,6 @@ def main() -> None:
             "BOT_TOKEN is not set. Please provide the environment variable.",
         )
         sys.exit(1)
-
-    try:
-        init_db()
-    except (SQLAlchemyError, ValueError) as err:
-        logger.exception("Failed to initialize the database: %s", err)
-        sys.exit(
-            "Database initialization failed. Please check your configuration and try again."
-        )
 
     commands = [
         BotCommand("start", "Запустить бота"),

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -12,7 +12,7 @@ from .services.audit import log_patient_access
 from .schemas.profile import ProfileSchema
 from .schemas.reminders import ReminderSchema
 from .schemas.timezone import TimezoneSchema
-from .services.profile import save_profile, set_timezone
+from .services.profile import get_profile, save_profile, set_timezone
 from .services.reminders import list_reminders, save_reminder
 from .services import init_db
 
@@ -37,10 +37,26 @@ async def api_timezone(data: TimezoneSchema) -> dict:
     return {"status": "ok"}
 
 
-@app.post("/api/profile")
-async def api_profile(data: ProfileSchema) -> dict:
+@app.post("/profiles")
+async def profiles_post(data: ProfileSchema) -> dict:
     await save_profile(data)
     return {"status": "ok"}
+
+
+@app.get("/profiles")
+async def profiles_get(telegram_id: int) -> ProfileSchema:
+    profile = await get_profile(telegram_id)
+    if profile is None:
+        raise HTTPException(status_code=404, detail="profile not found")
+    return ProfileSchema(
+        telegram_id=profile.telegram_id,
+        icr=profile.icr,
+        cf=profile.cf,
+        target=profile.target_bg,
+        low=profile.low_threshold,
+        high=profile.high_threshold,
+        org_id=profile.org_id,
+    )
 
 
 @app.get("/api/reminders")


### PR DESCRIPTION
## Summary
- route profile operations through `libs/py-sdk` and remove direct DB init in bot
- add `/profiles` endpoints with validation and retrieval in API service
- centralize profile validation in service layer

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_handlers_profile.py` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689ac86f3718832ab02c105be4f330f8