### PR TITLE
[infra] Document optional URLs and keys

### DIFF
--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -16,6 +16,17 @@ DB_PASSWORD=postgres
 JWT_SECRET=change-me
 JWT_EXPIRE_DAYS=7
 
-# Optional API keys
+# Optional service URLs
+WEBAPP_URL=http://localhost:3000
+API_URL=http://localhost:8000
+
+# OpenAI configuration
 OPENAI_API_KEY=your-openai-api-key
+OPENAI_ASSISTANT_ID=your-openai-assistant-id
+OPENAI_PROXY=  # e.g., http://proxy.local:8080
+
+# Custom font directory
+FONT_DIR=infra/fonts
+
+# Telegram
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token


### PR DESCRIPTION
## Summary
- document optional service URLs and OpenAI fields in example env file

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689b1a5dba60832aae05afbb59e3ee6c