### PR TITLE
[py-sdk] Implement in-memory profile store

### DIFF
--- a/libs/py-sdk/diabetes_sdk/api/default_api.py
+++ b/libs/py-sdk/diabetes_sdk/api/default_api.py
@@ -17,6 +17,8 @@ class DefaultApi:
 
     def profiles_post(self, profile: Profile) -> None:
         """Store profile in memory with basic validation."""
+        if profile.telegram_id <= 0:
+            raise ApiException("telegram_id must be greater than 0")
         if (
             profile.icr <= 0
             or profile.cf <= 0
@@ -31,7 +33,12 @@ class DefaultApi:
 
     def profiles_get(self, *, telegram_id: int) -> Profile | None:
         """Retrieve profile by Telegram ID."""
-        return self._profiles.get(telegram_id)
+        if telegram_id <= 0:
+            raise ApiException("telegram_id must be greater than 0")
+        try:
+            return self._profiles[telegram_id]
+        except KeyError as exc:
+            raise ApiException("profile not found") from exc
 
     def __repr__(self) -> str:  # pragma: no cover - trivial
         return f"DefaultApi(api_client={self.api_client!r})"


### PR DESCRIPTION
## Summary
- store profiles in-memory keyed by telegram ID
- add validation and error handling for profile operations

## Testing
- `OPENAI_ASSISTANT_ID=dummy python -m pytest tests/`
- `ruff check services/api/app tests libs/py-sdk/diabetes_sdk/api/default_api.py`


------
https://chatgpt.com/codex/tasks/task_e_689b4bdc2b8c832a807c67b249c17b04