### PR TITLE
[tests] annotate async helpers and cast reminder stubs

### DIFF
--- a/tests/test_add_reminder_wizard.py
+++ b/tests/test_add_reminder_wizard.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from telegram import Update
+from telegram.ext import ContextTypes
 
 import services.api.app.diabetes.handlers.reminder_handlers as handlers
 from services.api.app.diabetes.handlers.common_handlers import commit_session
@@ -72,8 +74,10 @@ async def test_webapp_save_creates_reminder(
         session.commit()
 
     msg = DummyMessage(json.dumps({"type": "sugar", "value": "08:00"}))
-    update = UpdateStub(effective_message=msg, effective_user=DummyUser(id=1))
-    context = CallbackContextStub(job_queue=DummyJobQueue())
+    update = cast(Update, UpdateStub(effective_message=msg, effective_user=DummyUser(id=1)))
+    context = cast(
+        ContextTypes.DEFAULT_TYPE, CallbackContextStub(job_queue=DummyJobQueue())
+    )
     await handlers.reminder_webapp_save(update, context)
 
     with TestSession() as session:
@@ -96,8 +100,10 @@ async def test_webapp_save_creates_interval(
         session.commit()
 
     msg = DummyMessage(json.dumps({"type": "sugar", "value": "2h"}))
-    update = UpdateStub(effective_message=msg, effective_user=DummyUser(id=1))
-    context = CallbackContextStub(job_queue=DummyJobQueue())
+    update = cast(Update, UpdateStub(effective_message=msg, effective_user=DummyUser(id=1)))
+    context = cast(
+        ContextTypes.DEFAULT_TYPE, CallbackContextStub(job_queue=DummyJobQueue())
+    )
     await handlers.reminder_webapp_save(update, context)
 
     with TestSession() as session:

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -162,7 +162,7 @@ async def test_three_alerts_notify(monkeypatch) -> None:
 
     update = SimpleNamespace(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
     context: AlertContext = ContextStub(bot=cast(Bot, DummyBot()))
-    async def fake_get_coords_and_link():
+    async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
         return ("0,0", "link")
 
     monkeypatch.setattr(handlers, "get_coords_and_link", fake_get_coords_and_link)
@@ -210,7 +210,7 @@ async def test_alert_message_without_coords(monkeypatch) -> None:
     update = SimpleNamespace(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
     context: AlertContext = ContextStub(bot=cast(Bot, DummyBot()))
 
-    async def fake_get_coords_and_link():
+    async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
         return None, None
 
     monkeypatch.setattr(handlers, "get_coords_and_link", fake_get_coords_and_link)

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -70,7 +70,7 @@ async def test_entry_without_dose_has_no_unit(
         def add(self, entry):
             self.entry = entry
 
-    async def noop(*args, **kwargs):
+    async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
     monkeypatch.setattr(dose_handlers, "SessionLocal", lambda: DummySession())
@@ -116,7 +116,7 @@ async def test_entry_without_sugar_has_placeholder(
         def add(self, entry):
             self.entry = entry
 
-    async def noop(*args, **kwargs):
+    async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
     monkeypatch.setattr(dose_handlers, "SessionLocal", lambda: DummySession())

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -25,15 +25,15 @@ class DummyMessage(Message):
 async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) -> None:
     called = SimpleNamespace(flag=False)
 
-    async def fake_photo_handler(update, context):
+    async def fake_photo_handler(update, context) -> str:
         called.flag = True
         return "OK"
 
     class DummyFile:
-        async def download_to_drive(self, path):
+        async def download_to_drive(self, path) -> None:
             self.path = path
 
-    async def fake_get_file(file_id):
+    async def fake_get_file(file_id: str) -> DummyFile:
         return DummyFile()
 
     dummy_bot = SimpleNamespace(get_file=fake_get_file)
@@ -63,7 +63,7 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
 async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> None:
     called = SimpleNamespace(flag=False)
 
-    async def fake_photo_handler(update, context):
+    async def fake_photo_handler(update, context) -> None:
         called.flag = True
 
     document = SimpleNamespace(
@@ -106,17 +106,17 @@ async def test_photo_handler_preserves_file(monkeypatch, tmp_path) -> None:
         file_id = "fid"
         file_unique_id = "uid"
 
-    async def reply_text(*args, **kwargs):
+    async def reply_text(*args: Any, **kwargs: Any) -> None:
         pass
 
     message = SimpleNamespace(photo=[DummyPhoto()], reply_text=reply_text)
     update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
 
     class DummyFile:
-        async def download_to_drive(self, path):
+        async def download_to_drive(self, path) -> None:
             Path(path).write_bytes(b"img")
 
-    async def fake_get_file(file_id):
+    async def fake_get_file(file_id: str) -> DummyFile:
         return DummyFile()
 
     dummy_bot = SimpleNamespace(get_file=fake_get_file)
@@ -172,10 +172,10 @@ async def test_photo_then_freeform_calculates_dose(monkeypatch, tmp_path) -> Non
         file_unique_id = "uid"
 
     class DummyFile:
-        async def download_to_drive(self, path):
+        async def download_to_drive(self, path) -> None:
             Path(path).write_bytes(b"img")
 
-    async def fake_get_file(file_id):
+    async def fake_get_file(file_id: str) -> DummyFile:
         return DummyFile()
 
     monkeypatch.chdir(tmp_path)

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -60,7 +60,7 @@ session = DummySession()
 
 @pytest.mark.asyncio
 async def test_photo_flow_saves_entry(monkeypatch, tmp_path) -> None:
-    async def fake_parse_command(text):
+    async def fake_parse_command(text: str) -> dict[str, Any]:
         return {"action": "add_entry", "fields": {}, "entry_date": None, "time": None}
 
     monkeypatch.setattr(dose_handlers, "parse_command", fake_parse_command)
@@ -76,9 +76,9 @@ async def test_photo_flow_saves_entry(monkeypatch, tmp_path) -> None:
 
     monkeypatch.chdir(tmp_path)
 
-    async def fake_get_file(file_id):
+    async def fake_get_file(file_id: str) -> Any:
         class File:
-            async def download_to_drive(self, path):
+            async def download_to_drive(self, path: str) -> None:
                 Path(path).write_bytes(b"img")
 
         return File()
@@ -143,7 +143,7 @@ async def test_photo_flow_saves_entry(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(common_handlers, "SessionLocal", lambda: session)
     import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
 
-    async def noop(*a, **k):
+    async def noop(*a: Any, **k: Any) -> None:
         return None
 
     monkeypatch.setattr(alert_handlers, "check_alert", noop)

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -58,7 +58,9 @@ async def test_report_request_and_custom_flow(monkeypatch) -> None:
 
     called = {}
 
-    async def dummy_send_report(update, context, date_from, period_label, query=None):
+    async def dummy_send_report(
+        update, context, date_from, period_label, query=None
+    ) -> None:
         called["called"] = True
         expected = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
         assert date_from == expected
@@ -84,7 +86,9 @@ async def test_report_period_callback_week(monkeypatch) -> None:
 
     called: dict[str, datetime.datetime | str] = {}
 
-    async def dummy_send_report(update, context, date_from, period_label, query=None):
+    async def dummy_send_report(
+        update, context, date_from, period_label, query=None
+    ) -> None:
         called["date_from"] = date_from
         called["period_label"] = period_label
 

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -25,14 +25,14 @@ class DummyPhoto:
 async def test_photo_prompt_includes_dish_name(monkeypatch, tmp_path) -> None:
     monkeypatch.chdir(tmp_path)
 
-    async def fake_get_file(file_id):
+    async def fake_get_file(file_id: str) -> Any:
         class File:
-            async def download_to_drive(self, path):
+            async def download_to_drive(self, path: str) -> None:
                 Path(path).write_bytes(b"img")
 
         return File()
 
-    async def fake_send_chat_action(*args, **kwargs):
+    async def fake_send_chat_action(*args: Any, **kwargs: Any) -> None:
         pass
 
     context = SimpleNamespace(

--- a/tests/test_history_view_async.py
+++ b/tests/test_history_view_async.py
@@ -54,7 +54,7 @@ async def test_history_view_does_not_block_event_loop(monkeypatch) -> None:
 
     flag = False
 
-    async def marker():
+    async def marker() -> None:
         nonlocal flag
         await asyncio.sleep(0.1)
         flag = True

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -27,7 +27,7 @@ class DummyMessage:
         self.kwargs.append(kwargs)
 
 
-async def _exercise(handler):
+async def _exercise(handler) -> None:
     message = DummyMessage("📷 Фото еды")
     update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     context = SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}, "dose_method": "xe"})

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -90,7 +90,7 @@ async def test_profile_security_threshold_changes(monkeypatch, action, expected_
 
     calls = []
 
-    async def fake_eval(user_id, sugar, job_queue):
+    async def fake_eval(user_id, sugar, job_queue) -> None:
         calls.append((user_id, sugar, job_queue))
 
     monkeypatch.setattr(handlers, "evaluate_sugar", fake_eval)
@@ -135,7 +135,7 @@ async def test_profile_security_toggle_sos_alerts(monkeypatch) -> None:
 
     calls = []
 
-    async def fake_eval(user_id, sugar, job_queue):
+    async def fake_eval(user_id, sugar, job_queue) -> None:
         calls.append((user_id, sugar, job_queue))
 
     monkeypatch.setattr(handlers, "evaluate_sugar", fake_eval)
@@ -202,7 +202,7 @@ async def test_profile_security_add_delete_calls_handlers(monkeypatch) -> None:
 
     called = {"del": False}
 
-    async def fake_del(update, context):
+    async def fake_del(update, context) -> None:
         called["del"] = True
 
     monkeypatch.setattr(reminder_handlers, "delete_reminder", fake_del)
@@ -237,7 +237,7 @@ async def test_profile_security_sos_contact_calls_handler(monkeypatch) -> None:
 
     called = False
 
-    async def fake_sos(update, context):
+    async def fake_sos(update, context) -> None:
         nonlocal called
         called = True
 

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -238,7 +238,7 @@ async def test_reminders_list_no_keyboard(monkeypatch) -> None:
 
     captured: dict[str, dict] = {}
 
-    async def fake_reply_text(text, **kwargs):
+    async def fake_reply_text(text: str, **kwargs: Any) -> None:
         captured["text"] = text
         captured["kwargs"] = kwargs
 

--- a/tests/test_run_db.py
+++ b/tests/test_run_db.py
@@ -1,5 +1,6 @@
 import asyncio
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from sqlalchemy import create_engine
@@ -15,7 +16,7 @@ async def test_run_db_sqlite_in_memory(monkeypatch) -> None:
 
     called = False
 
-    async def fake_to_thread(fn, *args, **kwargs):
+    async def fake_to_thread(fn, *args: Any, **kwargs: Any) -> Any:
         nonlocal called
         called = True
         return fn(*args, **kwargs)
@@ -49,7 +50,7 @@ async def test_run_db_postgres(monkeypatch) -> None:
 
     called = False
 
-    async def fake_to_thread(fn, *args, **kwargs):
+    async def fake_to_thread(fn, *args: Any, **kwargs: Any) -> Any:
         nonlocal called
         called = True
         return fn(*args, **kwargs)

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -83,7 +83,7 @@ async def test_alert_notifies_user_and_contact(test_session, monkeypatch) -> Non
     context: AlertContext = ContextStub(bot=cast(Bot, SimpleNamespace()))
     send_mock = AsyncMock()
     monkeypatch.setattr(context.bot, "send_message", send_mock, raising=False)
-    async def fake_get_coords_and_link():
+    async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
         return ("0,0", "link")
 
     monkeypatch.setattr(alert_handlers, "get_coords_and_link", fake_get_coords_and_link)
@@ -122,7 +122,7 @@ async def test_alert_skips_phone_contact(test_session, monkeypatch) -> None:
     send_mock = AsyncMock()
     monkeypatch.setattr(context.bot, "send_message", send_mock, raising=False)
 
-    async def fake_get_coords_and_link():
+    async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
         return ("0,0", "link")
 
     monkeypatch.setattr(alert_handlers, "get_coords_and_link", fake_get_coords_and_link)


### PR DESCRIPTION
## Summary
- annotate async helper functions with explicit return types
- cast reminder stubs to `telegram.Update` and `ContextTypes.DEFAULT_TYPE` before calling `reminder_webapp_save`

## Testing
- `ruff check services/api/app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b8ed0ecc0832aae24c7d575425b7e