### PR TITLE
[webapp] Guard queries by user id

### DIFF
--- a/services/webapp/ui/src/pages/Analytics.tsx
+++ b/services/webapp/ui/src/pages/Analytics.tsx
@@ -13,6 +13,8 @@ const Analytics = () => {
   const { data, isLoading, error } = useQuery({
     queryKey: ['analytics', user?.id],
     queryFn: () => fetchAnalytics(user?.id ?? 0),
+    enabled: !!user?.id,
+    placeholderData: fallbackAnalytics,
   });
 
   const chartData = data ?? fallbackAnalytics;

--- a/services/webapp/ui/src/pages/Home.tsx
+++ b/services/webapp/ui/src/pages/Home.tsx
@@ -48,6 +48,8 @@ const Home = () => {
   const { data: stats, isLoading, error } = useQuery({
     queryKey: ['day-stats', user?.id],
     queryFn: () => fetchDayStats(user?.id ?? 0),
+    enabled: !!user?.id,
+    placeholderData: fallbackDayStats,
   });
 
   const dayStats = stats ?? fallbackDayStats;


### PR DESCRIPTION
## Summary
- Enable analytics and home stats queries only after user is loaded and provide placeholder data

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)

------
https://chatgpt.com/codex/tasks/task_e_689ba19d6bf4832ab90ac9b5d034d06b