### PR TITLE
[scripts] Remove backend symlink handling

### DIFF
--- a/scripts/restructure.sh
+++ b/scripts/restructure.sh
@@ -10,12 +10,6 @@ mkdir -p services/api services/bot libs infra docs/ADR
 : > infra/.gitkeep
 : > docs/ADR/.gitkeep
 
-# Move existing backend to services/api/app and create symlink for backward compatibility
-if [ -d backend ] && [ ! -L backend ]; then
-    mv backend services/api/app
-    ln -s services/api/app backend
-fi
-
 # Move webapp into services
 if [ -d webapp ]; then
     mv webapp services/webapp


### PR DESCRIPTION
## Summary
- remove obsolete backend symlink creation from restructure script

## Testing
- `pip install -r services/api/app/requirements-dev.txt`
- `pip install -r services/api/app/requirements.txt`
- `PYTHONPATH=libs/py-sdk pytest tests/` *(fails: AttributeError, connection refused)*
- `ruff check services/api/app tests`


------
https://chatgpt.com/codex/tasks/task_e_689ae680945c832aa757a0eedeff49be