### PR TITLE
[webapp] Normalize reminder intervals

### DIFF
--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -18,7 +18,7 @@ interface Reminder {
   title: string
   time: string   // "HH:MM"
   active: boolean
-  interval?: number
+  interval?: number // stored in minutes
 }
 
 const TYPE_LABEL: Record<'sugar'|'insulin'|'meal'|'medicine', string> = {
@@ -150,7 +150,7 @@ export default function Reminders() {
             title: TYPE_LABEL[nt],
             time: r.time || '',
             active: r.isEnabled ?? false,
-            interval: r.intervalHours ?? undefined,
+            interval: r.intervalHours != null ? r.intervalHours * 60 : undefined,
           }
         })
         normalized.sort((a, b) => parseTimeToMinutes(a.time) - parseTimeToMinutes(b.time))
@@ -182,7 +182,7 @@ export default function Reminders() {
         id,
         type: target.type,
         time: target.time,
-        intervalHours: target.interval,
+        intervalHours: target.interval != null ? target.interval / 60 : undefined,
         isEnabled: nextActive,
       })
       toast({
@@ -248,7 +248,7 @@ export default function Reminders() {
             reminder={reminder}
             index={index}
             onToggle={handleToggleReminder}
-            onEdit={(r) => navigate(`/reminders/${r.id}/edit`)}
+            onEdit={(r) => navigate(`/reminders/${r.id}/edit`, { state: r })}
             onDelete={handleDeleteReminder}
           />
         ))}

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -49,6 +49,7 @@ export default function CreateReminder() {
   const [type, setType] = useState<ReminderType>(editing?.type ?? "sugar");
   const [title, setTitle] = useState(editing?.title ?? "");
   const [time, setTime] = useState(editing?.time ?? "");
+  // interval is stored in minutes for UI, API expects hours
   const [interval, setInterval] = useState<number | undefined>(editing?.interval ?? 60);
   const [error, setError] = useState<string | null>(null);
   const [typeOpen, setTypeOpen] = useState(false);
@@ -66,7 +67,7 @@ export default function CreateReminder() {
       telegramId: user.id,
       type,
       time,
-      intervalHours: interval,
+      intervalHours: interval != null ? interval / 60 : undefined,
       isEnabled: true,
       ...(editing ? { id: editing.id } : {}),
     };


### PR DESCRIPTION
## Summary
- store reminder intervals in minutes in UI
- convert intervals to hours for API calls and vice versa
- pass reminder data when navigating to edit page

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689b7aef84f8832a962448674664b272