### PR TITLE
[setup] update frontend path message

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,5 +25,5 @@ if [ ! -f ".env" ]; then
 fi
 
 echo "Установка завершена! Проверьте файл .env и заполните свои токены и пароли."
-echo "Фронтенд собран в webapp/ui/dist."
+echo "Фронтенд собран в services/webapp/ui/dist."
 echo "Для запуска API: source venv/bin/activate && python services/api/app/main.py"


### PR DESCRIPTION
## Summary
- update frontend build path message in setup script

## Testing
- `ruff check services/api/app tests`
- `pytest tests` (fails: UNIQUE constraint failed: timezones.id)


------
https://chatgpt.com/codex/tasks/task_e_689e35af455c832aaaa55374db9d1f93