### PR TITLE
[backend] add compatibility package

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,26 @@
+"""Compatibility layer for legacy backend imports.
+
+This package re-exports modules from ``services.api.app`` to preserve
+backward compatibility with older import paths.
+"""
+
+from services.api.app import *  # noqa: F401,F403
+from services.api.app import (
+    bot,
+    config,
+    diabetes,
+    main,
+    middleware,
+    schemas,
+    services,
+)
+
+__all__ = [
+    "bot",
+    "config",
+    "diabetes",
+    "main",
+    "middleware",
+    "schemas",
+    "services",
+]


### PR DESCRIPTION
## Summary
- add `backend` package re-exporting `services.api.app` modules to keep legacy import path

## Testing
- `ruff check backend services/api/app tests`
- `pytest` *(fails: AttributeError in bot module, MaxRetryError on HTTP connections)*

------
https://chatgpt.com/codex/tasks/task_e_689af20b5cd0832a9dec4dd99d2c624c