### PR TITLE
[alerts] Handle missing geolocation

### DIFF
--- a/docs/ADR/003_sos-contact-alerts.md
+++ b/docs/ADR/003_sos-contact-alerts.md
@@ -4,7 +4,7 @@
 Users may need an emergency contact notified when blood sugar repeatedly hits critical levels. The bot already supports saving a contact through `/soscontact` and tracks sugar readings.
 
 ## Decision
-If a user has set an SOS contact and records three consecutive critical sugar values (below or above their thresholds), the bot sends an alert message containing a placeholder location to both the user and the saved contact.
+If a user has set an SOS contact and records three consecutive critical sugar values (below or above their thresholds), the bot sends an alert message to both the user and the saved contact. The message includes an approximate location when available.
 
 ## Acceptance Scenario
 1. **User sets SOS contact**
@@ -19,10 +19,10 @@ If a user has set an SOS contact and records three consecutive critical sugar va
      - User: `3`
      - Bot: `✅ Уровень сахара 3 ммоль/л сохранён.`
 3. **Alert dispatch**
-   - After the third reading, bot to user: `⚠️ У Ivan критический сахар 3 ммоль/л. 0.0,0.0 https://maps.google.com/?q=0.0,0.0`
-   - Bot to `@alice`: `⚠️ У Ivan критический сахар 3 ммоль/л. 0.0,0.0 https://maps.google.com/?q=0.0,0.0`
+   - After the third reading, bot to user: `⚠️ У Ivan критический сахар 3 ммоль/л.`
+   - Bot to `@alice`: `⚠️ У Ivan критический сахар 3 ммоль/л.`
 
 ## Consequences
 - Users receive their own alert after the third critical value.
-- The SOS contact receives the same alert with a placeholder location until precise geolocation is implemented.
+- The SOS contact receives the same alert; location is omitted if fetching coordinates fails.
 

--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -33,7 +33,9 @@ async def _send_alert_message(
     first_name: str,
 ) -> None:
     coords, link = await get_coords_and_link()
-    msg = f"⚠️ У {first_name} критический сахар {sugar} ммоль/л. {coords} {link}"
+    msg = f"⚠️ У {first_name} критический сахар {sugar} ммоль/л."
+    if coords and link:
+        msg += f" {coords} {link}"
     await context.bot.send_message(chat_id=user_id, text=msg)
     if profile_info.get("sos_contact") and profile_info.get("sos_alerts_enabled"):
         contact = profile_info["sos_contact"]

--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -64,12 +64,10 @@ async def get_coords_and_link() -> tuple[str | None, str | None]:
         return None, None
 
     try:
-        result = await asyncio.to_thread(_fetch)
-        if result:
-            return result
+        return await asyncio.to_thread(_fetch)
     except Exception as exc:  # pragma: no cover - network failures
         logging.warning("Failed to fetch coordinates: %s", exc)
-    return "0.0,0.0", "https://maps.google.com/?q=0.0,0.0"
+    return None, None
 
 
 def split_text_by_width(

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -27,8 +27,12 @@ def test_log_level_debug(monkeypatch):
 
     class DummyApp:
         bot = DummyBot()
+        job_queue = None
 
         def add_error_handler(self, _):
+            return None
+
+        def add_handler(self, _):
             return None
 
         def run_polling(self):
@@ -49,8 +53,11 @@ def test_log_level_debug(monkeypatch):
         def builder():
             return DummyBuilder()
 
+        def __class_getitem__(cls, _):  # Support subscripting in type hints
+            return cls
+
     monkeypatch.setattr(bot, "Application", DummyApplication)
-    monkeypatch.setattr(bot, "register_handlers", lambda app: None)
+    monkeypatch.setattr(bot, "register_handlers", lambda app: None, raising=False)
 
     # Reset and capture logging configuration
     root = logging.getLogger()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,8 +64,7 @@ async def test_get_coords_and_link_logs_warning(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING):
         coords, link = await utils.get_coords_and_link()
 
-    assert coords == "0.0,0.0"
-    assert link == "https://maps.google.com/?q=0.0,0.0"
+    assert coords is None and link is None
     assert any("Failed to fetch coordinates" in msg for msg in caplog.messages)
 
 


### PR DESCRIPTION
## Summary
- avoid sending placeholder coordinates by returning `(None, None)` when geolocation request fails
- only append coordinates in alert messages when real data is available
- document and test behavior without fallback coords

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689b6fdaf4b4832abb2fe510550a3c01