### PR TITLE
[services] encapsulate OpenAI client

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -7,7 +7,7 @@ from openai import OpenAIError
 
 from pydantic import ValidationError
 
-from services.api.app.diabetes.services.gpt_client import _get_client
+from services.api.app.diabetes.services.gpt_client import OpenAIClient
 from services.api.app.schemas import CommandSchema
 
 # Prompt guiding GPT to convert free-form diary text into a single JSON command
@@ -73,6 +73,9 @@ def _extract_first_json(text: str) -> dict | None:
     return None
 
 
+gpt_client = OpenAIClient()
+
+
 async def parse_command(text: str, timeout: float = 10) -> dict | None:
     try:
         # ``asyncio.to_thread`` runs the blocking OpenAI client in the event
@@ -80,7 +83,7 @@ async def parse_command(text: str, timeout: float = 10) -> dict | None:
         # fresh ``ThreadPoolExecutor`` for every invocation.
         response = await asyncio.wait_for(
             asyncio.to_thread(
-                _get_client().chat.completions.with_options(timeout=timeout).create,
+                gpt_client.client.chat.completions.with_options(timeout=timeout).create,
                 model="gpt-4o-mini",
                 messages=[
                     {"role": "system", "content": SYSTEM_PROMPT},

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -36,6 +36,7 @@ from services.api.app.diabetes.services.repository import commit
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from openai import OpenAIError
+from services.api.app.diabetes.services.gpt_client import OpenAIClient
 
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,9 @@ DEMO_PHOTO_PATH = (
 
 # Wizard states
 ONB_PROFILE_ICR, ONB_PROFILE_CF, ONB_PROFILE_TARGET, ONB_PROFILE_TZ, ONB_DEMO, ONB_REMINDERS = range(6)
+
+
+gpt_client = OpenAIClient()
 
 
 async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -62,10 +66,8 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     with SessionLocal() as session:
         user = session.get(User, user_id)
         if not user:
-            from services.api.app.diabetes.services.gpt_client import create_thread
-
             try:
-                thread_id = create_thread()
+                thread_id = gpt_client.create_thread()
             except OpenAIError as exc:  # pragma: no cover - network errors
                 logger.exception("Failed to create thread for user %s: %s", user_id, exc)
                 await update.message.reply_text(

--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -1,4 +1,11 @@
-# gpt_client.py
+"""OpenAI client wrapper with lazy initialization.
+
+This module exposes :class:`OpenAIClient` which encapsulates thread-safe
+initialization of the underlying OpenAI client and provides helper methods for
+creating threads and sending messages to the Assistant API.
+"""
+
+from __future__ import annotations
 
 import asyncio
 import logging
@@ -11,122 +18,151 @@ from openai import OpenAIError
 from services.api.app.config import settings
 from services.api.app.diabetes.utils.openai_utils import get_openai_client
 
+
 logger = logging.getLogger(__name__)
 
-_client = None
-_client_lock = threading.Lock()
 
+class OpenAIClient:
+    """A thin wrapper around the OpenAI SDK used in the project.
 
-def _get_client():
-    global _client
-    if _client is None:
-        with _client_lock:
-            if _client is None:
-                _client = get_openai_client()
-    return _client
-
-
-def create_thread() -> str:
-    """Создаём пустой thread (ассистент задаётся позже, в runs.create)."""
-    try:
-        thread = _get_client().beta.threads.create()
-    except OpenAIError as exc:
-        logger.exception("[OpenAI] Failed to create thread: %s", exc)
-        raise
-    return thread.id
-
-
-async def send_message(
-    thread_id: str,
-    content: str | None = None,
-    image_path: str | None = None,
-    *,
-    keep_image: bool = False,
-):
-    """Send text or (image + text) to the thread and start a run.
-
-    Parameters
-    ----------
-    thread_id: str
-        Target thread identifier.
-    content: str | None
-        Text message to send.  Must be provided if ``image_path`` is ``None``.
-    image_path: str | None
-        Path to an image to upload alongside the text.
-    keep_image: bool, default ``False``
-        If ``True`` the local file will not be removed after attempting the upload.
-
-    Returns
-    -------
-    run
-        The created run object.
+    The underlying client is created lazily and shared between threads.  Methods
+    in this class mirror the previous module-level helper functions so existing
+    call sites can simply instantiate :class:`OpenAIClient` and use the methods
+    ``create_thread`` and ``send_message``.
     """
-    if content is None and image_path is None:
-        raise ValueError("Either 'content' or 'image_path' must be provided")
 
-    # 1. Подготовка контента
-    text_block = {
-        "type": "text",
-        "text": content if content is not None else "Что изображено на фото?",
-    }
-    client = _get_client()
-    if image_path:
+    def __init__(self) -> None:
+        self._client: Any | None = None
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Client management
+    # ------------------------------------------------------------------
+    def _get_client(self) -> Any:
+        """Return a cached OpenAI client instance creating it if necessary."""
+
+        if self._client is None:
+            with self._lock:
+                if self._client is None:
+                    self._client = get_openai_client()
+        return self._client
+
+    @property
+    def client(self) -> Any:
+        """Expose the underlying OpenAI client (read‑only)."""
+
+        return self._get_client()
+
+    # ------------------------------------------------------------------
+    # API helpers
+    # ------------------------------------------------------------------
+    def create_thread(self) -> str:
+        """Создаём пустой thread (ассистент задаётся позже, в runs.create)."""
+
         try:
-            def _upload() -> Any:
-                with open(image_path, "rb") as f:
-                    return client.files.create(file=f, purpose="vision")
+            thread = self._get_client().beta.threads.create()
+        except OpenAIError as exc:  # pragma: no cover - network errors
+            logger.exception("[OpenAI] Failed to create thread: %s", exc)
+            raise
+        return thread.id
 
-            file = await asyncio.to_thread(_upload)
-        except OSError as exc:
-            logger.exception("[OpenAI] Failed to read %s: %s", image_path, exc)
-            raise
-        except OpenAIError as exc:
-            logger.exception("[OpenAI] Failed to upload %s: %s", image_path, exc)
-            raise
+    async def send_message(
+        self,
+        *,
+        thread_id: str,
+        content: str | None = None,
+        image_path: str | None = None,
+        keep_image: bool = False,
+    ):
+        """Send text or (image + text) to the thread and start a run.
+
+        Parameters
+        ----------
+        thread_id: str
+            Target thread identifier.
+        content: str | None
+            Text message to send.  Must be provided if ``image_path`` is
+            ``None``.
+        image_path: str | None
+            Path to an image to upload alongside the text.
+        keep_image: bool, default ``False``
+            If ``True`` the local file will not be removed after attempting the
+            upload.
+
+        Returns
+        -------
+        run
+            The created run object.
+        """
+
+        if content is None and image_path is None:
+            raise ValueError("Either 'content' or 'image_path' must be provided")
+
+        client = self._get_client()
+        text_block = {
+            "type": "text",
+            "text": content if content is not None else "Что изображено на фото?",
+        }
+
+        if image_path:
+            try:
+                def _upload() -> Any:
+                    with open(image_path, "rb") as f:
+                        return client.files.create(file=f, purpose="vision")
+
+                file = await asyncio.to_thread(_upload)
+            except OSError as exc:
+                logger.exception("[OpenAI] Failed to read %s: %s", image_path, exc)
+                raise
+            except OpenAIError as exc:  # pragma: no cover - network errors
+                logger.exception(
+                    "[OpenAI] Failed to upload %s: %s", image_path, exc
+                )
+                raise
+            else:
+                logger.info(
+                    "[OpenAI] Uploaded image %s, file_id=%s", image_path, file.id
+                )
+                content_block = [
+                    {"type": "image_file", "image_file": {"file_id": file.id}},
+                    text_block,
+                ]
+                if not keep_image:
+                    try:
+                        await asyncio.to_thread(os.remove, image_path)
+                    except OSError as e:  # pragma: no cover - best effort
+                        logger.warning(
+                            "[OpenAI] Failed to delete %s: %s", image_path, e
+                        )
         else:
-            logger.info(
-                "[OpenAI] Uploaded image %s, file_id=%s", image_path, file.id
+            content_block = [text_block]
+
+        try:
+            await asyncio.to_thread(
+                client.beta.threads.messages.create,
+                thread_id=thread_id,
+                role="user",
+                content=content_block,
             )
-            content_block = [
-                {"type": "image_file", "image_file": {"file_id": file.id}},
-                text_block,
-            ]
-            if not keep_image:
-                try:
-                    await asyncio.to_thread(os.remove, image_path)
-                except OSError as e:
-                    logger.warning(
-                        "[OpenAI] Failed to delete %s: %s", image_path, e
-                    )
-    else:
-        content_block = [text_block]
+        except OpenAIError as exc:  # pragma: no cover - network errors
+            logger.exception("[OpenAI] Failed to create message: %s", exc)
+            raise
 
-    # 2. Создаём сообщение в thread
-    try:
-        await asyncio.to_thread(
-            client.beta.threads.messages.create,
-            thread_id=thread_id,
-            role="user",
-            content=content_block,
-        )
-    except OpenAIError as exc:
-        logger.exception("[OpenAI] Failed to create message: %s", exc)
-        raise
+        if not settings.openai_assistant_id:
+            message = "OPENAI_ASSISTANT_ID is not set"
+            logger.error("[OpenAI] %s", message)
+            raise RuntimeError(message)
 
-    if not settings.openai_assistant_id:
-        message = "OPENAI_ASSISTANT_ID is not set"
-        logger.error("[OpenAI] %s", message)
-        raise RuntimeError(message)
+        try:
+            run = await asyncio.to_thread(
+                client.beta.threads.runs.create,
+                thread_id=thread_id,
+                assistant_id=settings.openai_assistant_id,
+            )
+        except OpenAIError as exc:  # pragma: no cover - network errors
+            logger.exception("[OpenAI] Failed to create run: %s", exc)
+            raise
 
-    # 3. Запускаем ассистента
-    try:
-        run = await asyncio.to_thread(
-            client.beta.threads.runs.create,
-            thread_id=thread_id,
-            assistant_id=settings.openai_assistant_id,
-        )
-    except OpenAIError as exc:
-        logger.exception("[OpenAI] Failed to create run: %s", exc)
-        raise
-    logger.debug("[OpenAI] Run %s started (thread %s)", run.id, thread_id)
-    return run
+        logger.debug("[OpenAI] Run %s started (thread %s)", run.id, thread_id)
+        return run
+

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -32,7 +32,7 @@ async def test_parse_command_timeout_non_blocking(monkeypatch) -> None:
             )
         )
     )
-    monkeypatch.setattr(gpt_command_parser, "_get_client", lambda: fake_client)
+    monkeypatch.setattr(gpt_command_parser, "gpt_client", SimpleNamespace(client=fake_client))
 
     start = time.perf_counter()
     result, _ = await asyncio.gather(
@@ -78,7 +78,7 @@ async def test_parse_command_with_explanatory_text(monkeypatch) -> None:
             )
         )
     )
-    monkeypatch.setattr(gpt_command_parser, "_get_client", lambda: fake_client)
+    monkeypatch.setattr(gpt_command_parser, "gpt_client", SimpleNamespace(client=fake_client))
 
     result = await gpt_command_parser.parse_command("test")
 
@@ -106,7 +106,7 @@ async def test_parse_command_with_array_response(monkeypatch) -> None:
             )
         )
     )
-    monkeypatch.setattr(gpt_command_parser, "_get_client", lambda: fake_client)
+    monkeypatch.setattr(gpt_command_parser, "gpt_client", SimpleNamespace(client=fake_client))
 
     result = await gpt_command_parser.parse_command("test")
 
@@ -134,7 +134,7 @@ async def test_parse_command_with_scalar_response(monkeypatch) -> None:
             )
         )
     )
-    monkeypatch.setattr(gpt_command_parser, "_get_client", lambda: fake_client)
+    monkeypatch.setattr(gpt_command_parser, "gpt_client", SimpleNamespace(client=fake_client))
 
     result = await gpt_command_parser.parse_command("test")
 
@@ -167,7 +167,7 @@ async def test_parse_command_with_invalid_schema(monkeypatch, caplog) -> None:
             )
         )
     )
-    monkeypatch.setattr(gpt_command_parser, "_get_client", lambda: fake_client)
+    monkeypatch.setattr(gpt_command_parser, "gpt_client", SimpleNamespace(client=fake_client))
 
     with caplog.at_level(logging.ERROR):
         result = await gpt_command_parser.parse_command("test")
@@ -191,7 +191,7 @@ async def test_parse_command_with_missing_content(monkeypatch, caplog) -> None:
             )
         )
     )
-    monkeypatch.setattr(gpt_command_parser, "_get_client", lambda: fake_client)
+    monkeypatch.setattr(gpt_command_parser, "gpt_client", SimpleNamespace(client=fake_client))
 
     with caplog.at_level(logging.ERROR):
         result = await gpt_command_parser.parse_command("test")
@@ -221,7 +221,7 @@ async def test_parse_command_with_non_string_content(monkeypatch, caplog) -> Non
             )
         )
     )
-    monkeypatch.setattr(gpt_command_parser, "_get_client", lambda: fake_client)
+    monkeypatch.setattr(gpt_command_parser, "gpt_client", SimpleNamespace(client=fake_client))
 
     with caplog.at_level(logging.ERROR):
         result = await gpt_command_parser.parse_command("test")
@@ -235,7 +235,7 @@ async def test_parse_command_handles_unexpected_exception(monkeypatch, caplog) -
     def bad_client() -> None:
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(gpt_command_parser, "_get_client", bad_client)
+    monkeypatch.setattr(gpt_command_parser, "gpt_client", SimpleNamespace(client=bad_client))
 
     with caplog.at_level(logging.ERROR):
         result = await gpt_command_parser.parse_command("test")

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -149,8 +149,9 @@ async def test_photo_handler_preserves_file(
             )
         )
 
-    monkeypatch.setattr(handlers, "send_message", fake_send_message)
-    monkeypatch.setattr(handlers, "_get_client", lambda: DummyClient())
+    fake_client = DummyClient()
+    monkeypatch.setattr(handlers.gpt_client, "send_message", fake_send_message)
+    monkeypatch.setattr(handlers.gpt_client, "_get_client", lambda: fake_client)
     monkeypatch.setattr(handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
     monkeypatch.setattr(handlers, "menu_keyboard", None)
     monkeypatch.setattr(
@@ -202,8 +203,9 @@ async def test_photo_then_freeform_calculates_dose(
             )
         )
 
-    monkeypatch.setattr(handlers, "send_message", fake_send_message)
-    monkeypatch.setattr(handlers, "_get_client", lambda: DummyClient())
+    fake_client2 = DummyClient()
+    monkeypatch.setattr(handlers.gpt_client, "send_message", fake_send_message)
+    monkeypatch.setattr(handlers.gpt_client, "_get_client", lambda: fake_client2)
     monkeypatch.setattr(handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
     monkeypatch.setattr(handlers, "menu_keyboard", None)
     monkeypatch.setattr(handlers, "confirm_keyboard", lambda: None)

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -123,8 +123,9 @@ async def test_photo_flow_saves_entry(
             )
         )
 
-    monkeypatch.setattr(dose_handlers, "send_message", fake_send_message)
-    monkeypatch.setattr(dose_handlers, "_get_client", lambda: DummyClient())
+    fake_client = DummyClient()
+    monkeypatch.setattr(dose_handlers.gpt_client, "send_message", fake_send_message)
+    monkeypatch.setattr(dose_handlers.gpt_client, "_get_client", lambda: fake_client)
     monkeypatch.setattr(dose_handlers, "extract_nutrition_info", lambda text: (30.0, 2.0))
     context.user_data["thread_id"] = "tid"
 

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -74,8 +74,9 @@ async def test_photo_prompt_includes_dish_name(monkeypatch, tmp_path) -> None:
             )
         )
 
-    monkeypatch.setattr(dose_handlers, "send_message", fake_send_message)
-    monkeypatch.setattr(dose_handlers, "_get_client", lambda: DummyClient())
+    fake_client = DummyClient()
+    monkeypatch.setattr(dose_handlers.gpt_client, "send_message", fake_send_message)
+    monkeypatch.setattr(dose_handlers.gpt_client, "_get_client", lambda: fake_client)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
     msg_photo = DummyMessage(photo=[DummyPhoto()])

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -34,9 +34,8 @@ async def test_onboarding_demo_photo_missing(monkeypatch, caplog) -> None:
 
     import services.api.app.diabetes.handlers.common_handlers  # noqa: F401
     import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
-    import services.api.app.diabetes.services.gpt_client as gpt_client
 
-    monkeypatch.setattr(gpt_client, "create_thread", lambda: "tid")
+    monkeypatch.setattr(onboarding.gpt_client, "create_thread", lambda: "tid")
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -54,9 +54,8 @@ async def test_onboarding_flow(monkeypatch) -> None:
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 
     import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
-    import services.api.app.diabetes.services.gpt_client as gpt_client
 
-    monkeypatch.setattr(gpt_client, "create_thread", lambda: "tid")
+    monkeypatch.setattr(onboarding.gpt_client, "create_thread", lambda: "tid")
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -216,8 +216,9 @@ async def test_send_report_uses_gpt(monkeypatch) -> None:
             )
         )
 
-    monkeypatch.setattr(handlers, "send_message", fake_send_message)
-    monkeypatch.setattr(handlers, "_get_client", lambda: DummyClient())
+    fake_client = DummyClient()
+    monkeypatch.setattr(handlers.gpt_client, "send_message", fake_send_message)
+    monkeypatch.setattr(handlers.gpt_client, "_get_client", lambda: fake_client)
     monkeypatch.setattr(
         handlers, "make_sugar_plot", lambda entries, period_label: io.BytesIO(b"img")
     )


### PR DESCRIPTION
## Summary
- encapsulate OpenAI functionality in `OpenAIClient` with thread-safe initialization and messaging helpers
- update GPT command parser and handlers to use `OpenAIClient` instances
- adjust tests for the new client interface

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689c13958f0c832a961bcbdbce07ed7f