### PR TITLE
[webapp] Load telegram init script without module

### DIFF
--- a/services/webapp/ui/index.html
+++ b/services/webapp/ui/index.html
@@ -33,7 +33,7 @@
 
     <!-- Telegram SDK + инициализация темы (не бандлим, грузим отдельным скриптом) -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <script type="module" src="/ui/telegram-init.js"></script>
+    <script src="/telegram-init.js"></script>
 
     <!-- Open Graph / Twitter -->
     <meta property="og:title" content="СахарФото — ассистент для диабетиков" />


### PR DESCRIPTION
## Summary
- load telegram init script without module attribute and adjust path

## Testing
- `npm run build` *(fails: npm: No such file or directory)*
- `pytest tests` *(fails: pytest: No such file or directory)*
- `ruff services/api/app tests` *(fails: ruff: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ece4bc1a4832a9adb2f02439c44c3