### PR TITLE
[handlers] Improve error handling in dose handlers

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -802,6 +802,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
                     "[PHOTO][TYPING_ACTION] Unexpected error: %s",
                     exc,
                 )
+                raise
 
         await send_typing_action()
 
@@ -830,6 +831,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
                         "[PHOTO][STATUS_EDIT] Unexpected error: %s",
                         exc,
                     )
+                    raise
             await send_typing_action()
 
         if run.status not in ("completed", "failed", "cancelled", "expired"):
@@ -849,6 +851,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
                         "[PHOTO][TIMEOUT_EDIT] Unexpected error: %s",
                         exc,
                     )
+                    raise
             else:
                 await message.reply_text(
                     "⚠️ Время ожидания Vision истекло. Попробуйте позже."
@@ -872,6 +875,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
                         "[PHOTO][RUN_FAILED_EDIT] Unexpected error: %s",
                         exc,
                     )
+                    raise
             else:
                 await message.reply_text("⚠️ Vision не смог обработать фото.")
             return ConversationHandler.END
@@ -928,6 +932,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
                     "[PHOTO][DELETE_STATUS] Unexpected error: %s",
                     exc,
                 )
+                raise
         await message.reply_text(
             f"🍽️ На фото:\n{vision_text}\n\n"
             "Введите текущий сахар (ммоль/л) — и я рассчитаю дозу инсулина.",


### PR DESCRIPTION
## Summary
- Re-raise unexpected exceptions in photo analysis workflow to avoid silent failures

## Testing
- `ruff check services/api/app tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_689b653d5e0c832aa90a2561258f8184