### PR TITLE
[db] Use public session bind and add run_db tests

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -58,9 +58,10 @@ async def run_db(
         with sessionmaker() as session:
             return fn(session, *args, **kwargs)
 
-    engine = getattr(getattr(sessionmaker, "kw", {}), "get", lambda _k, _d=None: _d)("bind")
-    url = getattr(engine, "url", None)
-    if getattr(url, "drivername", "") == "sqlite" and getattr(url, "database", None) == ":memory:":
+    with sessionmaker() as _session:
+        engine = _session.get_bind()
+
+    if engine.url.drivername == "sqlite" and engine.url.database == ":memory:":
         return wrapper()
 
     return await asyncio.to_thread(wrapper)

--- a/tests/test_run_db.py
+++ b/tests/test_run_db.py
@@ -1,0 +1,64 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.api.app.diabetes.services.db import run_db
+
+
+@pytest.mark.asyncio
+async def test_run_db_sqlite_in_memory(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+
+    called = False
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        nonlocal called
+        called = True
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    def work(session):
+        return 42
+
+    result = await run_db(work, sessionmaker=Session)
+    assert result == 42
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_run_db_postgres(monkeypatch):
+    dummy_engine = SimpleNamespace(url=SimpleNamespace(drivername="postgresql", database="db"))
+
+    class DummySession:
+        def get_bind(self):
+            return dummy_engine
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    def dummy_sessionmaker():
+        return DummySession()
+
+    called = False
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        nonlocal called
+        called = True
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    def work(session):
+        return 42
+
+    result = await run_db(work, sessionmaker=dummy_sessionmaker)
+    assert result == 42
+    assert called is True


### PR DESCRIPTION
## Summary
- use sessionmaker().get_bind() and engine.url for in-memory SQLite detection
- add regression tests for run_db with SQLite and PostgreSQL sessionmakers

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: AttributeError: 'DefaultApi' object has no attribute 'profiles_get', OPENAI_ASSISTANT_ID is not set, Profile.__init__ errors)*
- `pytest tests/test_run_db.py`


------
https://chatgpt.com/codex/tasks/task_e_689b42a00e94832ab62fc8e448b03753