### PR TITLE
[config] remove legacy constants

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -69,22 +69,6 @@ class Settings(BaseSettings):
 settings = Settings()
 
 
-# Legacy module-level variables for backward compatibility
-LOG_LEVEL = settings.log_level
-DB_HOST = settings.db_host
-DB_PORT = settings.db_port
-DB_NAME = settings.db_name
-DB_USER = settings.db_user
-UVICORN_WORKERS = settings.uvicorn_workers
-WEBAPP_URL = settings.webapp_url
-API_URL = settings.api_url
-OPENAI_API_KEY = settings.openai_api_key
-OPENAI_ASSISTANT_ID = settings.openai_assistant_id
-OPENAI_PROXY = settings.openai_proxy
-FONT_DIR = settings.font_dir
-TELEGRAM_TOKEN = settings.telegram_token
-
-
 def get_db_password() -> Optional[str]:
     """Return the database password from a fresh ``Settings`` instance."""
     return Settings().db_password

--- a/services/api/app/diabetes/handlers/profile_handlers.py
+++ b/services/api/app/diabetes/handlers/profile_handlers.py
@@ -32,7 +32,7 @@ from services.api.app.diabetes.utils.ui import (
     back_keyboard,
     menu_keyboard,
 )
-from services.api.app.config import WEBAPP_URL, API_URL
+from services.api.app.config import settings
 from .db_helpers import commit_session
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
@@ -51,7 +51,7 @@ def _get_api():
             "diabetes_sdk is required but not installed. Install it with 'pip install -r requirements.txt'."
         )
         return None, None, None
-    api = DefaultApi(ApiClient(Configuration(host=API_URL)))
+    api = DefaultApi(ApiClient(Configuration(host=settings.api_url)))
     return api, ApiException, ProfileModel
 
 
@@ -238,13 +238,13 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         [InlineKeyboardButton("🌐 Часовой пояс", callback_data="profile_timezone")],
         [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
     ]
-    if WEBAPP_URL:
+    if settings.webapp_url:
         rows.insert(
             1,
             [
                 InlineKeyboardButton(
                     "📝 Заполнить форму",
-                    web_app=WebAppInfo(f"{WEBAPP_URL}/profile"),
+                    web_app=WebAppInfo(f"{settings.webapp_url}/profile"),
                 )
             ],
         )
@@ -480,9 +480,9 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
         await sos_handlers.sos_contact_start(update.callback_query, context)
         return
-    if action == "add" and WEBAPP_URL:
+    if action == "add" and settings.webapp_url:
         button = InlineKeyboardButton(
-            "📝 Новое", web_app=WebAppInfo(f"{WEBAPP_URL}/reminders")
+            "📝 Новое", web_app=WebAppInfo(f"{settings.webapp_url}/reminders")
         )
         keyboard = InlineKeyboardMarkup([[button]])
         await query.message.reply_text("Создать напоминание:", reply_markup=keyboard)

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -28,7 +28,7 @@ from services.api.app.diabetes.services.db import (
     run_db,
 )
 from .db_helpers import commit_session as _commit_session
-from services.api.app.config import WEBAPP_URL
+from services.api.app.config import settings
 from services.api.app.diabetes.utils.helpers import (
     INVALID_TIME_MSG,
     parse_time_interval,
@@ -137,16 +137,16 @@ def _render_reminders(
     if active_count > limit:
         header += " ⚠️"
     add_button_row: list[InlineKeyboardButton] | None = None
-    if WEBAPP_URL:
+    if settings.webapp_url:
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
-                web_app=WebAppInfo(f"{WEBAPP_URL}/reminders"),
+                web_app=WebAppInfo(f"{settings.webapp_url}/reminders"),
             )
         ]
     if not rems:
         text = header
-        if WEBAPP_URL:
+        if settings.webapp_url:
             text += "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
             return text, InlineKeyboardMarkup([add_button_row])
         text += "\nУ вас нет напоминаний. Отправьте /addreminder."
@@ -163,11 +163,11 @@ def _render_reminders(
         line = f"{r.id}. {title}"
         status_icon = "🔔" if r.is_enabled else "🔕"
         row: list[InlineKeyboardButton] = []
-        if WEBAPP_URL:
+        if settings.webapp_url:
             row.append(
                 InlineKeyboardButton(
                     "✏️",
-                    web_app=WebAppInfo(f"{WEBAPP_URL}/reminders?id={r.id}"),
+                    web_app=WebAppInfo(f"{settings.webapp_url}/reminders?id={r.id}"),
                 )
             )
         row.extend(

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -22,12 +22,7 @@ import logging
 import threading
 from typing import Any, Callable, TypeVar
 
-from services.api.app import config
-
-DB_HOST = config.DB_HOST
-DB_PORT = config.DB_PORT
-DB_NAME = config.DB_NAME
-DB_USER = config.DB_USER
+from services.api.app.config import get_db_password, settings
 logger = logging.getLogger(__name__)
 
 
@@ -169,16 +164,16 @@ class ReminderLog(Base):
 # ────────────────────── инициализация ────────────────────────
 def init_db() -> None:
     """Создать таблицы, если их ещё нет (для локального запуска)."""
-    password = config.get_db_password()
+    password = get_db_password()
     if not password:
         raise ValueError("DB_PASSWORD environment variable must be set")
     database_url = URL.create(
         "postgresql",
-        username=DB_USER,
+        username=settings.db_user,
         password=password,
-        host=DB_HOST,
-        port=int(DB_PORT),
-        database=DB_NAME,
+        host=settings.db_host,
+        port=int(settings.db_port),
+        database=settings.db_name,
     )
 
     global engine

--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from openai import OpenAIError
 
-from services.api.app.config import OPENAI_ASSISTANT_ID
+from services.api.app.config import settings
 from services.api.app.diabetes.utils.openai_utils import get_openai_client
 
 logger = logging.getLogger(__name__)
@@ -113,7 +113,7 @@ async def send_message(
         logger.exception("[OpenAI] Failed to create message: %s", exc)
         raise
 
-    if not OPENAI_ASSISTANT_ID:
+    if not settings.openai_assistant_id:
         message = "OPENAI_ASSISTANT_ID is not set"
         logger.error("[OpenAI] %s", message)
         raise RuntimeError(message)
@@ -123,7 +123,7 @@ async def send_message(
         run = await asyncio.to_thread(
             client.beta.threads.runs.create,
             thread_id=thread_id,
-            assistant_id=OPENAI_ASSISTANT_ID,
+            assistant_id=settings.openai_assistant_id,
         )
     except OpenAIError as exc:
         logger.exception("[OpenAI] Failed to create run: %s", exc)

--- a/services/api/app/diabetes/services/reporting.py
+++ b/services/api/app/diabetes/services/reporting.py
@@ -13,11 +13,11 @@ from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont, TTFError
 from reportlab.pdfgen import canvas
 
-from services.api.app.config import FONT_DIR
+from services.api.app.config import settings
 
 # Регистрация шрифтов для поддержки кириллицы и жирного начертания
 DEFAULT_FONT_DIR = '/usr/share/fonts/truetype/dejavu'
-_font_dir = FONT_DIR or DEFAULT_FONT_DIR
+_font_dir = settings.font_dir or DEFAULT_FONT_DIR
 
 
 def _register_font(name, filename):

--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from openai import OpenAI
-from services.api.app.config import OPENAI_API_KEY, OPENAI_ASSISTANT_ID, OPENAI_PROXY
+from services.api.app.config import settings
 
 
 def get_openai_client() -> OpenAI:
@@ -10,16 +10,16 @@ def get_openai_client() -> OpenAI:
     Sets proxy environment variables and validates that required
     credentials are provided.
     """
-    if OPENAI_PROXY:
-        os.environ["HTTP_PROXY"] = OPENAI_PROXY
-        os.environ["HTTPS_PROXY"] = OPENAI_PROXY
+    if settings.openai_proxy:
+        os.environ["HTTP_PROXY"] = settings.openai_proxy
+        os.environ["HTTPS_PROXY"] = settings.openai_proxy
 
-    if not OPENAI_API_KEY:
+    if not settings.openai_api_key:
         message = "OPENAI_API_KEY is not set"
         logging.error("[OpenAI] %s", message)
         raise RuntimeError(message)
 
-    client = OpenAI(api_key=OPENAI_API_KEY)
-    if OPENAI_ASSISTANT_ID:
-        logging.info("[OpenAI] Using assistant: %s", OPENAI_ASSISTANT_ID)
+    client = OpenAI(api_key=settings.openai_api_key)
+    if settings.openai_assistant_id:
+        logging.info("[OpenAI] Using assistant: %s", settings.openai_assistant_id)
     return client

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -14,7 +14,7 @@ from telegram import (
     KeyboardButton,
     WebAppInfo,
 )
-from services.api.app.config import WEBAPP_URL
+from services.api.app.config import settings
 
 __all__ = (
     "menu_keyboard",
@@ -102,10 +102,10 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
         Button instance when ``WEBAPP_URL`` is set and valid, otherwise ``None``.
     """
 
-    if not WEBAPP_URL:
+    if not settings.webapp_url:
         return None
 
     return InlineKeyboardButton(
         "Определить автоматически",
-        web_app=WebAppInfo(WEBAPP_URL),
+        web_app=WebAppInfo(settings.webapp_url),
     )

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from services.api.app.diabetes.services.db import init_db
 
-from services.api.app.config import LOG_LEVEL, settings
+from services.api.app.config import settings
 logger = logging.getLogger(__name__)
 
 
@@ -29,7 +29,7 @@ async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> N
 def main() -> None:
     """Configure and run the bot."""
     logging.basicConfig(
-        level=LOG_LEVEL,
+        level=settings.log_level,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
     logger.info("=== Bot started ===")

--- a/tests/test_db_reinit.py
+++ b/tests/test_db_reinit.py
@@ -4,7 +4,6 @@ import sys
 import pytest
 
 
-
 def _reload(module: str):
     if module in sys.modules:
         del sys.modules[module]
@@ -23,8 +22,8 @@ class DummyEngine:
 @pytest.mark.parametrize(
     ("attr", "orig", "new", "url_attr"),
     [
-        ("DB_HOST", "host1", "host2", "host"),
-        ("DB_NAME", "name1", "name2", "database"),
+        ("db_host", "host1", "host2", "host"),
+        ("db_name", "name1", "name2", "database"),
     ],
 )
 
@@ -43,13 +42,13 @@ def test_init_db_recreates_engine_on_url_change(monkeypatch, attr, orig, new, ur
     monkeypatch.setattr(db, "create_engine", fake_create_engine)
     monkeypatch.setattr(db.Base.metadata, "create_all", lambda bind: None)
 
-    monkeypatch.setattr(db, attr, orig, raising=False)
+    monkeypatch.setattr(db.settings, attr, orig)
     db.engine = None
     db.init_db()
     first_engine = db.engine
     assert getattr(first_engine.url, url_attr) == orig
 
-    monkeypatch.setattr(db, attr, new, raising=False)
+    monkeypatch.setattr(db.settings, attr, new)
     db.init_db()
     second_engine = db.engine
 

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -7,6 +7,7 @@ import pytest
 from openai import OpenAIError
 
 from services.api.app.diabetes.services import gpt_client
+from services.api.app.config import settings
 
 
 def test_get_client_thread_safe(monkeypatch):
@@ -115,7 +116,7 @@ async def test_send_message_empty_string_preserved(tmp_path, monkeypatch):
     )
 
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
-    monkeypatch.setattr(gpt_client, "OPENAI_ASSISTANT_ID", "asst_test")
+    monkeypatch.setattr(settings, "openai_assistant_id", "asst_test")
 
     await gpt_client.send_message(thread_id="t", content="", image_path=str(img))
     assert captured["content"][1]["text"] == ""

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -10,6 +10,7 @@ import services.api.app.diabetes.handlers.profile_handlers as handlers
 from services.api.app.diabetes.handlers.db_helpers import commit_session
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
+from services.api.app.config import settings
 
 
 class DummyMessage:
@@ -207,7 +208,7 @@ async def test_profile_security_add_delete_calls_handlers(monkeypatch) -> None:
 
     monkeypatch.setattr(reminder_handlers, "delete_reminder", fake_del)
 
-    monkeypatch.setattr(handlers, "WEBAPP_URL", "http://example")
+    monkeypatch.setattr(settings, "webapp_url", "http://example")
     query_add = DummyQuery("profile_security:add")
     update_add = SimpleNamespace(callback_query=query_add, effective_user=SimpleNamespace(id=1))
     context = SimpleNamespace(application=SimpleNamespace(job_queue="jq"))

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -13,6 +13,7 @@ import services.api.app.diabetes.handlers.reminder_handlers as handlers
 import services.api.app.diabetes.handlers.router as router
 from services.api.app.diabetes.handlers.db_helpers import commit_session
 from services.api.app.diabetes.utils.helpers import parse_time_interval
+from services.api.app.config import settings
 
 
 class DummyMessage:
@@ -156,7 +157,7 @@ def test_render_reminders_formatting(monkeypatch):
         "_describe",
         lambda r, u=None: f"{'🔔' if r.is_enabled else '🔕'}title{r.id}",
     )
-    monkeypatch.setattr(handlers, "WEBAPP_URL", "https://example.org")
+    monkeypatch.setattr(settings, "webapp_url", "https://example.org")
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add_all(
@@ -196,7 +197,7 @@ def test_render_reminders_no_webapp(monkeypatch):
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.setattr(handlers, "WEBAPP_URL", None)
+    monkeypatch.setattr(settings, "webapp_url", None)
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar", time="08:00", is_enabled=True))
@@ -215,7 +216,7 @@ def test_render_reminders_no_entries_no_webapp(monkeypatch):
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.setattr(handlers, "WEBAPP_URL", None)
+    monkeypatch.setattr(settings, "webapp_url", None)
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
@@ -231,7 +232,7 @@ async def test_reminders_list_no_keyboard(monkeypatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.setattr(handlers, "WEBAPP_URL", None)
+    monkeypatch.setattr(settings, "webapp_url", None)
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.commit()


### PR DESCRIPTION
## Summary
- drop module-level constants from configuration
- use `settings` fields across services and handlers
- patch tests to update `settings` instead of constants

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689c0078a564832a8341f7ac3f6587ff