### PR TITLE
[handlers] Remove redundant local commit in profile command

### DIFF
--- a/services/api/app/diabetes/handlers/profile_handlers.py
+++ b/services/api/app/diabetes/handlers/profile_handlers.py
@@ -179,11 +179,6 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         await update.message.reply_text(str(exc))
         return ConversationHandler.END
 
-    session = SessionLocal()
-    if not commit_session(session):
-        await update.message.reply_text("⚠️ Не удалось сохранить профиль.")
-        return ConversationHandler.END
-
     await update.message.reply_text(
         f"✅ Профиль обновлён:\n"
         f"• ИКХ: {icr} г/ед.\n"


### PR DESCRIPTION
## Summary
- avoid creating a session in `profile_command` where no local DB changes are made
- update tests to reflect removal of local commit and stub profile API

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b78273988832ab31c2c55676c0360