### PR TITLE
[ui] Use Link for NotFound page navigation

### DIFF
--- a/services/webapp/ui/src/pages/NotFound.tsx
+++ b/services/webapp/ui/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -16,9 +16,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- use React Router's Link instead of an anchor tag on the NotFound page to enable client-side navigation

## Testing
- `ruff check services/api/app tests`
- `pytest tests`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in UI components)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b820e7a5c832aa9548a6d50161b18