### PR TITLE
[webapp] extract history api module

### DIFF
--- a/services/webapp/ui/src/api/history.ts
+++ b/services/webapp/ui/src/api/history.ts
@@ -1,0 +1,61 @@
+export interface HistoryRecord {
+  id: string;
+  date: string;
+  time: string;
+  sugar?: number;
+  carbs?: number;
+  breadUnits?: number;
+  insulin?: number;
+  notes?: string;
+  type: 'measurement' | 'meal' | 'insulin';
+}
+
+export async function getHistory(): Promise<HistoryRecord[]> {
+  try {
+    const res = await fetch('/api/history');
+    if (!res.ok) {
+      throw new Error('Не удалось загрузить историю');
+    }
+    const data = await res.json();
+    if (!Array.isArray(data)) {
+      throw new Error('Некорректный ответ');
+    }
+    return data as HistoryRecord[];
+  } catch (error) {
+    console.error('Failed to fetch history:', error);
+    throw new Error('Не удалось загрузить историю');
+  }
+}
+
+export async function updateRecord(record: HistoryRecord) {
+  try {
+    const res = await fetch('/api/history', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(record),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || data.status !== 'ok') {
+      throw new Error(data.detail || 'Не удалось обновить запись');
+    }
+    return data;
+  } catch (error) {
+    console.error('Failed to update history record:', error);
+    throw new Error('Не удалось обновить запись');
+  }
+}
+
+export async function deleteRecord(id: string) {
+  try {
+    const res = await fetch(`/api/history/${id}`, { method: 'DELETE' });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || data.status !== 'ok') {
+      throw new Error(data.detail || 'Не удалось удалить запись');
+    }
+    return data;
+  } catch (error) {
+    console.error('Failed to delete history record:', error);
+    throw new Error('Не удалось удалить запись');
+  }
+}
+


### PR DESCRIPTION
## Summary
- add dedicated history API helpers
- load history entries via API on mount
- use helpers for updating and deleting records

## Testing
- `ruff check services/api/app tests`
- `pytest tests -q`
- `npm --prefix services/webapp/ui run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689c001773a4832a89c45bbbad59853b