### PR TITLE
[webapp] Handle reminder API errors

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -3,39 +3,64 @@ import { DefaultApi, Reminder } from '@sdk';
 const api = new DefaultApi();
 
 export async function getReminders(telegramId: number): Promise<Reminder[]> {
-  const data = await api.remindersGet({ telegramId });
+  try {
+    const data = await api.remindersGet({ telegramId });
 
-  if (!data) {
-    return [];
+    if (!data) {
+      return [];
+    }
+
+    if (!Array.isArray(data)) {
+      console.error('Unexpected reminders API response:', data);
+      return [];
+    }
+
+    return data;
+  } catch (error) {
+    console.error('Failed to fetch reminders:', error);
+    throw new Error('Не удалось загрузить напоминания');
   }
-
-  if (!Array.isArray(data)) {
-    console.error('Unexpected reminders API response:', data);
-    return [];
-  }
-
-  return data;
 }
 
 export async function getReminder(
   telegramId: number,
   id: number,
 ): Promise<Reminder | null> {
-  const data = await api.remindersGet({ telegramId, id });
-  if (Array.isArray(data)) {
-    return data[0] ?? null;
+  try {
+    const data = await api.remindersGet({ telegramId, id });
+    if (Array.isArray(data)) {
+      return data[0] ?? null;
+    }
+    return data ?? null;
+  } catch (error) {
+    console.error('Failed to fetch reminder:', error);
+    throw new Error('Не удалось загрузить напоминание');
   }
-  return data ?? null;
 }
 
 export async function createReminder(reminder: Reminder) {
-  return api.remindersPost({ reminder });
+  try {
+    return await api.remindersPost({ reminder });
+  } catch (error) {
+    console.error('Failed to create reminder:', error);
+    throw new Error('Не удалось создать напоминание');
+  }
 }
 
 export async function updateReminder(reminder: Reminder) {
-  return api.remindersPatch({ reminder });
+  try {
+    return await api.remindersPatch({ reminder });
+  } catch (error) {
+    console.error('Failed to update reminder:', error);
+    throw new Error('Не удалось обновить напоминание');
+  }
 }
 
 export async function deleteReminder(telegramId: number, id: number) {
-  return api.remindersDelete({ telegramId, id });
+  try {
+    return await api.remindersDelete({ telegramId, id });
+  } catch (error) {
+    console.error('Failed to delete reminder:', error);
+    throw new Error('Не удалось удалить напоминание');
+  }
 }

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -155,10 +155,11 @@ export default function Reminders() {
         })
         normalized.sort((a, b) => parseTimeToMinutes(a.time) - parseTimeToMinutes(b.time))
         setReminders(normalized)
-      } catch {
+      } catch (err) {
         if (!cancelled) {
-          setError('Не удалось загрузить напоминания')
-          toast({ title: 'Ошибка', description: 'Не удалось загрузить напоминания', variant: 'destructive' })
+          const message = err instanceof Error ? err.message : 'Не удалось загрузить напоминания'
+          setError(message)
+          toast({ title: 'Ошибка', description: message, variant: 'destructive' })
         }
       } finally {
         if (!cancelled) setLoading(false)
@@ -189,11 +190,12 @@ export default function Reminders() {
         title: 'Напоминание обновлено',
         description: 'Статус напоминания изменён',
       })
-    } catch {
+    } catch (err) {
       setReminders(prevReminders)
+      const message = err instanceof Error ? err.message : 'Не удалось обновить напоминание'
       toast({
         title: 'Ошибка',
-        description: 'Не удалось обновить напоминание',
+        description: message,
         variant: 'destructive',
       })
     }
@@ -209,11 +211,12 @@ export default function Reminders() {
         title: 'Напоминание удалено',
         description: 'Напоминание успешно удалено',
       })
-    } catch {
+    } catch (err) {
       setReminders(prevReminders)
+      const message = err instanceof Error ? err.message : 'Не удалось удалить напоминание'
       toast({
         title: 'Ошибка',
-        description: 'Не удалось удалить напоминание',
+        description: message,
         variant: 'destructive',
       })
     }

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { createReminder, updateReminder, getReminder } from "@/api/reminders";
 import { Reminder as ApiReminder } from "@sdk";
 import { useTelegram } from "@/hooks/useTelegram";
+import { useToast } from "@/hooks/use-toast";
 
 type ReminderType = "sugar" | "insulin" | "meal";
 
@@ -45,6 +46,7 @@ export default function CreateReminder() {
   const location = useLocation();
   const params = useParams();
   const { user } = useTelegram();
+  const { toast } = useToast();
   const [editing, setEditing] = useState<Reminder | undefined>(
     (location.state as Reminder | undefined) ?? undefined,
   );
@@ -77,10 +79,15 @@ export default function CreateReminder() {
             setTime(loaded.time);
             setInterval(loaded.interval ?? 60);
           } else {
-            setError("Не удалось загрузить напоминание");
+            const message = "Не удалось загрузить напоминание";
+            setError(message);
+            toast({ title: "Ошибка", description: message, variant: "destructive" });
           }
-        } catch {
-          setError("Не удалось загрузить напоминание");
+        } catch (err) {
+          const message =
+            err instanceof Error ? err.message : "Не удалось загрузить напоминание";
+          setError(message);
+          toast({ title: "Ошибка", description: message, variant: "destructive" });
         }
       })();
     }
@@ -110,8 +117,11 @@ export default function CreateReminder() {
         await createReminder(payload);
       }
       navigate("/reminders");
-    } catch {
-      setError("Не удалось сохранить напоминание");
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Не удалось сохранить напоминание";
+      setError(message);
+      toast({ title: "Ошибка", description: message, variant: "destructive" });
     }
   };
 


### PR DESCRIPTION
## Summary
- wrap reminders API calls with try/catch and descriptive errors
- handle reminder API failures on listing page
- surface reminder load/save errors in editor page

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b98925318832aa132acb4b08862c6