### PR TITLE
[ci] Update SDK and test workflows

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -40,3 +40,6 @@ jobs:
             Regenerated SDKs from updated OpenAPI spec.
           branch: sdk/regenerate
           delete-branch: true
+          add-paths: |
+            libs/ts-sdk/index.ts
+            libs/py-sdk/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,17 @@ name: Tests
 
 on:
   push:
+    paths:
+      - '.github/workflows/tests.yml'
+      - 'services/**'
+      - 'tests/**'
+      - 'libs/contracts/openapi.yaml'
   pull_request:
+    paths:
+      - '.github/workflows/tests.yml'
+      - 'services/**'
+      - 'tests/**'
+      - 'libs/contracts/openapi.yaml'
 
 jobs:
   tests:
@@ -14,8 +24,8 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          pip install -r services/api/app/requirements.txt
+          pip install -r services/api/app/requirements-dev.txt
       - name: Build webapp UI
         working-directory: webapp/ui
         run: |


### PR DESCRIPTION
## Summary
- install dependencies from services/api/app in CI tests workflow
- include SDK outputs when regenerating clients and run tests on OpenAPI changes

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689b00dd8c6c832a99a5780a7c02b545