### PR TITLE
[reminders] Verify reminder ownership in callback

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -560,11 +560,15 @@ async def reminder_job(context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
-    await query.answer()
     action, rid_str = query.data.split(":")
     rid = int(rid_str)
     chat_id = update.effective_user.id
     with SessionLocal() as session:
+        rem = session.get(Reminder, rid)
+        if not rem or rem.telegram_id != chat_id:
+            await query.answer("Не найдено", show_alert=True)
+            return
+        await query.answer()
         session.add(
             ReminderLog(reminder_id=rid, telegram_id=chat_id, action=action)
         )


### PR DESCRIPTION
## Summary
- ensure reminder_callback checks reminder ownership before logging
- return warning if reminder is missing or belongs to another user
- add regression test for foreign reminder id

## Testing
- `ruff check services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py`
- `pytest tests/test_reminders.py::test_cancel_callback tests/test_reminders.py::test_reminder_callback_foreign_rid -q`

------
https://chatgpt.com/codex/tasks/task_e_689b839828a4832a834dc89210ff6f1b