### PR TITLE
[tests] Add pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+markers =
+    asyncio: mark a coroutine test


### PR DESCRIPTION
## Summary
- configure pytest to auto-detect asyncio tests and register `asyncio` marker

## Testing
- `pytest`
- `ruff check services/api/app tests`

------
https://chatgpt.com/codex/tasks/task_e_689b65255c10832a9702cddc577214a5