### PR TITLE
[tests] Annotate _reload return type

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,11 +2,13 @@
 
 import importlib
 import sys
+from types import ModuleType
+from typing import Any, cast
 
 import pytest
 
 
-def _reload(module: str):
+def _reload(module: str) -> ModuleType:
     if module in sys.modules:
         del sys.modules[module]
     return importlib.import_module(module)
@@ -19,8 +21,8 @@ def test_import_config_without_db_password(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_init_db_raises_when_no_password(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DB_PASSWORD", raising=False)
-    config = _reload("services.api.app.config")
-    db = _reload("services.api.app.diabetes.services.db")
+    config = cast(Any, _reload("services.api.app.config"))
+    db = cast(Any, _reload("services.api.app.diabetes.services.db"))
     assert config.get_db_password() is None
     with pytest.raises(ValueError):
         db.init_db()

--- a/tests/test_db_reinit.py
+++ b/tests/test_db_reinit.py
@@ -1,4 +1,5 @@
-from typing import Any
+from typing import Any, cast
+from types import ModuleType
 
 import importlib
 import sys
@@ -6,7 +7,7 @@ import sys
 import pytest
 
 
-def _reload(module: str):
+def _reload(module: str) -> ModuleType:
     if module in sys.modules:
         del sys.modules[module]
     return importlib.import_module(module)
@@ -32,7 +33,7 @@ class DummyEngine:
 def test_init_db_recreates_engine_on_url_change(monkeypatch: pytest.MonkeyPatch, attr: Any, orig: Any, new: Any, url_attr: Any) -> None:
     monkeypatch.setenv("DB_PASSWORD", "pwd")
     _reload("services.api.app.config")
-    db = _reload("services.api.app.diabetes.services.db")
+    db = cast(Any, _reload("services.api.app.diabetes.services.db"))
 
     created = []
 


### PR DESCRIPTION
## Summary
- type `_reload` helper to return `ModuleType`
- cast reloaded modules in tests to satisfy the type checker

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_config.py tests/test_db_reinit.py`
- `mypy tests/test_config.py tests/test_db_reinit.py`


------
https://chatgpt.com/codex/tasks/task_e_689f29b2c1d4832ab1fd8a8bc6d89831