### PR TITLE
docs: update deployment paths to project name

### DIFF
--- a/docs/deploy/diabetes-assistant.service
+++ b/docs/deploy/diabetes-assistant.service
@@ -5,8 +5,8 @@ After=network.target
 [Service]
 Type=simple
 User=www-data
-WorkingDirectory=/opt/diabetes-assistant
-EnvironmentFile=/opt/diabetes-assistant/.env
+WorkingDirectory=/opt/saharlight-ux
+EnvironmentFile=/opt/saharlight-ux/.env
 ExecStart=/usr/bin/env uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000 --workers 4
 Restart=on-failure
 RestartSec=5

--- a/docs/deploy/supervisord.conf
+++ b/docs/deploy/supervisord.conf
@@ -1,5 +1,5 @@
 [program:diabetes-webapp]
-directory=/opt/diabetes-assistant
+directory=/opt/saharlight-ux
 command=uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000 --workers 4
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- replace hardcoded /opt/diabetes-assistant path with /opt/saharlight-ux in deploy service configs

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` *(fails: tests/test_webapp_timezone.py::test_timezone_concurrent_writes)*

------
https://chatgpt.com/codex/tasks/task_e_689e35b2b22c832a9301cea4d3987270