### PR TITLE
[infra] Use root env file for Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ python services/api/app/main.py
    Приложение также подключает маршруты из `legacy.py`, предоставляя эндпоинты `/profiles` и `/api/reminders`, совместимые с SDK.
 
 ### Docker Compose
+
+Перед запуском создайте файл `.env` в корне проекта (например, `cp infra/env/.env.example .env`) и убедитесь, что в `infra/docker/docker-compose.yml` путь `env_file` указывает на него (`../../.env`).
+
 ```bash
 docker compose -f infra/docker/docker-compose.yml up --build
 ```

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ../..
       dockerfile: infra/docker/Dockerfile.api
-    env_file: [ ../env/.env.example ]
+    env_file: [ ../../.env ]
     ports:
       - "8000:8000"
     command: >-


### PR DESCRIPTION
## Summary
- use root .env in docker-compose
- document .env creation for Docker Compose

## Testing
- `pytest tests/`
- `pre-commit run --files infra/docker/docker-compose.yml README.md`


------
https://chatgpt.com/codex/tasks/task_e_689e35ac62b0832aacc503ce0b48b8d2