### PR TITLE
[docs] Use local py-sdk for API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
    source venv/bin/activate
    ```
 3. **Установите зависимости и соберите фронтенд:**
+   Локальный Python SDK подключается из каталога `libs/py-sdk`, поэтому он будет установлен вместе с зависимостями:
    ```bash
    pip install -r requirements.txt
 

--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -3,7 +3,7 @@ anyio==4.9.0
 certifi==2025.4.26
 contourpy==1.3.2
 cycler==0.12.1
-diabetes-assistant-api-client==1.0.0  # provides diabetes_sdk
+-e libs/py-sdk  # provides diabetes_sdk via local path
 distro==1.9.0
 fonttools==4.58.4
 greenlet==3.2.1


### PR DESCRIPTION
## Summary
- use local `libs/py-sdk` instead of remote diabetes-assistant-api-client in API requirements
- document that installing requirements installs the SDK from the repo

## Testing
- `pip install -r requirements.txt`
- `ruff check services/api/app tests`
- `pytest tests` *(fails: Profile.__init__() got an unexpected keyword argument 'telegram_id', AttributeError: 'DefaultApi' object has no attribute 'profiles_get')*

------
https://chatgpt.com/codex/tasks/task_e_689b3bc036cc832a889dedf3f4e93778