### PR TITLE
[utils] Remove redundant cast in extract_nutrition_info

### DIFF
--- a/services/api/app/diabetes/utils/functions.py
+++ b/services/api/app/diabetes/utils/functions.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 import re
-from typing import cast
 
 # ---------------------------------------------------------------------------
 # Regex helpers
@@ -181,7 +180,7 @@ def extract_nutrition_info(text: object) -> tuple[float | None, float | None]:
     """
     if not isinstance(text, str):
         return (None, None)
-    text = cast(str, text)
+    # На этом этапе ``text`` гарантированно строка.
     # Если первая строка не содержит цифр или ключевых слов,
     # считаем её названием блюда и игнорируем
     lines = text.splitlines()


### PR DESCRIPTION
## Summary
- drop unnecessary `cast` in `extract_nutrition_info`
- rely on `isinstance` check to ensure `text` is a string

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689f657109dc832a8148904ff2b4568d