### PR TITLE
[webapp] Use aiofiles for history persistence

### DIFF
--- a/tests/test_webapp_history.py
+++ b/tests/test_webapp_history.py
@@ -1,0 +1,26 @@
+import json
+from fastapi.testclient import TestClient
+import services.api.app.main as server
+
+
+def test_history_persist_and_update(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(server, "HISTORY_FILE", tmp_path / "history.json")
+    client = TestClient(server.app)
+
+    rec1 = {"id": "1", "date": "2024-01-01", "time": "12:00", "type": "measurement"}
+    resp = client.post("/api/history", json=rec1)
+    assert resp.status_code == 200
+    rec1_dump = {**rec1, "sugar": None, "carbs": None, "breadUnits": None, "insulin": None, "notes": None}
+    assert json.loads(server.HISTORY_FILE.read_text(encoding="utf-8")) == [rec1_dump]
+
+    rec1_update = {**rec1, "sugar": 5.5}
+    resp = client.post("/api/history", json=rec1_update)
+    assert resp.status_code == 200
+    rec1_update_dump = {**rec1_dump, "sugar": 5.5}
+    assert json.loads(server.HISTORY_FILE.read_text(encoding="utf-8")) == [rec1_update_dump]
+
+    rec2 = {"id": "2", "date": "2024-01-02", "time": "13:00", "type": "meal"}
+    resp = client.post("/api/history", json=rec2)
+    assert resp.status_code == 200
+    rec2_dump = {**rec2, "sugar": None, "carbs": None, "breadUnits": None, "insulin": None, "notes": None}
+    assert json.loads(server.HISTORY_FILE.read_text(encoding="utf-8")) == [rec1_update_dump, rec2_dump]


### PR DESCRIPTION
## Summary
- use aiofiles and executor helpers for non-blocking history persistence
- add test covering saving and updating history records

## Testing
- `pre-commit run --files services/api/app/main.py tests/test_webapp_history.py`
- `pytest tests/test_webapp_server.py tests/test_webapp_timezone.py tests/test_webapp_history.py tests/test_webapp_server_startup.py`

------
https://chatgpt.com/codex/tasks/task_e_689b728b4210832aa9f7895cf040c300