### PR TITLE
ci: install attrs for mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,5 @@
 [mypy]
 explicit_package_bases = True
-plugins = attrs.mypy_plugin
 
 [mypy-telegram.*]
 ignore_missing_imports = True

--- a/services/api/app/requirements-dev.txt
+++ b/services/api/app/requirements-dev.txt
@@ -3,3 +3,4 @@ pre-commit
 pytest-cov
 mypy
 playwright
+attrs>=22.0.0


### PR DESCRIPTION
## Summary
- add attrs to dev requirements for mypy
- remove unused attrs plugin from mypy config

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: Item "None" of "Message | None" has no attribute "reply_text" and 1250 similar errors)*
- `pytest` *(fails: test_timezone_concurrent_writes)*

------
https://chatgpt.com/codex/tasks/task_e_689edf5b4868832a9b66c6e49ce2ab45