### PR TITLE
[webapp] add profile save api

### DIFF
--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,0 +1,12 @@
+import { DefaultApi, Profile } from '@sdk';
+
+const api = new DefaultApi();
+
+export async function saveProfile(profile: Profile) {
+  try {
+    return await api.profilesPost({ profile });
+  } catch (error) {
+    console.error('Failed to save profile:', error);
+    throw new Error('Не удалось сохранить профиль');
+  }
+}

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -4,10 +4,13 @@ import { Save } from 'lucide-react';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useToast } from '@/hooks/use-toast';
 import MedicalButton from '@/components/MedicalButton';
+import { saveProfile } from '@/api/profile';
+import { useTelegram } from '@/hooks/useTelegram';
 
 const Profile = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { user } = useTelegram();
 
   const [profile, setProfile] = useState({
     icr: '12',
@@ -21,12 +24,38 @@ const Profile = () => {
     setProfile(prev => ({ ...prev, [field]: value }));
   };
 
-  const handleSave = () => {
-    // Здесь будет отправка данных на сервер
-    toast({
-      title: "Профиль сохранен",
-      description: "Ваши настройки успешно обновлены"
-    });
+  const handleSave = async () => {
+    if (!user?.id) {
+      toast({
+        title: 'Ошибка',
+        description: 'Не удалось определить пользователя',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      await saveProfile({
+        telegramId: user.id,
+        icr: Number(profile.icr),
+        cf: Number(profile.correctionFactor),
+        target: Number(profile.targetSugar),
+        low: Number(profile.lowThreshold),
+        high: Number(profile.highThreshold),
+      });
+      toast({
+        title: 'Профиль сохранен',
+        description: 'Ваши настройки успешно обновлены',
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Не удалось сохранить профиль';
+      toast({
+        title: 'Ошибка',
+        description: message,
+        variant: 'destructive',
+      });
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- add profile API function to save settings
- wire Profile page to call save API and show toasts for success/error

## Testing
- `ruff check services/api/app tests`
- `pytest tests`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689bb3b4b978832a9856a9ff37e650d2