### PR TITLE
[py-sdk] Improve reminder parse error handling

### DIFF
--- a/libs/py-sdk/diabetes_assistant_api_client/api/default/get_api_reminders.py
+++ b/libs/py-sdk/diabetes_assistant_api_client/api/default/get_api_reminders.py
@@ -1,3 +1,4 @@
+import logging
 from http import HTTPStatus
 from typing import Any, Optional, Union
 
@@ -8,6 +9,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.reminder import Reminder
 from ...types import UNSET, Response, Unset
 
+logger = logging.getLogger(__name__)
 
 def _get_kwargs(
     *,
@@ -43,8 +45,8 @@ def _parse_response(
                 response_200_type_0 = Reminder.from_dict(data)
 
                 return response_200_type_0
-            except:  # noqa: E722
-                pass
+            except (TypeError, ValueError) as exc:
+                logger.warning("Failed to parse reminder from dict: %s", exc)
             if not isinstance(data, list):
                 raise TypeError()
             response_200_type_1 = []


### PR DESCRIPTION
## Summary
- log detailed errors when parsing reminders fails
- tighten except blocks to TypeError and ValueError for reminder parsing

## Testing
- `ruff check libs/py-sdk/diabetes_assistant_api_client/api/default/get_api_reminders.py services/api/app tests`
- `pytest tests` *(fails: OPENAI_ASSISTANT_ID is not set; AttributeError: DefaultApi object has no attribute 'profiles_get')*


------
https://chatgpt.com/codex/tasks/task_e_689b4b6905c8832aa872190ca1801ac5