### PR TITLE
[handlers] Build demo photo path via pathlib

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -14,6 +14,7 @@ invocations show the greeting and menu without triggering the wizard.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from telegram import (
     InlineKeyboardButton,
@@ -35,6 +36,10 @@ from .common_handlers import commit_session
 from zoneinfo import ZoneInfo
 
 logger = logging.getLogger(__name__)
+
+DEMO_PHOTO_PATH = (
+    Path(__file__).resolve().parents[5] / "docs" / "assets" / "demo.jpg"
+)
 
 
 # Wizard states
@@ -231,7 +236,7 @@ async def onboarding_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE
         [[InlineKeyboardButton("Далее", callback_data="onb_next")]]
     )
     try:
-        with open("docs/assets/demo.jpg", "rb") as photo:
+        with DEMO_PHOTO_PATH.open("rb") as photo:
             await update.message.reply_photo(
                 photo=photo,
                 caption="2/3. Вот пример распознавания еды.",

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -58,16 +58,16 @@ async def test_onboarding_demo_photo_missing(monkeypatch, caplog) -> None:
     update.message.text = "6"
     await onboarding.onboarding_target(update, context)
 
-    import builtins
+    import pathlib
 
-    orig_open = builtins.open
+    orig_open = pathlib.Path.open
 
-    def fake_open(path, *args, **kwargs):
-        if path == "docs/assets/demo.jpg":
+    def fake_open(self, *args, **kwargs):
+        if self == onboarding.DEMO_PHOTO_PATH:
             raise OSError("missing")
-        return orig_open(path, *args, **kwargs)
+        return orig_open(self, *args, **kwargs)
 
-    monkeypatch.setattr(builtins, "open", fake_open)
+    monkeypatch.setattr(pathlib.Path, "open", fake_open)
 
     update.message.text = "Europe/Moscow"
     with caplog.at_level(logging.ERROR):


### PR DESCRIPTION
## Summary
- construct demo photo path using `Path` and read via `Path.open`
- adjust onboarding demo photo test to mock `Path.open`

## Testing
- `ruff check services/api/app tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_689b9dd194cc832ab633dbef3438f5a0