### PR TITLE
[webapp] Ensure toast listener attaches only once

### DIFF
--- a/services/webapp/ui/src/hooks/use-toast.ts
+++ b/services/webapp/ui/src/hooks/use-toast.ts
@@ -179,7 +179,8 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // Empty dependency array ensures listener is added once and cleaned up on unmount
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent `useToast` from registering multiple listeners by using an empty dependency array
- keep cleanup to remove listener on unmount

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: DummyQuery.answer() got an unexpected keyword argument 'show_alert')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689b851b4db0832aa6a4adf4197ee18b