### PR TITLE
[webapp] Handle empty reminder responses

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -4,7 +4,17 @@ const api = new DefaultApi();
 
 export async function getReminders(telegramId: number): Promise<Reminder[]> {
   const data = await api.remindersGet({ telegramId });
-  return Array.isArray(data) ? data : [data];
+
+  if (!data) {
+    return [];
+  }
+
+  if (!Array.isArray(data)) {
+    console.error('Unexpected reminders API response:', data);
+    return [];
+  }
+
+  return data;
 }
 
 export async function getReminder(


### PR DESCRIPTION
## Summary
- Guard against falsy reminder responses
- Log unexpected reminder payload shapes

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` *(fails: DummyQuery.answer() got an unexpected keyword argument 'show_alert')*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689b86ce8d24832ab3bdb1d77c82a536