### PR TITLE
[bot] Annotate Application generics

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -8,7 +8,7 @@ import sys
 from typing import Any
 
 from telegram import BotCommand
-from telegram.ext import Application, ContextTypes
+from telegram.ext import Application, ContextTypes, ExtBot
 from sqlalchemy.exc import SQLAlchemyError
 
 from services.api.app.diabetes.services.db import init_db
@@ -66,11 +66,13 @@ def main() -> None:
     ]
 
     async def post_init(
-        app: Application[Any, Any, Any, Any, Any, Any]
+        app: Application[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]]
     ) -> None:
         await app.bot.set_my_commands(commands)
 
-    application: Application[Any, Any, Any, Any, Any, Any] = (
+    application: Application[
+        ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]
+    ] = (
         Application.builder()
         .token(BOT_TOKEN)
         .post_init(post_init)  # registers post-init handler


### PR DESCRIPTION
## Summary
- type Application in bot main with explicit generics
- keep registration handler signature typed

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689f3c9fe27c832aa837aabd5143c572