### PR TITLE
[webapp] Ensure history records disappear on deletion

### DIFF
--- a/services/webapp/ui/src/pages/History.tsx
+++ b/services/webapp/ui/src/pages/History.tsx
@@ -107,12 +107,28 @@ const History = () => {
       }
     }
   };
+  const handleDeleteRecord = async (id: string) => {
+    // Optimistically remove record from UI
+    setRecords(prev => prev.filter(r => r.id !== id));
 
-  const handleDeleteRecord = (id: string) => {
-    toast({
-      title: "Запись удалена",
-      description: "Запись успешно удалена из истории"
-    });
+    try {
+      const res = await fetch(`/api/history/${id}`, { method: 'DELETE' });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.status !== 'ok') {
+        throw new Error(data.detail || 'Не удалось удалить запись');
+      }
+      toast({
+        title: 'Запись удалена',
+        description: 'Запись успешно удалена из истории',
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Неизвестная ошибка';
+      toast({
+        title: 'Ошибка',
+        description: message,
+        variant: 'destructive',
+      });
+    }
   };
 
   const getRecordIcon = (type: string) => {


### PR DESCRIPTION
## Summary
- Optimistically remove history records from UI when deleted
- Attempt backend deletion via DELETE /api/history/:id and handle errors

## Testing
- `pre-commit run --files services/webapp/ui/src/pages/History.tsx`
- `npm --prefix services/webapp/ui run lint` *(fails: An interface declaring no members is equivalent to its supertype)*
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b80c54e28832aa1323580524519d7