### PR TITLE
[ui] append timezone path to webapp

### DIFF
--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -122,5 +122,5 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
 
     return InlineKeyboardButton(
         "Определить автоматически",
-        web_app=WebAppInfo(settings.webapp_url),
+        web_app=WebAppInfo(f"{settings.webapp_url}/timezone"),
     )

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -1,0 +1,21 @@
+import importlib
+from urllib.parse import urlparse
+
+
+def test_timezone_button_webapp_url(monkeypatch):
+    """Timezone button should open webapp path for timezone detection."""
+    monkeypatch.setenv("WEBAPP_URL", "https://example.com")
+
+    import services.api.app.config as config
+    import services.api.app.diabetes.utils.ui as ui
+
+    importlib.reload(config)
+    importlib.reload(ui)
+
+    button = ui.build_timezone_webapp_button()
+    assert button is not None
+    assert urlparse(button.web_app.url).path == "/timezone"
+
+    monkeypatch.delenv("WEBAPP_URL", raising=False)
+    importlib.reload(config)
+    importlib.reload(ui)


### PR DESCRIPTION
## Summary
- append `/timezone` to timezone detection WebApp URL
- cover timezone WebApp button with test

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689cbc19e2d4832a990e9eddc30677be