### PR TITLE
[bot] Fix error handler type for mypy compatibility

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -7,7 +7,7 @@ import logging
 import sys
 from typing import Any
 
-from telegram import BotCommand, Update
+from telegram import BotCommand
 from telegram.ext import Application, ContextTypes
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 TELEGRAM_TOKEN = settings.telegram_token
 
 
-async def error_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Log errors that occur while processing updates."""
     logger.exception(
         "Exception while handling update %s", update, exc_info=context.error


### PR DESCRIPTION
## Summary
- allow `error_handler` to accept `object` instead of `Update`
- clean up imports in `services/bot/main.py`

## Testing
- `ruff check services/api/app tests services/bot/main.py`
- `mypy services/bot/main.py --ignore-missing-imports --follow-imports skip`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_689b93bb4fdc832aa5d85799f27be7e0