### PR TITLE
[config] Drop cached DB password constant

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -75,7 +75,6 @@ DB_HOST = settings.db_host
 DB_PORT = settings.db_port
 DB_NAME = settings.db_name
 DB_USER = settings.db_user
-DB_PASSWORD = settings.db_password
 UVICORN_WORKERS = settings.uvicorn_workers
 WEBAPP_URL = settings.webapp_url
 API_URL = settings.api_url


### PR DESCRIPTION
## Summary
- remove cached `DB_PASSWORD` constant from configuration
- rely on dynamic `get_db_password()` when obtaining DB credentials

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b5088260c832a9e6725db813d1d59