### PR TITLE
[db] Add org_id to reminders

### DIFF
--- a/services/api/alembic/versions/c3dc6e5961a3_add_org_id_to_reminders.py
+++ b/services/api/alembic/versions/c3dc6e5961a3_add_org_id_to_reminders.py
@@ -1,0 +1,26 @@
+"""add org_id to reminders
+
+Revision ID: c3dc6e5961a3
+Revises: 02857aa7fc3e
+Create Date: 2025-08-12 15:59:18.142298
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c3dc6e5961a3'
+down_revision: Union[str, None] = '02857aa7fc3e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('reminders', sa.Column('org_id', sa.Integer()))
+
+
+def downgrade() -> None:
+    op.drop_column('reminders', 'org_id')


### PR DESCRIPTION
## Summary
- add Alembic migration to include `org_id` column on reminders

## Testing
- `ruff check services/api/app tests`
- `pytest tests/`
- `alembic -c services/api/alembic.ini upgrade head` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689b64612340832abe123e318f1c9a12