### PR TITLE
[tests] update imports for py_sdk

### DIFF
--- a/libs/py-sdk/test/__init__.py
+++ b/libs/py-sdk/test/__init__.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure repository root on sys.path for py_sdk package
+sys.path.append(str(Path(__file__).resolve().parents[3]))

--- a/libs/py-sdk/test/test_auth_request.py
+++ b/libs/py-sdk/test/test_auth_request.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from diabetes_sdk.models.auth_request import AuthRequest
+from py_sdk.diabetes_sdk.models.auth_request import AuthRequest
 
 class TestAuthRequest(unittest.TestCase):
     """AuthRequest unit test stubs"""

--- a/libs/py-sdk/test/test_auth_response.py
+++ b/libs/py-sdk/test/test_auth_response.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from diabetes_sdk.models.auth_response import AuthResponse
+from py_sdk.diabetes_sdk.models.auth_response import AuthResponse
 
 class TestAuthResponse(unittest.TestCase):
     """AuthResponse unit test stubs"""

--- a/libs/py-sdk/test/test_default_api.py
+++ b/libs/py-sdk/test/test_default_api.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from diabetes_sdk.api.default_api import DefaultApi
+from py_sdk.diabetes_sdk.api.default_api import DefaultApi
 
 
 class TestDefaultApi(unittest.TestCase):

--- a/libs/py-sdk/test/test_entries_get200_response.py
+++ b/libs/py-sdk/test/test_entries_get200_response.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from diabetes_sdk.models.entries_get200_response import EntriesGet200Response
+from py_sdk.diabetes_sdk.models.entries_get200_response import EntriesGet200Response
 
 class TestEntriesGet200Response(unittest.TestCase):
     """EntriesGet200Response unit test stubs"""

--- a/libs/py-sdk/test/test_entries_post200_response.py
+++ b/libs/py-sdk/test/test_entries_post200_response.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from diabetes_sdk.models.entries_post200_response import EntriesPost200Response
+from py_sdk.diabetes_sdk.models.entries_post200_response import EntriesPost200Response
 
 class TestEntriesPost200Response(unittest.TestCase):
     """EntriesPost200Response unit test stubs"""

--- a/libs/py-sdk/test/test_entry.py
+++ b/libs/py-sdk/test/test_entry.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from diabetes_sdk.models.entry import Entry
+from py_sdk.diabetes_sdk.models.entry import Entry
 
 class TestEntry(unittest.TestCase):
     """Entry unit test stubs"""

--- a/libs/py-sdk/test/test_profile.py
+++ b/libs/py-sdk/test/test_profile.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from diabetes_sdk.models.profile import Profile
+from py_sdk.diabetes_sdk.models.profile import Profile
 
 class TestProfile(unittest.TestCase):
     """Profile unit test stubs"""

--- a/libs/py-sdk/test/test_reminder.py
+++ b/libs/py-sdk/test/test_reminder.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from diabetes_sdk.models.reminder import Reminder
+from py_sdk.diabetes_sdk.models.reminder import Reminder
 
 class TestReminder(unittest.TestCase):
     """Reminder unit test stubs"""

--- a/libs/py-sdk/test/test_reminders_get200_response.py
+++ b/libs/py-sdk/test/test_reminders_get200_response.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from diabetes_sdk.models.reminders_get200_response import RemindersGet200Response
+from py_sdk.diabetes_sdk.models.reminders_get200_response import RemindersGet200Response
 
 class TestRemindersGet200Response(unittest.TestCase):
     """RemindersGet200Response unit test stubs"""

--- a/libs/py-sdk/test/test_status.py
+++ b/libs/py-sdk/test/test_status.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from diabetes_sdk.models.status import Status
+from py_sdk.diabetes_sdk.models.status import Status
 
 class TestStatus(unittest.TestCase):
     """Status unit test stubs"""

--- a/libs/py-sdk/test/test_timezone.py
+++ b/libs/py-sdk/test/test_timezone.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from diabetes_sdk.models.timezone import Timezone
+from py_sdk.diabetes_sdk.models.timezone import Timezone
 
 class TestTimezone(unittest.TestCase):
     """Timezone unit test stubs"""

--- a/py_sdk/__init__.py
+++ b/py_sdk/__init__.py
@@ -1,0 +1,14 @@
+"""Helper package to expose diabetes_sdk under py_sdk namespace."""
+import importlib
+import sys
+from pathlib import Path
+
+_pkg_path = Path(__file__).resolve().parent.parent / "libs" / "py-sdk"
+_pkg_abs = _pkg_path.resolve()
+if _pkg_abs.is_dir() and str(_pkg_abs) not in sys.path:
+    sys.path.append(str(_pkg_abs))
+
+diabetes_sdk = importlib.import_module("diabetes_sdk")
+sys.modules[__name__ + ".diabetes_sdk"] = diabetes_sdk
+
+__all__ = ["diabetes_sdk"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,2 +1,3 @@
 line-length = 120
 extend-exclude = ["services/api/app/diabetes/handlers.py", "services/api/alembic"]
+src = ["services", "libs", "py_sdk", "tests"]


### PR DESCRIPTION
## Summary
- allow importing the generated SDK via `py_sdk.diabetes_sdk`
- update SDK tests to use the new import path
- configure ruff to lint services, libs, py_sdk, and tests

## Testing
- `pytest services libs -q`
- `ruff check services libs py_sdk`


------
https://chatgpt.com/codex/tasks/task_e_689ace89a664832aa3884ac5e58fc48a