### PR TITLE
[tests] Add type annotations to run_db tests

### DIFF
--- a/tests/test_run_db.py
+++ b/tests/test_run_db.py
@@ -1,10 +1,10 @@
-from types import SimpleNamespace
-from typing import Any
+from types import SimpleNamespace, TracebackType
+from typing import Any, Callable
 
 import asyncio
 import pytest
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session as SASession, sessionmaker
 
 from services.api.app.diabetes.services.db import run_db
 
@@ -16,14 +16,14 @@ async def test_run_db_sqlite_in_memory(monkeypatch: pytest.MonkeyPatch) -> None:
 
     called = False
 
-    async def fake_to_thread(fn, *args: Any, **kwargs: Any) -> Any:
+    async def fake_to_thread(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         nonlocal called
         called = True
         return fn(*args, **kwargs)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
 
-    def work(session):
+    def work(session: SASession) -> int:
         return 42
 
     result = await run_db(work, sessionmaker=Session)
@@ -36,28 +36,33 @@ async def test_run_db_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
     dummy_engine = SimpleNamespace(url=SimpleNamespace(drivername="postgresql", database="db"))
 
     class DummySession:
-        def get_bind(self):
+        def get_bind(self) -> SimpleNamespace:
             return dummy_engine
 
         def __enter__(self) -> "DummySession":
             return self
 
-        def __exit__(self, exc_type, exc, tb) -> None:
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> None:
             pass
 
-    def dummy_sessionmaker():
+    def dummy_sessionmaker() -> DummySession:
         return DummySession()
 
     called = False
 
-    async def fake_to_thread(fn, *args: Any, **kwargs: Any) -> Any:
+    async def fake_to_thread(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         nonlocal called
         called = True
         return fn(*args, **kwargs)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
 
-    def work(session):
+    def work(session: SASession) -> int:
         return 42
 
     result = await run_db(work, sessionmaker=dummy_sessionmaker)
@@ -69,7 +74,7 @@ async def test_run_db_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_run_db_without_engine() -> None:
     Session = sessionmaker()
 
-    def work(session):
+    def work(session: SASession) -> int:
         return 42
 
     with pytest.raises(RuntimeError, match="init_db"):


### PR DESCRIPTION
## Summary
- add Callable typing to fake_to_thread helpers
- type annotate DummySession and session worker functions in run_db tests

## Testing
- `mypy --strict .` *(fails: Library stubs missing and many untyped definitions; 1072 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f29b09454832aa0317f30442949ea