### PR TITLE
[clinic-panel] resolve ts-sdk path and use api

### DIFF
--- a/libs/ts-sdk/package.json
+++ b/libs/ts-sdk/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ts-sdk",
+  "version": "0.1.0",
+  "main": "apis/index.ts",
+  "types": "apis/index.ts"
+}

--- a/services/clinic-panel/next.config.js
+++ b/services/clinic-panel/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  transpilePackages: ['ts-sdk'],
+};
 
 module.exports = nextConfig;

--- a/services/clinic-panel/package-lock.json
+++ b/services/clinic-panel/package-lock.json
@@ -19,7 +19,9 @@
         "typescript": "5.3.3"
       }
     },
-    "../../libs/ts-sdk": {},
+    "../../libs/ts-sdk": {
+      "version": "0.1.0"
+    },
     "node_modules/@next/env": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.0.tgz",

--- a/services/clinic-panel/pages/index.tsx
+++ b/services/clinic-panel/pages/index.tsx
@@ -4,7 +4,11 @@ import { DefaultApi } from 'ts-sdk';
 export default function Home() {
   useEffect(() => {
     const api = new DefaultApi();
-    console.log('API client ready', api);
+    api.healthGet().then((res) => {
+      console.log('API client ready', res);
+    }).catch((err) => {
+      console.error('API client error', err);
+    });
   }, []);
 
   return <main>Clinic Panel</main>;


### PR DESCRIPTION
## Summary
- package ts-sdk with package.json to allow imports
- configure Next.js clinic panel to transpile ts-sdk
- use DefaultApi from ts-sdk on clinic panel index page

## Testing
- `pytest tests` *(fails: Profile.__init__ unexpected keyword argument telegram_id)*
- `npm --prefix services/clinic-panel run build`


------
https://chatgpt.com/codex/tasks/task_e_689b482b8808832aad17ebf05b157432