### PR TITLE
[webapp] Limit 404 logging to development

### DIFF
--- a/services/webapp/ui/src/pages/NotFound.tsx
+++ b/services/webapp/ui/src/pages/NotFound.tsx
@@ -5,10 +5,12 @@ const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    console.error(
-      "404 Error: User attempted to access non-existent route:",
-      location.pathname
-    );
+    if (import.meta.env.DEV) {
+      console.error(
+        "404 Error: User attempted to access non-existent route:",
+        location.pathname
+      );
+    }
   }, [location.pathname]);
 
   return (


### PR DESCRIPTION
## Summary
- restrict 404 error logging to development-only in NotFound page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: lint errors in unrelated files)
- `npx eslint src/pages/NotFound.tsx`
- `pre-commit run --files services/webapp/ui/src/pages/NotFound.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689c084e704c832ab3620c5daf2cbbdd