### PR TITLE
[migrations] add org_id to profiles, entries, and alerts

### DIFF
--- a/services/api/alembic/versions/20250814_add_org_id_to_profiles.py
+++ b/services/api/alembic/versions/20250814_add_org_id_to_profiles.py
@@ -1,0 +1,44 @@
+"""add org_id to profiles safely
+
+Revision ID: 20250814_add_org_id_to_profiles
+Revises: 20250813_add_org_id_to_users
+Create Date: 2025-08-14 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20250814_add_org_id_to_profiles"
+down_revision: Union[str, None] = "20250813_add_org_id_to_users"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    columns = [col["name"] for col in inspector.get_columns("profiles")]
+    if "org_id" not in columns:
+        op.add_column("profiles", sa.Column("org_id", sa.Integer(), nullable=True))
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("profiles")]
+    if "ix_profiles_org_id" not in indexes:
+        op.create_index("ix_profiles_org_id", "profiles", ["org_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("profiles")]
+    if "ix_profiles_org_id" in indexes:
+        op.drop_index("ix_profiles_org_id", table_name="profiles")
+
+    columns = [col["name"] for col in inspector.get_columns("profiles")]
+    if "org_id" in columns:
+        op.drop_column("profiles", "org_id")

--- a/services/api/alembic/versions/20250815_add_org_id_to_entries.py
+++ b/services/api/alembic/versions/20250815_add_org_id_to_entries.py
@@ -1,0 +1,44 @@
+"""add org_id to entries safely
+
+Revision ID: 20250815_add_org_id_to_entries
+Revises: 20250814_add_org_id_to_profiles
+Create Date: 2025-08-15 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20250815_add_org_id_to_entries"
+down_revision: Union[str, None] = "20250814_add_org_id_to_profiles"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    columns = [col["name"] for col in inspector.get_columns("entries")]
+    if "org_id" not in columns:
+        op.add_column("entries", sa.Column("org_id", sa.Integer(), nullable=True))
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("entries")]
+    if "ix_entries_org_id" not in indexes:
+        op.create_index("ix_entries_org_id", "entries", ["org_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("entries")]
+    if "ix_entries_org_id" in indexes:
+        op.drop_index("ix_entries_org_id", table_name="entries")
+
+    columns = [col["name"] for col in inspector.get_columns("entries")]
+    if "org_id" in columns:
+        op.drop_column("entries", "org_id")

--- a/services/api/alembic/versions/20250816_add_org_id_to_alerts.py
+++ b/services/api/alembic/versions/20250816_add_org_id_to_alerts.py
@@ -1,0 +1,44 @@
+"""add org_id to alerts safely
+
+Revision ID: 20250816_add_org_id_to_alerts
+Revises: 20250815_add_org_id_to_entries
+Create Date: 2025-08-16 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20250816_add_org_id_to_alerts"
+down_revision: Union[str, None] = "20250815_add_org_id_to_entries"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    columns = [col["name"] for col in inspector.get_columns("alerts")]
+    if "org_id" not in columns:
+        op.add_column("alerts", sa.Column("org_id", sa.Integer(), nullable=True))
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("alerts")]
+    if "ix_alerts_org_id" not in indexes:
+        op.create_index("ix_alerts_org_id", "alerts", ["org_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("alerts")]
+    if "ix_alerts_org_id" in indexes:
+        op.drop_index("ix_alerts_org_id", table_name="alerts")
+
+    columns = [col["name"] for col in inspector.get_columns("alerts")]
+    if "org_id" in columns:
+        op.drop_column("alerts", "org_id")


### PR DESCRIPTION
## Summary
- add safe migrations for org_id on profiles, entries, and alerts tables

## Testing
- `alembic -c services/api/alembic.ini upgrade head` (fails: sqlite3.OperationalError: near "ALTER": syntax error)
- `ruff check services/api/app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba6408e20832ab8ce28aab90bc68c