### PR TITLE
[webapp] Use Telegram user ID for reminders

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -2,7 +2,7 @@ import { DefaultApi, Reminder } from '@sdk';
 
 const api = new DefaultApi();
 
-export async function getReminders(telegramId = 1): Promise<Reminder[]> {
+export async function getReminders(telegramId: number): Promise<Reminder[]> {
   const data = await api.remindersGet({ telegramId });
   return Array.isArray(data) ? data : [data];
 }


### PR DESCRIPTION
## Summary
- import Telegram context hook in Reminders page and use `user.id` for fetching, updating and deleting reminders
- remove default Telegram ID from API helper so callers must provide actual user ID

## Testing
- `pre-commit run --files services/webapp/ui/src/pages/Reminders.tsx services/webapp/ui/src/api/reminders.ts`
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689b5fc2bd80832a9ac3587b00e196bd