### PR TITLE
[tests] add types for dummy messages

### DIFF
--- a/tests/test_alert_stats.py
+++ b/tests/test_alert_stats.py
@@ -1,5 +1,6 @@
 import datetime
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from sqlalchemy import create_engine
@@ -13,7 +14,7 @@ class DummyMessage:
     def __init__(self):
         self.texts: list[str] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
 
 

--- a/tests/test_dose_sugar_missing.py
+++ b/tests/test_dose_sugar_missing.py
@@ -1,6 +1,7 @@
 import datetime
-from types import SimpleNamespace
 import os
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from telegram.ext import ConversationHandler
@@ -12,12 +13,12 @@ from services.api.app.diabetes.handlers import dose_handlers
 
 
 class DummyMessage:
-    def __init__(self, text=""):
+    def __init__(self, text: str = ""):
         self.text = text
         self.replies: list[str] = []
-        self.kwargs: list[dict] = []
+        self.kwargs: list[dict[str, Any]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
         self.kwargs.append(kwargs)
 

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -1,6 +1,7 @@
 import os
 import datetime
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from sqlalchemy import create_engine
@@ -17,7 +18,7 @@ class DummyMessage:
         self.message_id = message_id
         self.replies: list[tuple[str, dict]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append((text, kwargs))
 
 

--- a/tests/test_freeform_handler_unknown.py
+++ b/tests/test_freeform_handler_unknown.py
@@ -1,15 +1,17 @@
 import pytest
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
+
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
 
 class DummyMessage:
-    def __init__(self, text):
+    def __init__(self, text: str):
         self.text = text
-        self.replies = []
+        self.replies: list[tuple[str, dict[str, Any]]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append((text, kwargs))
 
 

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -1,20 +1,21 @@
-import os
 import logging
+import os
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 
 class DummyMessage:
     def __init__(self):
-        self.replies = []
+        self.replies: list[tuple[str, dict[str, Any]]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append((text, kwargs))
 
 
 class DummyQuery:
-    def __init__(self, data):
+    def __init__(self, data: str):
         self.data = data
         self.edited = []
         self.edit_kwargs = []

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -1,8 +1,9 @@
 import datetime
+import json
 import logging
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
-import json
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
@@ -14,14 +15,14 @@ import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
 class DummyMessage:
     def __init__(self):
-        self.texts = []
+        self.texts: list[str] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
 
 
 class DummyQuery:
-    def __init__(self, data):
+    def __init__(self, data: str):
         self.data = data
         self.edited = []
 

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -1,8 +1,8 @@
-import pytest
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 from telegram import Message
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -1,16 +1,17 @@
 import datetime
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
 
 class DummyMessage:
-    def __init__(self, text):
+    def __init__(self, text: str):
         self.text = text
-        self.replies = []
+        self.replies: list[tuple[str, dict[str, Any]]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append((text, kwargs))
 
 

--- a/tests/test_handlers_freeform_units.py
+++ b/tests/test_handlers_freeform_units.py
@@ -1,14 +1,16 @@
 import pytest
 from types import SimpleNamespace
+from typing import Any
+
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
 
 class DummyMessage:
-    def __init__(self, text):
+    def __init__(self, text: str):
         self.text = text
-        self.replies = []
+        self.replies: list[tuple[str, dict[str, Any]]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append((text, kwargs))
 
 

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -1,6 +1,7 @@
-import os
 import datetime
+import os
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from sqlalchemy import create_engine
@@ -17,9 +18,9 @@ class DummyMessage:
         self.text = text
         self.chat_id = chat_id
         self.message_id = message_id
-        self.replies: list[tuple[str, dict]] = []
+        self.replies: list[tuple[str, dict[str, Any]]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append((text, kwargs))
 
 

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -8,24 +9,24 @@ import services.api.app.diabetes.handlers.common_handlers as common_handlers
 
 
 class DummyMessage:
-    def __init__(self, text=None, photo=None):
+    def __init__(self, text: str | None = None, photo: list[Any] | None = None):
         self.text = text
         self.photo = photo
-        self.replies = []
+        self.replies: list[tuple[str, dict[str, Any]]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append((text, kwargs))
 
 
 class DummyQuery:
-    def __init__(self, data):
+    def __init__(self, data: str):
         self.data = data
-        self.edited = []
+        self.edited: list[str] = []
 
-    async def answer(self):
+    async def answer(self) -> None:
         pass
 
-    async def edit_message_text(self, text, **kwargs):
+    async def edit_message_text(self, text: str, **kwargs: Any) -> None:
         self.edited.append(text)
 
 

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -1,5 +1,6 @@
 import pytest
 from types import SimpleNamespace
+from typing import Any
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from unittest.mock import MagicMock
@@ -13,14 +14,14 @@ from services.api.app.diabetes.services.db import Base, User, Profile
 
 class DummyMessage:
     def __init__(self):
-        self.texts = []
-        self.markups = []
+        self.texts: list[str] = []
+        self.markups: list[Any] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
         self.markups.append(kwargs.get("reply_markup"))
 
-    async def delete(self):
+    async def delete(self) -> None:
         pass
 
 

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -1,5 +1,6 @@
-from types import SimpleNamespace
 import os
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -13,9 +14,9 @@ from services.api.app.diabetes.utils.ui import sugar_keyboard
 class DummyMessage:
     def __init__(self):
         self.texts: list[str] = []
-        self.kwargs: list[dict] = []
+        self.kwargs: list[dict[str, Any]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
         self.kwargs.append(kwargs)
 

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -1,6 +1,7 @@
-import os
 import datetime
+import os
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -8,9 +9,9 @@ import pytest
 class DummyMessage:
     def __init__(self, text: str = ""):
         self.text = text
-        self.replies: list[tuple[str, dict]] = []
+        self.replies: list[tuple[str, dict[str, Any]]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append((text, kwargs))
 
 

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -1,17 +1,18 @@
 import pytest
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 
 
 class DummyMessage:
-    def __init__(self, text=None, photo=None):
+    def __init__(self, text: str | None = None, photo: list[Any] | None = None):
         self.text = text
         self.photo = photo
-        self.replies = []
+        self.replies: list[tuple[str, dict[str, Any]]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append((text, kwargs))
 
 

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -1,15 +1,16 @@
-import pytest
 from types import SimpleNamespace
+from typing import Any
 
+import pytest
 import services.api.app.diabetes.handlers.common_handlers as handlers
 
 
 class DummyMessage:
     def __init__(self):
-        self.replies = []
-        self.kwargs = []
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
         self.kwargs.append(kwargs)
 

--- a/tests/test_history_view_async.py
+++ b/tests/test_history_view_async.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -8,7 +9,7 @@ from services.api.app.diabetes.handlers import reporting_handlers
 
 
 class DummyMessage:
-    async def reply_text(self, *args, **kwargs):
+    async def reply_text(self, *args: Any, **kwargs: Any) -> None:
         pass
 
 

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -1,5 +1,6 @@
-from types import SimpleNamespace
 import os
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from telegram.ext import CommandHandler
@@ -11,12 +12,12 @@ from services.api.app.diabetes.handlers import dose_handlers
 
 
 class DummyMessage:
-    def __init__(self, text=""):
+    def __init__(self, text: str = ""):
         self.text = text
         self.replies: list[str] = []
-        self.kwargs: list[dict] = []
+        self.kwargs: list[dict[str, Any]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
         self.kwargs.append(kwargs)
 

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -1,7 +1,8 @@
+import logging
 import os
 from types import SimpleNamespace
+from typing import Any
 
-import logging
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -11,15 +12,17 @@ from services.api.app.diabetes.services.db import Base
 
 class DummyMessage:
     def __init__(self):
-        self.texts = []
-        self.photos = []
-        self.markups = []
+        self.texts: list[str] = []
+        self.photos: list[tuple[Any, str | None]] = []
+        self.markups: list[Any] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
         self.markups.append(kwargs.get("reply_markup"))
 
-    async def reply_photo(self, photo, caption=None, **kwargs):
+    async def reply_photo(
+        self, photo: Any, caption: str | None = None, **kwargs: Any
+    ) -> None:
         self.photos.append((photo, caption))
         self.markups.append(kwargs.get("reply_markup"))
 

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -1,5 +1,6 @@
 import os
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from sqlalchemy import create_engine
@@ -12,25 +13,29 @@ from services.api.app.diabetes.services.db import Base, User
 
 class DummyMessage:
     def __init__(self):
-        self.texts = []
-        self.photos = []
-        self.polls = []
-        self.markups = []
+        self.texts: list[str] = []
+        self.photos: list[tuple[Any, str | None]] = []
+        self.polls: list[tuple[str, list[str]]] = []
+        self.markups: list[Any] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
         self.markups.append(kwargs.get("reply_markup"))
 
-    async def reply_photo(self, photo, caption=None, **kwargs):
+    async def reply_photo(
+        self, photo: Any, caption: str | None = None, **kwargs: Any
+    ) -> None:
         self.photos.append((photo, caption))
         self.markups.append(kwargs.get("reply_markup"))
 
-    async def reply_poll(self, question, options, **kwargs):
+    async def reply_poll(
+        self, question: str, options: list[str], **kwargs: Any
+    ) -> SimpleNamespace:
         self.polls.append((question, options))
         self.markups.append(kwargs.get("reply_markup"))
         return SimpleNamespace(poll=SimpleNamespace(id="p1"))
 
-    async def delete(self):
+    async def delete(self) -> None:
         pass
 
 

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -1,5 +1,6 @@
-from types import SimpleNamespace
 import os
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from telegram.ext import MessageHandler
@@ -19,9 +20,9 @@ class DummyMessage:
     def __init__(self, text: str = ""):
         self.text = text
         self.replies: list[str] = []
-        self.kwargs: list[dict] = []
+        self.kwargs: list[dict[str, Any]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
         self.kwargs.append(kwargs)
 

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -1,5 +1,6 @@
 import os
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -13,12 +14,12 @@ from sqlalchemy.orm import sessionmaker
 
 
 class DummyMessage:
-    def __init__(self, text=""):
+    def __init__(self, text: str = ""):
         self.text = text
         self.replies: list[str] = []
-        self.kwargs: list[dict] = []
+        self.kwargs: list[dict[str, Any]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
         self.kwargs.append(kwargs)
 

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -1,8 +1,9 @@
 import pytest
-from types import SimpleNamespace
-from unittest.mock import MagicMock
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
 
 from services.api.app.diabetes.services.db import Base, User, Profile, Alert, Reminder
 import services.api.app.diabetes.handlers.profile_handlers as handlers
@@ -13,18 +14,18 @@ import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
 
 class DummyMessage:
     def __init__(self):
-        self.texts = []
-        self.markups = []
+        self.texts: list[str] = []
+        self.markups: list[Any] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
         self.markups.append(kwargs.get("reply_markup"))
 
 
 class DummyQuery:
-    def __init__(self, data):
+    def __init__(self, data: str):
         self.data = data
-        self.edits = []
+        self.edits: list[tuple[str, dict[str, Any]]] = []
         self.message = DummyMessage()
 
     async def answer(self):

--- a/tests/test_quick_input_help_button.py
+++ b/tests/test_quick_input_help_button.py
@@ -1,16 +1,17 @@
 import pytest
 from types import SimpleNamespace
+from typing import Any
 
 import services.api.app.diabetes.handlers.common_handlers as handlers
 
 
 class DummyMessage:
-    def __init__(self, text=""):
+    def __init__(self, text: str = ""):
         self.text = text
-        self.replies = []
-        self.kwargs = []
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
         self.kwargs.append(kwargs)
 

--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -1,5 +1,6 @@
 import json
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from sqlalchemy import create_engine
@@ -15,7 +16,7 @@ class DummyMessage:
         self.web_app_data = SimpleNamespace(data=data)
         self.replies: list[str] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
 
 

--- a/tests/test_reminder_limit_free_vs_pro.py
+++ b/tests/test_reminder_limit_free_vs_pro.py
@@ -1,6 +1,7 @@
-from types import SimpleNamespace
-
 import json
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -14,7 +15,7 @@ class DummyMessage:
         self.web_app_data = SimpleNamespace()
         self.replies: list[str] = []
 
-    async def reply_text(self, text, **kwargs):  # pragma: no cover - kwargs unused
+    async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - kwargs unused
         self.replies.append(text)
 
 

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -6,6 +6,8 @@ from types import SimpleNamespace
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from typing import Any
+
 from services.api.app.diabetes.services.db import Base, User, Reminder, ReminderLog
 import services.api.app.diabetes.handlers.reminder_handlers as handlers
 import services.api.app.diabetes.handlers.common_handlers as common_handlers
@@ -14,15 +16,15 @@ from services.api.app.diabetes.utils.helpers import parse_time_interval
 
 
 class DummyMessage:
-    def __init__(self, text=None):
+    def __init__(self, text: str | None = None):
         self.text = text
-        self.texts = []
-        self.edited = None
+        self.texts: list[str] = []
+        self.edited: tuple[str, dict[str, Any]] | None = None
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
 
-    async def edit_text(self, text, **kwargs):
+    async def edit_text(self, text: str, **kwargs: Any) -> None:
         self.edited = (text, kwargs)
 
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -4,6 +4,7 @@ import datetime
 import io
 import os
 from types import SimpleNamespace
+from typing import Any
 
 import matplotlib.pyplot as plt
 import pytest
@@ -167,15 +168,15 @@ async def test_send_report_uses_gpt(monkeypatch):
 
     class DummyMessage:
         def __init__(self):
-            self.docs = []
+            self.docs: list[Any] = []
 
-        async def reply_text(self, *args, **kwargs):
+        async def reply_text(self, *args: Any, **kwargs: Any) -> None:
             pass
 
-        async def reply_photo(self, *args, **kwargs):
+        async def reply_photo(self, *args: Any, **kwargs: Any) -> None:
             pass
 
-        async def reply_document(self, document, **kwargs):
+        async def reply_document(self, document: Any, **kwargs: Any) -> None:
             self.docs.append(document)
 
     message = DummyMessage()

--- a/tests/test_security_handlers.py
+++ b/tests/test_security_handlers.py
@@ -1,14 +1,15 @@
 import pytest
 from types import SimpleNamespace
+from typing import Any
 
 import services.api.app.diabetes.handlers.security_handlers as handlers
 
 
 class DummyMessage:
     def __init__(self):
-        self.replies = []
+        self.replies: list[str] = []
 
-    async def reply_text(self, text):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
 
 

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -1,8 +1,10 @@
 import os
 import re
-import pytest
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, call
+
+import pytest
 
 from .context_stub import AlertContext, ContextStub
 
@@ -19,11 +21,11 @@ from services.api.app.diabetes.utils.ui import menu_keyboard
 
 
 class DummyMessage:
-    def __init__(self, text):
+    def __init__(self, text: str):
         self.text = text
-        self.replies = []
+        self.replies: list[str] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
 
 

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -1,5 +1,6 @@
-from types import SimpleNamespace
 import os
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from telegram.ext import ConversationHandler, MessageHandler
@@ -11,12 +12,12 @@ from services.api.app.diabetes.handlers import dose_handlers
 
 
 class DummyMessage:
-    def __init__(self, text=""):
+    def __init__(self, text: str = ""):
         self.text = text
         self.replies: list[str] = []
-        self.kwargs: list[dict] = []
+        self.kwargs: list[dict[str, Any]] = []
 
-    async def reply_text(self, text, **kwargs):
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
         self.kwargs.append(kwargs)
 


### PR DESCRIPTION
## Summary
- annotate dummy message helpers with concrete types across tests
- cast Update and CallbackContext in photo fallback test

## Testing
- `pre-commit run --files tests/test_alert_stats.py tests/test_dose_conv_photo_fallback.py tests/test_dose_sugar_missing.py tests/test_edit_record.py tests/test_freeform_handler_unknown.py tests/test_handlers_cancel_entry.py tests/test_handlers_commit_failures.py tests/test_handlers_doc.py tests/test_handlers_freeform_pending.py tests/test_handlers_freeform_units.py tests/test_handlers_history_edit.py tests/test_handlers_photo_sugar_save.py tests/test_handlers_profile.py tests/test_handlers_prompts.py tests/test_handlers_report_request.py tests/test_handlers_vision_prompt.py tests/test_help_command.py tests/test_history_view_async.py tests/test_menu_fallbacks.py tests/test_onboarding_demo_photo_missing.py tests/test_onboarding_flow.py tests/test_photo_fallbacks.py tests/test_profile_ignores_sugar_conv.py tests/test_profile_security.py tests/test_quick_input_help_button.py tests/test_reminder_edit_block_leak.py tests/test_reminder_limit_free_vs_pro.py tests/test_reminders.py tests/test_reporting.py tests/test_security_handlers.py tests/test_sos_contact.py tests/test_sugar_exit.py`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b83735988832a95f59d842c8e0a83