### PR TITLE
tests: type DummySession context managers

### DIFF
--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import os
 from dataclasses import dataclass
+from types import TracebackType
 from typing import Any, cast
 
 import pytest
@@ -64,7 +65,12 @@ async def test_entry_without_dose_has_no_unit(
         def __enter__(self) -> "DummySession":
             return self
 
-        def __exit__(self, exc_type, exc, tb) -> None:
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> None:
             pass
 
         def add(self, entry: Any) -> None:
@@ -110,7 +116,12 @@ async def test_entry_without_sugar_has_placeholder(
         def __enter__(self) -> "DummySession":
             return self
 
-        def __exit__(self, exc_type, exc, tb) -> None:
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> None:
             pass
 
         def add(self, entry: Any) -> None:

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
 from typing import Any, cast
 
 import pytest
@@ -223,7 +223,12 @@ async def test_photo_then_freeform_calculates_dose(
         def __enter__(self) -> "DummySession":
             return self
 
-        def __exit__(self, exc_type, exc, tb) -> None:
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> None:
             pass
 
         def get(self, model, user_id):

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -1,5 +1,5 @@
 import datetime
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
 from typing import Any, cast
 
 import pytest
@@ -62,7 +62,12 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         def __enter__(self) -> "DummySession":
             return self
 
-        def __exit__(self, exc_type, exc, tb) -> None:
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: TracebackType | None,
+        ) -> None:
             pass
 
         def get(self, model, user_id):

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
 from typing import Any, cast
 
 import pytest
@@ -44,7 +44,12 @@ class DummySession:
     def __enter__(self) -> "DummySession":
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         pass
 
     def add(self, entry: Any) -> None:
@@ -151,7 +156,7 @@ async def test_photo_flow_saves_entry(
     monkeypatch.setattr(router, "SessionLocal", lambda: session)
     import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
 
-    async def noop(*a: Any, **k: Any) -> None:
+    async def noop(*args: Any, **kwargs: Any) -> None:
         return None
 
     monkeypatch.setattr(alert_handlers, "check_alert", noop)


### PR DESCRIPTION
## Summary
- add explicit TracebackType imports
- type `__exit__` on DummySession helpers
- standardize noop helper signature

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689f3c98a238832abb2561385507dfa2