### PR TITLE
[webapp] use stable css reference for timezone page

### DIFF
--- a/services/webapp/public/timezone.html
+++ b/services/webapp/public/timezone.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/ui/assets/index-Cz8THv6W.css">
+    <link rel="stylesheet" href="/style.css">
     <title>Часовой пояс</title>
     <script src="/ui/telegram-init.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- replace hashed css link with stable `/style.css` for timezone page

## Testing
- `pytest tests/`
- `ruff check services/api/app tests`
- `npm --prefix services/webapp/ui run build` *(fails: Rollup failed to resolve import "/ui/telegram-init.js")*

------
https://chatgpt.com/codex/tasks/task_e_689cbf27b338832aa9752acd3ddeeb20