### PR TITLE
[legacy] Ensure logging and FastAPI imports

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -1,5 +1,5 @@
 import logging
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Depends, Request
 
 from .middleware.auth import require_role
 from .services.audit import log_patient_access


### PR DESCRIPTION
## Summary
- ensure legacy module imports logging and fastapi components in expected order

## Testing
- `ruff check services/api/app tests`
- `pytest tests -q` *(fails: 13 failed, 184 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689b2aa3f234832aaa658842461fbfe9