### PR TITLE
[docker] Install dependencies from requirements file

### DIFF
--- a/infra/docker/Dockerfile.api
+++ b/infra/docker/Dockerfile.api
@@ -3,9 +3,16 @@ FROM python:3.12-slim
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
-COPY services/api/ /app/services/api/
+# Copy dependency definitions
+COPY requirements.txt ./
+COPY services/api/app/requirements.txt services/api/app/
+COPY libs/py-sdk/ libs/py-sdk/
 
-RUN pip install --no-cache-dir fastapi uvicorn pydantic psycopg2-binary
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY services/api/ services/api/
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- install Python dependencies from `requirements.txt` in Docker build
- copy `libs/py-sdk` and app requirements before `pip install`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689e35a9a35c832ab010733f98582dbe