### PR TITLE
[handlers] Register addreminder command

### DIFF
--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -284,6 +284,7 @@ def register_handlers(app: Application) -> None:
     app.add_handler(CommandHandler("help", help_command))
     app.add_handler(CommandHandler("gpt", dose_handlers.chat_with_gpt))
     app.add_handler(CommandHandler("reminders", reminder_handlers.reminders_list))
+    app.add_handler(CommandHandler("addreminder", reminder_handlers.add_reminder))
     app.add_handler(reminder_handlers.reminder_action_handler)
     app.add_handler(reminder_handlers.reminder_webapp_handler)
     app.add_handler(CommandHandler("delreminder", reminder_handlers.delete_reminder))

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -25,7 +25,7 @@ class DummyQuery:
         self.data = data
         self.edited = []
 
-    async def answer(self):
+    async def answer(self, *args, **kwargs):
         pass
 
     async def edit_message_text(self, text, **kwargs):
@@ -240,8 +240,10 @@ async def test_reminder_callback_commit_failure(monkeypatch, caplog):
     session.add = MagicMock()
     session.commit.side_effect = SQLAlchemyError("fail")
     session.rollback = MagicMock()
+    session.get.return_value = SimpleNamespace(id=1, telegram_id=1)
 
     monkeypatch.setattr(reminder_handlers, "SessionLocal", lambda: session)
+    reminder_handlers.commit_session = common_handlers.commit_session
 
     query = DummyQuery("remind_snooze:1")
     update = SimpleNamespace(

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -50,6 +50,11 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
         and h.callback is reminder_handlers.reminder_webapp_save
         for h in handlers
     )
+    assert any(
+        isinstance(h, CommandHandler)
+        and h.callback is reminder_handlers.add_reminder
+        for h in handlers
+    )
 
     onb_conv = [
         h


### PR DESCRIPTION
## Summary
- register /addreminder command alongside other reminder handlers
- cover new command registration in tests and fix reminder callback failure test

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b8731331c832a8e4c885cd11da29f