### PR TITLE
[tests] assert update message before text assignment

### DIFF
--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -3,7 +3,7 @@ import os
 from types import SimpleNamespace
 from typing import Any, cast
 
-from telegram import Update
+from telegram import Message, Update
 from telegram.ext import CallbackContext
 
 import pytest
@@ -64,11 +64,14 @@ async def test_onboarding_demo_photo_missing(monkeypatch: pytest.MonkeyPatch, ca
     )
 
     await onboarding.start_command(update, context)
-    update.message.text = "10"
+    assert update.message
+    cast(Message, update.message).text = "10"
     await onboarding.onboarding_icr(update, context)
-    update.message.text = "3"
+    assert update.message
+    cast(Message, update.message).text = "3"
     await onboarding.onboarding_cf(update, context)
-    update.message.text = "6"
+    assert update.message
+    cast(Message, update.message).text = "6"
     await onboarding.onboarding_target(update, context)
 
     import pathlib
@@ -82,7 +85,8 @@ async def test_onboarding_demo_photo_missing(monkeypatch: pytest.MonkeyPatch, ca
 
     monkeypatch.setattr(pathlib.Path, "open", fake_open)
 
-    update.message.text = "Europe/Moscow"
+    assert update.message
+    cast(Message, update.message).text = "Europe/Moscow"
     with caplog.at_level(logging.ERROR):
         state = await onboarding.onboarding_timezone(update, context)
 

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from telegram import Update
+from telegram import Message, Update
 from telegram.ext import CallbackContext, ConversationHandler
 
 from services.api.app.diabetes.services.db import Base, User
@@ -85,19 +85,23 @@ async def test_onboarding_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert state == onboarding.ONB_PROFILE_ICR
     assert "1/3" in message.texts[-1]
 
-    update.message.text = "10"
+    assert update.message
+    cast(Message, update.message).text = "10"
     state = await onboarding.onboarding_icr(update, context)
     assert state == onboarding.ONB_PROFILE_CF
 
-    update.message.text = "3"
+    assert update.message
+    cast(Message, update.message).text = "3"
     state = await onboarding.onboarding_cf(update, context)
     assert state == onboarding.ONB_PROFILE_TARGET
 
-    update.message.text = "6"
+    assert update.message
+    cast(Message, update.message).text = "6"
     state = await onboarding.onboarding_target(update, context)
     assert state == onboarding.ONB_PROFILE_TZ
 
-    update.message.text = "Europe/Moscow"
+    assert update.message
+    cast(Message, update.message).text = "Europe/Moscow"
     state = await onboarding.onboarding_timezone(update, context)
     assert state == onboarding.ONB_DEMO
     assert message.photos


### PR DESCRIPTION
## Summary
- Ensure `update.message` is asserted non-null before setting message text in onboarding tests
- Cast `update.message` to `Message` after the assertion for clearer typing

## Testing
- `ruff check services/api/app tests` *(fails: unused import and undefined name in services/api/app/main.py)*
- `ruff check tests/test_onboarding_flow.py tests/test_onboarding_demo_photo_missing.py`
- `pytest tests` *(fails: NameError: DBUser not defined)*
- `pytest tests/test_onboarding_demo_photo_missing.py tests/test_onboarding_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_689f879be04c832aacd26f30571a2709