### PR TITLE
[bot] Add type hints and fix db error test

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -5,16 +5,15 @@ Bot entry point and configuration.
 
 import logging
 import sys
+from typing import Any
 
 from telegram import BotCommand
 from telegram.ext import Application, ContextTypes
 from sqlalchemy.exc import SQLAlchemyError
 
-from services.api.app.services import init_db
+from services.api.app.diabetes.services.db import init_db
 
 from services.api.app.config import LOG_LEVEL, settings
-from services.api.app.diabetes.handlers.common_handlers import register_handlers
-
 logger = logging.getLogger(__name__)
 
 
@@ -60,7 +59,8 @@ def main() -> None:
         BotCommand("delreminder", "Удалить напоминание"),
         BotCommand("help", "Справка"),
     ]
-    async def post_init(app: Application) -> None:
+
+    async def post_init(app: Application[Any, Any, Any, Any]) -> None:
         await app.bot.set_my_commands(commands)
 
     application = (
@@ -70,6 +70,9 @@ def main() -> None:
         .build()
     )
     application.add_error_handler(error_handler)
+
+    from services.api.app.diabetes.handlers.common_handlers import register_handlers
+
     register_handlers(application)
     application.run_polling()
 

--- a/tests/test_bot_db_error.py
+++ b/tests/test_bot_db_error.py
@@ -1,22 +1,23 @@
 import logging
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
-import asyncio
 
 import services.bot.main as bot
 
 
-def test_main_logs_db_error(monkeypatch, caplog):
+def test_main_logs_db_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     monkeypatch.setattr(bot, "TELEGRAM_TOKEN", "token")
 
-    def faulty_init_db():
+    def faulty_init_db() -> None:
         raise SQLAlchemyError("boom")
 
     monkeypatch.setattr(bot, "init_db", faulty_init_db)
 
     with caplog.at_level(logging.ERROR):
         with pytest.raises(SystemExit) as exc:
-            asyncio.run(bot.main())
+            bot.main()
 
     assert (
         exc.value.code


### PR DESCRIPTION
## Summary
- specify explicit Application generics in bot entry point
- lazily import handler registration and refine init_db import
- add type annotations to db error test and call bot.main directly

## Testing
- `ruff check services/bot/main.py tests/test_bot_db_error.py`
- `mypy services/bot/main.py tests/test_bot_db_error.py --ignore-missing-imports --follow-imports=skip`
- `pytest tests/test_bot_db_error.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b63660fdc832a84a47eb49957b530