### PR TITLE
[gpt_parser] validate response content

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -103,7 +103,25 @@ async def parse_command(text: str, timeout: float = 10) -> dict | None:
     if not choices:
         logging.error("No choices in GPT response")
         return None
-    content = choices[0].message.content.strip()
+
+    first = choices[0]
+    message = getattr(first, "message", None)
+    if message is None:
+        logging.error("No message in first choice")
+        return None
+
+    content = getattr(message, "content", None)
+    if content is None:
+        logging.error("No content in GPT response")
+        return None
+    if not isinstance(content, str):
+        logging.error("Content is not a string in GPT response")
+        return None
+    content = content.strip()
+    if not content:
+        logging.error("Content is empty in GPT response")
+        return None
+
     safe_content = _sanitize_sensitive_data(content)
     logging.info("GPT raw response: %s", safe_content[:200])
     parsed = _extract_first_json(content)


### PR DESCRIPTION
## Summary
- guard against missing choice message or content before parsing
- test parser with missing or non-string content responses

## Testing
- `ruff check services/api/app/diabetes/gpt_command_parser.py tests/test_gpt_command_parser.py`
- `pytest tests/test_gpt_command_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_689b3cd8da34832aafb9e19df83d98d3