### PR TITLE
[api] add webapp user and name fields

### DIFF
--- a/services/api/alembic/versions/20250818_add_name_fields_to_users.py
+++ b/services/api/alembic/versions/20250818_add_name_fields_to_users.py
@@ -1,0 +1,37 @@
+"""add name fields to users"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250818_add_name_fields_to_users"
+down_revision: Union[str, None] = "20250817_add_timezone_and_history_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    columns = [col["name"] for col in inspector.get_columns("users")]
+    if "first_name" not in columns:
+        op.add_column("users", sa.Column("first_name", sa.String(), nullable=True))
+    if "last_name" not in columns:
+        op.add_column("users", sa.Column("last_name", sa.String(), nullable=True))
+    if "username" not in columns:
+        op.add_column("users", sa.Column("username", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    columns = [col["name"] for col in inspector.get_columns("users")]
+    if "username" in columns:
+        op.drop_column("users", "username")
+    if "last_name" in columns:
+        op.drop_column("users", "last_name")
+    if "first_name" in columns:
+        op.drop_column("users", "first_name")

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -88,6 +88,9 @@ class User(Base):
         BigInteger, primary_key=True, index=True
     )
     thread_id: Mapped[str] = mapped_column(String, nullable=False)
+    first_name: Mapped[str | None] = mapped_column(String)
+    last_name: Mapped[str | None] = mapped_column(String)
+    username: Mapped[str | None] = mapped_column(String)
     onboarding_complete: Mapped[bool] = mapped_column(Boolean, default=False)
     plan: Mapped[str] = mapped_column(String, default="free")
     timezone: Mapped[str] = mapped_column(String, default="UTC")

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -19,6 +19,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from .diabetes.services.db import (
     HistoryRecord as HistoryRecordDB,
     Timezone as TimezoneDB,
+    User as DBUser,
     run_db,
 )
 from .legacy import router
@@ -38,6 +39,10 @@ UI_DIR = UI_DIR.resolve()
 
 class Timezone(BaseModel):
     tz: str
+
+
+class WebUser(BaseModel):
+    telegram_id: int
 
 
 @app.get("/health", include_in_schema=False)
@@ -95,6 +100,20 @@ async def catch_all_ui(full_path: str) -> FileResponse:
 @app.get("/ui", include_in_schema=False)
 async def catch_root_ui() -> FileResponse:
     return await catch_all_ui("")
+
+
+@app.post("/api/user")
+async def create_user(data: WebUser) -> dict:
+    """Ensure a user exists in the database."""
+
+    def _create_user(session, telegram_id: int) -> None:
+        user = session.get(DBUser, telegram_id)
+        if user is None:
+            session.add(DBUser(telegram_id=telegram_id, thread_id="webapp"))
+        session.commit()
+
+    await run_db(_create_user, data.telegram_id)
+    return {"status": "ok"}
 
 
 @app.post("/api/history")

--- a/tests/test_webapp_user.py
+++ b/tests/test_webapp_user.py
@@ -1,0 +1,35 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import services.api.app.main as server
+from services.api.app.diabetes.services import db
+
+
+def setup_db(monkeypatch):
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    Session = sessionmaker(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+
+    async def run_db_wrapper(fn, *args, **kwargs):
+        return await db.run_db(fn, *args, sessionmaker=Session, **kwargs)
+
+    monkeypatch.setattr(server, "run_db", run_db_wrapper)
+    return Session
+
+
+def test_create_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    Session = setup_db(monkeypatch)
+    client = TestClient(server.app)
+
+    resp = client.post("/api/user", json={"telegram_id": 42})
+    assert resp.status_code == 200
+
+    with Session() as session:
+        user = session.get(db.User, 42)
+        assert user is not None
+        assert user.thread_id == "webapp"


### PR DESCRIPTION
## Summary
- ensure webapp API can create `User` records with a default `thread_id`
- add optional name columns for users and migration
- cover user creation with a test

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689f7f4761b8832aa750d9cf422a837a