### PR TITLE
[tests] Add type annotations for reload helpers

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,11 +2,12 @@
 
 import importlib
 import sys
+from types import ModuleType
 
 import pytest
 
 
-def _reload(module: str):
+def _reload(module: str) -> ModuleType:
     if module in sys.modules:
         del sys.modules[module]
     return importlib.import_module(module)

--- a/tests/test_db_reinit.py
+++ b/tests/test_db_reinit.py
@@ -1,4 +1,5 @@
-from typing import Any
+from types import ModuleType
+from typing import Any, cast
 
 import importlib
 import sys
@@ -6,18 +7,18 @@ import sys
 import pytest
 
 
-def _reload(module: str):
+def _reload(module: str) -> ModuleType:
     if module in sys.modules:
         del sys.modules[module]
     return importlib.import_module(module)
 
 
 class DummyEngine:
-    def __init__(self, url):
+    def __init__(self, url: Any) -> None:
         self.url = url
         self.disposed = False
 
-    def dispose(self):
+    def dispose(self) -> None:
         self.disposed = True
 
 
@@ -32,11 +33,11 @@ class DummyEngine:
 def test_init_db_recreates_engine_on_url_change(monkeypatch: pytest.MonkeyPatch, attr: Any, orig: Any, new: Any, url_attr: Any) -> None:
     monkeypatch.setenv("DB_PASSWORD", "pwd")
     _reload("services.api.app.config")
-    db = _reload("services.api.app.diabetes.services.db")
+    db = cast(Any, _reload("services.api.app.diabetes.services.db"))
 
     created = []
 
-    def fake_create_engine(url):
+    def fake_create_engine(url: Any) -> DummyEngine:
         engine = DummyEngine(url)
         created.append(engine)
         return engine


### PR DESCRIPTION
## Summary
- add return type ModuleType to _reload helper
- type DummyEngine parameters and fake_create_engine

## Testing
- `ruff check tests/test_db_reinit.py tests/test_config.py`
- `pytest tests/test_db_reinit.py tests/test_config.py -q`
- `mypy tests/test_db_reinit.py tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_689f29b317e8832a995f42ed5ccc72bf