### PR TITLE
fix(api): use UserDB when creating users

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -122,9 +122,9 @@ async def create_user(data: WebUser) -> dict:
     """Ensure a user exists in the database."""
 
     def _create_user(session, telegram_id: int) -> None:
-        user = session.get(DBUser, telegram_id)
+        user = session.get(UserDB, telegram_id)
         if user is None:
-            session.add(DBUser(telegram_id=telegram_id, thread_id="webapp"))
+            session.add(UserDB(telegram_id=telegram_id, thread_id="webapp"))
         session.commit()
 
     await run_db(_create_user, data.telegram_id)


### PR DESCRIPTION
## Summary
- use UserDB model in webapp user creation

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689f881d7978832ab6f8b8713d79d4e6