### PR TITLE
config: guard pydantic-settings import

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -6,7 +6,13 @@ import logging
 from typing import Optional
 
 from pydantic import Field, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+
+try:  # pragma: no cover - import guard
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+except ModuleNotFoundError as exc:  # pragma: no cover - executed at import time
+    raise ImportError(
+        "`pydantic-settings` is required. Install it with `pip install pydantic-settings`."
+    ) from exc
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
## Summary
- guard `pydantic-settings` import in config and provide helpful error

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: AttributeError: 'DefaultApi' object has no attribute 'profiles_get')*

------
https://chatgpt.com/codex/tasks/task_e_689b2a286d90832ab38f7afee56126e2