### PR TITLE
[services] Use relative imports

### DIFF
--- a/services/api/app/services/__init__.py
+++ b/services/api/app/services/__init__.py
@@ -1,4 +1,4 @@
-from services.api.app.diabetes.services.db import init_db
+from ..diabetes.services.db import init_db
 
 from .profile import save_profile, set_timezone
 from .reminders import list_reminders, save_reminder

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from fastapi import HTTPException
-from services.api.app.diabetes.services.db import Profile, SessionLocal, User, run_db
-from services.api.app.schemas.profile import ProfileSchema
+from ..diabetes.services.db import Profile, SessionLocal, User, run_db
+from ..schemas.profile import ProfileSchema
 
 
 async def set_timezone(telegram_id: int, tz: str) -> None:

--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -4,8 +4,8 @@ from typing import List
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from services.api.app.diabetes.services.db import Reminder, SessionLocal, run_db
-from services.api.app.schemas.reminders import ReminderSchema
+from ..diabetes.services.db import Reminder, SessionLocal, run_db
+from ..schemas.reminders import ReminderSchema
 
 
 async def list_reminders(telegram_id: int) -> List[Reminder]:


### PR DESCRIPTION
## Summary
- refactor services api imports to use package-relative paths

## Testing
- `ruff check services/api/app`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689eec73f598832a95a1c229ed20dcce