### PR TITLE
[services] centralize session commit handling

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -32,7 +32,7 @@ from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import Cal
 
 from services.api.app.diabetes.services.db import SessionLocal, User, Profile, Reminder
 from services.api.app.diabetes.utils.ui import menu_keyboard, build_timezone_webapp_button
-from .db_helpers import commit_session
+from services.api.app.diabetes.services.repository import commit
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from openai import OpenAIError
@@ -74,7 +74,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
                 return ConversationHandler.END
             user = User(telegram_id=user_id, thread_id=thread_id)
             session.add(user)
-            if not commit_session(session):
+            if not commit(session):
                 await update.message.reply_text(
                     "⚠️ Не удалось сохранить профиль пользователя."
                 )
@@ -186,7 +186,7 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         prof.icr = icr
         prof.cf = cf
         prof.target_bg = target
-        if not commit_session(session):
+        if not commit(session):
             await update.message.reply_text("⚠️ Не удалось сохранить профиль.")
             return ConversationHandler.END
 
@@ -242,7 +242,7 @@ async def onboarding_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE
         user = session.get(User, user_id)
         if user:
             user.timezone = tz_name
-            if not commit_session(session):
+            if not commit(session):
                 await update.message.reply_text(
 
                     "⚠️ Не удалось сохранить часовой пояс."
@@ -333,7 +333,7 @@ async def onboarding_reminders(
                 )
                 for rem in reminders:
                     rem.is_enabled = False
-            if not commit_session(session):
+            if not commit(session):
                 await query.message.reply_text(
                     "⚠️ Не удалось сохранить настройки."
                 )
@@ -381,7 +381,7 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         user = session.get(User, user_id)
         if user:
             user.onboarding_complete = True
-            if not commit_session(session):
+            if not commit(session):
                 await query.message.reply_text(
 
                     "⚠️ Не удалось сохранить настройки.",

--- a/services/api/app/diabetes/handlers/profile_handlers.py
+++ b/services/api/app/diabetes/handlers/profile_handlers.py
@@ -33,7 +33,7 @@ from services.api.app.diabetes.utils.ui import (
     menu_keyboard,
 )
 from services.api.app.config import settings
-from .db_helpers import commit_session
+from services.api.app.diabetes.services.repository import commit
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
 logger = logging.getLogger(__name__)
@@ -341,7 +341,7 @@ def _set_timezone(session, user_id: int, tz: str) -> tuple[bool, bool]:
     if not user:
         return False, False
     user.timezone = tz
-    ok = commit_session(session)
+    ok = commit(session)
     return True, ok
 
 
@@ -439,7 +439,7 @@ def _security_db(session, user_id: int, action: str | None):
     commit_ok = True
     alert_sugar = None
     if changed:
-        commit_ok = commit_session(session)
+        commit_ok = commit(session)
         if commit_ok:
             alert = (
                 session.query(Alert)
@@ -699,7 +699,7 @@ def _save_profile(
     prof.target_bg = target
     prof.low_threshold = low
     prof.high_threshold = high
-    return commit_session(session)
+    return commit(session)
 
 
 async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -23,7 +23,7 @@ from services.api.app.diabetes.services.gpt_client import (
     _get_client,
     create_thread,
 )
-from .db_helpers import commit_session
+from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.services.reporting import make_sugar_plot, generate_pdf_report
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
@@ -250,7 +250,7 @@ async def send_report(
                     user.thread_id = thread_id
                 else:
                     session.add(User(telegram_id=user_id, thread_id=thread_id))
-                if commit_session(session):
+                if commit(session):
                     context.user_data["thread_id"] = thread_id
                 else:
                     thread_id = None

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -7,7 +7,7 @@ from telegram.ext import ContextTypes
 from services.api.app.diabetes.services.db import Entry, SessionLocal
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
-from .db_helpers import commit_session
+from services.api.app.diabetes.services.repository import commit
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         with SessionLocal() as session:
             entry = Entry(**entry_data)
             session.add(entry)
-            if not commit_session(session):
+            if not commit(session):
                 await query.edit_message_text("⚠️ Не удалось сохранить запись.")
                 return
         sugar = entry_data.get("sugar_before")
@@ -81,7 +81,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 return
             if action == "del":
                 session.delete(entry)
-                if not commit_session(session):
+                if not commit(session):
                     await query.edit_message_text("⚠️ Не удалось удалить запись.")
                     return
                 await query.edit_message_text("❌ Запись удалена.")

--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -15,7 +15,7 @@ from telegram.ext import (
 
 from services.api.app.diabetes.services.db import SessionLocal, Profile
 from services.api.app.diabetes.utils.ui import back_keyboard, menu_keyboard
-from .db_helpers import commit_session
+from services.api.app.diabetes.services.repository import commit
 from . import dose_handlers
 from .dose_handlers import _cancel_then
 
@@ -59,7 +59,7 @@ async def sos_contact_save(
             profile = Profile(telegram_id=user_id)
             session.add(profile)
         profile.sos_contact = contact
-        if not commit_session(session):
+        if not commit(session):
             await update.message.reply_text(
                 "⚠️ Не удалось сохранить контакт.",
                 reply_markup=menu_keyboard,

--- a/tests/test_add_reminder_wizard.py
+++ b/tests/test_add_reminder_wizard.py
@@ -11,7 +11,7 @@ from telegram import Update
 from telegram.ext import ContextTypes
 
 import services.api.app.diabetes.handlers.reminder_handlers as handlers
-from services.api.app.diabetes.handlers.db_helpers import commit_session
+from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.services.db import Base, Reminder, User
 
 
@@ -67,7 +67,7 @@ async def test_webapp_save_creates_reminder(
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -93,7 +93,7 @@ async def test_webapp_save_creates_interval(
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -11,7 +11,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 import services.api.app.diabetes.handlers.alert_handlers as handlers
-from services.api.app.diabetes.handlers.db_helpers import commit_session
+from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.services.db import Base, User, Profile, Alert
 
 
@@ -56,7 +56,7 @@ async def test_threshold_evaluation() -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t1"))
@@ -89,7 +89,7 @@ async def test_repeat_logic(monkeypatch: pytest.MonkeyPatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -135,7 +135,7 @@ async def test_normal_reading_resolves_alert() -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -160,7 +160,7 @@ async def test_three_alerts_notify(monkeypatch: pytest.MonkeyPatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t1"))
@@ -205,7 +205,7 @@ async def test_alert_message_without_coords(monkeypatch: pytest.MonkeyPatch) -> 
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t1"))

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -74,7 +74,7 @@ async def test_entry_without_dose_has_no_unit(
         pass
 
     monkeypatch.setattr(dose_handlers, "SessionLocal", lambda: DummySession())
-    monkeypatch.setattr(dose_handlers, "commit_session", lambda session: True)
+    monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
@@ -120,7 +120,7 @@ async def test_entry_without_sugar_has_placeholder(
         pass
 
     monkeypatch.setattr(dose_handlers, "SessionLocal", lambda: DummySession())
-    monkeypatch.setattr(dose_handlers, "commit_session", lambda session: True)
+    monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -10,7 +10,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from telegram.ext import ConversationHandler
 import services.api.app.diabetes.handlers.profile_handlers as profile_handlers
 import services.api.app.diabetes.handlers.router as router
-from services.api.app.diabetes.handlers.db_helpers import commit_session
+from services.api.app.diabetes.services.repository import commit
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
 
@@ -120,7 +120,7 @@ async def test_add_reminder_commit_failure(monkeypatch, caplog) -> None:
     session.rollback = MagicMock()
 
     monkeypatch.setattr(reminder_handlers, "SessionLocal", lambda: session)
-    monkeypatch.setattr(reminder_handlers, "commit_session", commit_session)
+    monkeypatch.setattr(reminder_handlers, "commit", commit)
     schedule_mock = MagicMock()
     monkeypatch.setattr(reminder_handlers, "schedule_reminder", schedule_mock)
 
@@ -251,13 +251,13 @@ async def test_reminder_callback_commit_failure(monkeypatch, caplog) -> None:
     session.get.return_value = rem
 
     monkeypatch.setattr(reminder_handlers, "SessionLocal", lambda: session)
-    reminder_handlers.commit_session = commit_session
+    reminder_handlers.commit = commit
 
     def failing_commit(sess):
         sess.rollback()
         return False
 
-    monkeypatch.setattr(reminder_handlers, "commit_session", failing_commit)
+    monkeypatch.setattr(reminder_handlers, "commit", failing_commit)
 
     query = DummyQuery("remind_snooze:1")
     update = SimpleNamespace(

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -104,7 +104,7 @@ async def test_profile_command_invalid_values(monkeypatch, args) -> None:
 
     commit_mock = MagicMock()
     session_local_mock = MagicMock()
-    monkeypatch.setattr(handlers, "commit_session", commit_mock)
+    monkeypatch.setattr(handlers, "commit", commit_mock)
     monkeypatch.setattr(handlers, "SessionLocal", session_local_mock)
 
     message = DummyMessage()

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 from services.api.app.diabetes.services.db import Base, User, Profile, Alert, Reminder
 import services.api.app.diabetes.handlers.profile_handlers as handlers
-from services.api.app.diabetes.handlers.db_helpers import commit_session
+from services.api.app.diabetes.services.repository import commit
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
 from services.api.app.config import settings
@@ -71,7 +71,7 @@ async def test_profile_security_threshold_changes(monkeypatch, action, expected_
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(handlers, "SessionLocal", TestSession)
-    monkeypatch.setattr(handlers, "commit_session", commit_session)
+    monkeypatch.setattr(handlers, "commit", commit)
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -116,7 +116,7 @@ async def test_profile_security_toggle_sos_alerts(monkeypatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(handlers, "SessionLocal", TestSession)
-    monkeypatch.setattr(handlers, "commit_session", commit_session)
+    monkeypatch.setattr(handlers, "commit", commit)
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -160,7 +160,7 @@ async def test_profile_security_shows_reminders(monkeypatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(handlers, "SessionLocal", TestSession)
-    monkeypatch.setattr(handlers, "commit_session", commit_session)
+    monkeypatch.setattr(handlers, "commit", commit)
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -194,7 +194,7 @@ async def test_profile_security_add_delete_calls_handlers(monkeypatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(handlers, "SessionLocal", TestSession)
-    monkeypatch.setattr(handlers, "commit_session", commit_session)
+    monkeypatch.setattr(handlers, "commit", commit)
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -229,7 +229,7 @@ async def test_profile_security_sos_contact_calls_handler(monkeypatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(handlers, "SessionLocal", TestSession)
-    monkeypatch.setattr(handlers, "commit_session", commit_session)
+    monkeypatch.setattr(handlers, "commit", commit)
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))

--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import sessionmaker
 
 from services.api.app.diabetes.services.db import Base, User, Reminder, Entry
 import services.api.app.diabetes.handlers.reminder_handlers as handlers
-from services.api.app.diabetes.handlers.db_helpers import commit_session
+from services.api.app.diabetes.services.repository import commit
 
 
 class DummyMessage:
@@ -36,7 +36,7 @@ def _setup_db():
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar", time="08:00", is_enabled=True))

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -11,7 +11,7 @@ from typing import Any
 from services.api.app.diabetes.services.db import Base, User, Reminder, ReminderLog
 import services.api.app.diabetes.handlers.reminder_handlers as handlers
 import services.api.app.diabetes.handlers.router as router
-from services.api.app.diabetes.handlers.db_helpers import commit_session
+from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.helpers import parse_time_interval
 from services.api.app.config import settings
 
@@ -259,7 +259,7 @@ async def test_toggle_reminder_cb(monkeypatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -290,7 +290,7 @@ async def test_delete_reminder_cb(monkeypatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -319,7 +319,7 @@ async def test_edit_reminder(monkeypatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -353,7 +353,7 @@ async def test_trigger_job_logs(monkeypatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -392,7 +392,7 @@ async def test_cancel_callback(monkeypatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -417,7 +417,7 @@ async def test_reminder_callback_foreign_rid(monkeypatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    handlers.commit_session = commit_session
+    handlers.commit = commit
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -18,7 +18,7 @@ from services.api.app.diabetes.services.db import Base, User, Profile
 import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
 import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
 import services.api.app.diabetes.handlers.registration as handlers
-from services.api.app.diabetes.handlers.db_helpers import commit_session
+from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
 
@@ -38,8 +38,8 @@ def test_session(monkeypatch):
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(sos_handlers, "SessionLocal", TestSession)
     monkeypatch.setattr(alert_handlers, "SessionLocal", TestSession)
-    monkeypatch.setattr(sos_handlers, "commit_session", commit_session)
-    monkeypatch.setattr(alert_handlers, "commit_session", commit_session)
+    monkeypatch.setattr(sos_handlers, "commit", commit)
+    monkeypatch.setattr(alert_handlers, "commit", commit)
     return TestSession
 
 


### PR DESCRIPTION
## Summary
- add `repository` module with `commit` helper and `transactional` context manager
- replace legacy `commit_session` calls across handlers and tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_689c0ac560a4832a9953bf24a6b3d64f