### PR TITLE
[handlers] Notify reminder save failure

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -483,6 +483,9 @@ async def reminder_webapp_save(
         )
         return
     if status == "error":
+        await update.effective_message.reply_text(
+            "⚠️ Не удалось сохранить напоминание."
+        )
         return
 
     schedule_reminder(rem, context.job_queue)

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -173,7 +173,7 @@ async def test_reminder_webapp_save_commit_failure(monkeypatch, caplog):
     assert not session.refresh.called
     assert not schedule_mock.called
     assert not render_mock.called
-    assert message.texts == []
+    assert message.texts == ["⚠️ Не удалось сохранить напоминание."]
     assert "Failed to commit reminder via webapp" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- Inform users when webapp reminder saving fails
- Update commit failure test accordingly

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b8a60ab80832aa392b6ad7b6685d1