### PR TITLE
[alembic] Reference Base metadata in Alembic env

### DIFF
--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -6,7 +6,7 @@ from alembic import context
 import os
 import sys
 from dotenv import load_dotenv
-from services.api.app.diabetes.models import metadata
+from services.api.app.diabetes.services.db import Base
 from services.api.app.config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
 
 # Загрузка переменных окружения
@@ -18,7 +18,7 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-target_metadata = metadata
+target_metadata = Base.metadata
 
 DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 


### PR DESCRIPTION
## Summary
- Import Base from the shared DB models and expose its metadata to Alembic
- Confirm Alembic configuration points to `services/api/alembic`

## Testing
- `ruff check services/api tests`
- `pytest tests -q` *(fails: ModuleNotFoundError: No module named 'telegram', 'openai', 'reportlab', 'fastapi')*
- `alembic -c services/api/alembic.ini upgrade head`


------
https://chatgpt.com/codex/tasks/task_e_689afaed9fd0832aa9adab8d11f33745