### PR TITLE
[api] mount ui fallback

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -16,7 +16,10 @@ logger = logging.getLogger(__name__)
 app = FastAPI()
 
 BASE_DIR = Path(__file__).resolve().parents[2] / "webapp"
-UI_DIR = (BASE_DIR / "ui").resolve()
+UI_DIR = BASE_DIR / "ui" / "dist"
+if not UI_DIR.exists():
+    UI_DIR = BASE_DIR / "ui"
+UI_DIR = UI_DIR.resolve()
 TIMEZONE_FILE = Path(__file__).resolve().parent / "timezone.txt"
 HISTORY_FILE = Path(__file__).resolve().parent / "history.json"
 
@@ -58,8 +61,7 @@ async def put_timezone(data: Timezone) -> dict:
     return {"status": "ok"}
 
 
-if UI_DIR.exists():
-    app.mount("/ui", StaticFiles(directory=UI_DIR, html=True), name="ui")
+app.mount("/ui", StaticFiles(directory=UI_DIR, html=True), name="ui")
 
 
 @app.post("/api/history")

--- a/tests/test_webapp_server_startup.py
+++ b/tests/test_webapp_server_startup.py
@@ -8,12 +8,15 @@ import pytest
 
 def test_app_import_without_ui(monkeypatch: pytest.MonkeyPatch) -> None:
     """Importing services.api.app.main should succeed even if UI build is missing."""
-    ui_dir = (Path(__file__).resolve().parents[1] / "services" / "webapp" / "ui" / "dist").resolve()
+    ui_dist = Path(__file__).resolve().parents[1] / "services" / "webapp" / "ui" / "dist"
+    ui_dir = ui_dist.parent
     original_exists = Path.exists
 
     def fake_exists(self: Path) -> bool:  # noqa: ANN001
-        if self == ui_dir:
+        if self == ui_dist:
             return False
+        if self == ui_dir:
+            return True
         return original_exists(self)
 
     monkeypatch.setattr(Path, "exists", fake_exists)


### PR DESCRIPTION
## Summary
- default to serving compiled web app from `ui/dist` and fall back to source `ui`
- stub ui build path in startup test to ensure import works without frontend build

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_webapp_server_startup.py`
- `pytest tests` *(fails: AttributeError: <module 'services.bot.main'> has no attribute 'register_handlers')*

------
https://chatgpt.com/codex/tasks/task_e_689b6aacd9c8832aadb987d14e6eadd8