### PR TITLE
[dependencies] add types-reportlab to dev requirements

### DIFF
--- a/services/api/app/requirements-dev.txt
+++ b/services/api/app/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-cov
 mypy
 playwright
 attrs>=22.0.0
+types-reportlab


### PR DESCRIPTION
## Summary
- add types-reportlab to dev requirements to provide reportlab type hints

## Testing
- `pip install -r services/api/app/requirements-dev.txt`
- `ruff check services/api/app tests`
- `mypy --strict . | tail -n 10`


------
https://chatgpt.com/codex/tasks/task_e_689f2648a380832aabc4a9abf03da327