### PR TITLE
[docs] Add Running tests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,27 @@ npx @openapitools/openapi-generator-cli generate -i libs/contracts/openapi.yaml 
 
 ## Тесты и линтинг
 
-Для проверки качества кода:
+### Running tests
+
+Перед запуском убедитесь, что установлены зависимости и переменные окружения:
+
+```bash
+pip install -r services/api/app/requirements.txt
+pip install -e libs/py-sdk
+```
+
+Тесты используют переменные `OPENAI_API_KEY`, `DB_PASSWORD` и другие из `.env`.
+Отсутствие обязательных пакетов (например, SQLAlchemy, `python-telegram-bot`, `openai`) приведёт к `ModuleNotFoundError`.
+
+Запустите тесты:
+
+```bash
+pytest tests/
+```
+
+### Линтинг
 
 ```bash
 pip install -r services/api/app/requirements-dev.txt
 ruff services/api/app/diabetes tests
-pytest tests/
 ```


### PR DESCRIPTION
## Summary
- document how to set up and run tests
- note required environment variables and dependencies

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: OPENAI_ASSISTANT_ID is not set; DefaultApi missing attributes)*

------
https://chatgpt.com/codex/tasks/task_e_689b3d462b28832aaa973ad5dba64504