### PR TITLE
[docs] update service paths and SDK instructions

### DIFF
--- a/services/webapp/ui/index.html
+++ b/services/webapp/ui/index.html
@@ -1,4 +1,4 @@
-<!-- file: webapp/ui/index.html -->
+<!-- file: services/webapp/ui/index.html -->
 <!doctype html>
 <html lang="ru">
   <head>
@@ -16,7 +16,7 @@
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0b0f19" media="(prefers-color-scheme: dark)" />
 
-    <!-- Иконки (положи файлы в webapp/ui/public/, будут доступны как /ui/...) -->
+    <!-- Иконки (положи файлы в services/webapp/ui/public/, будут доступны как /ui/...) -->
     <link rel="icon" type="image/png" href="/ui/app-icon.png" />
     <link rel="apple-touch-icon" href="/ui/app-icon.png" />
 
@@ -39,7 +39,7 @@
     <meta property="og:title" content="СахарФото — ассистент для диабетиков" />
     <meta property="og:description" content="Распознаёт еду по фото, считает углеводы/ХЕ, напоминает об измерении сахара, инсулине и лекарствах." />
     <meta property="og:type" content="website" />
-    <!-- Помести og-изображение в webapp/ui/public/app-og.png -->
+    <!-- Помести og-изображение в services/webapp/ui/public/app-og.png -->
     <meta property="og:image" content="/ui/app-og.png" />
     <meta property="og:locale" content="ru_RU" />
 

--- a/services/webapp/ui/src/main.tsx
+++ b/services/webapp/ui/src/main.tsx
@@ -1,4 +1,4 @@
-// file: webapp/ui/src/main.tsx
+// file: services/webapp/ui/src/main.tsx
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -1,4 +1,4 @@
-// Файл: webapp/ui/src/pages/Reminders.tsx
+// Файл: services/webapp/ui/src/pages/Reminders.tsx
 import { useState, useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Plus, Clock, Edit2, Trash2, Bell } from 'lucide-react'

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -1,4 +1,4 @@
-// file: webapp/ui/vite.config.ts
+// file: services/webapp/ui/vite.config.ts
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import path from 'path'

--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,7 @@ pip install --upgrade pip
 pip install -r services/api/app/requirements.txt
 
 echo "Сборка фронтенда (npm ci && npm run build)…"
-pushd webapp/ui >/dev/null
+pushd services/webapp/ui >/dev/null
 npm ci
 npm run build
 popd >/dev/null
@@ -25,5 +25,5 @@ if [ ! -f ".env" ]; then
 fi
 
 echo "Установка завершена! Проверьте файл .env и заполните свои токены и пароли."
-echo "Фронтенд собран в webapp/ui/dist."
-echo "Для запуска API: source venv/bin/activate && python services/api/app/main.py"
+echo "Фронтенд собран в services/webapp/ui/dist."
+echo "Для запуска API: source venv/bin/activate && uvicorn services.api.app.main:app --reload"


### PR DESCRIPTION
## Summary
- refresh setup script and README for new `services/webapp` paths
- document service run commands and SDK generation steps
- sync webapp file headers with current directory layout

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_689ace96bcd4832aab6a889383055df1