### PR TITLE
[handlers] Split profile handlers into modules

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -41,7 +41,7 @@ from services.api.app.diabetes.services.repository import commit
 from .common_handlers import menu_command
 from .alert_handlers import check_alert
 from .reporting_handlers import send_report, history_view, report_request, render_entry
-from .profile_handlers import profile_view
+from .profile import profile_view
 
 
 logger = logging.getLogger(__name__)

--- a/services/api/app/diabetes/handlers/profile/__init__.py
+++ b/services/api/app/diabetes/handlers/profile/__init__.py
@@ -1,0 +1,18 @@
+"""Expose profile conversation handlers and helpers."""
+
+from . import conversation as _conversation
+from .api import get_api, save_profile, set_timezone, fetch_profile, post_profile
+from .validation import parse_profile_args
+
+# Attach helper functions to the conversation module so tests and other modules
+# can monkeypatch or access them directly.
+_conversation.get_api = get_api
+_conversation.save_profile = save_profile
+_conversation.set_timezone = set_timezone
+_conversation.fetch_profile = fetch_profile
+_conversation.post_profile = post_profile
+_conversation.parse_profile_args = parse_profile_args
+
+# Re-export the conversation module as the package itself
+import sys as _sys
+_sys.modules[__name__] = _conversation

--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -1,0 +1,87 @@
+import logging
+from services.api.app.config import settings
+from services.api.app.diabetes.services.db import Profile, SessionLocal, User
+from services.api.app.diabetes.services.repository import commit
+
+logger = logging.getLogger(__name__)
+
+
+def get_api():
+    """Return API client, its exception type and profile model.
+
+    Separate function to make API access testable without importing SDK in UI
+    modules.
+    """
+    try:
+        from diabetes_sdk.api.default_api import DefaultApi
+        from diabetes_sdk.api_client import ApiClient
+        from diabetes_sdk.configuration import Configuration
+        from diabetes_sdk.exceptions import ApiException
+        from diabetes_sdk.models.profile import Profile as ProfileModel
+    except ImportError:
+        logger.warning(
+            "diabetes_sdk is required but not installed. Install it with 'pip install -r requirements.txt'."
+        )
+        return None, None, None
+    api = DefaultApi(ApiClient(Configuration(host=settings.api_url)))
+    return api, ApiException, ProfileModel
+
+
+def save_profile(session, user_id: int, icr: float, cf: float, target: float, low: float, high: float) -> bool:
+    """Persist profile values into the local database."""
+    prof = session.get(Profile, user_id)
+    if not prof:
+        prof = Profile(telegram_id=user_id)
+        session.add(prof)
+    prof.icr = icr
+    prof.cf = cf
+    prof.target_bg = target
+    prof.low_threshold = low
+    prof.high_threshold = high
+    return commit(session)
+
+
+def set_timezone(session, user_id: int, tz: str) -> tuple[bool, bool]:
+    """Update user timezone in the database."""
+    user = session.get(User, user_id)
+    if not user:
+        return False, False
+    user.timezone = tz
+    ok = commit(session)
+    return True, ok
+
+
+def fetch_profile(api, ApiException, user_id: int):
+    """Fetch profile via synchronous SDK call."""
+    try:
+        return api.profiles_get(telegram_id=user_id)
+    except ApiException:
+        return None
+
+
+def post_profile(
+    api,
+    ApiException,
+    ProfileModel,
+    user_id: int,
+    icr: float,
+    cf: float,
+    target: float,
+    low: float,
+    high: float,
+) -> tuple[bool, str | None]:
+    """Save profile via SDK and return success flag and optional error message."""
+    profile = ProfileModel(
+        telegram_id=user_id,
+        icr=icr,
+        cf=cf,
+        target=target,
+        low=low,
+        high=high,
+    )
+    try:
+        api.profiles_post(profile)
+        return True, None
+    except ApiException as exc:
+        logger.error("API call failed: %s", exc)
+        return False, str(exc)

--- a/services/api/app/diabetes/handlers/profile/validation.py
+++ b/services/api/app/diabetes/handlers/profile/validation.py
@@ -1,0 +1,33 @@
+"""Utilities for parsing and validating user input for profile handlers."""
+
+from __future__ import annotations
+
+
+def parse_profile_args(args: list[str]) -> dict[str, str] | None:
+    """Parse ``/profile`` command arguments into a dict."""
+    if len(args) == 5 and all("=" not in a for a in args):
+        return {
+            "icr": args[0],
+            "cf": args[1],
+            "target": args[2],
+            "low": args[3],
+            "high": args[4],
+        }
+
+    parsed: dict[str, str] = {}
+    for arg in args:
+        if "=" not in arg:
+            return None
+        key, val = arg.split("=", 1)
+        key = key.lower()
+        match = None
+        for full in ("icr", "cf", "target", "low", "high"):
+            if full.startswith(key):
+                match = full
+                break
+        if not match:
+            return None
+        parsed[match] = val
+    if set(parsed) == {"icr", "cf", "target", "low", "high"}:
+        return parsed
+    return None

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -25,7 +25,7 @@ def register_handlers(app: Application) -> None:
     # (for example OpenAI client initialization).
     from . import (
         dose_handlers,
-        profile_handlers,
+        profile,
         reporting_handlers,
         reminder_handlers,
         alert_handlers,
@@ -39,8 +39,8 @@ def register_handlers(app: Application) -> None:
     app.add_handler(dose_handlers.dose_conv)
     # Register profile conversation before sugar conversation so that numeric
     # inputs for profile aren't captured by sugar logging
-    app.add_handler(profile_handlers.profile_conv)
-    app.add_handler(profile_handlers.profile_webapp_handler)
+    app.add_handler(profile.profile_conv)
+    app.add_handler(profile.profile_webapp_handler)
     app.add_handler(dose_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
     app.add_handler(CommandHandler("cancel", dose_handlers.dose_cancel))
@@ -55,7 +55,7 @@ def register_handlers(app: Application) -> None:
     app.add_handler(CommandHandler("hypoalert", security_handlers.hypo_alert_faq))
     app.add_handler(PollAnswerHandler(onboarding_poll_answer))
     app.add_handler(
-        MessageHandler(filters.Regex("^📄 Мой профиль$"), profile_handlers.profile_view)
+        MessageHandler(filters.Regex("^📄 Мой профиль$"), profile.profile_view)
     )
     app.add_handler(
         MessageHandler(filters.Regex("^📈 Отчёт$"), reporting_handlers.report_request)
@@ -101,11 +101,11 @@ def register_handlers(app: Application) -> None:
     )
     app.add_handler(
         CallbackQueryHandler(
-            profile_handlers.profile_security, pattern="^profile_security"
+            profile.profile_security, pattern="^profile_security"
         )
     )
     app.add_handler(
-        CallbackQueryHandler(profile_handlers.profile_back, pattern="^profile_back$")
+        CallbackQueryHandler(profile.profile_back, pattern="^profile_back$")
     )
     app.add_handler(CallbackQueryHandler(reminder_handlers.reminder_callback, pattern="^remind_"))
     app.add_handler(CallbackQueryHandler(callback_router))

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
 from telegram.ext import ConversationHandler
-import services.api.app.diabetes.handlers.profile_handlers as profile_handlers
+from services.api.app.diabetes.handlers import profile as profile_handlers
 import services.api.app.diabetes.handlers.router as router
 from services.api.app.diabetes.services.repository import commit
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
@@ -56,7 +56,7 @@ async def test_profile_command_no_local_session(monkeypatch) -> None:
 
     dummy_api = SimpleNamespace(profiles_post=MagicMock())
     monkeypatch.setattr(
-        profile_handlers, "_get_api", lambda: (dummy_api, Exception, MagicMock)
+        profile_handlers, "get_api", lambda: (dummy_api, Exception, MagicMock)
     )
 
     message = DummyMessage()

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -41,7 +41,7 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import services.api.app.diabetes.handlers.profile_handlers as handlers
+    from services.api.app.diabetes.handlers import profile as handlers
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
@@ -100,7 +100,7 @@ async def test_profile_command_invalid_values(monkeypatch, args) -> None:
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import services.api.app.diabetes.handlers.profile_handlers as handlers
+    from services.api.app.diabetes.handlers import profile as handlers
 
     commit_mock = MagicMock()
     session_local_mock = MagicMock()
@@ -125,7 +125,7 @@ async def test_profile_command_help_and_dialog(monkeypatch) -> None:
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import services.api.app.diabetes.handlers.profile_handlers as handlers
+    from services.api.app.diabetes.handlers import profile as handlers
 
     # Test /profile help
     help_msg = DummyMessage()
@@ -152,7 +152,7 @@ async def test_profile_view_preserves_user_data(monkeypatch) -> None:
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    import services.api.app.diabetes.handlers.profile_handlers as handlers
+    from services.api.app.diabetes.handlers import profile as handlers
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -11,7 +11,7 @@ os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import (
     dose_handlers,
-    profile_handlers,
+    profile as profile_handlers,
     onboarding_handlers,
     sos_handlers,
 )

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -7,7 +7,7 @@ import pytest
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from services.api.app.diabetes.handlers import dose_handlers, profile_handlers
+from services.api.app.diabetes.handlers import dose_handlers, profile as profile_handlers
 from services.api.app.diabetes.services.db import Base, Entry, User
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -6,7 +6,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from services.api.app.diabetes.services.db import Base, User, Profile, Alert, Reminder
-import services.api.app.diabetes.handlers.profile_handlers as handlers
+from services.api.app.diabetes.handlers import profile as handlers
 from services.api.app.diabetes.services.repository import commit
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
@@ -41,7 +41,7 @@ async def test_profile_view_has_security_button(monkeypatch) -> None:
     dummy_profile = SimpleNamespace(icr=10, cf=2, target=6, low=4, high=9)
     dummy_api = SimpleNamespace(profiles_get=lambda telegram_id: dummy_profile)
     monkeypatch.setattr(
-        handlers, "_get_api", lambda: (dummy_api, Exception, MagicMock)
+        handlers, "get_api", lambda: (dummy_api, Exception, MagicMock)
     )
 
     msg = DummyMessage()

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -19,7 +19,11 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    from services.api.app.diabetes.handlers import dose_handlers, profile_handlers, reporting_handlers
+    from services.api.app.diabetes.handlers import (
+        dose_handlers,
+        profile as profile_handlers,
+        reporting_handlers,
+    )
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
     register_handlers(app)


### PR DESCRIPTION
## Summary
- break up profile handlers into API, validation, and conversation modules
- isolate synchronous SDK calls from UI logic for easier testing
- update handler registration to use new profile package

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689c18b55bf4832aa15dfbb9f437b9c6