### PR TITLE
[config] Add telegram token setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@
 
 Все секреты и настройки задаются в файле `.env` (см. шаблон `infra/env/.env.example`).
 
-- обязательные значения: `TELEGRAM_TOKEN`, `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
+- обязательные значения: `TELEGRAM_TOKEN` (токен бота), `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
 - дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `UVICORN_WORKERS`
 - при необходимости настройте прокси для OpenAI через переменные окружения
 

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -29,4 +29,4 @@ OPENAI_PROXY=  # e.g., http://proxy.local:8080
 FONT_DIR=infra/fonts
 
 # Telegram
-TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+TELEGRAM_TOKEN=your-telegram-bot-token

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -21,7 +21,10 @@ class Settings(BaseSettings):
     Environment variables are loaded from ``infra/env/.env``.
     """
 
-    model_config = SettingsConfigDict(env_file="infra/env/.env")
+    model_config = SettingsConfigDict(
+        env_file="infra/env/.env",
+        extra="ignore",
+    )
 
     # General application settings
     app_name: str = "diabetes-bot"
@@ -49,6 +52,7 @@ class Settings(BaseSettings):
     openai_assistant_id: Optional[str] = Field(default=None, alias="OPENAI_ASSISTANT_ID")
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
     font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
+    telegram_token: Optional[str] = Field(default=None, alias="TELEGRAM_TOKEN")
 
     @field_validator("log_level", mode="before")
     @classmethod
@@ -79,4 +83,5 @@ OPENAI_API_KEY = settings.openai_api_key
 OPENAI_ASSISTANT_ID = settings.openai_assistant_id
 OPENAI_PROXY = settings.openai_proxy
 FONT_DIR = settings.font_dir
+TELEGRAM_TOKEN = settings.telegram_token
 

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -4,7 +4,6 @@ Bot entry point and configuration.
 """
 
 import logging
-import os
 import sys
 
 from telegram import BotCommand
@@ -13,13 +12,13 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from services.api.app.services import init_db
 
-from services.api.app.config import LOG_LEVEL
+from services.api.app.config import LOG_LEVEL, settings
 from services.api.app.diabetes.handlers.common_handlers import register_handlers
 
 logger = logging.getLogger(__name__)
 
 
-TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+TELEGRAM_TOKEN = settings.telegram_token
 
 
 async def error_handler(update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- add optional `telegram_token` setting and ignore unknown env vars
- switch bot to use `settings.telegram_token`
- rename Telegram token env var to `TELEGRAM_TOKEN` in docs

## Testing
- `ruff check services/api/app services/bot tests`
- `pytest tests` *(fails: 14)*
- `pytest tests/test_bot_db_error.py tests/test_bot_debug_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_689b4231f500832aa66d84f1ffaf97df