### PR TITLE
[tests] add typing to dummy handlers

### DIFF
--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -15,7 +15,7 @@ from services.api.app.diabetes.services.db import Base, User, Entry
 
 
 class DummyMessage:
-    def __init__(self, text: str = "", chat_id: int = 1, message_id: int = 1):
+    def __init__(self, text: str = "", chat_id: int = 1, message_id: int = 1) -> None:
         self.text = text
         self.chat_id = chat_id
         self.message_id = message_id
@@ -26,7 +26,7 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str, message: DummyMessage | None = None):
+    def __init__(self, data: str, message: DummyMessage | None = None) -> None:
         self.data = data
         self.message = message or DummyMessage()
         self.markups = []
@@ -90,7 +90,10 @@ async def test_history_view_buttons(monkeypatch: pytest.MonkeyPatch) -> None:
         entry_ids = [e.id for e in session.query(Entry).all()]
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
     context = cast(
         CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
     )
@@ -162,8 +165,9 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     entry_message = DummyMessage(chat_id=42, message_id=24)
     query = DummyQuery(f"edit:{entry_id}", message=entry_message)
-    update_cb = SimpleNamespace(
-        callback_query=query, effective_user=SimpleNamespace(id=1)
+    update_cb = cast(
+        Update,
+        SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
         CallbackContext[Any, Any, Any, Any],
@@ -171,6 +175,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     await router.callback_router(update_cb, context)
+    assert context.user_data is not None
     assert context.user_data["edit_entry"] == {
         "id": entry_id,
         "chat_id": 42,
@@ -183,10 +188,12 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert f"edit_field:{entry_id}:dose" in buttons
 
     field_query = DummyQuery(f"edit_field:{entry_id}:xe", message=entry_message)
-    update_cb2 = SimpleNamespace(
-        callback_query=field_query, effective_user=SimpleNamespace(id=1)
+    update_cb2 = cast(
+        Update,
+        SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1)),
     )
     await router.callback_router(update_cb2, context)
+    assert context.user_data is not None
     assert context.user_data["edit_id"] == entry_id
     assert context.user_data["edit_field"] == "xe"
     assert context.user_data["edit_query"] is field_query
@@ -201,12 +208,14 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with TestSession() as session:
         updated = session.get(Entry, entry_id)
+        assert updated is not None
         assert updated.xe == 3
         assert updated.carbs_g == 10
         assert updated.dose == 2
         assert updated.sugar_before == 5
 
     assert field_query.answer_texts[-1] == "Изменено"
+    assert context.user_data is not None
     assert not any(
         k in context.user_data for k in ("edit_id", "edit_field", "edit_entry", "edit_query")
     )


### PR DESCRIPTION
## Summary
- add explicit return types to dummy message/query classes
- cast SimpleNamespace mocks to Update/CallbackContext
- assert user_data and session fetches before use

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689f3c79e444832a99799c03d66c68ee