### PR TITLE
[webapp] Use SDK for reminders

### DIFF
--- a/libs/ts-sdk/apis/DefaultApi.ts
+++ b/libs/ts-sdk/apis/DefaultApi.ts
@@ -54,6 +54,15 @@ export interface RemindersPostRequest {
     reminder: Reminder;
 }
 
+export interface RemindersPatchRequest {
+    reminder: Reminder;
+}
+
+export interface RemindersDeleteRequest {
+    telegramId: number;
+    id: number;
+}
+
 export interface TimezonePostRequest {
     timezone: Timezone;
 }
@@ -251,6 +260,87 @@ export class DefaultApi extends runtime.BaseAPI {
      */
     async remindersPost(requestParameters: RemindersPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<RemindersPost200Response> {
         const response = await this.remindersPostRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * Update reminder
+     */
+    async remindersPatchRaw(requestParameters: RemindersPatchRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<RemindersPost200Response>> {
+        if (requestParameters['reminder'] == null) {
+            throw new runtime.RequiredError(
+                'reminder',
+                'Required parameter "reminder" was null or undefined when calling remindersPatch().' 
+            );
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        headerParameters['Content-Type'] = 'application/json';
+
+        let urlPath = `/api/reminders`;
+
+        const response = await this.request({
+            path: urlPath,
+            method: 'PATCH',
+            headers: headerParameters,
+            query: queryParameters,
+            body: ReminderToJSON(requestParameters['reminder']),
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => RemindersPost200ResponseFromJSON(jsonValue));
+    }
+
+    /**
+     * Update reminder
+     */
+    async remindersPatch(requestParameters: RemindersPatchRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<RemindersPost200Response> {
+        const response = await this.remindersPatchRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * Delete reminder
+     */
+    async remindersDeleteRaw(requestParameters: RemindersDeleteRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Status>> {
+        if (requestParameters['telegramId'] == null) {
+            throw new runtime.RequiredError(
+                'telegramId',
+                'Required parameter "telegramId" was null or undefined when calling remindersDelete().' 
+            );
+        }
+        if (requestParameters['id'] == null) {
+            throw new runtime.RequiredError(
+                'id',
+                'Required parameter "id" was null or undefined when calling remindersDelete().' 
+            );
+        }
+
+        const queryParameters: any = {};
+        queryParameters['telegram_id'] = requestParameters['telegramId'];
+        queryParameters['id'] = requestParameters['id'];
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        let urlPath = `/api/reminders`;
+
+        const response = await this.request({
+            path: urlPath,
+            method: 'DELETE',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => StatusFromJSON(jsonValue));
+    }
+
+    /**
+     * Delete reminder
+     */
+    async remindersDelete(requestParameters: RemindersDeleteRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Status> {
+        const response = await this.remindersDeleteRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -2,17 +2,19 @@ import { DefaultApi, Reminder } from '@sdk';
 
 const api = new DefaultApi();
 
-export async function getReminders(telegramId = 1) {
-  const { data } = await api.remindersGet(telegramId);
-  return data;
+export async function getReminders(telegramId = 1): Promise<Reminder[]> {
+  const data = await api.remindersGet({ telegramId });
+  return Array.isArray(data) ? data : [data];
 }
 
-export async function updateReminder(payload: Reminder & { id: number }) {
-  const { data } = await api.remindersPost(payload);
-  return { ...data, id: Number(data.id) };
+export async function createReminder(reminder: Reminder) {
+  return api.remindersPost({ reminder });
 }
 
-export async function createReminder(payload: Reminder) {
-  const { data } = await api.remindersPost(payload);
-  return { ...data, id: Number(data.id) };
+export async function updateReminder(reminder: Reminder) {
+  return api.remindersPatch({ reminder });
+}
+
+export async function deleteReminder(telegramId: number, id: number) {
+  return api.remindersDelete({ telegramId, id });
 }

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { MedicalButton, Sheet } from "@/components";
 import { cn } from "@/lib/utils";
+import { createReminder, updateReminder } from "@/api/reminders";
+import { Reminder as ApiReminder } from "@sdk";
 
 type ReminderType = "sugar" | "insulin" | "meal";
 
@@ -58,19 +60,19 @@ export default function CreateReminder() {
     e.preventDefault();
     if (!formValid) return;
     setError(null);
+    const payload: ApiReminder = {
+      telegramId: 1,
+      type,
+      time,
+      intervalHours: interval,
+      isEnabled: true,
+      ...(editing ? { id: editing.id } : {}),
+    };
     try {
-        const res = await fetch("/reminders", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            type,
-            text: title.trim(),
-            value: `${time}|${interval}`,
-            ...(editing ? { id: editing.id } : {})
-          })
-        });
-      if (!res.ok) {
-        throw new Error("Failed to create reminder");
+      if (editing) {
+        await updateReminder(payload);
+      } else {
+        await createReminder(payload);
       }
       navigate("/reminders");
     } catch {


### PR DESCRIPTION
## Summary
- refactor reminder components to use DefaultApi instead of fetch
- add SDK helpers for reminder CRUD including PATCH/DELETE
- extend TypeScript SDK with reminder update and delete methods

## Testing
- `ruff check services/api/app tests`
- `pytest tests`
- `npx eslint src/api/reminders.ts src/pages/Reminders.tsx src/reminders/CreateReminder.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689b5cd1d884832a84ce36f36c56492b