### PR TITLE
[webapp] fetch analytics and stats with fallbacks

### DIFF
--- a/services/webapp/ui/src/api/stats.ts
+++ b/services/webapp/ui/src/api/stats.ts
@@ -1,0 +1,49 @@
+export interface AnalyticsPoint {
+  date: string;
+  sugar: number;
+}
+
+export interface DayStats {
+  sugar: number;
+  breadUnits: number;
+  insulin: number;
+}
+
+export const fallbackAnalytics: AnalyticsPoint[] = [
+  { date: '2024-01-01', sugar: 5.5 },
+  { date: '2024-01-02', sugar: 6.1 },
+  { date: '2024-01-03', sugar: 5.8 },
+  { date: '2024-01-04', sugar: 6.0 },
+  { date: '2024-01-05', sugar: 5.4 },
+];
+
+export const fallbackDayStats: DayStats = {
+  sugar: 6.2,
+  breadUnits: 4,
+  insulin: 12,
+};
+
+export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint[]> {
+  const res = await fetch(`/api/analytics?telegramId=${telegramId}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch analytics');
+  }
+  const data = await res.json();
+  if (!Array.isArray(data)) {
+    throw new Error('Invalid analytics data');
+  }
+  return data as AnalyticsPoint[];
+}
+
+export async function fetchDayStats(telegramId: number): Promise<DayStats> {
+  const res = await fetch(`/api/stats?telegramId=${telegramId}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch stats');
+  }
+  const data = await res.json();
+  return {
+    sugar: Number(data.sugar),
+    breadUnits: Number(data.breadUnits),
+    insulin: Number(data.insulin),
+  };
+}

--- a/services/webapp/ui/src/pages/Analytics.tsx
+++ b/services/webapp/ui/src/pages/Analytics.tsx
@@ -1,23 +1,34 @@
 import { useNavigate } from 'react-router-dom';
 import { LineChart, Line, XAxis, YAxis } from 'recharts';
+import { useQuery } from '@tanstack/react-query';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
-
-const data = [
-  { date: '2024-01-01', sugar: 5.5 },
-  { date: '2024-01-02', sugar: 6.1 },
-  { date: '2024-01-03', sugar: 5.8 },
-  { date: '2024-01-04', sugar: 6.0 },
-  { date: '2024-01-05', sugar: 5.4 },
-];
+import { useTelegram } from '@/hooks/useTelegram';
+import { fetchAnalytics, fallbackAnalytics } from '@/api/stats';
 
 const Analytics = () => {
   const navigate = useNavigate();
+  const { user } = useTelegram();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['analytics', user?.id],
+    queryFn: () => fetchAnalytics(user?.id ?? 0),
+  });
+
+  const chartData = data ?? fallbackAnalytics;
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
       <MedicalHeader title="Аналитика" showBack onBack={() => navigate('/history')} />
       <main className="container mx-auto px-4 py-6">
+        {isLoading && (
+          <p className="text-center text-muted-foreground mb-4">Загрузка...</p>
+        )}
+        {error && (
+          <p className="text-center text-destructive mb-4">
+            Не удалось загрузить данные
+          </p>
+        )}
         <ChartContainer
           config={{
             sugar: {
@@ -27,7 +38,7 @@ const Analytics = () => {
           }}
           className="h-64"
         >
-          <LineChart data={data}>
+          <LineChart data={chartData}>
             <XAxis dataKey="date" />
             <YAxis />
             <ChartTooltip content={<ChartTooltipContent />} />

--- a/services/webapp/ui/src/pages/Home.tsx
+++ b/services/webapp/ui/src/pages/Home.tsx
@@ -1,8 +1,10 @@
 import { Clock, User, BookOpen, Star } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useTelegram } from '@/hooks/useTelegram';
 import MedicalButton from '@/components/MedicalButton';
+import { fetchDayStats, fallbackDayStats } from '@/api/stats';
 
 const menuItems = [
   {
@@ -42,6 +44,13 @@ const menuItems = [
 const Home = () => {
   const navigate = useNavigate();
   const { user } = useTelegram();
+
+  const { data: stats, isLoading, error } = useQuery({
+    queryKey: ['day-stats', user?.id],
+    queryFn: () => fetchDayStats(user?.id ?? 0),
+  });
+
+  const dayStats = stats ?? fallbackDayStats;
 
   const handleTileClick = (route: string) => {
     navigate(route);
@@ -117,17 +126,25 @@ const Home = () => {
         </div>
 
         {/* Статистика дня */}
+        {isLoading && (
+          <p className="text-center text-muted-foreground mt-6">Загрузка статистики...</p>
+        )}
+        {error && (
+          <p className="text-center text-destructive mt-6">
+            Не удалось загрузить статистику
+          </p>
+        )}
         <div className="mt-6 grid grid-cols-3 gap-3">
           <div className="medical-card text-center py-4">
-            <div className="text-2xl font-bold text-medical-blue">6.2</div>
+            <div className="text-2xl font-bold text-medical-blue">{dayStats.sugar}</div>
             <div className="text-xs text-muted-foreground">ммоль/л</div>
           </div>
           <div className="medical-card text-center py-4">
-            <div className="text-2xl font-bold text-medical-teal">4</div>
+            <div className="text-2xl font-bold text-medical-teal">{dayStats.breadUnits}</div>
             <div className="text-xs text-muted-foreground">ХЕ</div>
           </div>
           <div className="medical-card text-center py-4">
-            <div className="text-2xl font-bold text-medical-success">12</div>
+            <div className="text-2xl font-bold text-medical-success">{dayStats.insulin}</div>
             <div className="text-xs text-muted-foreground">ед.</div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- fetch analytics data using react-query and show loading and error states
- load home page day stats from API with fallbacks
- add shared API helpers with default data

## Testing
- `npm --prefix services/webapp/ui run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest tests/`
- `ruff check services/api/app tests`


------
https://chatgpt.com/codex/tasks/task_e_689b9eeb1758832abd64880abab4a131