### PR TITLE
[setup] Update frontend path in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,7 @@ pip install --upgrade pip
 pip install -r requirements.txt
 
 echo "Сборка фронтенда (npm ci && npm run build)…"
-pushd webapp/ui >/dev/null
+pushd services/webapp/ui >/dev/null
 npm ci
 npm run build
 popd >/dev/null
@@ -25,5 +25,5 @@ if [ ! -f ".env" ]; then
 fi
 
 echo "Установка завершена! Проверьте файл .env и заполните свои токены и пароли."
-echo "Фронтенд собран в webapp/ui/dist."
+echo "Фронтенд собран в services/webapp/ui/dist."
 echo "Для запуска API: source venv/bin/activate && python services/api/app/main.py"


### PR DESCRIPTION
## Summary
- build frontend in `services/webapp/ui`
- update setup script completion message to new path

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: sqlite interface error in `tests/test_webapp_timezone.py::test_timezone_concurrent_writes`)*

------
https://chatgpt.com/codex/tasks/task_e_689e35a362b4832a8f97f8a5be3936ea