### PR TITLE
[infra] update env example with jwt and api keys

### DIFF
--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -1,7 +1,21 @@
 # Example environment variables
-TELEGRAM_TOKEN=your-telegram-token
+
+# General application settings
+APP_NAME=diabetes-bot
+DEBUG=False
+
+# Database configuration
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/diabetes
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=diabetes
 DB_USER=postgres
 DB_PASSWORD=postgres
+
+# JWT settings
+JWT_SECRET=change-me
+JWT_EXPIRE_DAYS=7
+
+# Optional API keys
+OPENAI_API_KEY=your-openai-api-key
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token


### PR DESCRIPTION
## Summary
- expand environment template with app name, debug toggle, database URL and JWT settings
- add placeholders for OpenAI and Telegram API keys

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'sqlalchemy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689b14fe6e08832abda7e606189af13b