### PR TITLE
[api] Fix module imports when running main directly

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -4,7 +4,11 @@ from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 if __name__ == "__main__" and __package__ is None:  # pragma: no cover - setup for direct execution
-    sys.path.append(str(Path(__file__).resolve().parents[3]))
+    # Ensure repository root is the first entry so that the correct `services`
+    # package is imported when running this file directly.  There is another
+    # third-party package named ``services`` installed in the environment which
+    # would otherwise take precedence and cause `ModuleNotFoundError`.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
     __package__ = "services.api.app"
 
 from fastapi import FastAPI, HTTPException


### PR DESCRIPTION
## Summary
- ensure repository root is first on sys.path when running `services/api/app/main.py`

## Testing
- `python services/api/app/main.py`
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689eea4cc69c832ab46fdfd37193303b