### PR TITLE
[handlers] Add typings for _cancel_then wrapper

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -1,0 +1,6 @@
+"""Handlers package public exports."""
+
+from .dose_handlers import _cancel_then
+
+__all__ = ["_cancel_then"]
+

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -434,7 +434,8 @@ async def onboarding_poll_answer(
 
 
 async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-    from .dose_handlers import _cancel_then, photo_prompt
+    from . import _cancel_then
+    from .dose_handlers import photo_prompt
 
     message = update.message
     user_data = context.user_data

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
 from telegram.ext import (
     CommandHandler,
@@ -708,10 +709,13 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     return ConversationHandler.END
 
 
-async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    from ..dose_handlers import _cancel_then, photo_prompt
+async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    from .. import _cancel_then
+    from ..dose_handlers import photo_prompt
 
-    handler = _cancel_then(photo_prompt)
+    handler: Callable[[Update, ContextTypes.DEFAULT_TYPE], Awaitable[int]] = _cancel_then(
+        photo_prompt
+    )
     return await handler(update, context)
 
 

--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -16,8 +16,7 @@ from telegram.ext import (
 from services.api.app.diabetes.services.db import SessionLocal, Profile
 from services.api.app.diabetes.utils.ui import back_keyboard, menu_keyboard
 from services.api.app.diabetes.services.repository import commit
-from . import dose_handlers
-from .dose_handlers import _cancel_then
+from . import dose_handlers, _cancel_then
 
 SOS_CONTACT, = range(1)
 


### PR DESCRIPTION
## Summary
- type annotate the `_cancel_then` helper using `Update` and `ContextTypes.DEFAULT_TYPE`
- expose `_cancel_then` from handlers package and update imports

## Testing
- `ruff check services/api/app tests` *(fails: unused import and undefined names in services/api/app/main.py)*
- `pytest tests` *(fails: InterfaceError and NameError in webapp tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f879ce96c832aad5bd45174c0c3ba