### PR TITLE
[bot] Expand Application type hints

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -22,7 +22,14 @@ logger = logging.getLogger(__name__)
 
 
 def register_handlers(
-    app: Application[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]]
+    app: Application[
+        ExtBot[None],
+        dict[str, Any],
+        dict[str, Any],
+        dict[str, Any],
+        Any,
+        Any,
+    ]
 ) -> None:
     """Register bot handlers on the provided ``Application`` instance."""
 

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -66,12 +66,24 @@ def main() -> None:
     ]
 
     async def post_init(
-        app: Application[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]]
+        app: Application[
+            ExtBot[None],
+            dict[str, Any],
+            dict[str, Any],
+            dict[str, Any],
+            Any,
+            Any,
+        ]
     ) -> None:
         await app.bot.set_my_commands(commands)
 
     application: Application[
-        ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]
+        ExtBot[None],
+        dict[str, Any],
+        dict[str, Any],
+        dict[str, Any],
+        Any,
+        Any,
     ] = (
         Application.builder()
         .token(BOT_TOKEN)


### PR DESCRIPTION
## Summary
- include missing generic parameters for telegram Application in registration handler and bot entry point
- annotate post-init and application variables with full Application generics

## Testing
- `ruff check services/api/app tests` *(fails: services/api/app/main.py:26:13 F401 import unused, services/api/app/main.py:125:28 F821 undefined name)*
- `ruff check services/api/app/diabetes/handlers/registration.py services/bot/main.py`
- `pytest tests` *(fails: tests/test_webapp_timezone.py::test_timezone_concurrent_writes - InterfaceError, tests/test_webapp_user.py::test_create_user - NameError)*

------
https://chatgpt.com/codex/tasks/task_e_689f879bf790832ab9d1ea9897f23c1b