### PR TITLE
refactor: make env validation optional

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,53 @@
+"""Application-wide configuration helpers.
+
+This module exposes selected environment variables and provides a
+:func:`validate_tokens` helper that can be used to assert the presence of
+required variables.  In tests we often import modules that depend on
+configuration, but the full set of production environment variables is
+not available.  ``validate_tokens`` therefore accepts an optional list of
+variable names to check instead of assuming a fixed, exhaustive list.
+
+If called without arguments no validation is performed, keeping imports
+lightweight.  When running the real application, callers can pass the
+variables that are mandatory for their context.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+# Expose commonly used environment variables so importing modules can
+# reference them directly if needed.  Values default to ``None`` when not
+# provided which is convenient for tests where most variables are unset.
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+DB_HOST = os.getenv("DB_HOST")
+DB_PORT = os.getenv("DB_PORT")
+DB_NAME = os.getenv("DB_NAME")
+DB_USER = os.getenv("DB_USER")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+
+
+def validate_tokens(required: Iterable[str] | None = None) -> None:
+    """Validate that the given environment variables are present.
+
+    Parameters
+    ----------
+    required:
+        Iterable of environment variable names to validate.  If ``None``
+        (the default) no variables are considered mandatory.
+
+    Raises
+    ------
+    RuntimeError
+        If any of the requested variables are missing from the
+        environment.
+    """
+
+    required_vars = list(required or [])
+    missing = [var for var in required_vars if not globals().get(var)]
+    if missing:
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(missing)
+        )


### PR DESCRIPTION
## Summary
- add lightweight config helper to expose env vars
- make `validate_tokens` optional so imports don't crash in tests

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy', 'telegram', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689f4b4b55fc832aad52d2b1a3e0c4aa