### PR TITLE
[worker] Handle missing diabetes_sdk

### DIFF
--- a/services/worker/main.py
+++ b/services/worker/main.py
@@ -1,5 +1,16 @@
-from diabetes_sdk import Configuration
-from diabetes_sdk.api import default_api
+"""Worker service entry point."""
+
+import sys
+
+try:
+  from diabetes_sdk import Configuration
+  from diabetes_sdk.api import default_api
+except ImportError:
+  print(
+    "diabetes_sdk is required to run the worker. "
+    "Install it with 'pip install diabetes_sdk'."
+  )
+  sys.exit(1)
 
 
 def run() -> None:

--- a/services/worker/requirements.txt
+++ b/services/worker/requirements.txt
@@ -1,1 +1,4 @@
+diabetes_sdk
+
+# Optional: use local SDK for development
 -e ../../libs/py-sdk


### PR DESCRIPTION
## Summary
- handle missing `diabetes_sdk` gracefully in worker entry point
- document `diabetes_sdk` in worker requirements

## Testing
- `ruff check services/worker/main.py`
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_689b327800ac832a958e8f004cae2c67