### PR TITLE
[alembic] Expand version_num length

### DIFF
--- a/services/api/alembic/versions/20250816a_expand_alembic_version_len.py
+++ b/services/api/alembic/versions/20250816a_expand_alembic_version_len.py
@@ -1,0 +1,18 @@
+"""Expand alembic_version.version_num to VARCHAR(255)."""
+
+from alembic import op
+
+# NB: новая ревизия ВСТАВЛЯЕТСЯ между 20250816 и 20250817
+revision = "20250816a_expand_alembic_version_len"
+down_revision = "20250816_add_org_id_to_alerts"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TABLE alembic_version ALTER COLUMN version_num TYPE VARCHAR(255);")
+
+
+def downgrade():
+    # осторожно: может не влезть, если в истории уже длинные id
+    op.execute("ALTER TABLE alembic_version ALTER COLUMN version_num TYPE VARCHAR(32);")

--- a/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
+++ b/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
@@ -1,7 +1,7 @@
 """add timezone and history tables
 
 Revision ID: 20250817_add_timezone_and_history_tables
-Revises: 20250816_add_org_id_to_alerts
+Revises: 20250816a_expand_alembic_version_len
 Create Date: 2025-08-17 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "20250817_add_timezone_and_history_tables"
-down_revision: Union[str, None] = "20250816_add_org_id_to_alerts"
+down_revision: Union[str, None] = "20250816a_expand_alembic_version_len"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- add tech migration expanding `alembic_version.version_num` to `VARCHAR(255)`
- rebase timezone/history migration on the new revision

## Testing
- `ruff check services/api/app tests`
- `pytest tests`
- ⚠️ `alembic -c services/api/alembic.ini upgrade head` *(fails: relation "users" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689c4322b0b4832a90ebecf897ee3a7f