### PR TITLE
[webapp] Use existing button variant

### DIFF
--- a/services/webapp/ui/src/pages/Subscription.tsx
+++ b/services/webapp/ui/src/pages/Subscription.tsx
@@ -158,7 +158,7 @@ const Subscription = () => {
                       disabled={plan.price === '0'}
                       className="w-full"
                       size="lg"
-                      variant={plan.recommended ? 'primary' : 'secondary'}
+                      variant={plan.recommended ? 'default' : 'secondary'}
                     >
                       {plan.price === '0' ? 'Текущий тариф' : 'Выбрать тариф'}
                     </MedicalButton>


### PR DESCRIPTION
## Summary
- replace unsupported `primary` variant with `default` for recommended plan button

## Testing
- `pre-commit run --files services/webapp/ui/src/pages/Subscription.tsx`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype in components/ui/command.tsx; A `require()` style import is forbidden in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689b76945d1c832aa9f8463745fe5145