### PR TITLE
[alembic] Use settings for database URL

### DIFF
--- a/services/api/alembic.ini
+++ b/services/api/alembic.ini
@@ -65,7 +65,7 @@ version_path_separator = os
 
 
 #sqlalchemy.url = driver://user:pass@localhost/dbname
-sqlalchemy.url = postgresql://fake:fake@localhost/fake
+sqlalchemy.url = postgresql+psycopg2://sahar:sahar@localhost:5432/sahar_db
 
 
 

--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -5,12 +5,10 @@ from alembic import context
 
 import os
 import sys
-from dotenv import load_dotenv
-from services.api.app.diabetes.services.db import Base
-from services.api.app.config import DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
 
-# Загрузка переменных окружения
-load_dotenv(".env")
+from services.api.app.diabetes.services.db import Base
+from services.api.app.config import Settings
+
 sys.path.append(os.getcwd())
 
 # Alembic Config
@@ -18,9 +16,10 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
+settings = Settings()
 target_metadata = Base.metadata
 
-DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+DATABASE_URL = settings.database_url
 
 
 def run_migrations_offline() -> None:


### PR DESCRIPTION
## Summary
- simplify Alembic env to load DB config from Settings
- point Alembic config to the local Postgres URL

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: No module named 'sqlalchemy', 'telegram', 'openai', ...)*

------
https://chatgpt.com/codex/tasks/task_e_689b13ef328c832aa4b9a4f68710954c