### PR TITLE
[webapp] Use initDataUnsafe for Telegram user

### DIFF
--- a/services/webapp/ui/src/hooks/useTelegram.ts
+++ b/services/webapp/ui/src/hooks/useTelegram.ts
@@ -45,7 +45,7 @@ interface TelegramWebApp {
   ready?: () => void;
   colorScheme?: Scheme;
   themeParams?: ThemeParams;
-  user?: TelegramUser;
+  initDataUnsafe?: { user?: TelegramUser };
   setBackgroundColor?: (color: string) => void;
   setHeaderColor?: (color: string) => void;
   onEvent?: (eventType: string, handler: () => void) => void;
@@ -114,7 +114,7 @@ export const useTelegram = (
       tg.expand?.();
       tg.ready?.();
       applyTheme(tg, forceLight);
-      setUser(tg.user ?? null);
+      setUser(tg.initDataUnsafe?.user ?? null);
       setReady(true);
       const onTheme = () => applyTheme(tg, forceLight);
       tg.onEvent?.("themeChanged", onTheme);


### PR DESCRIPTION
## Summary
- read user data from `initDataUnsafe` and expose in hook state
- align hook with current Telegram WebApp API

## Testing
- `npm --workspace services/webapp/ui run lint` *(fails: An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)*
- `npm --workspace services/webapp/ui exec eslint src/hooks/useTelegram.ts`
- `npm --workspace services/webapp/ui test` *(fails: Missing script "test")*
- `pytest tests/test_webapp_history.py tests/test_webapp_server.py tests/test_webapp_server_startup.py tests/test_webapp_timezone.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f2c7188d8832a8f7db1a128584d73