### PR TITLE
[webapp] propagate profile save errors

### DIFF
--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -7,6 +7,9 @@ export async function saveProfile(profile: Profile) {
     return await api.profilesPost({ profile });
   } catch (error) {
     console.error('Failed to save profile:', error);
-    throw new Error('Не удалось сохранить профиль');
+    if (error instanceof Error) {
+      throw new Error(`Не удалось сохранить профиль: ${error.message}`);
+    }
+    throw error;
   }
 }

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -48,8 +48,7 @@ const Profile = () => {
         description: 'Ваши настройки успешно обновлены',
       });
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Не удалось сохранить профиль';
+      const message = error instanceof Error ? error.message : String(error);
       toast({
         title: 'Ошибка',
         description: message,


### PR DESCRIPTION
## Summary
- propagate API error messages when saving profiles
- surface error messages to user in profile page

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` (fails: UNIQUE constraint failed: timezones.id)
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 3 errors)

------
https://chatgpt.com/codex/tasks/task_e_689c1d304554832abf07455a9e56da1f