### PR TITLE
[diabetes] Use with_options for GPT timeout

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -77,7 +77,7 @@ async def parse_command(text: str, timeout: float = 10) -> dict | None:
         # fresh ``ThreadPoolExecutor`` for every invocation.
         response = await asyncio.wait_for(
             asyncio.to_thread(
-                _get_client().chat.completions.create,
+                _get_client().chat.completions.with_options(timeout=timeout).create,
                 model="gpt-4o-mini",
                 messages=[
                     {"role": "system", "content": SYSTEM_PROMPT},
@@ -85,7 +85,6 @@ async def parse_command(text: str, timeout: float = 10) -> dict | None:
                 ],
                 temperature=0,
                 max_tokens=256,
-                timeout=timeout,
             ),
             timeout,
         )
@@ -97,6 +96,9 @@ async def parse_command(text: str, timeout: float = 10) -> dict | None:
         return None
     except ValueError:
         logging.exception("Invalid value during command parsing")
+        return None
+    except TypeError:
+        logging.exception("Invalid type during command parsing")
         return None
     except Exception:
         logging.exception("Unexpected error during command parsing")

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -25,7 +25,12 @@ async def test_parse_command_timeout_non_blocking(monkeypatch):
         return FakeResponse()
 
     fake_client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=slow_create))
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=slow_create,
+                with_options=lambda **kwargs: SimpleNamespace(create=slow_create),
+            )
+        )
     )
     monkeypatch.setattr(gpt_command_parser, "_get_client", lambda: fake_client)
 
@@ -63,10 +68,13 @@ async def test_parse_command_with_explanatory_text(monkeypatch):
             )
         ]
 
+    def create(*args, **kwargs):
+        return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
             completions=SimpleNamespace(
-                create=lambda *args, **kwargs: FakeResponse()
+                create=create,
+                with_options=lambda **kwargs: SimpleNamespace(create=create),
             )
         )
     )
@@ -88,10 +96,13 @@ async def test_parse_command_with_array_response(monkeypatch):
             )
         ]
 
+    def create(*args, **kwargs):
+        return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
             completions=SimpleNamespace(
-                create=lambda *args, **kwargs: FakeResponse()
+                create=create,
+                with_options=lambda **kwargs: SimpleNamespace(create=create),
             )
         )
     )
@@ -113,10 +124,13 @@ async def test_parse_command_with_scalar_response(monkeypatch):
             )
         ]
 
+    def create(*args, **kwargs):
+        return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
             completions=SimpleNamespace(
-                create=lambda *args, **kwargs: FakeResponse()
+                create=create,
+                with_options=lambda **kwargs: SimpleNamespace(create=create),
             )
         )
     )
@@ -132,10 +146,13 @@ async def test_parse_command_with_missing_content(monkeypatch, caplog):
     class FakeResponse:
         choices = [type("Choice", (), {"message": type("Msg", (), {})()})]
 
+    def create(*args, **kwargs):
+        return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
             completions=SimpleNamespace(
-                create=lambda *args, **kwargs: FakeResponse()
+                create=create,
+                with_options=lambda **kwargs: SimpleNamespace(create=create),
             )
         )
     )
@@ -159,10 +176,13 @@ async def test_parse_command_with_non_string_content(monkeypatch, caplog):
             )
         ]
 
+    def create(*args, **kwargs):
+        return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
             completions=SimpleNamespace(
-                create=lambda *args, **kwargs: FakeResponse()
+                create=create,
+                with_options=lambda **kwargs: SimpleNamespace(create=create),
             )
         )
     )


### PR DESCRIPTION
## Summary
- Route GPT completion calls through `with_options` to set request timeouts
- Handle `TypeError` from command parsing and return `None`
- Adjust command parser tests for new OpenAI client pattern

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689b5edecf00832a83649ad14ab7b13a