### PR TITLE
[mypy] Ignore missing imports for external SDKs

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,11 @@
 [mypy]
 explicit_package_bases = True
+
+[mypy-telegram.*]
+ignore_missing_imports = True
+
+[mypy-openai.*]
+ignore_missing_imports = True
+
+[mypy-diabetes_sdk.*]
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- silence missing import errors for telegram, openai, and diabetes_sdk modules

## Testing
- `mypy services/api/app`
- `ruff check services/api/app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b959d695c832a97a49b5f7c06c889