### PR TITLE
[py-sdk] remove long type support

### DIFF
--- a/libs/py-sdk/diabetes_sdk/api_client.py
+++ b/libs/py-sdk/diabetes_sdk/api_client.py
@@ -61,7 +61,6 @@ class ApiClient:
     PRIMITIVE_TYPES = (float, bool, bytes, str, int)
     NATIVE_TYPES_MAPPING = {
         'int': int,
-        'long': int, # TODO remove as only py3 is supported?
         'float': float,
         'str': str,
         'bool': bool,
@@ -337,7 +336,7 @@ class ApiClient:
 
         If obj is None, return None.
         If obj is SecretStr, return obj.get_secret_value()
-        If obj is str, int, long, float, bool, return directly.
+        If obj is str, int, float, bool, return directly.
         If obj is datetime.datetime, datetime.date
             convert to string in iso8601 format.
         If obj is decimal.Decimal return string representation.
@@ -719,7 +718,7 @@ class ApiClient:
         :param data: str.
         :param klass: class literal.
 
-        :return: int, long, float, str, bool.
+        :return: int, float, str, bool.
         """
         try:
             return klass(data)


### PR DESCRIPTION
## Summary
- remove deprecated `long` from native type mapping
- update serialization docstrings to mention only supported types

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_689b1532beac832aa91aecbc4f25bb73