### PR TITLE
[webapp] Remove unused Telegram button hooks

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -2,13 +2,11 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Save } from 'lucide-react';
 import { MedicalHeader } from '@/components/MedicalHeader';
-import { useTelegram } from '@/hooks/useTelegram';
 import { useToast } from '@/hooks/use-toast';
 import MedicalButton from '@/components/MedicalButton';
 
 const Profile = () => {
   const navigate = useNavigate();
-  const { showMainButton, hideMainButton } = useTelegram();
   const { toast } = useToast();
 
   const [profile, setProfile] = useState({


### PR DESCRIPTION
## Summary
- remove unused show/hide main button hook calls from Profile page

## Testing
- `npx eslint src/pages/Profile.tsx && echo ESLINT_OK`
- `ruff check services/api/app tests`
- `pytest tests` *(fails: AttributeError: <module 'services.bot.main'... has no attribute 'register_handlers')*

------
https://chatgpt.com/codex/tasks/task_e_689b70c7432c832aa56d8460a1cce812