### PR TITLE
[sdk] Log Unicode decode errors

### DIFF
--- a/libs/py-sdk/diabetes_sdk/exceptions.py
+++ b/libs/py-sdk/diabetes_sdk/exceptions.py
@@ -11,6 +11,7 @@
     Do not edit the class manually.
 """  # noqa: E501
 
+import logging
 from typing import Any, Optional
 from typing_extensions import Self
 
@@ -126,8 +127,8 @@ class ApiException(OpenApiException):
             if self.body is None:
                 try:
                     self.body = http_resp.data.decode('utf-8')
-                except Exception:
-                    pass
+                except UnicodeDecodeError as exc:
+                    logging.error("Unicode decode error while decoding HTTP response body: %s", exc)
             self.headers = http_resp.getheaders()
 
     @classmethod


### PR DESCRIPTION
## Summary
- Log Unicode decode errors when decoding HTTP response body
- Replace broad exception handling with UnicodeDecodeError

## Testing
- `ruff check libs/py-sdk/diabetes_sdk/exceptions.py services/api/app tests`
- `pytest tests/` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689b1482b24c832a89f85a172623fd6b