### PR TITLE
[webapp] Use custom reminder titles

### DIFF
--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -147,7 +147,7 @@ export default function Reminders() {
           return {
             id: r.id ?? 0,
             type: nt,
-            title: TYPE_LABEL[nt],
+            title: r.title ?? TYPE_LABEL[nt],
             time: r.time || '',
             active: r.isEnabled ?? false,
             interval: r.intervalHours != null ? r.intervalHours * 60 : undefined,


### PR DESCRIPTION
## Summary
- Display user's custom reminder title when available

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b7ef106dc832a9ad3f5d0876635bf