### PR TITLE
[handlers] Handle timezone errors explicitly

### DIFF
--- a/services/api/app/diabetes/handlers/profile_handlers.py
+++ b/services/api/app/diabetes/handlers/profile_handlers.py
@@ -12,7 +12,7 @@ from telegram.ext import (
 )
 import json
 import logging
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from diabetes_sdk.api.default_api import DefaultApi
 from diabetes_sdk.api_client import ApiClient
@@ -329,7 +329,8 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
         return await profile_cancel(update, context)
     try:
         ZoneInfo(raw)
-    except Exception:
+    except ZoneInfoNotFoundError:
+        logger.warning("Invalid timezone provided: %s", raw)
         await update.message.reply_text(
             "Некорректный часовой пояс. Пример: Europe/Moscow",
             reply_markup=back_keyboard,


### PR DESCRIPTION
## Summary
- handle invalid timezone inputs with `ZoneInfoNotFoundError`
- log invalid timezone selections during profile setup

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: ImportError: cannot import name 'WEBAPP_URL' from 'services.api.app.config'; 35 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b1028adb0832a8dea3aad80b5783a