### PR TITLE
[bot] Handle invalid database configuration

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -36,9 +36,14 @@ def main() -> None:
 
     try:
         init_db()
+    except ValueError as exc:
+        logger.error("Invalid database configuration", exc_info=exc)
+        sys.exit("Invalid configuration. Please check your settings and try again.")
     except SQLAlchemyError as exc:
         logger.error("Failed to initialize the database", exc_info=exc)
-        sys.exit("Database initialization failed. Please check your configuration and try again.")
+        sys.exit(
+            "Database initialization failed. Please check your configuration and try again."
+        )
 
     BOT_TOKEN = TELEGRAM_TOKEN
     if not BOT_TOKEN:


### PR DESCRIPTION
## Summary
- gracefully handle `ValueError` when initializing the bot's database

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b8e876fe4832a81186d947bf0263a