### PR TITLE
[utils] Allow OpenAI client without assistant ID

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -106,6 +106,11 @@ def send_message(
         logger.exception("[OpenAI] Failed to create message: %s", exc)
         raise
 
+    if not OPENAI_ASSISTANT_ID:
+        message = "OPENAI_ASSISTANT_ID is not set"
+        logger.error("[OpenAI] %s", message)
+        raise RuntimeError(message)
+
     # 3. Запускаем ассистента
     try:
         run = _get_client().beta.threads.runs.create(

--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -18,11 +18,8 @@ def get_openai_client() -> OpenAI:
         message = "OPENAI_API_KEY is not set"
         logging.error("[OpenAI] %s", message)
         raise RuntimeError(message)
-    if not OPENAI_ASSISTANT_ID:
-        message = "OPENAI_ASSISTANT_ID is not set"
-        logging.error("[OpenAI] %s", message)
-        raise RuntimeError(message)
 
     client = OpenAI(api_key=OPENAI_API_KEY)
-    logging.info("[OpenAI] Using assistant: %s", OPENAI_ASSISTANT_ID)
+    if OPENAI_ASSISTANT_ID:
+        logging.info("[OpenAI] Using assistant: %s", OPENAI_ASSISTANT_ID)
     return client


### PR DESCRIPTION
## Summary
- permit OpenAI client initialization without assistant id
- validate assistant id when sending messages

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_689b39c6b9a0832aa8ff243d7b224de5