### PR TITLE
[webapp] Fetch user profile in Profile page

### DIFF
--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,9 +1,24 @@
 import { DefaultApi, Profile } from '@sdk';
-import { Configuration } from '@sdk/runtime';
+import { Configuration, ResponseError } from '@sdk/runtime';
 
 const api = new DefaultApi(
   new Configuration({ basePath: import.meta.env.VITE_API_BASE }),
 );
+
+export async function getProfile(telegramId: number): Promise<Profile | null> {
+  try {
+    return await api.profilesGet({ telegramId });
+  } catch (error) {
+    console.error('Failed to fetch profile:', error);
+    if (error instanceof ResponseError && error.response.status === 404) {
+      return null;
+    }
+    if (error instanceof Error) {
+      throw new Error(`Не удалось загрузить профиль: ${error.message}`);
+    }
+    throw error;
+  }
+}
 
 export async function saveProfile(profile: Profile) {
   try {

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Save } from 'lucide-react';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useToast } from '@/hooks/use-toast';
 import MedicalButton from '@/components/MedicalButton';
-import { saveProfile } from '@/api/profile';
+import { getProfile, saveProfile } from '@/api/profile';
 import { useTelegram } from '@/hooks/useTelegram';
 
 const Profile = () => {
@@ -13,12 +13,50 @@ const Profile = () => {
   const { user } = useTelegram();
 
   const [profile, setProfile] = useState({
-    icr: '12',
-    correctionFactor: '2.5',
-    targetSugar: '6.0',
-    lowThreshold: '4.0',
-    highThreshold: '10.0'
+    icr: '',
+    correctionFactor: '',
+    targetSugar: '',
+    lowThreshold: '',
+    highThreshold: '',
   });
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!user?.id) {
+      return;
+    }
+    let active = true;
+    const loadProfile = async () => {
+      setIsLoading(true);
+      try {
+        const data = await getProfile(user.id);
+        if (data && active) {
+          setProfile({
+            icr: data.icr.toString(),
+            correctionFactor: data.cf.toString(),
+            targetSugar: data.target.toString(),
+            lowThreshold: data.low.toString(),
+            highThreshold: data.high.toString(),
+          });
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        toast({
+          title: 'Ошибка',
+          description: message,
+          variant: 'destructive',
+        });
+      } finally {
+        if (active) {
+          setIsLoading(false);
+        }
+      }
+    };
+    loadProfile();
+    return () => {
+      active = false;
+    };
+  }, [user?.id, toast]);
 
   const handleInputChange = (field: string, value: string) => {
     setProfile(prev => ({ ...prev, [field]: value }));
@@ -66,142 +104,148 @@ const Profile = () => {
       />
       
       <main className="container mx-auto px-4 py-6">
-        <div className="medical-card animate-slide-up">
-          <div className="space-y-6">
-            {/* ICR */}
-            <div>
-              <label className="block text-sm font-medium text-foreground mb-2">
-                ICR (Инсулино-углеводное соотношение)
-              </label>
-              <div className="relative">
-                <input
-                  type="number"
-                  step="0.1"
-                  value={profile.icr}
-                  onChange={(e) => handleInputChange('icr', e.target.value)}
-                  className="medical-input"
-                  placeholder="12"
-                />
-                <span className="absolute right-3 top-3 text-muted-foreground text-sm">
-                  г/ед.
-                </span>
-              </div>
-              <p className="text-xs text-muted-foreground mt-1">
-                Сколько граммов углеводов покрывает 1 единица инсулина
-              </p>
-            </div>
-
-            {/* Коэффициент коррекции */}
-            <div>
-              <label className="block text-sm font-medium text-foreground mb-2">
-                Коэффициент коррекции (КЧ)
-              </label>
-              <div className="relative">
-                <input
-                  type="number"
-                  step="0.1"
-                  value={profile.correctionFactor}
-                  onChange={(e) => handleInputChange('correctionFactor', e.target.value)}
-                  className="medical-input"
-                  placeholder="2.5"
-                />
-                <span className="absolute right-3 top-3 text-muted-foreground text-sm">
-                  ммоль/л
-                </span>
-              </div>
-              <p className="text-xs text-muted-foreground mt-1">
-                На сколько снижает сахар 1 единица инсулина
-              </p>
-            </div>
-
-            {/* Целевой сахар */}
-            <div>
-              <label className="block text-sm font-medium text-foreground mb-2">
-                Целевой уровень сахара
-              </label>
-              <div className="relative">
-                <input
-                  type="number"
-                  step="0.1"
-                  value={profile.targetSugar}
-                  onChange={(e) => handleInputChange('targetSugar', e.target.value)}
-                  className="medical-input"
-                  placeholder="6.0"
-                />
-                <span className="absolute right-3 top-3 text-muted-foreground text-sm">
-                  ммоль/л
-                </span>
-              </div>
-            </div>
-
-            {/* Пороги */}
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-foreground mb-2">
-                  Нижний порог
-                </label>
-                <div className="relative">
-                  <input
-                    type="number"
-                    step="0.1"
-                    value={profile.lowThreshold}
-                    onChange={(e) => handleInputChange('lowThreshold', e.target.value)}
-                    className="medical-input"
-                    placeholder="4.0"
-                  />
-                  <span className="absolute right-3 top-3 text-muted-foreground text-xs">
-                    ммоль/л
-                  </span>
+        {isLoading ? (
+          <p className="text-center text-muted-foreground">Загрузка профиля...</p>
+        ) : (
+          <>
+            <div className="medical-card animate-slide-up">
+              <div className="space-y-6">
+                {/* ICR */}
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-2">
+                    ICR (Инсулино-углеводное соотношение)
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="number"
+                      step="0.1"
+                      value={profile.icr}
+                      onChange={(e) => handleInputChange('icr', e.target.value)}
+                      className="medical-input"
+                      placeholder="12"
+                    />
+                    <span className="absolute right-3 top-3 text-muted-foreground text-sm">
+                      г/ед.
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Сколько граммов углеводов покрывает 1 единица инсулина
+                  </p>
                 </div>
-              </div>
 
-              <div>
-                <label className="block text-sm font-medium text-foreground mb-2">
-                  Верхний порог
-                </label>
-                <div className="relative">
-                  <input
-                    type="number"
-                    step="0.1"
-                    value={profile.highThreshold}
-                    onChange={(e) => handleInputChange('highThreshold', e.target.value)}
-                    className="medical-input"
-                    placeholder="10.0"
-                  />
-                  <span className="absolute right-3 top-3 text-muted-foreground text-xs">
-                    ммоль/л
-                  </span>
+                {/* Коэффициент коррекции */}
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-2">
+                    Коэффициент коррекции (КЧ)
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="number"
+                      step="0.1"
+                      value={profile.correctionFactor}
+                      onChange={(e) => handleInputChange('correctionFactor', e.target.value)}
+                      className="medical-input"
+                      placeholder="2.5"
+                    />
+                    <span className="absolute right-3 top-3 text-muted-foreground text-sm">
+                      ммоль/л
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    На сколько снижает сахар 1 единица инсулина
+                  </p>
                 </div>
+
+                {/* Целевой сахар */}
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-2">
+                    Целевой уровень сахара
+                  </label>
+                  <div className="relative">
+                    <input
+                      type="number"
+                      step="0.1"
+                      value={profile.targetSugar}
+                      onChange={(e) => handleInputChange('targetSugar', e.target.value)}
+                      className="medical-input"
+                      placeholder="6.0"
+                    />
+                    <span className="absolute right-3 top-3 text-muted-foreground text-sm">
+                      ммоль/л
+                    </span>
+                  </div>
+                </div>
+
+                {/* Пороги */}
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-2">
+                      Нижний порог
+                    </label>
+                    <div className="relative">
+                      <input
+                        type="number"
+                        step="0.1"
+                        value={profile.lowThreshold}
+                        onChange={(e) => handleInputChange('lowThreshold', e.target.value)}
+                        className="medical-input"
+                        placeholder="4.0"
+                      />
+                      <span className="absolute right-3 top-3 text-muted-foreground text-xs">
+                        ммоль/л
+                      </span>
+                    </div>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-2">
+                      Верхний порог
+                    </label>
+                    <div className="relative">
+                      <input
+                        type="number"
+                        step="0.1"
+                        value={profile.highThreshold}
+                        onChange={(e) => handleInputChange('highThreshold', e.target.value)}
+                        className="medical-input"
+                        placeholder="10.0"
+                      />
+                      <span className="absolute right-3 top-3 text-muted-foreground text-xs">
+                        ммоль/л
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Кнопка сохранения */}
+                <MedicalButton
+                  onClick={handleSave}
+                  className="w-full flex items-center justify-center gap-2"
+                  size="lg"
+                >
+                  <Save className="w-4 h-4" />
+                  Сохранить настройки
+                </MedicalButton>
               </div>
             </div>
 
-            {/* Кнопка сохранения */}
-            <MedicalButton
-              onClick={handleSave}
-              className="w-full flex items-center justify-center gap-2"
-              size="lg"
-            >
-              <Save className="w-4 h-4" />
-              Сохранить настройки
-            </MedicalButton>
-          </div>
-        </div>
-
-        {/* Дополнительная информация */}
-        <div className="mt-6 medical-card">
-          <h3 className="font-semibold text-foreground mb-3">Справка</h3>
-          <div className="space-y-3 text-sm text-muted-foreground">
-            <p>
-              <strong>ICR</strong> - показывает, сколько граммов углеводов покрывает 1 единица быстрого инсулина
-            </p>
-            <p>
-              <strong>КЧ</strong> - показывает, на сколько ммоль/л снижает уровень глюкозы 1 единица быстрого инсулина
-            </p>
-            <p>
-              Эти параметры индивидуальны и должны быть определены совместно с вашим врачом
-            </p>
-          </div>
-        </div>
+            {/* Дополнительная информация */}
+            <div className="mt-6 medical-card">
+              <h3 className="font-semibold text-foreground mb-3">Справка</h3>
+              <div className="space-y-3 text-sm text-muted-foreground">
+                <p>
+                  <strong>ICR</strong> - показывает, сколько граммов углеводов покрывает 1 единица быстрого инсулина
+                </p>
+                <p>
+                  <strong>КЧ</strong> - показывает, на сколько ммоль/л снижает уровень глюкозы 1 единица быстрого инсулина
+                </p>
+                <p>
+                  Эти параметры индивидуальны и должны быть определены совместно с вашим врачом
+                </p>
+              </div>
+            </div>
+          </>
+        )}
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- add API helper to retrieve user profile
- load profile data on the profile page with loading and error handling

## Testing
- ❌ `npm --prefix services/webapp/ui run lint` (fails: errors in existing files)
- ⚠️ `npm test` (no test script)


------
https://chatgpt.com/codex/tasks/task_e_689f23e70a78832a84d7a5fcd7e182f4