### PR TITLE
[alembic] annotate migration functions return types

### DIFF
--- a/services/api/alembic/versions/20250816a_expand_alembic_version_len.py
+++ b/services/api/alembic/versions/20250816a_expand_alembic_version_len.py
@@ -9,10 +9,10 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade():
+def upgrade() -> None:
     op.execute("ALTER TABLE alembic_version ALTER COLUMN version_num TYPE VARCHAR(255);")
 
 
-def downgrade():
+def downgrade() -> None:
     # осторожно: может не влезть, если в истории уже длинные id
     op.execute("ALTER TABLE alembic_version ALTER COLUMN version_num TYPE VARCHAR(32);")


### PR DESCRIPTION
## Summary
- add explicit `-> None` annotations to `upgrade` and `downgrade` in alembic version length migration
- confirm all migrations use explicit `None` return types for upgrade/downgrade

## Testing
- `python -m pip install -r services/api/app/requirements-dev.txt`
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689f16374cb4832a9fe1a8eadf2ae59d