### PR TITLE
[infra] Use Python 3.12 in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,10 +5,12 @@ set -e
 
 echo "Обновление списка пакетов и установка системных зависимостей…"
 sudo apt-get update || { echo "APT update failed" >&2; exit 1; }
-sudo apt-get install -y python3-venv python3-dev build-essential libpq-dev || { echo "APT install failed" >&2; exit 1; }
+sudo add-apt-repository ppa:deadsnakes/ppa -y || { echo "Add-apt-repository failed" >&2; exit 1; }
+sudo apt-get update || { echo "APT update failed" >&2; exit 1; }
+sudo apt-get install -y python3.12-venv python3.12-dev build-essential libpq-dev || { echo "APT install failed" >&2; exit 1; }
 
 echo "Создание виртуального окружения…"
-python3 -m venv venv
+python3.12 -m venv venv
 source venv/bin/activate
 
 echo "Установка Python-зависимостей…"


### PR DESCRIPTION
## Summary
- install Python 3.12 via Deadsnakes PPA and use its venv and dev packages
- build virtual environment with python3.12

## Testing
- `pytest tests/`
- `ruff check services/api/app tests`


------
https://chatgpt.com/codex/tasks/task_e_689eb685d030832abc0c0b97b5a0cb03