### PR TITLE
[alembic] Remove hardcoded sqlalchemy url

### DIFF
--- a/services/api/alembic.ini
+++ b/services/api/alembic.ini
@@ -64,8 +64,9 @@ version_path_separator = os
 # output_encoding = utf-8
 
 
-#sqlalchemy.url = driver://user:pass@localhost/dbname
-sqlalchemy.url = postgresql+psycopg2://sahar:sahar@localhost:5432/sahar_db
+# env.py injects the URL dynamically.
+# sqlalchemy.url = driver://user:pass@localhost/dbname
+# sqlalchemy.url = postgresql+psycopg2://sahar:sahar@localhost:5432/sahar_db
 
 
 


### PR DESCRIPTION
## Summary
- comment out hard-coded `sqlalchemy.url` in Alembic config and document that `env.py` injects it dynamically

## Testing
- `ruff check services/api/app tests`
- `python -m pytest tests` *(fails: DummyQuery.answer() got unexpected keyword argument 'show_alert')*

------
https://chatgpt.com/codex/tasks/task_e_689b854253e8832a8cd242bd7c7ebe22