### PR TITLE
[services] Annotate _upload return type

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import threading
+from typing import Any
 
 from openai import OpenAIError
 
@@ -71,7 +72,7 @@ async def send_message(
     client = _get_client()
     if image_path:
         try:
-            def _upload() -> any:
+            def _upload() -> Any:
                 with open(image_path, "rb") as f:
                     return client.files.create(file=f, purpose="vision")
 


### PR DESCRIPTION
## Summary
- import `Any` typing utility
- annotate nested `_upload` helper with `Any` return type

## Testing
- `ruff check services/api/app tests`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_689bb16cafc8832a88df0fd62d4d3a16