### PR TITLE
[webapp] Notify bot after reminder save

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -207,6 +207,9 @@ def _render_reminders(
 
 
 def schedule_reminder(rem: Reminder, job_queue) -> None:
+    name = f"reminder_{rem.id}"
+    for job in job_queue.get_jobs_by_name(name):
+        job.schedule_removal()
     if not rem.is_enabled:
         logger.debug(
             "Reminder %s disabled, skipping (type=%s, time=%s, interval=%s, minutes_after=%s)",
@@ -217,9 +220,6 @@ def schedule_reminder(rem: Reminder, job_queue) -> None:
             rem.minutes_after,
         )
         return
-    name = f"reminder_{rem.id}"
-    for job in job_queue.get_jobs_by_name(name):
-        job.schedule_removal()
 
     tz = timezone.utc
     user = rem.__dict__.get("user")

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -131,7 +131,7 @@ function ReminderRow({
 export default function Reminders() {
   const navigate = useNavigate()
   const { toast } = useToast()
-  const { user } = useTelegram()
+  const { user, sendData } = useTelegram()
 
   const [reminders, setReminders] = useState<Reminder[]>([])
   const [loading, setLoading] = useState(true)
@@ -188,6 +188,10 @@ export default function Reminders() {
         intervalHours: target.interval != null ? target.interval / 60 : undefined,
         isEnabled: nextActive,
       })
+      const hours = target.interval != null ? target.interval / 60 : undefined
+      const value =
+        hours != null && Number.isInteger(hours) ? `${hours}h` : target.time
+      sendData({ id, type: target.type, value })
       toast({
         title: 'Напоминание обновлено',
         description: 'Статус напоминания изменён',

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -53,7 +53,7 @@ export default function CreateReminder() {
   const navigate = useNavigate();
   const location = useLocation();
   const params = useParams();
-  const { user } = useTelegram();
+  const { user, sendData } = useTelegram();
   const { toast } = useToast();
   const [editing, setEditing] = useState<Reminder | undefined>(
     (location.state as Reminder | undefined) ?? undefined,
@@ -121,10 +121,15 @@ export default function CreateReminder() {
       ...(editing ? { id: editing.id } : {}),
     };
     try {
-      if (editing) {
-        await updateReminder(payload);
-      } else {
-        await createReminder(payload);
+      const res = editing
+        ? await updateReminder(payload)
+        : await createReminder(payload);
+      const rid = editing ? editing.id : res?.id;
+      const hours = interval != null ? interval / 60 : undefined;
+      const value =
+        hours != null && Number.isInteger(hours) ? `${hours}h` : time;
+      if (rid) {
+        sendData({ id: rid, type, value });
       }
       navigate("/reminders");
     } catch (err) {


### PR DESCRIPTION
## Summary
- send reminder info to Telegram bot after creating or updating reminders
- reschedule jobs through reminder_webapp_save handler on changes

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689c82297acc832a8a5d26e5391932d2