### PR TITLE
[gpt] handle unexpected errors in command parser

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -102,7 +102,7 @@ async def parse_command(text: str, timeout: float = 10) -> dict | None:
         return None
     except Exception:
         logging.exception("Unexpected error during command parsing")
-        raise
+        return None
 
     choices = getattr(response, "choices", None)
     if not choices:

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -195,6 +195,20 @@ async def test_parse_command_with_non_string_content(monkeypatch, caplog) -> Non
     assert "Content is not a string in GPT response" in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_parse_command_handles_unexpected_exception(monkeypatch, caplog) -> None:
+    def bad_client() -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(gpt_command_parser, "_get_client", bad_client)
+
+    with caplog.at_level(logging.ERROR):
+        result = await gpt_command_parser.parse_command("test")
+
+    assert result is None
+    assert "Unexpected error during command parsing" in caplog.text
+
+
 @pytest.mark.parametrize(
     "token",
     [


### PR DESCRIPTION
## Summary
- make GPT command parser resilient to unexpected errors by logging and returning `None`
- cover fallback behavior with tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba0edbfac832aae23aca281b7bf24