### PR TITLE
[webapp] handle delete error in history

### DIFF
--- a/services/webapp/ui/src/pages/History.tsx
+++ b/services/webapp/ui/src/pages/History.tsx
@@ -73,8 +73,9 @@ const History = () => {
     }
   };
   const handleDeleteRecord = async (id: string) => {
+    const prev = [...records];
     // Optimistically remove record from UI
-    setRecords(prev => prev.filter(r => r.id !== id));
+    setRecords(prevRecords => prevRecords.filter(r => r.id !== id));
 
     try {
       await deleteRecord(id);
@@ -83,6 +84,7 @@ const History = () => {
         description: 'Запись успешно удалена из истории',
       });
     } catch (err) {
+      setRecords(prev);
       const message = err instanceof Error ? err.message : 'Неизвестная ошибка';
       toast({
         title: 'Ошибка',


### PR DESCRIPTION
## Summary
- snapshot records before deletion to allow rollback on failure
- restore records and notify user if history deletion fails

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_webapp_timezone.py::test_timezone_concurrent_writes -vv` *(fails: sqlite3.IntegrityError: UNIQUE constraint failed: timezones.id)*

------
https://chatgpt.com/codex/tasks/task_e_689c18dfcdfc832a8071d1eb9780bbc5