### PR TITLE
ci: fix webapp build path

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           pip install -r services/api/app/requirements.txt
           pip install -r services/api/app/requirements-dev.txt
       - name: Build webapp UI
-        working-directory: webapp/ui
+        working-directory: services/webapp/ui
         run: |
           npm ci
           npm run build


### PR DESCRIPTION
## Summary
- fix working directory for webapp build step in tests workflow

## Testing
- `npm ci`
- `npm run build` *(fails: Could not resolve ../../../../libs/ts-sdk)*
- `ruff check services/api/app tests`
- `pytest tests` *(fails: Interrupted: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689b1a99c1bc832a958f237cc7421769