### PR TITLE
[lint] Update ruff exclude for handlers directory

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,3 @@
 line-length = 120
-extend-exclude = ["services/api/app/diabetes/handlers.py", "services/api/alembic"]
+extend-exclude = ["services/api/app/diabetes/handlers", "services/api/alembic"]
 src = ["services", "libs", "tests"]


### PR DESCRIPTION
## Summary
- update `ruff.toml` to exclude the new `services/api/app/diabetes/handlers` directory instead of the old single `handlers.py`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689c050ef528832a81cf1dd9bb145790