### PR TITLE
[tests] Replace SimpleNamespace context with typed stub

### DIFF
--- a/tests/context_stub.py
+++ b/tests/context_stub.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+class AlertContext(Protocol):
+    """Protocol for context objects used in alert handlers tests."""
+    job: Any | None
+    job_queue: Any | None
+    bot: Any | None
+
+
+@dataclass
+class ContextStub:
+    job: Any | None = None
+    job_queue: Any | None = None
+    bot: Any | None = None

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -2,6 +2,8 @@ from datetime import timedelta
 from types import SimpleNamespace
 from typing import Any, Callable, Optional
 
+from .context_stub import AlertContext, ContextStub
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -94,7 +96,8 @@ async def test_repeat_logic():
     await handlers.evaluate_sugar(1, 3, job_queue)
 
     for i in range(1, 4):
-        context = SimpleNamespace(job=SimpleNamespace(data={"user_id": 1, "count": i}), job_queue=job_queue)
+        job = SimpleNamespace(data={"user_id": 1, "count": i})
+        context: AlertContext = ContextStub(job=job, job_queue=job_queue)
         await handlers.alert_job(context)
 
     assert len(job_queue.jobs) == 3
@@ -151,7 +154,7 @@ async def test_three_alerts_notify(monkeypatch):
             self.sent.append((chat_id, text))
 
     update = SimpleNamespace(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
-    context = SimpleNamespace(bot=DummyBot())
+    context: AlertContext = ContextStub(bot=DummyBot())
     async def fake_get_coords_and_link():
         return ("0,0", "link")
 
@@ -198,7 +201,7 @@ async def test_alert_message_without_coords(monkeypatch):
             self.sent.append((chat_id, text))
 
     update = SimpleNamespace(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
-    context = SimpleNamespace(bot=DummyBot())
+    context: AlertContext = ContextStub(bot=DummyBot())
 
     async def fake_get_coords_and_link():
         return None, None

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -4,6 +4,8 @@ import pytest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, call
 
+from .context_stub import AlertContext, ContextStub
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from telegram.ext import ApplicationBuilder, MessageHandler
@@ -73,7 +75,7 @@ async def test_alert_notifies_user_and_contact(test_session, monkeypatch):
     update_alert = SimpleNamespace(
         effective_user=SimpleNamespace(id=1, first_name="Ivan")
     )
-    context = SimpleNamespace(bot=SimpleNamespace())
+    context: AlertContext = ContextStub(bot=SimpleNamespace())
     send_mock = AsyncMock()
     monkeypatch.setattr(context.bot, "send_message", send_mock, raising=False)
     async def fake_get_coords_and_link():
@@ -109,7 +111,7 @@ async def test_alert_skips_phone_contact(test_session, monkeypatch):
     update_alert = SimpleNamespace(
         effective_user=SimpleNamespace(id=1, first_name="Ivan")
     )
-    context = SimpleNamespace(bot=SimpleNamespace())
+    context: AlertContext = ContextStub(bot=SimpleNamespace())
     send_mock = AsyncMock()
     monkeypatch.setattr(context.bot, "send_message", send_mock, raising=False)
 


### PR DESCRIPTION
## Summary
- add `AlertContext` protocol and `ContextStub` dataclass for alert handler tests
- use typed context stub when calling `alert_job` and `check_alert`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b72b5f2b4832ab2bbcbb994ffe11d