### PR TITLE
[webapp] add telegram context provider

### DIFF
--- a/services/webapp/ui/src/App.tsx
+++ b/services/webapp/ui/src/App.tsx
@@ -4,9 +4,9 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Routes, Route } from "react-router-dom";
-import { useTelegram } from "@/hooks/useTelegram";
 import { ThemeProvider } from "next-themes";
 import { Suspense, lazy } from "react";
+import { useTelegramContext } from "@/contexts/TelegramContext";
 
 const Home = lazy(() => import("./pages/Home"));
 const Profile = lazy(() => import("./pages/Profile"));
@@ -22,7 +22,7 @@ const NotFound = lazy(() => import("./pages/NotFound"));
 const queryClient = new QueryClient();
 
 const AppContent = () => {
-  const { isReady } = useTelegram();
+  const { isReady } = useTelegramContext();
 
   if (!isReady) {
     return (

--- a/services/webapp/ui/src/contexts/TelegramContext.tsx
+++ b/services/webapp/ui/src/contexts/TelegramContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext, ReactNode } from "react";
+import { useTelegram } from "@/hooks/useTelegram";
+
+// TelegramContext will hold values returned by useTelegram hook
+const TelegramContext = createContext<ReturnType<typeof useTelegram> | null>(null);
+
+export const TelegramProvider = ({ children }: { children: ReactNode }) => {
+  const telegram = useTelegram();
+  return (
+    <TelegramContext.Provider value={telegram}>
+      {children}
+    </TelegramContext.Provider>
+  );
+};
+
+export const useTelegramContext = () => {
+  const context = useContext(TelegramContext);
+  if (!context) {
+    throw new Error("useTelegramContext must be used within TelegramProvider");
+  }
+  return context;
+};
+

--- a/services/webapp/ui/src/main.tsx
+++ b/services/webapp/ui/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { createRoot } from 'react-dom/client'
 
 import App from './App'
+import { TelegramProvider } from '@/contexts/TelegramContext'
 
 // Базовые стили проекта
 import './styles/theme.css'
@@ -11,6 +12,8 @@ import './index.css'
 
 createRoot(document.getElementById('root')!).render(
   <BrowserRouter basename={import.meta.env.BASE_URL}>
-    <App />
+    <TelegramProvider>
+      <App />
+    </TelegramProvider>
   </BrowserRouter>
 )

--- a/services/webapp/ui/src/pages/Analytics.tsx
+++ b/services/webapp/ui/src/pages/Analytics.tsx
@@ -3,12 +3,12 @@ import { LineChart, Line, XAxis, YAxis } from 'recharts';
 import { useQuery } from '@tanstack/react-query';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
-import { useTelegram } from '@/hooks/useTelegram';
 import { fetchAnalytics, fallbackAnalytics } from '@/api/stats';
+import { useTelegramContext } from '@/contexts/TelegramContext';
 
 const Analytics = () => {
   const navigate = useNavigate();
-  const { user } = useTelegram();
+  const { user } = useTelegramContext();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['analytics', user?.id],

--- a/services/webapp/ui/src/pages/Home.tsx
+++ b/services/webapp/ui/src/pages/Home.tsx
@@ -2,8 +2,8 @@ import { Clock, User, BookOpen, Star } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { MedicalHeader } from '@/components/MedicalHeader';
-import { useTelegram } from '@/hooks/useTelegram';
 import MedicalButton from '@/components/MedicalButton';
+import { useTelegramContext } from '@/contexts/TelegramContext';
 import { fetchDayStats, fallbackDayStats } from '@/api/stats';
 
 const menuItems = [
@@ -43,7 +43,7 @@ const menuItems = [
 
 const Home = () => {
   const navigate = useNavigate();
-  const { user } = useTelegram();
+  const { user } = useTelegramContext();
 
   const { data: stats, isLoading, error } = useQuery({
     queryKey: ['day-stats', user?.id],

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -5,12 +5,12 @@ import { MedicalHeader } from '@/components/MedicalHeader';
 import { useToast } from '@/hooks/use-toast';
 import MedicalButton from '@/components/MedicalButton';
 import { getProfile, saveProfile } from '@/api/profile';
-import { useTelegram } from '@/hooks/useTelegram';
+import { useTelegramContext } from '@/contexts/TelegramContext';
 
 const Profile = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
-  const { user } = useTelegram();
+  const { user } = useTelegramContext();
 
   const [profile, setProfile] = useState({
     icr: '',

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -5,8 +5,8 @@ import { Plus, Clock, Edit2, Trash2, Bell } from 'lucide-react'
 import { MedicalHeader } from '@/components/MedicalHeader'
 import { useToast } from '@/hooks/use-toast'
 import { getReminders, updateReminder, deleteReminder } from '@/api/reminders'
-import { useTelegram } from '@/hooks/useTelegram'
 import MedicalButton from '@/components/MedicalButton'
+import { useTelegramContext } from '@/contexts/TelegramContext'
 import { cn } from '@/lib/utils'
 import { Reminder as ApiReminder } from '@sdk'
 
@@ -131,7 +131,7 @@ function ReminderRow({
 export default function Reminders() {
   const navigate = useNavigate()
   const { toast } = useToast()
-  const { user, sendData, isReady } = useTelegram()
+  const { user, sendData, isReady } = useTelegramContext()
 
   const [reminders, setReminders] = useState<Reminder[]>([])
   const [loading, setLoading] = useState(true)

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -4,7 +4,7 @@ import { MedicalButton, Sheet } from "@/components";
 import { cn } from "@/lib/utils";
 import { createReminder, updateReminder, getReminder } from "@/api/reminders";
 import { Reminder as ApiReminder } from "@sdk";
-import { useTelegram } from "@/hooks/useTelegram";
+import { useTelegramContext } from "@/contexts/TelegramContext";
 import { useToast } from "@/hooks/use-toast";
 
 // Reminder type returned from API may contain legacy value "meds",
@@ -53,7 +53,7 @@ export default function CreateReminder() {
   const navigate = useNavigate();
   const location = useLocation();
   const params = useParams();
-  const { user, sendData } = useTelegram();
+  const { user, sendData } = useTelegramContext();
   const { toast } = useToast();
   const [editing, setEditing] = useState<Reminder | undefined>(
     (location.state as Reminder | undefined) ?? undefined,


### PR DESCRIPTION
## Summary
- add TelegramProvider context to initialize and share Telegram WebApp data
- wrap app with provider to avoid multiple useTelegram calls
- read user state from context on pages instead of calling useTelegram directly

## Testing
- `pytest tests`
- `ruff check services/api/app tests`
- `npm --workspace services/webapp/ui run lint` *(fails: An interface declaring no members is equivalent to its supertype @typescript-eslint/no-empty-object-type, A require() style import is forbidden @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689f398be5a0832a8e7f19d014e43cce