### PR TITLE
[tests] Add return type for DummyApplication.__class_getitem__

### DIFF
--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -1,5 +1,7 @@
 """Tests for debug logging configuration in bot.main."""
 
+from __future__ import annotations
+
 import importlib
 import logging
 import sys
@@ -55,7 +57,7 @@ def test_log_level_debug(monkeypatch: pytest.MonkeyPatch) -> None:
         def builder() -> DummyBuilder:
             return DummyBuilder()
 
-        def __class_getitem__(cls, _: object):  # Support subscripting in type hints
+        def __class_getitem__(cls, _: object) -> type[DummyApplication]:  # Support subscripting in type hints
             return cls
 
     monkeypatch.setattr(bot, "Application", DummyApplication)


### PR DESCRIPTION
## Summary
- add postponed annotation evaluation for test module
- specify `DummyApplication.__class_getitem__` return type for mypy

## Testing
- `ruff check services/api/app tests/test_bot_debug_logging.py`
- `pytest tests/test_bot_debug_logging.py::test_log_level_debug -q`
- `mypy tests/test_bot_debug_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_689f29b41bdc832a845256558e5b2780