### PR TITLE
[worker] Use logging instead of print

### DIFF
--- a/services/worker/main.py
+++ b/services/worker/main.py
@@ -1,23 +1,25 @@
 """Worker service entry point."""
 
+import logging
 import sys
 
 try:
-  from diabetes_sdk import Configuration
-  from diabetes_sdk.api import default_api
+    from diabetes_sdk import Configuration
+    from diabetes_sdk.api import default_api
 except ImportError:
-  print(
-    "diabetes_sdk is required to run the worker. "
-    "Install it with 'pip install diabetes_sdk'."
-  )
-  sys.exit(1)
+    logging.error(
+        "diabetes_sdk is required to run the worker. "
+        "Install it with 'pip install diabetes_sdk'."
+    )
+    sys.exit(1)
 
 
 def run() -> None:
-  """Entry point for the worker service."""
-  api = default_api.DefaultApi(configuration=Configuration())
-  print("Worker started. API client ready:", api)
+    """Entry point for the worker service."""
+    api = default_api.DefaultApi(configuration=Configuration())
+    logging.info("Worker started. API client ready: %s", api)
 
 
 if __name__ == "__main__":
-  run()
+    logging.basicConfig(level=logging.INFO)
+    run()


### PR DESCRIPTION
## Summary
- import logging and replace prints with structured logging calls in worker entry
- configure logging and standardize indentation

## Testing
- `ruff check services/worker/main.py services/api/app tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_689b55e53d58832a91e3cd9ab5a798fe