### PR TITLE
[tests] cast filters to Regex before pattern access

### DIFF
--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -1,6 +1,8 @@
 import os
 import re
-from telegram.ext import ApplicationBuilder, MessageHandler
+from typing import cast
+
+from telegram.ext import ApplicationBuilder, MessageHandler, filters
 from services.api.app.diabetes.utils.ui import menu_keyboard
 import services.api.app.diabetes.handlers.registration as handlers
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
@@ -21,6 +23,6 @@ def test_reminders_button_matches_regex() -> None:
         for h in app.handlers[0]
         if isinstance(h, MessageHandler) and h.callback is reminder_handlers.reminders_list
     )
-    pattern = reminder_handler.filters.pattern.pattern
+    pattern = cast(filters.Regex, reminder_handler.filters).pattern.pattern
     assert pattern == "^⏰ Напоминания$"
     assert re.fullmatch(pattern, "⏰ Напоминания")

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -13,7 +13,7 @@ from .context_stub import AlertContext, ContextStub
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from telegram import Bot, Update
-from telegram.ext import ApplicationBuilder, CallbackContext, MessageHandler
+from telegram.ext import ApplicationBuilder, CallbackContext, MessageHandler, filters
 
 from services.api.app.diabetes.services.db import Base, User, Profile
 import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
@@ -163,7 +163,7 @@ async def test_sos_contact_menu_button_starts_conv(monkeypatch: pytest.MonkeyPat
         for h in app.handlers[0]
         if isinstance(h, MessageHandler) and h.callback is sos_handlers.sos_contact_start
     )
-    pattern = sos_handler.filters.pattern.pattern
+    pattern = cast(filters.Regex, sos_handler.filters).pattern.pattern
     assert re.fullmatch(pattern, "🆘 SOS контакт")
 
     message = DummyMessage("🆘 SOS контакт")


### PR DESCRIPTION
## Summary
- cast `handler.filters` to `filters.Regex` before reading `.pattern` in tests
- add missing imports for `cast` and `filters`

## Testing
- `ruff check tests/test_reminders_button_regex.py tests/test_sos_contact.py`
- `pytest tests/test_reminders_button_regex.py tests/test_sos_contact.py`


------
https://chatgpt.com/codex/tasks/task_e_689ef9bc8bc0832a8377b5bc5bc0b702