### PR TITLE
[tests] Improve alert type hints

### DIFF
--- a/tests/context_stub.py
+++ b/tests/context_stub.py
@@ -1,21 +1,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
-from telegram import Bot
 from telegram.ext import Job, JobQueue
 
 
 class AlertContext(Protocol):
     """Protocol for context objects used in alert handlers tests."""
-    job: Job | None
-    job_queue: JobQueue | None
-    bot: Bot | None
+    job: Job[Any] | None
+    job_queue: JobQueue[Any] | None
+    bot: Any | None
 
 
 @dataclass
 class ContextStub:
-    job: Job | None = None
-    job_queue: JobQueue | None = None
-    bot: Bot | None = None
+    job: Job[Any] | None = None
+    job_queue: JobQueue[Any] | None = None
+    bot: Any | None = None

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,11 +1,8 @@
 from datetime import timedelta
 from types import SimpleNamespace
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, cast
 
-from typing import cast
-
-from telegram import Bot
-from telegram.ext import CallbackContext
+from telegram.ext import CallbackContext, Job, JobQueue
 
 from .context_stub import AlertContext, ContextStub
 
@@ -69,23 +66,25 @@ async def test_threshold_evaluation() -> None:
         session.commit()
 
     job_queue_low = DummyJobQueue()
-    await handlers.evaluate_sugar(1, 3, job_queue_low)
+    await handlers.evaluate_sugar(1, 3, cast(JobQueue[Any], job_queue_low))
     with TestSession() as session:
         alert = session.query(Alert).filter_by(user_id=1).first()
+        assert alert is not None
         assert alert.type == "hypo"
     assert job_queue_low.get_jobs_by_name("alert_1")
     assert job_queue_low.jobs[0].when == handlers.ALERT_REPEAT_DELAY
 
     job_queue_high = DummyJobQueue()
-    await handlers.evaluate_sugar(2, 9, job_queue_high)
+    await handlers.evaluate_sugar(2, 9, cast(JobQueue[Any], job_queue_high))
     with TestSession() as session:
         alert2 = session.query(Alert).filter_by(user_id=2).first()
+        assert alert2 is not None
         assert alert2.type == "hyper"
     assert job_queue_high.get_jobs_by_name("alert_2")
 
 
 @pytest.mark.asyncio
-async def test_repeat_logic(monkeypatch) -> None:
+async def test_repeat_logic(monkeypatch: pytest.MonkeyPatch) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -98,14 +97,14 @@ async def test_repeat_logic(monkeypatch) -> None:
         session.commit()
 
     job_queue = DummyJobQueue()
-    await handlers.evaluate_sugar(1, 3, job_queue)
+    await handlers.evaluate_sugar(1, 3, cast(JobQueue[Any], job_queue))
 
     calls: list[tuple[int, float]] = []
 
     async def dummy_send_alert_message(
         user_id: int,
         sugar: float,
-        profile: dict,
+        profile: dict[str, Any],
         context: Any,
         first_name: str,
     ) -> None:
@@ -115,8 +114,13 @@ async def test_repeat_logic(monkeypatch) -> None:
 
     for i in range(handlers.MAX_REPEATS):
         job = job_queue.jobs[i]
-        context: AlertContext = ContextStub(
-            job=job, job_queue=job_queue, bot=cast(Bot, SimpleNamespace())
+        context = cast(
+            AlertContext,
+            ContextStub(
+                job=cast(Job[Any], job),
+                job_queue=cast(JobQueue[Any], job_queue),
+                bot=SimpleNamespace(),
+            ),
         )
         await handlers.alert_job(cast(CallbackContext[Any, Any, Any, Any], context))
 
@@ -139,18 +143,19 @@ async def test_normal_reading_resolves_alert() -> None:
         session.commit()
 
     job_queue = DummyJobQueue()
-    await handlers.evaluate_sugar(1, 3, job_queue)
+    await handlers.evaluate_sugar(1, 3, cast(JobQueue[Any], job_queue))
     assert job_queue.jobs
 
-    await handlers.evaluate_sugar(1, 5, job_queue)
+    await handlers.evaluate_sugar(1, 5, cast(JobQueue[Any], job_queue))
     with TestSession() as session:
         alert = session.query(Alert).filter_by(user_id=1).first()
+        assert alert is not None
         assert alert.resolved
     assert job_queue.jobs[0].removed
 
 
 @pytest.mark.asyncio
-async def test_three_alerts_notify(monkeypatch) -> None:
+async def test_three_alerts_notify(monkeypatch: pytest.MonkeyPatch) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -176,7 +181,7 @@ async def test_three_alerts_notify(monkeypatch) -> None:
             self.sent.append((chat_id, text))
 
     update = SimpleNamespace(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
-    context: AlertContext = ContextStub(bot=cast(Bot, DummyBot()))
+    context = cast(AlertContext, ContextStub(bot=DummyBot()))
     async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
         return ("0,0", "link")
 
@@ -195,7 +200,7 @@ async def test_three_alerts_notify(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_alert_message_without_coords(monkeypatch) -> None:
+async def test_alert_message_without_coords(monkeypatch: pytest.MonkeyPatch) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -223,7 +228,7 @@ async def test_alert_message_without_coords(monkeypatch) -> None:
             self.sent.append((chat_id, text))
 
     update = SimpleNamespace(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
-    context: AlertContext = ContextStub(bot=cast(Bot, DummyBot()))
+    context = cast(AlertContext, ContextStub(bot=DummyBot()))
 
     async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
         return None, None


### PR DESCRIPTION
## Summary
- Refine alert context stub to accept Any for bot and generics for job/job_queue
- Strengthen alert tests with explicit typing and safety checks

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689ba84f5208832a8d0f3eb3831f7841