### PR TITLE
[py-sdk] type configuration parameter

### DIFF
--- a/libs/py-sdk/diabetes_sdk/api/default_api.py
+++ b/libs/py-sdk/diabetes_sdk/api/default_api.py
@@ -1,4 +1,5 @@
 from ..api_client import ApiClient
+from ..configuration import Configuration
 from ..exceptions import ApiException
 from ..models import Profile
 
@@ -8,7 +9,9 @@ class DefaultApi:
 
     _profiles_store: dict[int, Profile] = {}
 
-    def __init__(self, api_client: ApiClient | None = None, *, configuration=None) -> None:
+    def __init__(
+        self, api_client: ApiClient | None = None, *, configuration: Configuration | None = None
+    ) -> None:
         if api_client is not None:
             self.api_client = api_client
         else:


### PR DESCRIPTION
## Summary
- add Configuration import to default API client
- type the configuration constructor parameter

## Testing
- `ruff check libs/py-sdk/diabetes_sdk/api/default_api.py`
- `mypy libs/py-sdk/diabetes_sdk/api/default_api.py --config-file=/dev/null`
- `pytest tests -q` *(fails: sqlalchemy.exc.DatabaseError: UNIQUE constraint failed: timezones.id)*

------
https://chatgpt.com/codex/tasks/task_e_689ed38e3ec4832aac7a7dd1b482a700