### PR TITLE
[middleware] Validate X-User-Id header

### DIFF
--- a/services/api/app/middleware/auth.py
+++ b/services/api/app/middleware/auth.py
@@ -9,7 +9,14 @@ logger = logging.getLogger(__name__)
 
 class AuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        user_id = request.headers.get("X-User-Id")
+        user_id_header = request.headers.get("X-User-Id")
+        if user_id_header is None:
+            raise HTTPException(status_code=401, detail="invalid user id")
+        try:
+            user_id = int(user_id_header)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=401, detail="invalid user id")
+
         role = request.headers.get("X-Role", "patient")
         if role not in ALLOWED_ROLES:
             raise HTTPException(status_code=401, detail="invalid role")

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,0 +1,43 @@
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
+
+from services.api.app.middleware.auth import AuthMiddleware
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware)
+
+    @app.get("/whoami")
+    async def whoami(request: Request) -> dict[str, int]:
+        return {"user_id": request.state.user_id}
+
+    return app
+
+
+def test_valid_user_id_header() -> None:
+    app = create_app()
+    client = TestClient(app)
+    response = client.get("/whoami", headers={"X-User-Id": "123"})
+    assert response.status_code == 200
+    assert response.json() == {"user_id": 123}
+
+
+def test_missing_user_id_header() -> None:
+    app = create_app()
+    client = TestClient(app)
+    with pytest.raises(HTTPException) as exc_info:
+        client.get("/whoami")
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "invalid user id"
+
+
+def test_invalid_user_id_header() -> None:
+    app = create_app()
+    client = TestClient(app)
+    with pytest.raises(HTTPException) as exc_info:
+        client.get("/whoami", headers={"X-User-Id": "abc"})
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "invalid user id"
+


### PR DESCRIPTION
## Summary
- Validate `X-User-Id` header and store parsed integer in request state
- Test middleware for valid, missing, and invalid user id headers

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b919a225c832a928e054df16ef6e9