### PR TITLE
[utils] Split overlong words by width in PDFs

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -82,14 +82,41 @@ def split_text_by_width(
     words = text.split()
     lines: list[str] = []
     current_line = ""
+
+    def _split_word(word: str) -> list[str]:
+        """Split a single word into chunks that fit within ``max_width_mm``."""
+
+        parts: list[str] = []
+        part = ""
+        for ch in word:
+            test_part = part + ch
+            if stringWidth(test_part, font_name, font_size) / mm > max_width_mm and part:
+                parts.append(part)
+                part = ch
+            else:
+                part = test_part
+        if part:
+            parts.append(part)
+        return parts
+
     for word in words:
         test_line = (current_line + " " + word).strip()
         width = stringWidth(test_line, font_name, font_size) / mm
-        if width > max_width_mm and current_line:
+        if width <= max_width_mm:
+            current_line = test_line
+            continue
+
+        if current_line:
             lines.append(current_line)
+            current_line = ""
+
+        if stringWidth(word, font_name, font_size) / mm <= max_width_mm:
             current_line = word
         else:
-            current_line = test_line
+            parts = _split_word(word)
+            lines.extend(parts[:-1])
+            current_line = parts[-1] if parts else ""
+
     if current_line:
         lines.append(current_line)
     return lines

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,11 +7,17 @@ import logging
 from datetime import timedelta
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.pdfbase.pdfmetrics import stringWidth
+from reportlab.lib.units import mm
 
 import pytest
 
 import services.api.app.diabetes.utils.helpers as utils
-from services.api.app.diabetes.utils.helpers import clean_markdown, parse_time_interval, split_text_by_width
+from services.api.app.diabetes.utils.helpers import (
+    clean_markdown,
+    parse_time_interval,
+    split_text_by_width,
+)
 
 def test_clean_markdown():
     text = "**Жирный**\n# Заголовок\n* элемент\n1. Первый"
@@ -28,6 +34,21 @@ def test_split_text_by_width_simple():
     lines = split_text_by_width(text, "DejaVuSans", 12, 50)
     assert isinstance(lines, list)
     assert all(isinstance(line, str) for line in lines)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Supercalifragilisticexpialidocious",
+        "Hello Supercalifragilisticexpialidocious world",
+    ],
+)
+def test_split_text_by_width_respects_limit(text):
+    pdfmetrics.registerFont(TTFont("DejaVuSans", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"))
+    max_width = 20
+    lines = split_text_by_width(text, "DejaVuSans", 12, max_width)
+    for line in lines:
+        assert stringWidth(line, "DejaVuSans", 12) / mm <= max_width
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- handle words wider than max_width_mm when splitting text for PDF rendering
- test that split_text_by_width never produces lines exceeding the width limit

## Testing
- `ruff check services/api/app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b74dd5c28832ab2e2a71a972c4531