### PR TITLE
[infra] Centralize environment variables

### DIFF
--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -1,30 +1,49 @@
 # .env.example — пример заполнения переменных окружения
 
 # --- Telegram Bot ---
+# Token for the Telegram bot
 TELEGRAM_TOKEN=your-telegram-token-here
+# Chat ID to receive error notifications (optional)
+MAINTAINER_CHAT_ID=
 
 # --- OpenAI ---
+# API key for OpenAI
 OPENAI_API_KEY=sk-...
+# Assistant ID used for replies
 OPENAI_ASSISTANT_ID=asst_...
+# Optional HTTP proxy for OpenAI requests
 OPENAI_PROXY=http://user:pass@proxy_host:port
 
 # --- Database (PostgreSQL/MySQL) ---
+# Hostname of the database server
 DB_HOST=localhost
+# Port of the database server
 DB_PORT=5432
+# Name of the database
 DB_NAME=diabetes_bot
+# Username for the database
 DB_USER=diabetes_user
+# Password for the database user
 DB_PASSWORD=your_db_password
 
 # --- WebApp ---
-# URL where the auxiliary WebApp is hosted.
-# Telegram accepts only HTTPS URLs.
+# URL where the auxiliary WebApp is hosted (must be HTTPS)
 WEBAPP_URL=https://your-domain.example/
 # Set to true/1 to enable WebApp startup in Docker/start.sh
 # WebApp will be skipped if WEBAPP_URL is not HTTPS
 ENABLE_WEBAPP=false
-# (опционально, для логов, email и прочего — добавить по мере необходимости)
-# --- Logging ---
-# Set to DEBUG/1/true to enable verbose logging
-# LOG_LEVEL=DEBUG
-# Путь к пользовательским шрифтам для PDF (опционально)
-# FONT_DIR=/path/to/fonts
+# Base URL of the API service used by bot and WebApp
+API_URL=http://localhost:8000
+
+# --- Runtime options ---
+# Number of Uvicorn worker processes
+UVICORN_WORKERS=1
+# Log level; set to DEBUG/1/true for verbose logging
+LOG_LEVEL=INFO
+# Alternative flag to enable debug logging
+DEBUG=
+# Path to custom fonts for PDF reports (optional)
+FONT_DIR=/path/to/fonts
+# Set to any value to skip automatic loading of .env
+SKIP_DOTENV=
+

--- a/services/api/app/bot.py
+++ b/services/api/app/bot.py
@@ -4,23 +4,13 @@ Bot entry point and configuration.
 """
 
 from services.api.app.diabetes.handlers.common_handlers import register_handlers
-from services.api.app.config import LOG_LEVEL, TELEGRAM_TOKEN
+from services.api.app.config import LOG_LEVEL, TELEGRAM_TOKEN, MAINTAINER_CHAT_ID
 from telegram import BotCommand
 from telegram.ext import Application, ContextTypes
 import logging
-import os
 import sys
 
 logger = logging.getLogger(__name__)
-
-MAINTAINER_CHAT_ID = os.getenv("MAINTAINER_CHAT_ID")
-try:
-    MAINTAINER_CHAT_ID = (
-        int(MAINTAINER_CHAT_ID) if MAINTAINER_CHAT_ID is not None else None
-    )
-except (TypeError, ValueError):
-    logger.warning("Invalid MAINTAINER_CHAT_ID: %s", MAINTAINER_CHAT_ID)
-    MAINTAINER_CHAT_ID = None
 
 
 async def error_handler(update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -19,6 +19,13 @@ def _read_log_level() -> int:
 LOG_LEVEL = _read_log_level()
 
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+_raw_maintainer_chat_id = os.getenv("MAINTAINER_CHAT_ID")
+MAINTAINER_CHAT_ID = None
+if _raw_maintainer_chat_id:
+    try:
+        MAINTAINER_CHAT_ID = int(_raw_maintainer_chat_id)
+    except ValueError:
+        logger.warning("Invalid MAINTAINER_CHAT_ID %r", _raw_maintainer_chat_id)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 OPENAI_ASSISTANT_ID = os.getenv("OPENAI_ASSISTANT_ID")
 OPENAI_PROXY = os.getenv("OPENAI_PROXY")
@@ -49,3 +56,16 @@ elif not _raw_webapp_url.startswith("https://"):
     )
 else:
     WEBAPP_URL = _raw_webapp_url
+
+# Base URL of the API service
+API_URL = os.getenv("API_URL", "http://localhost:8000")
+
+# Number of worker processes for uvicorn when running the API server
+_raw_uvicorn_workers = os.getenv("UVICORN_WORKERS", "1")
+try:
+    UVICORN_WORKERS = int(_raw_uvicorn_workers)
+except ValueError:
+    logger.error(
+        "Invalid UVICORN_WORKERS %r; defaulting to 1", _raw_uvicorn_workers
+    )
+    UVICORN_WORKERS = 1

--- a/services/api/app/diabetes/config.py
+++ b/services/api/app/diabetes/config.py
@@ -1,7 +1,0 @@
-from services.api.app import config as _config
-
-__all__ = [name for name in dir(_config) if not name.startswith("_")]
-
-
-def __getattr__(name: str):  # pragma: no cover - simple proxy
-    return getattr(_config, name)

--- a/services/api/app/diabetes/handlers/profile_handlers.py
+++ b/services/api/app/diabetes/handlers/profile_handlers.py
@@ -11,7 +11,6 @@ from telegram.ext import (
     filters,
 )
 import json
-import os
 from zoneinfo import ZoneInfo
 
 from diabetes_sdk.api.default_api import DefaultApi
@@ -31,11 +30,11 @@ from services.api.app.diabetes.utils.ui import (
     back_keyboard,
     menu_keyboard,
 )
-from services.api.app.config import WEBAPP_URL
+from services.api.app.config import WEBAPP_URL, API_URL
 from .common_handlers import commit_session
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
-api = DefaultApi(ApiClient(Configuration(host=os.getenv("API_URL", "http://localhost:8000"))))
+api = DefaultApi(ApiClient(Configuration(host=API_URL)))
 
 
 PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(6)

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -15,6 +14,7 @@ from .schemas.timezone import TimezoneSchema
 from .services.profile import get_profile, save_profile, set_timezone
 from .services.reminders import list_reminders, save_reminder
 from .services import init_db
+from .config import UVICORN_WORKERS
 
 logger = logging.getLogger(__name__)
 
@@ -143,6 +143,7 @@ app.mount("/", StaticFiles(directory=str(PUBLIC_DIR)), name="public-root")
 if __name__ == "__main__":  # pragma: no cover
     import uvicorn
 
-    workers = int(os.getenv("UVICORN_WORKERS", "1"))
     init_db()
-    uvicorn.run("services.api.app.main:app", host="0.0.0.0", port=8000, workers=workers)
+    uvicorn.run(
+        "services.api.app.main:app", host="0.0.0.0", port=8000, workers=UVICORN_WORKERS
+    )


### PR DESCRIPTION
## Summary
- document and expand environment variables in `infra/env/.env.example`
- centralize environment configuration and expose MAINTAINER_CHAT_ID, API_URL and UVICORN_WORKERS
- drop duplicated `services/api/app/diabetes/config.py` and update services to use shared config

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689aca5ce1dc832a9ea42251477fca81