### PR TITLE
[alembic] Load root env file

### DIFF
--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -4,6 +4,7 @@ from sqlalchemy import pool
 from alembic import context
 
 import os
+from pathlib import Path
 from urllib.parse import quote_plus
 
 try:
@@ -12,7 +13,7 @@ except ModuleNotFoundError:  # pragma: no cover
     def load_dotenv(*_args, **_kwargs):  # type: ignore
         return None
 else:
-    load_dotenv()
+    load_dotenv(Path(__file__).resolve().parents[2] / ".env")
 
 
 config = context.config


### PR DESCRIPTION
## Summary
- ensure alembic loads root `.env` file using `Path`
- retain `quote_plus` password encoding

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b9853c8fc832a9c77dfa91e82b275