### PR TITLE
[ui] use computed base and port in vite config

### DIFF
--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig(async ({ mode }) => {
   const base   = mode === 'development' ? '/' : '/ui/'  // dev → '/', prod → '/ui/'
   const port   = 5173                                   // или оставьте 8080 и укажите его в .lovable.yml
   return {
-    base: '/ui/',
+    base,
     plugins,
     resolve: {
       alias: {
@@ -20,7 +20,7 @@ export default defineConfig(async ({ mode }) => {
         '@sdk': path.resolve(__dirname, '../../../libs/ts-sdk'),
       },
     },
-    server: { host: '::', port: 8080 },
+    server: { host: '::', port },
     build: { outDir: 'dist' }, // Явно задаём dist (по умолчанию и так dist)
   }
 })


### PR DESCRIPTION
## Summary
- use computed base and port in Vite config

## Testing
- `npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_689eef0b758c832a855169575e67709a