### PR TITLE
[tests] Type hint caplog fixture in logging truncation test

### DIFF
--- a/tests/test_dose_handlers_logging.py
+++ b/tests/test_dose_handlers_logging.py
@@ -1,9 +1,13 @@
 import logging
 
+import pytest
+
 from services.api.app.diabetes.handlers import dose_handlers
 
 
-def test_logging_truncates_content(caplog):
+def test_logging_truncates_content(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     long_text = "A" * 250 + "\x00\x01"
     with caplog.at_level(logging.DEBUG):
         dose_handlers.logger.debug("test %s", dose_handlers._sanitize(long_text))


### PR DESCRIPTION
## Summary
- add `pytest.LogCaptureFixture` type hint to `test_logging_truncates_content`

## Testing
- `ruff check services/api/app tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_689b91d3a11c832a81a22554b16f8a8a