### PR TITLE
[api] Validate UI path before serving file

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -72,7 +72,11 @@ async def put_timezone(data: Timezone) -> dict:
 
 @app.get("/ui/{full_path:path}", include_in_schema=False)
 async def catch_all_ui(full_path: str) -> FileResponse:
-    requested_file = UI_DIR / full_path
+    requested_file = (UI_DIR / full_path).resolve()
+    try:
+        requested_file.relative_to(UI_DIR)
+    except ValueError as exc:
+        raise HTTPException(status_code=404) from exc
     if requested_file.is_file():
         return FileResponse(requested_file)
     return FileResponse(UI_DIR / "index.html")


### PR DESCRIPTION
## Summary
- ensure `catch_all_ui` only serves files within `UI_DIR`
- fall back to `index.html` while blocking path traversal attempts

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` *(fails: UNIQUE constraint failed: timezones.id)*

------
https://chatgpt.com/codex/tasks/task_e_689eddf85268832aa73be738e827739a