### PR TITLE
[infra] Run uvicorn directly in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ python services/api/app/main.py
 ```bash
 docker compose -f infra/docker/docker-compose.yml up --build
 ```
+API контейнер запускает `uvicorn` напрямую как команду по умолчанию, поэтому отдельный скрипт запуска не требуется.
 
 ## Генерация SDK
 

--- a/infra/docker/Dockerfile.api
+++ b/infra/docker/Dockerfile.api
@@ -1,5 +1,6 @@
 FROM python:3.12-slim
 
+ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 COPY services/api/ /app/services/api/

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     env_file: [ ../env/.env.example ]
     ports:
       - "8000:8000"
+    command: >-
+      uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000
     depends_on:
       - db
 

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -e
-export PYTHONUNBUFFERED=1
-uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- remove start script and run uvicorn directly from Dockerfile
- document uvicorn startup and expose default command in docker-compose

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_689b1c013c40832aa6cd8cc04e36debd