### PR TITLE
[infra] remove pgdg repository from setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,8 +6,6 @@ set -e
 echo "Обновление списка пакетов и установка системных зависимостей…"
 sudo apt-get update || { echo "APT update failed" >&2; exit 1; }
 sudo add-apt-repository ppa:deadsnakes/ppa -y || { echo "Add-apt-repository failed" >&2; exit 1; }
-curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor --yes -o /usr/share/keyrings/pgdg.gpg || { echo "Add PGDG GPG key failed" >&2; exit 1; }
-echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt noble-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null || { echo "Add PGDG repository failed" >&2; exit 1; }
 sudo apt-get update || { echo "APT update failed" >&2; exit 1; }
 sudo apt-get install -y python3.12-venv python3.12-dev build-essential libpq-dev || { echo "APT install failed" >&2; exit 1; }
 


### PR DESCRIPTION
## Summary
- simplify setup.sh to rely on Ubuntu's default PostgreSQL packages

## Testing
- `sudo apt-get update`
- `bash setup.sh` *(npm build failed: Rollup failed to resolve import "/ui/telegram-init.js")*
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689eca092880832a90bf7f387b4875f6