### PR TITLE
[auth] Add Telegram auth utilities and tests

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -11,7 +11,7 @@ if __name__ == "__main__" and __package__ is None:  # pragma: no cover - setup f
     sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
     __package__ = "services.api.app"
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from sqlalchemy.exc import SQLAlchemyError
@@ -22,6 +22,7 @@ from .diabetes.services.db import (
     run_db,
 )
 from .legacy import router
+from .telegram_auth import require_tg_user
 from .schemas.history import HistoryRecordSchema
 
 logger = logging.getLogger(__name__)
@@ -78,6 +79,11 @@ async def put_timezone(data: Timezone) -> dict:
 
     await run_db(_save_timezone, data.tz)
     return {"status": "ok"}
+
+
+@app.get("/api/profile/self")
+async def profile_self(user: dict = Depends(require_tg_user)) -> dict:
+    return user
 
 
 @app.get("/ui/{full_path:path}", include_in_schema=False)

--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -1,0 +1,51 @@
+import hashlib
+import hmac
+import json
+from urllib.parse import parse_qsl
+
+from fastapi import Header, HTTPException
+
+from .config import settings
+
+
+def parse_and_verify_init_data(init_data: str, token: str) -> dict:
+    """Parse and validate Telegram WebApp initialization data.
+
+    Parameters
+    ----------
+    init_data:
+        Raw query string received from Telegram WebApp.
+    token:
+        Bot token used to compute the validation hash.
+    """
+    try:
+        params = dict(parse_qsl(init_data, strict_parsing=True))
+    except ValueError as exc:
+        raise HTTPException(status_code=401, detail="invalid init data") from exc
+    auth_hash = params.pop("hash", None)
+    if not auth_hash:
+        raise HTTPException(status_code=401, detail="missing hash")
+
+    data_check_string = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
+    secret = hmac.new(b"WebAppData", token.encode(), hashlib.sha256).digest()
+    check = hmac.new(secret, data_check_string.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(check, auth_hash):
+        raise HTTPException(status_code=401, detail="invalid hash")
+
+    if "user" in params:
+        params["user"] = json.loads(params["user"])
+    return params
+
+
+def require_tg_user(
+    init_data: str | None = Header(None, alias="X-Telegram-Init-Data"),
+) -> dict:
+    """Dependency ensuring request contains valid Telegram user info."""
+    if not init_data:
+        raise HTTPException(status_code=401, detail="missing init data")
+
+    data = parse_and_verify_init_data(init_data, settings.telegram_token or "")
+    user = data.get("user")
+    if not isinstance(user, dict) or "id" not in user:
+        raise HTTPException(status_code=401, detail="invalid user")
+    return user

--- a/tests/test_profile_self.py
+++ b/tests/test_profile_self.py
@@ -1,0 +1,40 @@
+import hashlib
+import hmac
+import json
+import urllib.parse
+
+from fastapi.testclient import TestClient
+
+from services.api.app.config import settings
+from services.api.app.main import app
+
+TOKEN = "test-token"
+client = TestClient(app)
+
+
+def build_init_data(user_id: int = 1) -> str:
+    user = json.dumps({"id": user_id, "first_name": "A"}, separators=(",", ":"))
+    params = {"auth_date": "123", "query_id": "abc", "user": user}
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
+    secret = hmac.new(b"WebAppData", TOKEN.encode(), hashlib.sha256).digest()
+    params["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return urllib.parse.urlencode(params)
+
+
+def test_profile_self_valid_header(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    init_data = build_init_data(42)
+    resp = client.get("/api/profile/self", headers={"X-Telegram-Init-Data": init_data})
+    assert resp.status_code == 200
+    assert resp.json()["id"] == 42
+
+
+def test_profile_self_missing_header() -> None:
+    resp = client.get("/api/profile/self")
+    assert resp.status_code == 401
+
+
+def test_profile_self_invalid_header(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    resp = client.get("/api/profile/self", headers={"X-Telegram-Init-Data": "bad"})
+    assert resp.status_code == 401

--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -1,0 +1,58 @@
+import hashlib
+import hmac
+import json
+import urllib.parse
+
+import pytest
+from fastapi import HTTPException
+
+from services.api.app.config import settings
+from services.api.app.telegram_auth import parse_and_verify_init_data, require_tg_user
+
+TOKEN = "test-token"
+
+
+def build_init_data(token: str = TOKEN, user_id: int = 1) -> str:
+    user = json.dumps({"id": user_id, "first_name": "A"}, separators=(",", ":"))
+    params = {
+        "auth_date": "123",
+        "query_id": "abc",
+        "user": user,
+    }
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
+    secret = hmac.new(b"WebAppData", token.encode(), hashlib.sha256).digest()
+    params["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return urllib.parse.urlencode(params)
+
+
+def test_parse_and_verify_init_data_valid() -> None:
+    init_data = build_init_data()
+    data = parse_and_verify_init_data(init_data, TOKEN)
+    assert data["user"]["id"] == 1
+
+
+def test_parse_and_verify_init_data_invalid_hash() -> None:
+    init_data = build_init_data()
+    parts = dict(urllib.parse.parse_qsl(init_data))
+    parts["hash"] = "0" * 64
+    tampered = urllib.parse.urlencode(parts)
+    with pytest.raises(HTTPException):
+        parse_and_verify_init_data(tampered, TOKEN)
+
+
+def test_require_tg_user_valid(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    init_data = build_init_data()
+    user = require_tg_user(init_data)
+    assert user["id"] == 1
+
+
+def test_require_tg_user_missing() -> None:
+    with pytest.raises(HTTPException):
+        require_tg_user(None)
+
+
+def test_require_tg_user_invalid(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    with pytest.raises(HTTPException):
+        require_tg_user("bad")


### PR DESCRIPTION
## Summary
- add Telegram init-data verifier and dependency
- expose `/api/profile/self` using Telegram header auth
- cover Telegram auth helpers and profile endpoint with tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689f7feec218832a8d40f31517d39133