### PR TITLE
[py-sdk] Fix poetry-core build-system requirement

### DIFF
--- a/libs/py-sdk/pyproject.toml
+++ b/libs/py-sdk/pyproject.toml
@@ -17,7 +17,7 @@ attrs = ">=22.2.0"
 python-dateutil = "^2.8.0"
 
 [build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0"]
+requires = ["poetry-core>=1.8,<2"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- allow installing libs/py-sdk by using existing poetry-core version range

## Testing
- `pip install -r requirements.txt`
- `pytest tests` *(fails: sqlite3.IntegrityError in tests/test_webapp_timezone.py::test_timezone_concurrent_writes)*
- `ruff check services/api/app tests`


------
https://chatgpt.com/codex/tasks/task_e_689eb261c270832aa44345da3ce23fa2