### PR TITLE
[ui] Use Telegram user ID for reminders

### DIFF
--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -4,6 +4,7 @@ import { MedicalButton, Sheet } from "@/components";
 import { cn } from "@/lib/utils";
 import { createReminder, updateReminder } from "@/api/reminders";
 import { Reminder as ApiReminder } from "@sdk";
+import { useTelegram } from "@/hooks/useTelegram";
 
 type ReminderType = "sugar" | "insulin" | "meal";
 
@@ -43,6 +44,7 @@ export default function CreateReminder() {
   const navigate = useNavigate();
   const location = useLocation();
   const editing = (location.state as Reminder | undefined) ?? undefined;
+  const { user } = useTelegram();
 
   const [type, setType] = useState<ReminderType>(editing?.type ?? "sugar");
   const [title, setTitle] = useState(editing?.title ?? "");
@@ -58,10 +60,10 @@ export default function CreateReminder() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!formValid) return;
+    if (!formValid || !user?.id) return;
     setError(null);
     const payload: ApiReminder = {
-      telegramId: 1,
+      telegramId: user.id,
       type,
       time,
       intervalHours: interval,


### PR DESCRIPTION
## Summary
- retrieve Telegram user data in CreateReminder component
- send real Telegram user ID when saving reminders

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689b79441ae0832aa996af454154d8d2