### PR TITLE
[gpt_client] Make send_message async

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -811,7 +811,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
                         return ConversationHandler.END
             context.user_data["thread_id"] = thread_id
 
-        run = send_message(
+        run = await send_message(
             thread_id=thread_id,
             content=(
                 "Определи **название** блюда и количество углеводов/ХЕ. Ответ:\n"
@@ -854,7 +854,8 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
             if run.status in ("completed", "failed", "cancelled", "expired"):
                 break
             await asyncio.sleep(2)
-            run = _get_client().beta.threads.runs.retrieve(
+            run = await asyncio.to_thread(
+                _get_client().beta.threads.runs.retrieve,
                 thread_id=run.thread_id,
                 run_id=run.id,
             )
@@ -922,7 +923,10 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
                 await message.reply_text("⚠️ Vision не смог обработать фото.")
             return ConversationHandler.END
 
-        messages = _get_client().beta.threads.messages.list(thread_id=run.thread_id)
+        messages = await asyncio.to_thread(
+            _get_client().beta.threads.messages.list,
+            thread_id=run.thread_id,
+        )
         for m in messages.data:
             content = _sanitize(m.content)
             logger.debug("[VISION][MSG] m.role=%s; content=%s", m.role, content)

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -124,7 +124,7 @@ async def test_photo_handler_preserves_file(monkeypatch, tmp_path) -> None:
 
     call = {}
 
-    def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs):
         call.update(kwargs)
 
         class Run:
@@ -186,7 +186,7 @@ async def test_photo_then_freeform_calculates_dose(monkeypatch, tmp_path) -> Non
         thread_id = "tid"
         id = "runid"
 
-    def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs):
         return Run()
 
     class DummyClient:

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -90,7 +90,7 @@ async def test_photo_flow_saves_entry(monkeypatch, tmp_path) -> None:
         thread_id = "tid"
         id = "runid"
 
-    def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs):
         return Run()
 
     class DummyClient:

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -47,7 +47,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch, tmp_path) -> None:
         thread_id = "tid"
         id = "runid"
 
-    def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs):
         captured["content"] = kwargs["content"]
         return Run()
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -190,7 +190,7 @@ async def test_send_report_uses_gpt(monkeypatch) -> None:
         thread_id = "tid"
         id = "rid"
 
-    def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs):
         return Run()
 
     class DummyClient:


### PR DESCRIPTION
## Summary
- make gpt_client.send_message asynchronous and wrap blocking operations with `asyncio.to_thread`
- await new send_message in handlers and poll OpenAI in background threads
- update tests for async API

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689b9e85bf78832aa56db3a8ccae92cc