### PR TITLE
[webapp] fix telegram init path

### DIFF
--- a/services/webapp/public/timezone.html
+++ b/services/webapp/public/timezone.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/ui/assets/index-Cz8THv6W.css">
     <title>Часовой пояс</title>
-    <script src="/telegram-init.js"></script>
+    <script src="/ui/telegram-init.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/services/webapp/ui/index.html
+++ b/services/webapp/ui/index.html
@@ -33,7 +33,7 @@
 
     <!-- Telegram SDK + инициализация темы (не бандлим, грузим отдельным скриптом) -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <script type="module" src="/telegram-init.js"></script>
+    <script type="module" src="/ui/telegram-init.js"></script>
 
     <!-- Open Graph / Twitter -->
     <meta property="og:title" content="СахарФото — ассистент для диабетиков" />


### PR DESCRIPTION
## Summary
- correct telegram-init.js path in webapp index
- use proper telegram-init.js path in timezone page

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689cba8385e8832aaa732e6dd9f9a078