### PR TITLE
[api] include legacy router

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ python services/api/app/main.py
    ```bash
    uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000
    ```
+   Приложение также подключает маршруты из `legacy.py`, предоставляя эндпоинты `/profiles` и `/api/reminders`, совместимые с SDK.
 
 ### Docker Compose
 ```bash

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -11,11 +11,13 @@ from .diabetes.services.db import (
     Timezone as TimezoneDB,
     run_db,
 )
+from .legacy import router
 from .schemas.history import HistoryRecordSchema
 
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
+app.include_router(router)
 
 BASE_DIR = Path(__file__).resolve().parents[2] / "webapp"
 UI_DIR = BASE_DIR / "ui" / "dist"


### PR DESCRIPTION
## Summary
- include legacy router to expose /profiles and /api/reminders
- document legacy endpoints in README

## Testing
- `ruff check services/api/app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c84c7be78832a9ea62bbd027c77ff