### PR TITLE
[handlers] Explicitly export profile conversation helpers

### DIFF
--- a/services/api/app/diabetes/handlers/profile/__init__.py
+++ b/services/api/app/diabetes/handlers/profile/__init__.py
@@ -2,7 +2,38 @@
 
 from . import conversation as _conversation
 from .api import get_api, save_profile, set_timezone, fetch_profile, post_profile
+from .conversation import (
+    profile_command,
+    profile_view,
+    profile_cancel,
+    profile_back,
+    profile_security,
+    profile_timezone,
+    profile_edit,
+    profile_conv,
+    profile_webapp_save,
+    profile_webapp_handler,
+)
 from .validation import parse_profile_args
+
+__all__ = [
+    "profile_command",
+    "profile_view",
+    "profile_cancel",
+    "profile_back",
+    "profile_security",
+    "profile_timezone",
+    "profile_edit",
+    "profile_conv",
+    "profile_webapp_save",
+    "profile_webapp_handler",
+    "get_api",
+    "save_profile",
+    "set_timezone",
+    "fetch_profile",
+    "post_profile",
+    "parse_profile_args",
+]
 
 # Attach helper functions to the conversation module so tests and other modules
 # can monkeypatch or access them directly.
@@ -13,6 +44,8 @@ _conversation.fetch_profile = fetch_profile
 _conversation.post_profile = post_profile
 _conversation.parse_profile_args = parse_profile_args
 
-# Re-export the conversation module as the package itself
+# Re-export the conversation module as the package itself for backward compatibility.
 import sys as _sys
+
 _sys.modules[__name__] = _conversation
+

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -1,10 +1,10 @@
-import pytest
-
 """Tests for debug logging configuration in bot.main."""
 
 import importlib
 import logging
 import sys
+
+import pytest
 
 
 def test_log_level_debug(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Re-export conversation handlers and helper functions in `profile` package so static analysis tools can detect them
- Move debug logging test docstring above imports for ruff compliance

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: sqlalchemy.exc.InterfaceError in tests/test_webapp_timezone.py::test_timezone_concurrent_writes)*

------
https://chatgpt.com/codex/tasks/task_e_689efc49fc28832aa4c1ee7cf47bd8f7