### PR TITLE
[handlers] Expose DB helpers for testing

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -3,18 +3,25 @@ from __future__ import annotations
 
 import datetime
 import logging
+from typing import Callable
 
+from sqlalchemy.orm import Session, sessionmaker
 from telegram.error import TelegramError
 from telegram.ext import ContextTypes
 
 from services.api.app.diabetes.services.db import (
     Alert,
     Profile,
-    SessionLocal,
+    SessionLocal as _SessionLocal,
     run_db,
 )
-from services.api.app.diabetes.handlers.common_handlers import commit_session
+from services.api.app.diabetes.handlers.common_handlers import (
+    commit_session as _commit_session,
+)
 from services.api.app.diabetes.utils.helpers import get_coords_and_link
+
+SessionLocal: sessionmaker[Session] = _SessionLocal
+commit_session: Callable[[Session], bool] = _commit_session
 
 logger = logging.getLogger(__name__)
 
@@ -199,5 +206,16 @@ async def alert_stats(update, context) -> None:
 
     text = f"За 7\u202Fдн.: гипо\u202F{hypo}, гипер\u202F{hyper}"
     await update.message.reply_text(text)
+
+
+__all__ = [
+    "schedule_alert",
+    "evaluate_sugar",
+    "check_alert",
+    "alert_job",
+    "alert_stats",
+    "SessionLocal",
+    "commit_session",
+]
 
 

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import datetime
-from datetime import timedelta, time, timezone
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
-import logging
 import json
+import logging
 import re
+from datetime import time, timedelta, timezone
+from typing import Callable
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from services.api.app.diabetes.utils.helpers import parse_time_interval
-
+from sqlalchemy.orm import Session, sessionmaker
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, WebAppInfo
 from telegram.ext import (
     CallbackQueryHandler,
@@ -20,9 +20,19 @@ from telegram.ext import (
 )
 from telegram.error import BadRequest
 
-from services.api.app.diabetes.services.db import Reminder, ReminderLog, SessionLocal, User, run_db
-from .common_handlers import commit_session
+from services.api.app.diabetes.services.db import (
+    Reminder,
+    ReminderLog,
+    SessionLocal as _SessionLocal,
+    User,
+    run_db,
+)
+from .common_handlers import commit_session as _commit_session
 from services.api.app.config import WEBAPP_URL
+from services.api.app.diabetes.utils.helpers import parse_time_interval
+
+SessionLocal: sessionmaker[Session] = _SessionLocal
+commit_session: Callable[[Session], bool] = _commit_session
 
 logger = logging.getLogger(__name__)
 
@@ -652,3 +662,21 @@ reminder_action_handler = CallbackQueryHandler(
 reminder_webapp_handler = MessageHandler(
     filters.StatusUpdate.WEB_APP_DATA, reminder_webapp_save
 )
+
+
+__all__ = [
+    "schedule_reminder",
+    "schedule_all",
+    "reminders_list",
+    "add_reminder",
+    "reminder_webapp_save",
+    "delete_reminder",
+    "reminder_job",
+    "reminder_callback",
+    "reminder_action_cb",
+    "schedule_after_meal",
+    "reminder_action_handler",
+    "reminder_webapp_handler",
+    "SessionLocal",
+    "commit_session",
+]


### PR DESCRIPTION
## Summary
- type annotate SessionLocal and commit_session in alert and reminder handlers
- export these helpers via `__all__` for easier dependency injection

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b7551de44832aa6d4a147f2817ace