### PR TITLE
[deps] Install local API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
    ```
 3. **Установите зависимости и соберите фронтенд:**
    ```bash
+   # requirements.txt установит локальный SDK из libs/py-sdk
    pip install -r requirements.txt
 
    (cd services/webapp/ui && npm ci)

--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -3,7 +3,7 @@ anyio==4.9.0
 certifi==2025.4.26
 contourpy==1.3.2
 cycler==0.12.1
-diabetes-assistant-api-client==1.0.0  # provides diabetes_sdk
+-e libs/py-sdk  # provides diabetes_sdk
 distro==1.9.0
 fonttools==4.58.4
 greenlet==3.2.1


### PR DESCRIPTION
## Summary
- use local diabetes API client via `libs/py-sdk`
- document local SDK install in README

## Testing
- `pip install --dry-run -r requirements.txt`
- `ruff check services/api/app tests`
- `pytest tests -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_689b3ca10d44832a8def64715b10b6ce