### PR TITLE
[config] Refine log level parser

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -57,13 +57,18 @@ class Settings(BaseSettings):
 
     @field_validator("log_level", mode="before")
     @classmethod
-    def parse_log_level(cls, v: object) -> int:  # pragma: no cover - simple parsing
-        if isinstance(v, str) and v.lower() in {"1", "true", "debug"}:
-            return logging.DEBUG
-        try:
-            return int(v)  # type: ignore[return-value]
-        except (TypeError, ValueError):
-            return logging.INFO
+    def parse_log_level(cls, v: int | str | None) -> int:  # pragma: no cover - simple parsing
+        if isinstance(v, str):
+            v_lower = v.lower()
+            if v_lower in {"1", "true", "debug"}:
+                return logging.DEBUG
+            try:
+                return int(v)
+            except ValueError:
+                return logging.INFO
+        if isinstance(v, int):
+            return v
+        return logging.INFO
 
 
 # Instantiate settings for external use


### PR DESCRIPTION
## Summary
- handle `str`, `int`, and `None` when parsing `LOG_LEVEL`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689f1912b51c832a801121061222b216