### PR TITLE
[ui] Split bundles with dynamic imports

### DIFF
--- a/services/webapp/ui/src/App.tsx
+++ b/services/webapp/ui/src/App.tsx
@@ -6,16 +6,18 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { useTelegram } from "@/hooks/useTelegram";
 import { ThemeProvider } from "next-themes";
-import Home from "./pages/Home";
-import Profile from "./pages/Profile";
-import Reminders from "./pages/Reminders";
-import CreateReminder from "./reminders/CreateReminder";
-import History from "./pages/History";
-import NewMeasurement from "./pages/NewMeasurement";
-import NewMeal from "./pages/NewMeal";
-import Analytics from "./pages/Analytics";
-import Subscription from "./pages/Subscription";
-import NotFound from "./pages/NotFound";
+import { Suspense, lazy } from "react";
+
+const Home = lazy(() => import("./pages/Home"));
+const Profile = lazy(() => import("./pages/Profile"));
+const Reminders = lazy(() => import("./pages/Reminders"));
+const CreateReminder = lazy(() => import("./reminders/CreateReminder"));
+const History = lazy(() => import("./pages/History"));
+const NewMeasurement = lazy(() => import("./pages/NewMeasurement"));
+const NewMeal = lazy(() => import("./pages/NewMeal"));
+const Analytics = lazy(() => import("./pages/Analytics"));
+const Subscription = lazy(() => import("./pages/Subscription"));
+const NotFound = lazy(() => import("./pages/NotFound"));
 
 const queryClient = new QueryClient();
 
@@ -34,19 +36,21 @@ const AppContent = () => {
   }
 
   return (
-    <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/profile" element={<Profile />} />
+    <Suspense fallback={<div>Загрузка...</div>}>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/profile" element={<Profile />} />
         <Route path="/reminders" element={<Reminders />} />
         <Route path="/reminders/new" element={<CreateReminder />} />
         <Route path="/reminders/:id/edit" element={<CreateReminder />} />
-      <Route path="/history" element={<History />} />
-      <Route path="/history/new-measurement" element={<NewMeasurement />} />
-      <Route path="/history/new-meal" element={<NewMeal />} />
-      <Route path="/analytics" element={<Analytics />} />
-      <Route path="/subscription" element={<Subscription />} />
-      <Route path="*" element={<NotFound />} />
-    </Routes>
+        <Route path="/history" element={<History />} />
+        <Route path="/history/new-measurement" element={<NewMeasurement />} />
+        <Route path="/history/new-meal" element={<NewMeal />} />
+        <Route path="/analytics" element={<Analytics />} />
+        <Route path="/subscription" element={<Subscription />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </Suspense>
   );
 };
 

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -21,6 +21,19 @@ export default defineConfig(async ({ mode }) => {
       },
     },
     server: { host: '::', port },
-    build: { outDir: 'dist' }, // Явно задаём dist (по умолчанию и так dist)
+    build: {
+      outDir: 'dist', // Явно задаём dist (по умолчанию и так dist)
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            vendor: [
+              'react',
+              'react-dom',
+              'react-router-dom'
+            ]
+          }
+        }
+      }
+    },
   }
 })


### PR DESCRIPTION
## Summary
- add manual vendor chunk to Vite build
- load pages lazily to enable route-level code splitting

## Testing
- `npx vite build`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type)*
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689ef0be7e00832ab6877ec4fc95b21c