### PR TITLE
[webapp] Add reminder toggle and delete API calls

### DIFF
--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -157,18 +157,53 @@ export default function Reminders() {
     return () => { cancelled = true }
   }, [toast])
 
-  const handleToggleReminder = (id: number) => {
+  const handleToggleReminder = async (id: number) => {
+    const prevReminders = [...reminders]
+    const target = prevReminders.find(r => r.id === id)
+    if (!target) return
+    const nextActive = !target.active
     setReminders(prev =>
-      prev.map(r => (r.id === id ? { ...r, active: !r.active } : r)),
+      prev.map(r => (r.id === id ? { ...r, active: nextActive } : r)),
     )
-    toast({ title: 'Напоминание обновлено', description: 'Статус напоминания изменён' })
-    // TODO: вызвать API toggle
+    try {
+      const res = await fetch(`/reminders/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ active: nextActive }),
+      })
+      if (!res.ok) throw new Error('Failed to update')
+      toast({
+        title: 'Напоминание обновлено',
+        description: 'Статус напоминания изменён',
+      })
+    } catch {
+      setReminders(prevReminders)
+      toast({
+        title: 'Ошибка',
+        description: 'Не удалось обновить напоминание',
+        variant: 'destructive',
+      })
+    }
   }
 
-  const handleDeleteReminder = (id: number) => {
+  const handleDeleteReminder = async (id: number) => {
+    const prevReminders = [...reminders]
     setReminders(prev => prev.filter(r => r.id !== id))
-    toast({ title: 'Напоминание удалено', description: 'Напоминание успешно удалено' })
-    // TODO: вызвать API delete
+    try {
+      const res = await fetch(`/reminders/${id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error('Failed to delete')
+      toast({
+        title: 'Напоминание удалено',
+        description: 'Напоминание успешно удалено',
+      })
+    } catch {
+      setReminders(prevReminders)
+      toast({
+        title: 'Ошибка',
+        description: 'Не удалось удалить напоминание',
+        variant: 'destructive',
+      })
+    }
   }
 
   const content = useMemo(() => {


### PR DESCRIPTION
## Summary
- add backend calls for toggling and deleting reminders
- handle network errors with local state rollback

## Testing
- `pytest tests/` *(fails: TypeError: Profile.__init__() got an unexpected keyword argument 'telegram_id', AttributeError: 'DefaultApi' object has no attribute 'profiles_get')*
- `ruff check services/api/app tests`

------
https://chatgpt.com/codex/tasks/task_e_689b2f446774832ab252cfd86cd6b43e