### PR TITLE
[api] Serve SPA index for /ui routes

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
@@ -71,15 +70,17 @@ async def put_timezone(data: Timezone) -> dict:
     return {"status": "ok"}
 
 
-app.mount("/ui", StaticFiles(directory=UI_DIR, html=True), name="ui")
-
-
 @app.get("/ui/{full_path:path}", include_in_schema=False)
 async def catch_all_ui(full_path: str) -> FileResponse:
     requested_file = UI_DIR / full_path
     if requested_file.is_file():
         return FileResponse(requested_file)
     return FileResponse(UI_DIR / "index.html")
+
+
+@app.get("/ui", include_in_schema=False)
+async def catch_root_ui() -> FileResponse:
+    return await catch_all_ui("")
 
 
 @app.post("/api/history")

--- a/tests/test_webapp_server.py
+++ b/tests/test_webapp_server.py
@@ -17,3 +17,9 @@ def test_static_ui_serving() -> None:
     resp = client.get("/ui")
     assert resp.status_code == 200
     assert "<html" in resp.text.lower()
+
+
+def test_unknown_ui_route_serves_index() -> None:
+    resp = client.get("/ui/reminders")
+    assert resp.status_code == 200
+    assert "<html" in resp.text.lower()


### PR DESCRIPTION
## Summary
- Remove redundant StaticFiles mount for /ui and serve all UI routes via catch-all
- Return index.html for unknown /ui paths while serving real files when present
- Test that /ui/reminders falls back to the main HTML page

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: sqlalchemy.orm.exc.StaleDataError in tests/test_webapp_timezone.py::test_timezone_concurrent_writes)*
- `pytest tests/test_webapp_server.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_689cb927fa48832abf790841cd0c15d6