### PR TITLE
[tests] track reply kwargs for dummy messages

### DIFF
--- a/tests/test_add_reminder_wizard.py
+++ b/tests/test_add_reminder_wizard.py
@@ -24,9 +24,11 @@ class DummyMessage:
     def __init__(self, data: str) -> None:
         self.web_app_data = WebAppData(data)
         self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 class DummyJobQueue:

--- a/tests/test_alert_stats.py
+++ b/tests/test_alert_stats.py
@@ -18,9 +18,11 @@ if TYPE_CHECKING:
 class DummyMessage:
     def __init__(self) -> None:
         self.texts: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
-    async def reply_text(self, text: str) -> None:
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
+        self.kwargs.append(kwargs)
 
 
 @pytest.mark.asyncio

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -19,9 +19,11 @@ class DummyMessage:
     def __init__(self, text: str) -> None:
         self.text = text
         self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
-    async def reply_text(self, text: str, **kwargs: dict[str, Any]) -> None:
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 @dataclass

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -18,10 +18,12 @@ class DummyMessage:
         self.text = text
         self.chat_id = chat_id
         self.message_id = message_id
-        self.replies: list[tuple[str, dict]] = []
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
-        self.replies.append((text, kwargs))
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 class DummyQuery:

--- a/tests/test_freeform_handler_unknown.py
+++ b/tests/test_freeform_handler_unknown.py
@@ -12,10 +12,12 @@ import services.api.app.diabetes.handlers.dose_handlers as handlers
 class DummyMessage:
     def __init__(self, text: str):
         self.text = text
-        self.replies: list[tuple[str, dict[str, Any]]] = []
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
-        self.replies.append((text, kwargs))
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 @pytest.mark.asyncio
@@ -36,4 +38,6 @@ async def test_freeform_handler_unknown_command(
     await handlers.freeform_handler(update, context)
 
     assert message.replies
-    assert message.replies[0][0] == "Не понял, воспользуйтесь /help или кнопками меню"
+    assert (
+        message.replies[0] == "Не понял, воспользуйтесь /help или кнопками меню"
+    )

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -10,10 +10,12 @@ from telegram.ext import CallbackContext
 
 class DummyMessage:
     def __init__(self):
-        self.replies: list[tuple[str, dict[str, Any]]] = []
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
-        self.replies.append((text, kwargs))
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 class DummyQuery:
@@ -51,7 +53,7 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     assert query.edited == ["❌ Запись отменена."]
     assert not query.edit_kwargs[0] or "reply_markup" not in query.edit_kwargs[0]
     assert len(query.message.replies) == 1
-    text, kwargs = query.message.replies[0]
+    kwargs = query.message.kwargs[0]
     assert kwargs["reply_markup"] == common_handlers.menu_keyboard
     assert "pending_entry" not in context.user_data
 

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -17,9 +17,11 @@ import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 class DummyMessage:
     def __init__(self):
         self.texts: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
+        self.kwargs.append(kwargs)
 
 
 class DummyQuery:

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -17,9 +17,11 @@ class DummyMessage(Message):
         self.text = text
         self.photo = photo
         self.texts: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
+        self.kwargs.append(kwargs)
 
 
 @pytest.mark.asyncio

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -12,10 +12,12 @@ import services.api.app.diabetes.handlers.dose_handlers as handlers
 class DummyMessage:
     def __init__(self, text: str):
         self.text = text
-        self.replies: list[tuple[str, dict[str, Any]]] = []
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
-        self.replies.append((text, kwargs))
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 @pytest.mark.asyncio
@@ -83,7 +85,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
 
     assert context.user_data["pending_entry"]["sugar_before"] == 5.6
     assert "pending_entry" in context.user_data
-    text, _ = message.replies[0]
+    text = message.replies[0]
     assert "5.6 ммоль/л" in text
 
 

--- a/tests/test_handlers_freeform_units.py
+++ b/tests/test_handlers_freeform_units.py
@@ -11,10 +11,12 @@ import services.api.app.diabetes.handlers.dose_handlers as handlers
 class DummyMessage:
     def __init__(self, text: str):
         self.text = text
-        self.replies: list[tuple[str, dict[str, Any]]] = []
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
-        self.replies.append((text, kwargs))
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 @pytest.mark.asyncio
@@ -31,7 +33,7 @@ async def test_freeform_handler_warns_on_sugar_unit_mix() -> None:
     await handlers.freeform_handler(update, context)
 
     assert message.replies
-    text, _ = message.replies[0]
+    text = message.replies[0]
     assert "ммоль/л" in text and "Сахар" in text
 
 
@@ -49,7 +51,7 @@ async def test_freeform_handler_warns_on_dose_unit_mix() -> None:
     await handlers.freeform_handler(update, context)
 
     assert message.replies
-    text, _ = message.replies[0]
+    text = message.replies[0]
     assert "ед" in text.lower() and "доза" in text.lower()
 
 
@@ -74,5 +76,5 @@ async def test_freeform_handler_guidance_on_valueerror(
     await handlers.freeform_handler(update, context)
 
     assert message.replies
-    text, _ = message.replies[0]
+    text = message.replies[0]
     assert "Не удалось распознать значения" in text

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -14,10 +14,12 @@ class DummyMessage:
     def __init__(self, text: str | None = None, photo: list[Any] | None = None):
         self.text = text
         self.photo = photo
-        self.replies: list[tuple[str, dict[str, Any]]] = []
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
-        self.replies.append((text, kwargs))
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 class DummyQuery:

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -16,10 +16,12 @@ class DummyMessage:
     def __init__(self):
         self.texts: list[str] = []
         self.markups: list[Any] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
         self.markups.append(kwargs.get("reply_markup"))
+        self.kwargs.append(kwargs)
 
     async def delete(self) -> None:
         pass

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -11,10 +11,12 @@ from telegram.ext import CallbackContext
 class DummyMessage:
     def __init__(self, text: str = ""):
         self.text = text
-        self.replies: list[tuple[str, dict[str, Any]]] = []
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
-        self.replies.append((text, kwargs))
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 class DummyQuery:
@@ -49,8 +51,8 @@ async def test_report_request_and_custom_flow(
 
     await reporting_handlers.report_request(update, context)
     assert "awaiting_report_date" not in context.user_data
-    assert any("Выберите период" in t[0] for t in message.replies)
-    assert message.replies[0][1].get("reply_markup") is not None
+    assert any("Выберите период" in t for t in message.replies)
+    assert message.kwargs[0].get("reply_markup") is not None
 
     query = DummyQuery("report_period:custom")
     update_cb = SimpleNamespace(

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -10,10 +10,12 @@ class DummyMessage:
     def __init__(self, text: str | None = None, photo: list[Any] | None = None):
         self.text = text
         self.photo = photo
-        self.replies: list[tuple[str, dict[str, Any]]] = []
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
-        self.replies.append((text, kwargs))
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 class DummyPhoto:
@@ -85,7 +87,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
 
     assert "название" in captured["content"]
     # Final reply should include dish name from Vision response
-    assert any("Борщ" in reply[0] for reply in msg_photo.replies)
+    assert any("Борщ" in reply for reply in msg_photo.replies)
     entry = context.user_data.get("pending_entry")
     assert entry["carbs_g"] == 30
     assert entry["xe"] == 2

--- a/tests/test_history_view_async.py
+++ b/tests/test_history_view_async.py
@@ -9,8 +9,13 @@ from services.api.app.diabetes.handlers import reporting_handlers
 
 
 class DummyMessage:
-    async def reply_text(self, *args: Any, **kwargs: Any) -> None:
-        pass
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -18,16 +18,19 @@ class DummyMessage:
         self.texts: list[str] = []
         self.photos: list[tuple[Any, str | None]] = []
         self.markups: list[Any] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
         self.markups.append(kwargs.get("reply_markup"))
+        self.kwargs.append(kwargs)
 
     async def reply_photo(
         self, photo: Any, caption: str | None = None, **kwargs: Any
     ) -> None:
         self.photos.append((photo, caption))
         self.markups.append(kwargs.get("reply_markup"))
+        self.kwargs.append(kwargs)
 
 
 @pytest.mark.asyncio

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -18,22 +18,26 @@ class DummyMessage:
         self.photos: list[tuple[Any, str | None]] = []
         self.polls: list[tuple[str, list[str]]] = []
         self.markups: list[Any] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
         self.markups.append(kwargs.get("reply_markup"))
+        self.kwargs.append(kwargs)
 
     async def reply_photo(
         self, photo: Any, caption: str | None = None, **kwargs: Any
     ) -> None:
         self.photos.append((photo, caption))
         self.markups.append(kwargs.get("reply_markup"))
+        self.kwargs.append(kwargs)
 
     async def reply_poll(
         self, question: str, options: list[str], **kwargs: Any
     ) -> SimpleNamespace:
         self.polls.append((question, options))
         self.markups.append(kwargs.get("reply_markup"))
+        self.kwargs.append(kwargs)
         return SimpleNamespace(poll=SimpleNamespace(id="p1"))
 
     async def delete(self) -> None:

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -17,10 +17,12 @@ class DummyMessage:
     def __init__(self):
         self.texts: list[str] = []
         self.markups: list[Any] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
         self.markups.append(kwargs.get("reply_markup"))
+        self.kwargs.append(kwargs)
 
 
 class DummyQuery:

--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -15,9 +15,11 @@ class DummyMessage:
     def __init__(self, data: str):
         self.web_app_data = SimpleNamespace(data=data)
         self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 class DummyJobQueue:

--- a/tests/test_reminder_limit_free_vs_pro.py
+++ b/tests/test_reminder_limit_free_vs_pro.py
@@ -14,9 +14,11 @@ class DummyMessage:
     def __init__(self):
         self.web_app_data = SimpleNamespace()
         self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - kwargs unused
         self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 @pytest.mark.asyncio

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -21,9 +21,11 @@ class DummyMessage:
         self.text = text
         self.texts: list[str] = []
         self.edited: tuple[str, dict[str, Any]] | None = None
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
+        self.kwargs.append(kwargs)
 
     async def edit_text(self, text: str, **kwargs: Any) -> None:
         self.edited = (text, kwargs)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -169,15 +169,17 @@ async def test_send_report_uses_gpt(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummyMessage:
         def __init__(self):
             self.docs: list[Any] = []
+            self.kwargs: list[dict[str, Any]] = []
 
-        async def reply_text(self, *args: Any, **kwargs: Any) -> None:
-            pass
+        async def reply_text(self, text: str, **kwargs: Any) -> None:
+            self.kwargs.append(kwargs)
 
         async def reply_photo(self, *args: Any, **kwargs: Any) -> None:
-            pass
+            self.kwargs.append(kwargs)
 
         async def reply_document(self, document: Any, **kwargs: Any) -> None:
             self.docs.append(document)
+            self.kwargs.append(kwargs)
 
     message = DummyMessage()
     update = SimpleNamespace(

--- a/tests/test_security_handlers.py
+++ b/tests/test_security_handlers.py
@@ -8,9 +8,11 @@ import services.api.app.diabetes.handlers.security_handlers as handlers
 class DummyMessage:
     def __init__(self):
         self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 @pytest.mark.asyncio

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -25,9 +25,11 @@ class DummyMessage:
     def __init__(self, text: str):
         self.text = text
         self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- store reply kwargs separately for dummy test messages
- adjust tests to reference message.kwargs

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689f3ca24ef4832aa66442762fab1240