### PR TITLE
[tests] Add type hints for DummyQuery

### DIFF
--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -25,11 +25,11 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str, message: DummyMessage | None = None):
+    def __init__(self, message: DummyMessage, data: str) -> None:
         self.data = data
-        self.message = message or DummyMessage()
-        self.markups = []
-        self.answer_texts = []
+        self.message = message
+        self.markups: list[Any] = []
+        self.answer_texts: list[str | None] = []
 
     async def answer(self, text: str | None = None) -> None:
         self.answer_texts.append(text)
@@ -76,7 +76,7 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
         entry_id = entry.id
 
     entry_message = DummyMessage(chat_id=42, message_id=24)
-    query = DummyQuery(f"edit:{entry_id}", message=entry_message)
+    query = DummyQuery(entry_message, f"edit:{entry_id}")
     update_cb = SimpleNamespace(
         callback_query=query, effective_user=SimpleNamespace(id=1)
     )
@@ -87,7 +87,7 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await router.callback_router(update_cb, context)
 
-    field_query = DummyQuery(f"edit_field:{entry_id}:dose", message=entry_message)
+    field_query = DummyQuery(entry_message, f"edit_field:{entry_id}:dose")
     update_cb2 = SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1))
     await router.callback_router(update_cb2, context)
     assert context.user_data["edit_field"] == "dose"

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -17,11 +17,11 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str):
+    def __init__(self, message: DummyMessage, data: str) -> None:
         self.data = data
+        self.message = message
         self.edited: list[str] = []
         self.edit_kwargs: list[dict[str, Any]] = []
-        self.message = DummyMessage()
 
     async def answer(self) -> None:
         pass
@@ -39,7 +39,7 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     import services.api.app.diabetes.handlers.router as router
     from services.api.app.diabetes.handlers import common_handlers
 
-    query = DummyQuery("cancel_entry")
+    query = DummyQuery(DummyMessage(), "cancel_entry")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
         CallbackContext[Any, Any, Any, Any],
@@ -65,7 +65,7 @@ async def test_callback_router_invalid_entry_id(
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
 
-    query = DummyQuery("del:abc")
+    query = DummyQuery(DummyMessage(), "del:abc")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
         CallbackContext[Any, Any, Any, Any],
@@ -88,7 +88,7 @@ async def test_callback_router_unknown_data(
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
 
-    query = DummyQuery("foo")
+    query = DummyQuery(DummyMessage(), "foo")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
         CallbackContext[Any, Any, Any, Any],
@@ -109,7 +109,7 @@ async def test_callback_router_ignores_reminder_action() -> None:
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
 
-    query = DummyQuery("rem_toggle:1")
+    query = DummyQuery(DummyMessage(), "rem_toggle:1")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
         CallbackContext[Any, Any, Any, Any],

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -23,9 +23,10 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str):
+    def __init__(self, message: DummyMessage, data: str) -> None:
         self.data = data
-        self.edited = []
+        self.message = message
+        self.edited: list[str] = []
 
 
     async def answer(self, text: str | None = None, **kwargs: Any) -> None:
@@ -93,7 +94,7 @@ async def test_callback_router_commit_failure(monkeypatch: pytest.MonkeyPatch, c
         "telegram_id": 1,
         "event_time": datetime.datetime.now(datetime.timezone.utc),
     }
-    query = DummyQuery("confirm_entry")
+    query = DummyQuery(DummyMessage(), "confirm_entry")
     update = SimpleNamespace(callback_query=query)
     context = SimpleNamespace(user_data={"pending_entry": pending_entry})
 
@@ -259,7 +260,7 @@ async def test_reminder_callback_commit_failure(monkeypatch: pytest.MonkeyPatch,
 
     monkeypatch.setattr(reminder_handlers, "commit", failing_commit)
 
-    query = DummyQuery("remind_snooze:1")
+    query = DummyQuery(DummyMessage(), "remind_snooze:1")
     update = SimpleNamespace(
         callback_query=query, effective_user=SimpleNamespace(id=1)
     )
@@ -290,7 +291,7 @@ async def test_reminder_action_cb_commit_failure(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(reminder_handlers, "schedule_reminder", schedule_mock)
 
     job_queue = SimpleNamespace(get_jobs_by_name=MagicMock())
-    query = DummyQuery("rem_toggle:1")
+    query = DummyQuery(DummyMessage(), "rem_toggle:1")
     update = SimpleNamespace(
         callback_query=query, effective_user=SimpleNamespace(id=1)
     )

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -26,11 +26,11 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str, message: DummyMessage | None = None):
+    def __init__(self, message: DummyMessage, data: str) -> None:
         self.data = data
-        self.message = message or DummyMessage()
-        self.markups = []
-        self.answer_texts = []
+        self.message = message
+        self.markups: list[Any | None] = []
+        self.answer_texts: list[str | None] = []
 
     async def answer(self, text: str | None = None) -> None:
         self.answer_texts.append(text)
@@ -161,7 +161,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         entry_id = entry.id
 
     entry_message = DummyMessage(chat_id=42, message_id=24)
-    query = DummyQuery(f"edit:{entry_id}", message=entry_message)
+    query = DummyQuery(entry_message, f"edit:{entry_id}")
     update_cb = SimpleNamespace(
         callback_query=query, effective_user=SimpleNamespace(id=1)
     )
@@ -182,7 +182,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert f"edit_field:{entry_id}:xe" in buttons
     assert f"edit_field:{entry_id}:dose" in buttons
 
-    field_query = DummyQuery(f"edit_field:{entry_id}:xe", message=entry_message)
+    field_query = DummyQuery(entry_message, f"edit_field:{entry_id}:xe")
     update_cb2 = SimpleNamespace(
         callback_query=field_query, effective_user=SimpleNamespace(id=1)
     )

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -21,8 +21,9 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str):
+    def __init__(self, message: DummyMessage, data: str) -> None:
         self.data = data
+        self.message = message
         self.edited: list[str] = []
 
     async def answer(self) -> None:
@@ -156,7 +157,7 @@ async def test_photo_flow_saves_entry(
 
     monkeypatch.setattr(alert_handlers, "check_alert", noop)
 
-    query = DummyQuery("confirm_entry")
+    query = DummyQuery(DummyMessage(), "confirm_entry")
     update_confirm = SimpleNamespace(callback_query=query)
     await router.callback_router(update_confirm, context)
 

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -18,8 +18,9 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str):
+    def __init__(self, message: DummyMessage, data: str) -> None:
         self.data = data
+        self.message = message
         self.edited: list[str] = []
 
     async def answer(self) -> None:
@@ -52,7 +53,7 @@ async def test_report_request_and_custom_flow(
     assert any("Выберите период" in t[0] for t in message.replies)
     assert message.replies[0][1].get("reply_markup") is not None
 
-    query = DummyQuery("report_period:custom")
+    query = DummyQuery(DummyMessage(), "report_period:custom")
     update_cb = SimpleNamespace(
         callback_query=query, effective_user=SimpleNamespace(id=1)
     )
@@ -114,7 +115,7 @@ async def test_report_period_callback_week(
 
     monkeypatch.setattr(reporting_handlers.datetime, "datetime", DummyDateTime)
 
-    query = DummyQuery("report_period:week")
+    query = DummyQuery(DummyMessage(), "report_period:week")
     update_cb = SimpleNamespace(
         callback_query=query, effective_user=SimpleNamespace(id=1)
     )

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -41,7 +41,7 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, message, data):
+    def __init__(self, message: DummyMessage, data: str) -> None:
         self.message = message
         self.data = data
 

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -24,10 +24,10 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str):
+    def __init__(self, message: DummyMessage, data: str) -> None:
         self.data = data
+        self.message = message
         self.edits: list[tuple[str, dict[str, Any]]] = []
-        self.message = DummyMessage()
 
     async def answer(self) -> None:
         pass
@@ -96,7 +96,7 @@ async def test_profile_security_threshold_changes(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setattr(handlers, "evaluate_sugar", fake_eval)
 
-    query = DummyQuery(f"profile_security:{action}")
+    query = DummyQuery(DummyMessage(), f"profile_security:{action}")
     update = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
     context = SimpleNamespace(application=SimpleNamespace(job_queue="jq"))
 
@@ -141,7 +141,7 @@ async def test_profile_security_toggle_sos_alerts(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setattr(handlers, "evaluate_sugar", fake_eval)
 
-    query = DummyQuery("profile_security:toggle_sos")
+    query = DummyQuery(DummyMessage(), "profile_security:toggle_sos")
     update = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
     context = SimpleNamespace(application=SimpleNamespace(job_queue="jq"))
 
@@ -178,7 +178,7 @@ async def test_profile_security_shows_reminders(monkeypatch: pytest.MonkeyPatch)
         session.add(Reminder(id=1, telegram_id=1, type="sugar", time="08:00"))
         session.commit()
 
-    query = DummyQuery("profile_security")
+    query = DummyQuery(DummyMessage(), "profile_security")
     update = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
     context = SimpleNamespace(application=SimpleNamespace(job_queue="jq"))
 
@@ -209,14 +209,14 @@ async def test_profile_security_add_delete_calls_handlers(monkeypatch: pytest.Mo
     monkeypatch.setattr(reminder_handlers, "delete_reminder", fake_del)
 
     monkeypatch.setattr(settings, "webapp_url", "http://example")
-    query_add = DummyQuery("profile_security:add")
+    query_add = DummyQuery(DummyMessage(), "profile_security:add")
     update_add = SimpleNamespace(callback_query=query_add, effective_user=SimpleNamespace(id=1))
     context = SimpleNamespace(application=SimpleNamespace(job_queue="jq"))
 
     await handlers.profile_security(update_add, context)
     assert query_add.message.texts[-1] == "Создать напоминание:"
 
-    query_del = DummyQuery("profile_security:del")
+    query_del = DummyQuery(DummyMessage(), "profile_security:del")
     update_del = SimpleNamespace(callback_query=query_del, effective_user=SimpleNamespace(id=1))
 
     await handlers.profile_security(update_del, context)
@@ -244,7 +244,7 @@ async def test_profile_security_sos_contact_calls_handler(monkeypatch: pytest.Mo
 
     monkeypatch.setattr(sos_handlers, "sos_contact_start", fake_sos)
 
-    query = DummyQuery("profile_security:sos_contact")
+    query = DummyQuery(DummyMessage(), "profile_security:sos_contact")
     update = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
     context = SimpleNamespace(application=SimpleNamespace(job_queue="jq"))
 


### PR DESCRIPTION
## Summary
- Require `DummyMessage` and `data` in every `DummyQuery` constructor across tests
- Annotate `DummyQuery` helpers with explicit return and attribute types

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: test_webapp_timezone.py::test_timezone_concurrent_writes)*

------
https://chatgpt.com/codex/tasks/task_e_689f3ca47ec8832a9508ab45c2d8c00c