### PR TITLE
[deps] Add alembic for mypy

### DIFF
--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -1,3 +1,4 @@
+alembic==1.16.4
 annotated-types==0.7.0
 anyio==4.9.0
 certifi==2025.4.26


### PR DESCRIPTION
## Summary
- add alembic dependency to API requirements for type checking

## Testing
- `ruff check services/api/app tests`
- `pytest tests`
- `mypy --strict services/api`


------
https://chatgpt.com/codex/tasks/task_e_689f0f3e73bc832aa244fc0a8bf83938