### PR TITLE
[setup] Use root requirements in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ source venv/bin/activate
 
 echo "Установка Python-зависимостей…"
 pip install --upgrade pip
-pip install -r services/api/app/requirements.txt
+pip install -r requirements.txt
 
 echo "Сборка фронтенда (npm ci && npm run build)…"
 pushd webapp/ui >/dev/null


### PR DESCRIPTION
## Summary
- install Python dependencies from root `requirements.txt` in setup script

## Testing
- `pytest tests/` *(fails: TypeError: Profile.__init__() got an unexpected keyword argument 'telegram_id')*
- `ruff check services/api/app tests`

------
https://chatgpt.com/codex/tasks/task_e_689b226d5830832a91ecbac767e000b8