### PR TITLE
[diabetes] Improve command parser error handling

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -95,9 +95,12 @@ async def parse_command(text: str, timeout: float = 10) -> dict | None:
     except OpenAIError:
         logging.exception("Command parsing failed")
         return None
+    except ValueError:
+        logging.exception("Invalid value during command parsing")
+        return None
     except Exception:
         logging.exception("Unexpected error during command parsing")
-        return None
+        raise
 
     choices = getattr(response, "choices", None)
     if not choices:


### PR DESCRIPTION
## Summary
- refine GPT command parsing error handling by catching `ValueError` and re-raising unexpected issues

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b5b8d5b54832aa4490e704553b9fb