### PR TITLE
[webapp] load reminder by id when editing

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -7,6 +7,17 @@ export async function getReminders(telegramId: number): Promise<Reminder[]> {
   return Array.isArray(data) ? data : [data];
 }
 
+export async function getReminder(
+  telegramId: number,
+  id: number,
+): Promise<Reminder | null> {
+  const data = await api.remindersGet({ telegramId, id });
+  if (Array.isArray(data)) {
+    return data[0] ?? null;
+  }
+  return data ?? null;
+}
+
 export async function createReminder(reminder: Reminder) {
   return api.remindersPost({ reminder });
 }


### PR DESCRIPTION
## Summary
- pass reminder data via router state when navigating to edit screen
- fetch reminder by id in CreateReminder if opened directly

## Testing
- `pytest tests`
- `ruff check services/api/app tests`


------
https://chatgpt.com/codex/tasks/task_e_689b7d431e98832abe161aaeaf8fea81