### PR TITLE
[tests] Add explicit typing for freeform handler tests

### DIFF
--- a/tests/test_freeform_handler_unknown.py
+++ b/tests/test_freeform_handler_unknown.py
@@ -1,7 +1,10 @@
 import pytest
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock
+
+from telegram import Update
+from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
@@ -16,10 +19,17 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_freeform_handler_unknown_command(monkeypatch) -> None:
+async def test_freeform_handler_unknown_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     message = DummyMessage("blah")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={})
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+    )
 
     monkeypatch.setattr(handlers, "parse_command", AsyncMock(return_value=None))
 

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
-from telegram import Message
+from telegram import Message, Update
+from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
@@ -99,7 +100,9 @@ async def test_photo_handler_handles_typeerror() -> None:
 
 
 @pytest.mark.asyncio
-async def test_photo_handler_preserves_file(monkeypatch, tmp_path) -> None:
+async def test_photo_handler_preserves_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     monkeypatch.chdir(tmp_path)
 
     class DummyPhoto:
@@ -164,7 +167,9 @@ async def test_photo_handler_preserves_file(monkeypatch, tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_photo_then_freeform_calculates_dose(monkeypatch, tmp_path) -> None:
+async def test_photo_then_freeform_calculates_dose(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     """photo_handler + freeform_handler produce dose in reply and context."""
 
     class DummyPhoto:
@@ -207,7 +212,10 @@ async def test_photo_then_freeform_calculates_dose(monkeypatch, tmp_path) -> Non
     update_photo = SimpleNamespace(
         message=photo_msg, effective_user=SimpleNamespace(id=1)
     )
-    context = SimpleNamespace(bot=dummy_bot, user_data={"thread_id": "tid"})
+    context = cast(
+        CallbackContext[Any, Any, Any, Any],
+        SimpleNamespace(bot=dummy_bot, user_data={"thread_id": "tid"}),
+    )
 
     await handlers.photo_handler(update_photo, context)
 
@@ -224,8 +232,9 @@ async def test_photo_then_freeform_calculates_dose(monkeypatch, tmp_path) -> Non
     handlers.SessionLocal = lambda: DummySession()
 
     sugar_msg = DummyMessage(text="5")
-    update_sugar = SimpleNamespace(
-        message=sugar_msg, effective_user=SimpleNamespace(id=1)
+    update_sugar = cast(
+        Update,
+        SimpleNamespace(message=sugar_msg, effective_user=SimpleNamespace(id=1)),
     )
 
     await handlers.freeform_handler(update_sugar, context)

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -1,8 +1,11 @@
 import datetime
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
 
@@ -27,8 +30,14 @@ async def test_freeform_handler_edits_pending_entry_keeps_state() -> None:
         "photo_path": "photos/img.jpg",
     }
     message = DummyMessage("dose=3.5 carbs=30")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={"pending_entry": entry})
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any],
+        SimpleNamespace(user_data={"pending_entry": entry}),
+    )
 
     await handlers.freeform_handler(update, context)
 
@@ -61,8 +70,14 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
 
     handlers.SessionLocal = lambda: DummySession()
     message = DummyMessage("5,6")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={"pending_entry": entry})
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any],
+        SimpleNamespace(user_data={"pending_entry": entry}),
+    )
 
     await handlers.freeform_handler(update, context)
 
@@ -84,8 +99,14 @@ async def test_freeform_handler_sugar_only_flow() -> None:
         "photo_path": None,
     }
     message = DummyMessage("4.2")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={"pending_entry": entry})
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any],
+        SimpleNamespace(user_data={"pending_entry": entry}),
+    )
 
     await handlers.freeform_handler(update, context)
 

--- a/tests/test_handlers_freeform_units.py
+++ b/tests/test_handlers_freeform_units.py
@@ -1,6 +1,9 @@
 import pytest
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
+
+from telegram import Update
+from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
@@ -17,8 +20,13 @@ class DummyMessage:
 @pytest.mark.asyncio
 async def test_freeform_handler_warns_on_sugar_unit_mix() -> None:
     message = DummyMessage("сахар 5 XE")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={})
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+    )
 
     await handlers.freeform_handler(update, context)
 
@@ -30,8 +38,13 @@ async def test_freeform_handler_warns_on_sugar_unit_mix() -> None:
 @pytest.mark.asyncio
 async def test_freeform_handler_warns_on_dose_unit_mix() -> None:
     message = DummyMessage("доза 7 ммоль")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={})
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+    )
 
     await handlers.freeform_handler(update, context)
 
@@ -41,10 +54,17 @@ async def test_freeform_handler_warns_on_dose_unit_mix() -> None:
 
 
 @pytest.mark.asyncio
-async def test_freeform_handler_guidance_on_valueerror(monkeypatch) -> None:
+async def test_freeform_handler_guidance_on_valueerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     message = DummyMessage("whatever")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={})
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+    )
 
     def fake_smart_input(_):
         raise ValueError("boom")

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 import services.api.app.diabetes.handlers.common_handlers as common_handlers
@@ -59,7 +61,9 @@ session = DummySession()
 
 
 @pytest.mark.asyncio
-async def test_photo_flow_saves_entry(monkeypatch, tmp_path) -> None:
+async def test_photo_flow_saves_entry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     async def fake_parse_command(text: str) -> dict[str, Any]:
         return {"action": "add_entry", "fields": {}, "entry_date": None, "time": None}
 
@@ -68,10 +72,13 @@ async def test_photo_flow_saves_entry(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
     msg_start = DummyMessage("/dose")
-    update_start = SimpleNamespace(
-        message=msg_start, effective_user=SimpleNamespace(id=1)
+    update_start = cast(
+        Update,
+        SimpleNamespace(message=msg_start, effective_user=SimpleNamespace(id=1)),
     )
-    context = SimpleNamespace(user_data={})
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+    )
     await dose_handlers.freeform_handler(update_start, context)
 
     monkeypatch.chdir(tmp_path)
@@ -133,8 +140,9 @@ async def test_photo_flow_saves_entry(monkeypatch, tmp_path) -> None:
     assert entry["photo_path"].endswith("uid.jpg")
 
     msg_sugar = DummyMessage("5.5")
-    update_sugar = SimpleNamespace(
-        message=msg_sugar, effective_user=SimpleNamespace(id=1)
+    update_sugar = cast(
+        Update,
+        SimpleNamespace(message=msg_sugar, effective_user=SimpleNamespace(id=1)),
     )
     dose_handlers.SessionLocal = lambda: session
     await dose_handlers.freeform_handler(update_sugar, context)

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -1,9 +1,11 @@
 import datetime
 import os
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
 
 
 class DummyMessage:
@@ -28,7 +30,9 @@ class DummyQuery:
 
 
 @pytest.mark.asyncio
-async def test_report_request_and_custom_flow(monkeypatch) -> None:
+async def test_report_request_and_custom_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
@@ -39,7 +43,9 @@ async def test_report_request_and_custom_flow(monkeypatch) -> None:
     update = SimpleNamespace(
         message=message, effective_user=SimpleNamespace(id=1)
     )
-    context = SimpleNamespace(user_data={})
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+    )
 
     await reporting_handlers.report_request(update, context)
     assert "awaiting_report_date" not in context.user_data
@@ -67,9 +73,12 @@ async def test_report_request_and_custom_flow(monkeypatch) -> None:
 
     monkeypatch.setattr(dose_handlers, "send_report", dummy_send_report)
 
-    update2 = SimpleNamespace(
-        message=DummyMessage(text="2024-01-01"),
-        effective_user=SimpleNamespace(id=1),
+    update2 = cast(
+        Update,
+        SimpleNamespace(
+            message=DummyMessage(text="2024-01-01"),
+            effective_user=SimpleNamespace(id=1),
+        ),
     )
     await dose_handlers.freeform_handler(update2, context)
 
@@ -78,7 +87,9 @@ async def test_report_request_and_custom_flow(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_report_period_callback_week(monkeypatch) -> None:
+async def test_report_period_callback_week(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401


### PR DESCRIPTION
## Summary
- annotate pytest `monkeypatch` fixtures
- cast `SimpleNamespace` to `Update` and `CallbackContext` before invoking `freeform_handler`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b9d49eeb4832aa137d64d225d64b5