### PR TITLE
[config] use pydantic settings

### DIFF
--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -20,6 +20,7 @@ pillow==11.2.1
 psycopg2-binary==2.9.6
 pydantic==2.11.4
 pydantic_core==2.33.2
+pydantic-settings==2.10.1
 pypdf==5.9.0
 pyparsing==3.2.3
 pytest==8.4.1


### PR DESCRIPTION
## Summary
- switch config to pydantic `Settings` class and expose `settings`
- add pydantic-settings to API requirements

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689b1268f108832a9bb8550b3d289bd8