### PR TITLE
[db] use DeclarativeBase

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.engine import URL
 from sqlalchemy.exc import UnboundExecutionError
-from sqlalchemy.orm import declarative_base, sessionmaker, relationship
+from sqlalchemy.orm import DeclarativeBase, sessionmaker, relationship
 import asyncio
 import logging
 import threading
@@ -30,7 +30,10 @@ logger = logging.getLogger(__name__)
 engine = None
 engine_lock = threading.Lock()
 SessionLocal = sessionmaker(autoflush=False, autocommit=False)
-Base = declarative_base()
+
+
+class Base(DeclarativeBase):
+    pass
 
 
 T = TypeVar("T")


### PR DESCRIPTION
## Summary
- use SQLAlchemy DeclarativeBase for model definitions

## Testing
- `mypy --strict services/api/app/diabetes/services/db.py`
- `ruff check services/api/app/diabetes/services/db.py`
- `pytest tests` *(fails: Interrupted: 48 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689f1ad60c6c832a8a5699f5c2f4172d