### PR TITLE
[services] Rename local 'engine' variable to 'bind'

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -59,9 +59,9 @@ async def run_db(
             return fn(session, *args, **kwargs)
 
     with sessionmaker() as _session:
-        engine = _session.get_bind()
+        bind = _session.get_bind()
 
-    if engine.url.drivername == "sqlite" and engine.url.database == ":memory:":
+    if bind.url.drivername == "sqlite" and bind.url.database == ":memory:":
         return wrapper()
 
     return await asyncio.to_thread(wrapper)


### PR DESCRIPTION
## Summary
- rename local `engine` variable to `bind` in `run_db` helper

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` *(fails: AttributeError: module 'services.bot.main' has no attribute 'register_handlers')*

------
https://chatgpt.com/codex/tasks/task_e_689b6be8c790832a9e4e6c5459abf4f9