### PR TITLE
[handlers] Ensure datetime import at top of alert handlers

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 import datetime


### PR DESCRIPTION
## Summary
- ensure `alert_handlers` has a datetime import at the module start

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: sqlalchemy.exc.InterfaceError in test_timezone_concurrent_writes)*


------
https://chatgpt.com/codex/tasks/task_e_689c17a97100832aa2b36321890c554a