### PR TITLE
[handlers] handle missing profile data

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -162,8 +162,13 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         )
         return ONB_PROFILE_TARGET
 
-    icr = context.user_data.pop("profile_icr")
-    cf = context.user_data.pop("profile_cf")
+    icr = context.user_data.pop("profile_icr", None)
+    cf = context.user_data.pop("profile_cf", None)
+    if icr is None or cf is None:
+        await update.message.reply_text(
+            "⚠️ Не хватает данных для профиля. Пожалуйста, начните заново."
+        )
+        return ConversationHandler.END
     user_id = update.effective_user.id
 
     with SessionLocal() as session:

--- a/services/api/app/diabetes/handlers/profile_handlers.py
+++ b/services/api/app/diabetes/handlers/profile_handlers.py
@@ -665,10 +665,15 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
             reply_markup=back_keyboard,
         )
         return PROFILE_HIGH
-    icr = context.user_data.pop("profile_icr")
-    cf = context.user_data.pop("profile_cf")
-    target = context.user_data.pop("profile_target")
-    context.user_data.pop("profile_low")
+    icr = context.user_data.pop("profile_icr", None)
+    cf = context.user_data.pop("profile_cf", None)
+    target = context.user_data.pop("profile_target", None)
+    context.user_data.pop("profile_low", None)
+    if icr is None or cf is None or target is None:
+        await update.message.reply_text(
+            "⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново."
+        )
+        return ConversationHandler.END
     user_id = update.effective_user.id
     with SessionLocal() as session:
         prof = session.get(Profile, user_id)


### PR DESCRIPTION
## Summary
- gracefully end onboarding when profile ICR/CF missing
- abort profile update if ICR/CF/target data absent

## Testing
- `ruff check services/api/app tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_689b7abbb5b8832aa793c865f3cff7d0