### PR TITLE
[services] add Session hints for reminders

### DIFF
--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -3,20 +3,21 @@ from __future__ import annotations
 from typing import List
 
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
 from ..diabetes.services.db import Reminder, SessionLocal, run_db
 from ..schemas.reminders import ReminderSchema
 
 
 async def list_reminders(telegram_id: int) -> List[Reminder]:
-    def _list(session):
+    def _list(session: Session) -> List[Reminder]:
         return session.query(Reminder).filter_by(telegram_id=telegram_id).all()
 
     return await run_db(_list, sessionmaker=SessionLocal)
 
 
 async def save_reminder(data: ReminderSchema) -> int:
-    def _save(session):
+    def _save(session: Session) -> int:
         if data.id is not None:
             rem = session.get(Reminder, data.id)
             if rem is None or rem.telegram_id != data.telegram_id:


### PR DESCRIPTION
## Summary
- type the reminders service's DB helpers with `sqlalchemy.orm.Session`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`
- `mypy services/api/app` *(fails: Item "None" of "Message | Any | None" has no attribute "reply_text" ...)*

------
https://chatgpt.com/codex/tasks/task_e_689f29ab0d30832aa63ed55b8b76b2e5