### PR TITLE
[ui] Add ts-sdk alias

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,4 +1,4 @@
-import { DefaultApi, Reminder } from '../../../../libs/ts-sdk';
+import { DefaultApi, Reminder } from '@sdk';
 
 const api = new DefaultApi();
 

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(async ({ mode }) => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),
+        '@sdk': path.resolve(__dirname, '../../../libs/ts-sdk'),
       },
     },
     server: {


### PR DESCRIPTION
## Summary
- add `@sdk` alias pointing to `libs/ts-sdk`
- update reminders API to import from `@sdk`

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_689b35d7b364832abb06d517d025a992