### PR TITLE
[parser] validate GPT command schema

### DIFF
--- a/services/api/app/schemas/__init__.py
+++ b/services/api/app/schemas/__init__.py
@@ -1,9 +1,11 @@
+from .command import CommandSchema
 from .history import HistoryRecordSchema
 from .profile import ProfileSchema
 from .reminders import ReminderSchema
 from .timezone import TimezoneSchema
 
 __all__ = [
+    "CommandSchema",
     "HistoryRecordSchema",
     "ProfileSchema",
     "ReminderSchema",

--- a/services/api/app/schemas/command.py
+++ b/services/api/app/schemas/command.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+
+class CommandSchema(BaseModel):
+    """Schema for GPT parsed command."""
+
+    action: str
+    entry_date: Optional[str] = None
+    time: Optional[str] = None
+    fields: dict[str, Any]


### PR DESCRIPTION
## Summary
- add CommandSchema pydantic model for GPT command parsing
- validate and log GPT command parsing with CommandSchema
- test invalid schema handling in parser

## Testing
- `ruff check services/api/app tests`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689badd812a8832abbfa7e45c11894d6