### PR TITLE
[handlers] Combine onboarding greeting lines

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -85,8 +85,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
             return ConversationHandler.END
 
     await update.message.reply_text(
-        "👋 Привет! Давай начнём.\n"
-        "1/3. Введите коэффициент ИКХ (г/ед.):",
+        "👋 Привет! Давай начнём.\n1/3. Введите коэффициент ИКХ (г/ед.):",
         reply_markup=_skip_markup(),
     )
     return ONB_PROFILE_ICR


### PR DESCRIPTION
## Summary
- simplify onboarding start message by merging greeting and step prompt into a single reply

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b97063b50832a88ff2df180dc6948