### PR TITLE
[handlers] Use exception logging for DB commit failures

### DIFF
--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -43,9 +43,9 @@ def commit_session(session) -> bool:
     try:
         session.commit()
         return True
-    except SQLAlchemyError as exc:  # pragma: no cover - logging only
+    except SQLAlchemyError:  # pragma: no cover - logging only
         session.rollback()
-        logger.error("DB commit failed: %s", exc)
+        logger.exception("DB commit failed")
         return False
 
 


### PR DESCRIPTION
## Summary
- use `logger.exception` in commit_session for failed database commits

## Testing
- `ruff check services/api/app tests`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_689b93682ce0832aba96c0a0b2c48008