### PR TITLE
[handlers] Allow numeric SOS contact IDs

### DIFF
--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -34,9 +34,10 @@ async def sos_contact_start(
 
 
 def _is_valid_contact(text: str) -> bool:
-    """Validate telegram username."""
+    """Validate telegram username or numeric chat ID."""
     username = re.fullmatch(r"@[A-Za-z][A-Za-z0-9_]{4,31}", text)
-    return bool(username)
+    chat_id = re.fullmatch(r"\d+", text)
+    return bool(username or chat_id)
 
 
 async def sos_contact_save(
@@ -46,7 +47,7 @@ async def sos_contact_save(
     contact = update.message.text.strip()
     if not _is_valid_contact(contact):
         await update.message.reply_text(
-            "❗ Укажите @username. Телефоны не поддерживаются.",
+            "❗ Укажите @username или числовой ID. Телефоны не поддерживаются.",
             reply_markup=back_keyboard,
         )
         return SOS_CONTACT

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -40,13 +40,14 @@ def test_session(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_soscontact_stores_contact(test_session):
+@pytest.mark.parametrize("contact", ["@alice", "123456"])
+async def test_soscontact_stores_contact(test_session, contact):
     with test_session() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(Profile(telegram_id=1))
         session.commit()
 
-    message = DummyMessage("@alice")
+    message = DummyMessage(contact)
     update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     context = SimpleNamespace()
 
@@ -57,7 +58,7 @@ async def test_soscontact_stores_contact(test_session):
 
     with test_session() as session:
         profile = session.get(Profile, 1)
-        assert profile.sos_contact == "@alice"
+        assert profile.sos_contact == contact
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow saving SOS contact by username or numeric chat id
- clarify SOS contact validation error message
- test SOS contact saving for usernames and numeric ids

## Testing
- `ruff check services/api/app tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689b8244e024832a9daba0725a8788c5