### PR TITLE
[handlers] Handle optional diabetes_sdk

### DIFF
--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -3,6 +3,7 @@ anyio==4.9.0
 certifi==2025.4.26
 contourpy==1.3.2
 cycler==0.12.1
+diabetes-assistant-api-client==1.0.0  # provides diabetes_sdk
 distro==1.9.0
 fonttools==4.58.4
 greenlet==3.2.1


### PR DESCRIPTION
## Summary
- Load diabetes_sdk lazily with helper and warn when missing
- Guard profile handlers against missing diabetes_sdk
- Declare diabetes-assistant-api-client dependency

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: AttributeError: 'DefaultApi' object has no attribute 'profiles_get')*

------
https://chatgpt.com/codex/tasks/task_e_689b2f2d662c832ab4e295ac8e38681f