### PR TITLE
[webapp] Add tgFetch helper for authenticated requests

### DIFF
--- a/services/webapp/ui/src/hooks/useTelegram.ts
+++ b/services/webapp/ui/src/hooks/useTelegram.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { tgFetch } from "../lib/tgFetch";
 
 type Scheme = "light" | "dark";
 
@@ -163,7 +164,7 @@ export const useTelegram = (
           }
           if (document.cookie) {
             try {
-              const resp = await fetch("/api/profile/self", {
+              const resp = await tgFetch("/api/profile/self", {
                 credentials: "include",
               });
               if (resp.ok) {

--- a/services/webapp/ui/src/lib/tgFetch.test.ts
+++ b/services/webapp/ui/src/lib/tgFetch.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { tgFetch } from './tgFetch';
+
+interface TelegramWebApp {
+  initData?: string;
+}
+
+interface TelegramWindow extends Window {
+  Telegram?: { WebApp?: TelegramWebApp };
+}
+
+const originalFetch = global.fetch;
+
+describe('tgFetch', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue(new Response());
+    vi.stubGlobal('window', {} as TelegramWindow);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('attaches X-Telegram-Init-Data header when init data is present', async () => {
+    (window as TelegramWindow).Telegram = { WebApp: { initData: 'test-data' } };
+    await tgFetch('/api/test', { credentials: 'include' });
+    const [, options] = (global.fetch as Mock).mock.calls[0] as [unknown, RequestInit];
+    const headers = options.headers as Headers;
+    expect(headers.get('X-Telegram-Init-Data')).toBe('test-data');
+  });
+
+  it('does not set header when init data is absent', async () => {
+    (window as TelegramWindow).Telegram = { WebApp: {} };
+    await tgFetch('/api/test', { credentials: 'include' });
+    const [, options] = (global.fetch as Mock).mock.calls[0] as [unknown, RequestInit];
+    const headers = options.headers as Headers;
+    expect(headers.has('X-Telegram-Init-Data')).toBe(false);
+  });
+});

--- a/services/webapp/ui/src/lib/tgFetch.ts
+++ b/services/webapp/ui/src/lib/tgFetch.ts
@@ -1,0 +1,21 @@
+interface TelegramWebApp {
+  initData?: string;
+}
+
+interface TelegramWindow extends Window {
+  Telegram?: { WebApp?: TelegramWebApp };
+}
+
+export async function tgFetch(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  const initData = typeof window !== 'undefined'
+    ? (window as TelegramWindow).Telegram?.WebApp?.initData
+    : undefined;
+  const headers = new Headers(init.headers ?? {});
+  if (initData) {
+    headers.set("X-Telegram-Init-Data", initData);
+  }
+  return fetch(input, { ...init, headers });
+}


### PR DESCRIPTION
## Summary
- use tgFetch in Telegram hook instead of direct fetch
- add tgFetch helper that sends X-Telegram-Init-Data header
- test tgFetch attaches init data header

## Testing
- `ruff check services/api/app tests`
- `npm --workspace services/webapp/ui exec vitest run`
- `pytest tests`
- `npm --workspace services/webapp/ui run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f7feb9c54832abc5765088a61561e