### PR TITLE
tests: simplify MessageHandler generics

### DIFF
--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -16,9 +16,9 @@ from services.api.app.diabetes.handlers import dose_handlers
 
 
 def _find_handler(
-    fallbacks: Iterable[BaseHandler[Any, Any]],
+    fallbacks: Iterable[BaseHandler[Any]],
     regex: str,
-) -> MessageHandler[Any, Any]:
+) -> MessageHandler[Any]:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -20,9 +20,9 @@ from services.api.app.diabetes.handlers import (
 
 
 def _find_handler(
-    fallbacks: Iterable[BaseHandler[Any, Any]],
+    fallbacks: Iterable[BaseHandler[Any]],
     regex: str,
-) -> MessageHandler[Any, Any]:
+) -> MessageHandler[Any]:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)
@@ -43,7 +43,7 @@ class DummyMessage:
         self.kwargs.append(kwargs)
 
 
-async def _exercise(handler: MessageHandler[Any, Any]) -> None:
+async def _exercise(handler: MessageHandler[Any]) -> None:
     message = DummyMessage("📷 Фото еды")
     update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     context = cast(


### PR DESCRIPTION
## Summary
- adjust test helpers to use `MessageHandler[Any]` instead of `MessageHandler[Any, Any]`
- update `_find_handler` signatures for new generics

## Testing
- `ruff check services/api/app tests` *(fails: Undefined name `DBUser`)*
- `pytest tests` *(fails: NameError: DBUser is not defined, sqlite3.InterfaceError)*

------
https://chatgpt.com/codex/tasks/task_e_689f87981884832aa9c1976ee37e493d