### PR TITLE
[profile] Validate target within thresholds

### DIFF
--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -30,6 +30,9 @@ def _validate_profile(data: ProfileSchema) -> None:
     ):
         raise HTTPException(status_code=400, detail="invalid profile values")
 
+    if not (data.low < data.target < data.high):
+        raise HTTPException(status_code=400, detail="target must be between low and high")
+
 
 async def save_profile(data: ProfileSchema) -> None:
     _validate_profile(data)

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -1,0 +1,33 @@
+import pytest
+from fastapi import HTTPException
+
+from services.api.app.schemas.profile import ProfileSchema
+from services.api.app.services.profile import _validate_profile
+
+
+def test_validate_profile_allows_target_between_limits():
+    data = ProfileSchema(
+        telegram_id=1,
+        icr=1.0,
+        cf=1.0,
+        target=5.0,
+        low=4.0,
+        high=7.0,
+    )
+    _validate_profile(data)
+
+
+@pytest.mark.parametrize("target", [3.0, 8.0])
+def test_validate_profile_rejects_target_outside_limits(target):
+    data = ProfileSchema(
+        telegram_id=1,
+        icr=1.0,
+        cf=1.0,
+        target=target,
+        low=4.0,
+        high=7.0,
+    )
+    with pytest.raises(HTTPException) as exc:
+        _validate_profile(data)
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "target must be between low and high"


### PR DESCRIPTION
## Summary
- ensure target glucose level is between low and high thresholds
- add tests for profile validation

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: AttributeError: 'DefaultApi' object has no attribute 'profiles_get')*
- `pytest tests/test_profile_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_689b2c5437c8832abb460ace04c32e8d