### PR TITLE
[config] Add optional service configuration fields

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -36,6 +36,14 @@ class Settings(BaseSettings):
     log_level: int = Field(default=logging.INFO, alias="LOG_LEVEL")
     uvicorn_workers: int = Field(default=1, alias="UVICORN_WORKERS")
 
+    # Optional service URLs and API keys
+    webapp_url: Optional[str] = Field(default=None, alias="WEBAPP_URL")
+    api_url: Optional[str] = Field(default=None, alias="API_URL")
+    openai_api_key: Optional[str] = Field(default=None, alias="OPENAI_API_KEY")
+    openai_assistant_id: Optional[str] = Field(default=None, alias="OPENAI_ASSISTANT_ID")
+    openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
+    font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
+
     @field_validator("log_level", mode="before")
     @classmethod
     def parse_log_level(cls, v: object) -> int:  # pragma: no cover - simple parsing
@@ -59,4 +67,10 @@ DB_NAME = settings.db_name
 DB_USER = settings.db_user
 DB_PASSWORD = settings.db_password
 UVICORN_WORKERS = settings.uvicorn_workers
+WEBAPP_URL = settings.webapp_url
+API_URL = settings.api_url
+OPENAI_API_KEY = settings.openai_api_key
+OPENAI_ASSISTANT_ID = settings.openai_assistant_id
+OPENAI_PROXY = settings.openai_proxy
+FONT_DIR = settings.font_dir
 


### PR DESCRIPTION
## Summary
- expand settings to include optional WEBAPP and API URLs, OpenAI credentials, proxy and font directory
- expose module-level variables for backward compatibility

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'fastapi', No module named 'diabetes_sdk')*
- `python - <<'PY'
import importlib, sys
sys.path.append('libs/py-sdk')
modules = [
    'services.api.app.diabetes.utils.ui',
    'services.api.app.diabetes.utils.openai_utils',
    'services.api.app.diabetes.handlers.profile_handlers',
    'services.api.app.diabetes.services.reporting',
]
for m in modules:
    importlib.import_module(m)
    print(m, 'OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689b17e47a58832a8da347033f862550