### PR TITLE
[config] Use dynamic DB password accessor

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -85,3 +85,8 @@ OPENAI_PROXY = settings.openai_proxy
 FONT_DIR = settings.font_dir
 TELEGRAM_TOKEN = settings.telegram_token
 
+
+def get_db_password() -> Optional[str]:
+    """Return the database password from a fresh ``Settings`` instance."""
+    return Settings().db_password
+

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -160,12 +160,13 @@ class ReminderLog(Base):
 # ────────────────────── инициализация ────────────────────────
 def init_db() -> None:
     """Создать таблицы, если их ещё нет (для локального запуска)."""
-    if not config.DB_PASSWORD:
+    password = config.get_db_password()
+    if not password:
         raise ValueError("DB_PASSWORD environment variable must be set")
     database_url = URL.create(
         "postgresql",
         username=DB_USER,
-        password=config.DB_PASSWORD,
+        password=password,
         host=DB_HOST,
         port=int(DB_PORT),
         database=DB_NAME,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,7 +21,7 @@ def test_init_db_raises_when_no_password(monkeypatch):
     monkeypatch.delenv("DB_PASSWORD", raising=False)
     config = _reload("services.api.app.config")
     db = _reload("services.api.app.diabetes.services.db")
-    assert config.DB_PASSWORD is None
+    assert config.get_db_password() is None
     with pytest.raises(ValueError):
         db.init_db()
 

--- a/tests/test_db_reinit.py
+++ b/tests/test_db_reinit.py
@@ -29,8 +29,8 @@ class DummyEngine:
 )
 
 def test_init_db_recreates_engine_on_url_change(monkeypatch, attr, orig, new, url_attr):
-    config = _reload("services.api.app.config")
-    config.DB_PASSWORD = "pwd"
+    monkeypatch.setenv("DB_PASSWORD", "pwd")
+    _reload("services.api.app.config")
     db = _reload("services.api.app.diabetes.services.db")
 
     created = []

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -112,6 +112,7 @@ def test_send_message_empty_string_preserved(tmp_path, monkeypatch):
     )
 
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
+    monkeypatch.setattr(gpt_client, "OPENAI_ASSISTANT_ID", "asst_test")
 
     gpt_client.send_message(thread_id="t", content="", image_path=str(img))
     assert captured["content"][1]["text"] == ""


### PR DESCRIPTION
## Summary
- add `get_db_password` helper to load DB password from a fresh Settings instance
- call `get_db_password` in `init_db` and adjust tests for dynamic retrieval

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b4d4f39dc832abb20a2a3faeeff21