### PR TITLE
[py-sdk] Add profile model fields

### DIFF
--- a/libs/py-sdk/diabetes_sdk/api/default_api.py
+++ b/libs/py-sdk/diabetes_sdk/api/default_api.py
@@ -1,14 +1,37 @@
 from ..api_client import ApiClient
+from ..exceptions import ApiException
+from ..models import Profile
 
 
 class DefaultApi:
-    """Placeholder default API client."""
+    """Very small in-memory API client used in tests."""
+
+    _profiles_store: dict[int, Profile] = {}
 
     def __init__(self, api_client: ApiClient | None = None, *, configuration=None) -> None:
         if api_client is not None:
             self.api_client = api_client
         else:
             self.api_client = ApiClient(configuration)
+        self._profiles = self._profiles_store
+
+    def profiles_post(self, profile: Profile) -> None:
+        """Store profile in memory with basic validation."""
+        if (
+            profile.icr <= 0
+            or profile.cf <= 0
+            or profile.target <= 0
+            or profile.low <= 0
+            or profile.high <= 0
+            or profile.low >= profile.high
+            or not (profile.low < profile.target < profile.high)
+        ):
+            raise ApiException("Все значения должны быть больше 0")
+        self._profiles[profile.telegram_id] = profile
+
+    def profiles_get(self, *, telegram_id: int) -> Profile | None:
+        """Retrieve profile by Telegram ID."""
+        return self._profiles.get(telegram_id)
 
     def __repr__(self) -> str:  # pragma: no cover - trivial
         return f"DefaultApi(api_client={self.api_client!r})"

--- a/libs/py-sdk/diabetes_sdk/models/profile.py
+++ b/libs/py-sdk/diabetes_sdk/models/profile.py
@@ -3,6 +3,11 @@ from dataclasses import dataclass
 
 @dataclass
 class Profile:
-    """Minimal profile model."""
+    """Patient profile data used by handlers and tests."""
 
-    pass
+    telegram_id: int
+    icr: float
+    cf: float
+    target: float
+    low: float
+    high: float

--- a/services/api/app/diabetes/handlers/profile_handlers.py
+++ b/services/api/app/diabetes/handlers/profile_handlers.py
@@ -174,7 +174,13 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     )
     try:
         api.profiles_post(profile)
-    except ApiException:
+    except ApiException as exc:
+        logger.error("DB commit failed: %s", exc)
+        await update.message.reply_text(str(exc))
+        return ConversationHandler.END
+
+    session = SessionLocal()
+    if not commit_session(session):
         await update.message.reply_text("⚠️ Не удалось сохранить профиль.")
         return ConversationHandler.END
 


### PR DESCRIPTION
## Summary
- define patient profile fields in Python SDK
- add in-memory DefaultApi with validation
- handle profile save failures in handler

## Testing
- `ruff check libs/py-sdk services/api/app tests`
- `OPENAI_API_KEY=test OPENAI_ASSISTANT_ID=asst_test pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b478da114832aa6fcb2f680bde107