### PR TITLE
[api] Move timezone and history storage to database

### DIFF
--- a/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
+++ b/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
@@ -1,0 +1,58 @@
+"""add timezone and history tables
+
+Revision ID: 20250817_add_timezone_and_history_tables
+Revises: 20250816_add_org_id_to_alerts
+Create Date: 2025-08-17 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20250817_add_timezone_and_history_tables"
+down_revision: Union[str, None] = "20250816_add_org_id_to_alerts"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = inspector.get_table_names()
+
+    if "timezones" not in tables:
+        op.create_table(
+            "timezones",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("tz", sa.String(), nullable=False),
+        )
+
+    if "history_records" not in tables:
+        op.create_table(
+            "history_records",
+            sa.Column("id", sa.String(), primary_key=True),
+            sa.Column("date", sa.String(), nullable=False),
+            sa.Column("time", sa.String(), nullable=False),
+            sa.Column("sugar", sa.Float(), nullable=True),
+            sa.Column("carbs", sa.Float(), nullable=True),
+            sa.Column("bread_units", sa.Float(), nullable=True),
+            sa.Column("insulin", sa.Float(), nullable=True),
+            sa.Column("notes", sa.Text(), nullable=True),
+            sa.Column("type", sa.String(), nullable=False),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = inspector.get_table_names()
+
+    if "history_records" in tables:
+        op.drop_table("history_records")
+
+    if "timezones" in tables:
+        op.drop_table("timezones")
+

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -161,6 +161,27 @@ class ReminderLog(Base):
     event_time = Column(TIMESTAMP(timezone=True), server_default=func.now())
 
 
+class Timezone(Base):
+    __tablename__ = "timezones"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tz = Column(String, nullable=False)
+
+
+class HistoryRecord(Base):
+    __tablename__ = "history_records"
+
+    id = Column(String, primary_key=True, index=True)
+    date = Column(String, nullable=False)
+    time = Column(String, nullable=False)
+    sugar = Column(Float)
+    carbs = Column(Float)
+    bread_units = Column(Float)
+    insulin = Column(Float)
+    notes = Column(Text)
+    type = Column(String, nullable=False)
+
+
 # ────────────────────── инициализация ────────────────────────
 def init_db() -> None:
     """Создать таблицы, если их ещё нет (для локального запуска)."""

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,18 +1,16 @@
-import asyncio
-import json
 import logging
-import os
 from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
-
-import aiofiles
-from contextlib import asynccontextmanager
-from filelock import FileLock
 
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
+from .diabetes.services.db import (
+    HistoryRecord as HistoryRecordDB,
+    Timezone as TimezoneDB,
+    run_db,
+)
 from .schemas.history import HistoryRecordSchema
 
 logger = logging.getLogger(__name__)
@@ -24,22 +22,6 @@ UI_DIR = BASE_DIR / "ui" / "dist"
 if not UI_DIR.exists():
     UI_DIR = BASE_DIR / "ui"
 UI_DIR = UI_DIR.resolve()
-TIMEZONE_FILE = Path(__file__).resolve().parent / "timezone.txt"
-HISTORY_FILE = Path(__file__).resolve().parent / "history.json"
-
-
-def _history_lock_file() -> Path:
-    return Path(str(HISTORY_FILE) + ".lock")
-
-
-@asynccontextmanager
-async def history_file_lock():
-    lock = FileLock(_history_lock_file())
-    await asyncio.to_thread(lock.acquire)
-    try:
-        yield
-    finally:
-        lock.release()
 
 
 class Timezone(BaseModel):
@@ -53,14 +35,17 @@ async def health() -> dict:
 
 @app.get("/timezone")
 async def get_timezone() -> dict:
-    if not TIMEZONE_FILE.exists():
+    def _get_timezone(session):
+        return session.get(TimezoneDB, 1)
+
+    tz_row = await run_db(_get_timezone)
+    if not tz_row:
         raise HTTPException(status_code=404, detail="timezone not set")
     try:
-        tz = TIMEZONE_FILE.read_text(encoding="utf-8").strip()
-        ZoneInfo(tz)
-    except (OSError, ZoneInfoNotFoundError) as exc:
-        raise HTTPException(status_code=500, detail="invalid timezone file") from exc
-    return {"tz": tz}
+        ZoneInfo(tz_row.tz)
+    except ZoneInfoNotFoundError as exc:
+        raise HTTPException(status_code=500, detail="invalid timezone entry") from exc
+    return {"tz": tz_row.tz}
 
 
 @app.put("/timezone")
@@ -70,16 +55,16 @@ async def put_timezone(data: Timezone) -> dict:
     except ZoneInfoNotFoundError as exc:
         raise HTTPException(status_code=400, detail="invalid timezone") from exc
 
-    async with aiofiles.tempfile.NamedTemporaryFile(
-        "w", dir=TIMEZONE_FILE.parent, delete=False, encoding="utf-8"
-    ) as tmp:
-        await tmp.write(data.tz)
-        await tmp.flush()
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, os.fsync, tmp.fileno())
+    def _save_timezone(session, tz: str):
+        obj = session.get(TimezoneDB, 1)
+        if obj is None:
+            obj = TimezoneDB(id=1, tz=tz)
+            session.add(obj)
+        else:
+            obj.tz = tz
+        session.commit()
 
-    loop = asyncio.get_running_loop()
-    await loop.run_in_executor(None, os.replace, tmp.name, TIMEZONE_FILE)
+    await run_db(_save_timezone, data.tz)
     return {"status": "ok"}
 
 
@@ -88,40 +73,38 @@ app.mount("/ui", StaticFiles(directory=UI_DIR, html=True), name="ui")
 
 @app.post("/api/history")
 async def post_history(data: HistoryRecordSchema) -> dict:
-    """Save or update a history record.
+    """Save or update a history record in the database."""
 
-    Records are stored in a local JSON file. If a record with the same ``id``
-    exists, it will be replaced.
-    """
+    def _save_history(session, record: HistoryRecordSchema) -> None:
+        obj = session.get(HistoryRecordDB, record.id)
+        if obj:
+            obj.date = record.date
+            obj.time = record.time
+            obj.sugar = record.sugar
+            obj.carbs = record.carbs
+            obj.bread_units = record.breadUnits
+            obj.insulin = record.insulin
+            obj.notes = record.notes
+            obj.type = record.type
+        else:
+            obj = HistoryRecordDB(
+                id=record.id,
+                date=record.date,
+                time=record.time,
+                sugar=record.sugar,
+                carbs=record.carbs,
+                bread_units=record.breadUnits,
+                insulin=record.insulin,
+                notes=record.notes,
+                type=record.type,
+            )
+            session.add(obj)
+        session.commit()
 
     try:
-        async with history_file_lock():
-            if HISTORY_FILE.exists():
-                async with aiofiles.open(HISTORY_FILE, "r", encoding="utf-8") as f:
-                    content = await f.read()
-                records = json.loads(content) if content else []
-                if not isinstance(records, list):  # pragma: no cover - corrupted file
-                    records = []
-            else:
-                records = []
-
-            for idx, rec in enumerate(records):
-                if rec.get("id") == data.id:
-                    records[idx] = data.model_dump()
-                    break
-            else:
-                records.append(data.model_dump())
-
-            async with aiofiles.tempfile.NamedTemporaryFile(
-                "w", dir=HISTORY_FILE.parent, delete=False, encoding="utf-8"
-            ) as tmp:
-                await tmp.write(json.dumps(records, ensure_ascii=False, indent=2))
-                await tmp.flush()
-                loop = asyncio.get_running_loop()
-                await loop.run_in_executor(None, os.fsync, tmp.fileno())
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, os.replace, tmp.name, HISTORY_FILE)
+        await run_db(_save_history, data)
     except Exception as exc:  # pragma: no cover - unexpected errors
         logger.exception("failed to save history")
         raise HTTPException(status_code=500, detail="failed to save history") from exc
     return {"status": "ok"}
+

--- a/tests/test_webapp_history.py
+++ b/tests/test_webapp_history.py
@@ -1,39 +1,64 @@
 import asyncio
-import json
 
 import pytest
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 import services.api.app.main as server
+from services.api.app.diabetes.services import db
 
 
-def test_history_persist_and_update(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr(server, "HISTORY_FILE", tmp_path / "history.json")
+def setup_db(monkeypatch):
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    Session = sessionmaker(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+
+    async def run_db_wrapper(fn, *args, **kwargs):
+        return await db.run_db(fn, *args, sessionmaker=Session, **kwargs)
+
+    monkeypatch.setattr(server, "run_db", run_db_wrapper)
+    return Session
+
+
+def test_history_persist_and_update(monkeypatch) -> None:
+    Session = setup_db(monkeypatch)
     client = TestClient(server.app)
 
     rec1 = {"id": "1", "date": "2024-01-01", "time": "12:00", "type": "measurement"}
     resp = client.post("/api/history", json=rec1)
     assert resp.status_code == 200
-    rec1_dump = {**rec1, "sugar": None, "carbs": None, "breadUnits": None, "insulin": None, "notes": None}
-    assert json.loads(server.HISTORY_FILE.read_text(encoding="utf-8")) == [rec1_dump]
+
+    with Session() as session:
+        stored = session.get(db.HistoryRecord, "1")
+        assert stored is not None
+        assert stored.date == "2024-01-01"
+        assert stored.sugar is None
 
     rec1_update = {**rec1, "sugar": 5.5}
     resp = client.post("/api/history", json=rec1_update)
     assert resp.status_code == 200
-    rec1_update_dump = {**rec1_dump, "sugar": 5.5}
-    assert json.loads(server.HISTORY_FILE.read_text(encoding="utf-8")) == [rec1_update_dump]
+
+    with Session() as session:
+        stored = session.get(db.HistoryRecord, "1")
+        assert stored.sugar == 5.5
 
     rec2 = {"id": "2", "date": "2024-01-02", "time": "13:00", "type": "meal"}
     resp = client.post("/api/history", json=rec2)
     assert resp.status_code == 200
-    rec2_dump = {**rec2, "sugar": None, "carbs": None, "breadUnits": None, "insulin": None, "notes": None}
-    assert json.loads(server.HISTORY_FILE.read_text(encoding="utf-8")) == [rec1_update_dump, rec2_dump]
+
+    with Session() as session:
+        records = session.query(db.HistoryRecord).order_by(db.HistoryRecord.id).all()
+        assert [r.id for r in records] == ["1", "2"]
 
 
 @pytest.mark.asyncio
-async def test_history_concurrent_writes(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr(server, "HISTORY_FILE", tmp_path / "history.json")
+async def test_history_concurrent_writes(monkeypatch) -> None:
+    Session = setup_db(monkeypatch)
     records = [
         {"id": str(i), "date": "2024-01-01", "time": "12:00", "type": "measurement"}
         for i in range(5)
@@ -46,7 +71,7 @@ async def test_history_concurrent_writes(tmp_path, monkeypatch) -> None:
 
     await asyncio.gather(*(post_record(r) for r in records))
 
-    dumped = json.loads(server.HISTORY_FILE.read_text(encoding="utf-8"))
-    default_fields = {"sugar": None, "carbs": None, "breadUnits": None, "insulin": None, "notes": None}
-    expected = [{**rec, **default_fields} for rec in records]
-    assert sorted(dumped, key=lambda d: d["id"]) == expected
+    with Session() as session:
+        stored = session.query(db.HistoryRecord).all()
+        assert sorted([r.id for r in stored]) == [r["id"] for r in records]
+


### PR DESCRIPTION
## Summary
- add timezone and history models to ORM
- move `/timezone` and `/api/history` endpoints to database persistence
- add Alembic migration for new tables and update tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_689c10ab2900832a91b32de30e623692