### PR TITLE
[docs] Add Alembic migration setup instructions

### DIFF
--- a/services/api/alembic/README
+++ b/services/api/alembic/README
@@ -1,1 +1,8 @@
+# Alembic Migrations
+
 Generic single-database configuration.
+
+## Running migrations
+
+Copy `infra/env/.env.example` to `.env`, edit credentials, and install `python-dotenv` before running `alembic upgrade head`.
+


### PR DESCRIPTION
## Summary
- document copying `.env.example` and installing `python-dotenv` before `alembic upgrade head`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b9b4dd2a4832aa6fcae506743b7c1