### PR TITLE
[deps] Adjust py-sdk path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ npx @openapitools/openapi-generator-cli generate -i libs/contracts/openapi.yaml 
 
 ```bash
 pip install -r services/api/app/requirements.txt
-pip install -e libs/py-sdk
 ```
 
 Тесты используют переменные `OPENAI_API_KEY`, `DB_PASSWORD` и другие из `.env`.

--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -3,7 +3,6 @@ anyio==4.9.0
 certifi==2025.4.26
 contourpy==1.3.2
 cycler==0.12.1
--e libs/py-sdk  # provides diabetes_sdk via local path
 distro==1.9.0
 fonttools==4.58.4
 greenlet==3.2.1


### PR DESCRIPTION
## Summary
- drop local py-sdk from service requirements so root file manages the SDK install
- streamline README test instructions by removing redundant py-sdk command

## Testing
- `pip install -r requirements.txt`
- `pip install -r services/api/app/requirements-dev.txt`
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689e35a630d8832a85da349a4a9c6cc0