### PR TITLE
[tests] Type CallbackContext casts and DummySession

### DIFF
--- a/tests/test_alert_stats.py
+++ b/tests/test_alert_stats.py
@@ -1,6 +1,6 @@
 import datetime
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from sqlalchemy import create_engine
@@ -86,7 +86,7 @@ async def test_alert_stats_counts(monkeypatch: pytest.MonkeyPatch) -> None:
         pass
 
     update = cast("Update", DummyUpdate(message=msg, effective_user=DummyUser(id=1)))
-    context = cast("CallbackContext", DummyContext())
+    context = cast("CallbackContext[Any, Any, Any, Any]", DummyContext())
 
     await alert_handlers.alert_stats(update, context)
     assert msg.texts == ["За 7\u202Fдн.: гипо\u202F1, гипер\u202F1"]

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -118,7 +118,7 @@ async def test_repeat_logic(monkeypatch) -> None:
         context: AlertContext = ContextStub(
             job=job, job_queue=job_queue, bot=cast(Bot, SimpleNamespace())
         )
-        await handlers.alert_job(cast(CallbackContext, context))
+        await handlers.alert_job(cast(CallbackContext[Any, Any, Any, Any], context))
 
     assert len(job_queue.jobs) == handlers.MAX_REPEATS
     assert len(calls) == handlers.MAX_REPEATS
@@ -183,9 +183,9 @@ async def test_three_alerts_notify(monkeypatch) -> None:
     monkeypatch.setattr(handlers, "get_coords_and_link", fake_get_coords_and_link)
 
     for _ in range(2):
-        await handlers.check_alert(update, cast(CallbackContext, context), 3)
+        await handlers.check_alert(update, cast(CallbackContext[Any, Any, Any, Any], context), 3)
     assert context.bot.sent == []
-    await handlers.check_alert(update, cast(CallbackContext, context), 3)
+    await handlers.check_alert(update, cast(CallbackContext[Any, Any, Any, Any], context), 3)
     assert len(context.bot.sent) == 2
     assert context.bot.sent[0][0] == 1
     assert context.bot.sent[1][0] == "@alice"
@@ -231,7 +231,7 @@ async def test_alert_message_without_coords(monkeypatch) -> None:
     monkeypatch.setattr(handlers, "get_coords_and_link", fake_get_coords_and_link)
 
     for _ in range(3):
-        await handlers.check_alert(update, cast(CallbackContext, context), 3)
+        await handlers.check_alert(update, cast(CallbackContext[Any, Any, Any, Any], context), 3)
 
     msg = "⚠️ У Ivan критический сахар 3 ммоль/л."
     assert context.bot.sent == [(1, msg), ("@alice", msg)]

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -38,7 +38,7 @@ async def test_photo_button_cancels_and_prompts_photo() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext,
+        CallbackContext[Any, Any, Any, Any],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
     await handler.callback(update, context)

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -50,7 +50,7 @@ async def test_entry_without_dose_has_no_unit(
         "xe": 2.0,
     }
     context = cast(
-        CallbackContext,
+        CallbackContext[Any, Any, Any, Any],
         DummyContext(
             user_data={"pending_entry": pending_entry, "pending_fields": ["sugar"]}
         ),
@@ -61,13 +61,13 @@ async def test_entry_without_dose_has_no_unit(
     )
 
     class DummySession:
-        def __enter__(self):
+        def __enter__(self) -> "DummySession":
             return self
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, exc_type, exc, tb) -> None:
             pass
 
-        def add(self, entry):
+        def add(self, entry: Any) -> None:
             self.entry = entry
 
     async def noop(*args: Any, **kwargs: Any) -> None:
@@ -96,7 +96,7 @@ async def test_entry_without_sugar_has_placeholder(
         "event_time": datetime.datetime.now(datetime.timezone.utc),
     }
     context = cast(
-        CallbackContext,
+        CallbackContext[Any, Any, Any, Any],
         DummyContext(
             user_data={"pending_entry": pending_entry, "pending_fields": ["dose"]}
         ),
@@ -107,13 +107,13 @@ async def test_entry_without_sugar_has_placeholder(
     )
 
     class DummySession:
-        def __enter__(self):
+        def __enter__(self) -> "DummySession":
             return self
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, exc_type, exc, tb) -> None:
             pass
 
-        def add(self, entry):
+        def add(self, entry: Any) -> None:
             self.entry = entry
 
     async def noop(*args: Any, **kwargs: Any) -> None:

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -220,10 +220,10 @@ async def test_photo_then_freeform_calculates_dose(
     await handlers.photo_handler(update_photo, context)
 
     class DummySession:
-        def __enter__(self):
+        def __enter__(self) -> "DummySession":
             return self
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, exc_type, exc, tb) -> None:
             pass
 
         def get(self, model, user_id):

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -59,10 +59,10 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         "photo_path": "photos/img.jpg",
     }
     class DummySession:
-        def __enter__(self):
+        def __enter__(self) -> "DummySession":
             return self
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, exc_type, exc, tb) -> None:
             pass
 
         def get(self, model, user_id):

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -41,14 +41,14 @@ class DummySession:
     def __init__(self):
         self.added = []
 
-    def __enter__(self):
+    def __enter__(self) -> "DummySession":
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(self, exc_type, exc, tb) -> None:
         pass
 
-    def add(self, obj):
-        self.added.append(obj)
+    def add(self, entry: Any) -> None:
+        self.added.append(entry)
 
     def commit(self):
         pass

--- a/tests/test_run_db.py
+++ b/tests/test_run_db.py
@@ -39,10 +39,10 @@ async def test_run_db_postgres(monkeypatch) -> None:
         def get_bind(self):
             return dummy_engine
 
-        def __enter__(self):
+        def __enter__(self) -> "DummySession":
             return self
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, exc_type, exc, tb) -> None:
             pass
 
     def dummy_sessionmaker():

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -90,7 +90,7 @@ async def test_alert_notifies_user_and_contact(test_session, monkeypatch) -> Non
 
     for _ in range(3):
         await alert_handlers.check_alert(
-            update_alert, cast(CallbackContext, context), 3
+            update_alert, cast(CallbackContext[Any, Any, Any, Any], context), 3
         )
 
     msg = "⚠️ У Ivan критический сахар 3 ммоль/л. 0,0 link"
@@ -129,7 +129,7 @@ async def test_alert_skips_phone_contact(test_session, monkeypatch) -> None:
 
     for _ in range(3):
         await alert_handlers.check_alert(
-            update_alert, cast(CallbackContext, context), 3
+            update_alert, cast(CallbackContext[Any, Any, Any, Any], context), 3
         )
 
     msg = "⚠️ У Ivan критический сахар 3 ммоль/л. 0,0 link"


### PR DESCRIPTION
## Summary
- replace `CallbackContext` casts with `CallbackContext[Any, Any, Any, Any]`
- type `DummySession` context manager methods and add method

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689ba41b842c832abc795d62b4078b0f