### PR TITLE
[tests] Improve type hints and safety

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import datetime
 import logging
-from typing import Callable
+from typing import Any, Callable
 
 from sqlalchemy.orm import Session, sessionmaker
 from telegram.error import TelegramError
@@ -34,7 +34,7 @@ def schedule_alert(
     job_queue,
     *,
     sugar: float,
-    profile: dict,
+    profile: dict[str, Any],
     first_name: str = "",
     count: int = 1,
 ) -> None:
@@ -55,7 +55,7 @@ def schedule_alert(
 async def _send_alert_message(
     user_id: int,
     sugar: float,
-    profile_info: dict,
+    profile_info: dict[str, Any],
     context: ContextTypes.DEFAULT_TYPE,
     first_name: str,
 ) -> None:

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -85,7 +85,7 @@ async def test_threshold_evaluation() -> None:
 
 
 @pytest.mark.asyncio
-async def test_repeat_logic(monkeypatch) -> None:
+async def test_repeat_logic(monkeypatch: pytest.MonkeyPatch) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -105,7 +105,7 @@ async def test_repeat_logic(monkeypatch) -> None:
     async def dummy_send_alert_message(
         user_id: int,
         sugar: float,
-        profile: dict,
+        profile: dict[str, Any],
         context: Any,
         first_name: str,
     ) -> None:
@@ -150,7 +150,7 @@ async def test_normal_reading_resolves_alert() -> None:
 
 
 @pytest.mark.asyncio
-async def test_three_alerts_notify(monkeypatch) -> None:
+async def test_three_alerts_notify(monkeypatch: pytest.MonkeyPatch) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -195,7 +195,9 @@ async def test_three_alerts_notify(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_alert_message_without_coords(monkeypatch) -> None:
+async def test_alert_message_without_coords(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,12 +12,16 @@ def _reload(module: str):
     return importlib.import_module(module)
 
 
-def test_import_config_without_db_password(monkeypatch):
+def test_import_config_without_db_password(
+    monkeypatch: pytest.MonkeyPatch,
+):
     monkeypatch.delenv("DB_PASSWORD", raising=False)
     _reload("services.api.app.config")  # should not raise
 
 
-def test_init_db_raises_when_no_password(monkeypatch):
+def test_init_db_raises_when_no_password(
+    monkeypatch: pytest.MonkeyPatch,
+):
     monkeypatch.delenv("DB_PASSWORD", raising=False)
     config = _reload("services.api.app.config")
     db = _reload("services.api.app.diabetes.services.db")

--- a/tests/test_db_reinit.py
+++ b/tests/test_db_reinit.py
@@ -28,7 +28,9 @@ class DummyEngine:
     ],
 )
 
-def test_init_db_recreates_engine_on_url_change(monkeypatch, attr, orig, new, url_attr):
+def test_init_db_recreates_engine_on_url_change(
+    monkeypatch: pytest.MonkeyPatch, attr, orig, new, url_attr
+):
     monkeypatch.setenv("DB_PASSWORD", "pwd")
     _reload("services.api.app.config")
     db = _reload("services.api.app.diabetes.services.db")

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -77,8 +77,8 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
 
     entry_message = DummyMessage(chat_id=42, message_id=24)
     query = DummyQuery(f"edit:{entry_id}", message=entry_message)
-    update_cb = SimpleNamespace(
-        callback_query=query, effective_user=SimpleNamespace(id=1)
+    update_cb = cast(
+        Update, SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
         CallbackContext[Any, Any, Any, Any],
@@ -88,7 +88,9 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
     await common_handlers.callback_router(update_cb, context)
 
     field_query = DummyQuery(f"edit_field:{entry_id}:dose", message=entry_message)
-    update_cb2 = SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1))
+    update_cb2 = cast(
+        Update, SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1))
+    )
     await common_handlers.callback_router(update_cb2, context)
     assert context.user_data["edit_field"] == "dose"
 
@@ -100,9 +102,11 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with TestSession() as session:
         updated = session.get(Entry, entry_id)
+        assert updated is not None
         assert updated.dose == 5.0
 
     assert field_query.answer_texts[-1] == "Изменено"
     edited_text, chat_id, message_id, kwargs = context.bot.edited[0]
     assert chat_id == 42 and message_id == 24
+    assert updated is not None
     assert f"💉 Доза: <b>{updated.dose}</b>" in edited_text

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -90,7 +90,9 @@ async def test_history_view_buttons(monkeypatch: pytest.MonkeyPatch) -> None:
         entry_ids = [e.id for e in session.query(Entry).all()]
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
     )
@@ -162,8 +164,9 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     entry_message = DummyMessage(chat_id=42, message_id=24)
     query = DummyQuery(f"edit:{entry_id}", message=entry_message)
-    update_cb = SimpleNamespace(
-        callback_query=query, effective_user=SimpleNamespace(id=1)
+    update_cb = cast(
+        Update,
+        SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
         CallbackContext[Any, Any, Any, Any],
@@ -183,8 +186,9 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert f"edit_field:{entry_id}:dose" in buttons
 
     field_query = DummyQuery(f"edit_field:{entry_id}:xe", message=entry_message)
-    update_cb2 = SimpleNamespace(
-        callback_query=field_query, effective_user=SimpleNamespace(id=1)
+    update_cb2 = cast(
+        Update,
+        SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1)),
     )
     await common_handlers.callback_router(update_cb2, context)
     assert context.user_data["edit_id"] == entry_id
@@ -201,6 +205,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with TestSession() as session:
         updated = session.get(Entry, entry_id)
+        assert updated is not None
         assert updated.xe == 3
         assert updated.carbs_g == 10
         assert updated.dose == 2

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -1,9 +1,11 @@
 import logging
 import os
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -28,7 +30,9 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_onboarding_demo_photo_missing(monkeypatch, caplog) -> None:
+async def test_onboarding_demo_photo_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 
@@ -45,10 +49,15 @@ async def test_onboarding_demo_photo_missing(monkeypatch, caplog) -> None:
     monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
 
     message = DummyMessage()
-    update = SimpleNamespace(
-        message=message, effective_user=SimpleNamespace(id=1, first_name="Ann")
+    update = cast(
+        Update,
+        SimpleNamespace(
+            message=message, effective_user=SimpleNamespace(id=1, first_name="Ann")
+        ),
     )
-    context = SimpleNamespace(user_data={}, bot_data={})
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={}, bot_data={})
+    )
 
     await onboarding.start_command(update, context)
     update.message.text = "10"

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -1,8 +1,10 @@
 import os
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -49,7 +51,7 @@ class DummyQuery:
 
 
 @pytest.mark.asyncio
-async def test_onboarding_flow(monkeypatch) -> None:
+async def test_onboarding_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 
@@ -65,10 +67,15 @@ async def test_onboarding_flow(monkeypatch) -> None:
     monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
 
     message = DummyMessage()
-    update = SimpleNamespace(
-        message=message, effective_user=SimpleNamespace(id=1, first_name="Ann")
+    update = cast(
+        Update,
+        SimpleNamespace(
+            message=message, effective_user=SimpleNamespace(id=1, first_name="Ann")
+        ),
     )
-    context = SimpleNamespace(user_data={}, bot_data={})
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={}, bot_data={})
+    )
 
     state = await onboarding.start_command(update, context)
     assert state == onboarding.ONB_PROFILE_ICR
@@ -92,13 +99,17 @@ async def test_onboarding_flow(monkeypatch) -> None:
     assert message.photos
 
     query = DummyQuery(message, "onb_next")
-    update_cb = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
+    update_cb = cast(
+        Update, SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
+    )
     state = await onboarding.onboarding_demo_next(update_cb, context)
     assert state == onboarding.ONB_REMINDERS
     assert "3/3" in message.texts[-1]
 
     query2 = DummyQuery(message, "onb_rem_no")
-    update_cb2 = SimpleNamespace(callback_query=query2, effective_user=SimpleNamespace(id=1))
+    update_cb2 = cast(
+        Update, SimpleNamespace(callback_query=query2, effective_user=SimpleNamespace(id=1))
+    )
     state = await onboarding.onboarding_reminders(update_cb2, context)
     assert state == ConversationHandler.END
     assert message.polls
@@ -108,10 +119,15 @@ async def test_onboarding_flow(monkeypatch) -> None:
         assert user.onboarding_complete is True
 
     message2 = DummyMessage()
-    update2 = SimpleNamespace(
-        message=message2, effective_user=SimpleNamespace(id=1, first_name="Ann")
+    update2 = cast(
+        Update,
+        SimpleNamespace(
+            message=message2, effective_user=SimpleNamespace(id=1, first_name="Ann")
+        ),
     )
-    context2 = SimpleNamespace(user_data={}, bot_data={})
+    context2 = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={}, bot_data={})
+    )
     state2 = await onboarding.start_command(update2, context2)
     assert state2 == ConversationHandler.END
     assert any("Выберите" in t for t in message2.texts)

--- a/tests/test_run_db.py
+++ b/tests/test_run_db.py
@@ -10,7 +10,9 @@ from services.api.app.diabetes.services.db import run_db
 
 
 @pytest.mark.asyncio
-async def test_run_db_sqlite_in_memory(monkeypatch) -> None:
+async def test_run_db_sqlite_in_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     engine = create_engine("sqlite:///:memory:")
     Session = sessionmaker(bind=engine)
 
@@ -32,7 +34,9 @@ async def test_run_db_sqlite_in_memory(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_db_postgres(monkeypatch) -> None:
+async def test_run_db_postgres(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     dummy_engine = SimpleNamespace(url=SimpleNamespace(drivername="postgresql", database="db"))
 
     class DummySession:

--- a/tests/test_webapp_history.py
+++ b/tests/test_webapp_history.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -8,7 +9,9 @@ from httpx import AsyncClient
 import services.api.app.main as server
 
 
-def test_history_persist_and_update(tmp_path, monkeypatch) -> None:
+def test_history_persist_and_update(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(server, "HISTORY_FILE", tmp_path / "history.json")
     client = TestClient(server.app)
 
@@ -32,14 +35,16 @@ def test_history_persist_and_update(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_history_concurrent_writes(tmp_path, monkeypatch) -> None:
+async def test_history_concurrent_writes(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(server, "HISTORY_FILE", tmp_path / "history.json")
     records = [
         {"id": str(i), "date": "2024-01-01", "time": "12:00", "type": "measurement"}
         for i in range(5)
     ]
 
-    async def post_record(rec: dict) -> None:
+    async def post_record(rec: dict[str, Any]) -> None:
         async with AsyncClient(app=server.app, base_url="http://test") as ac:
             resp = await ac.post("/api/history", json=rec)
             assert resp.status_code == 200

--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -8,7 +8,9 @@ from httpx import AsyncClient
 import services.api.app.main as server
 
 
-def test_timezone_persist_and_validate(tmp_path, monkeypatch) -> None:
+def test_timezone_persist_and_validate(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(server, "TIMEZONE_FILE", tmp_path / "timezone.txt")
     client = TestClient(server.app)
 
@@ -33,7 +35,9 @@ def test_timezone_persist_and_validate(tmp_path, monkeypatch) -> None:
     assert resp.status_code in {400, 422}
 
 
-def test_timezone_partial_file(tmp_path, monkeypatch) -> None:
+def test_timezone_partial_file(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(server, "TIMEZONE_FILE", tmp_path / "timezone.txt")
     server.TIMEZONE_FILE.write_text("Europe/Mosc", encoding="utf-8")
     client = TestClient(server.app)
@@ -41,7 +45,9 @@ def test_timezone_partial_file(tmp_path, monkeypatch) -> None:
     assert resp.status_code == 500
 
 
-def test_timezone_concurrent_writes(tmp_path, monkeypatch) -> None:
+def test_timezone_concurrent_writes(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(server, "TIMEZONE_FILE", tmp_path / "timezone.txt")
     timezones = ["Europe/Moscow", "America/New_York", "Asia/Tokyo", "Europe/Paris"]
 
@@ -63,7 +69,9 @@ def test_timezone_concurrent_writes(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_timezone_async_writes(tmp_path, monkeypatch) -> None:
+async def test_timezone_async_writes(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(server, "TIMEZONE_FILE", tmp_path / "timezone.txt")
     timezones = ["Europe/Moscow", "America/New_York", "Asia/Tokyo", "Europe/Paris"]
 


### PR DESCRIPTION
## Summary
- refine alert handler type hints for profile dictionaries
- add explicit pytest.MonkeyPatch annotations in tests
- cast SimpleNamespace test data to Update/CallbackContext and guard session lookups

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689b9ff69204832ab763a5da34f949d8