### PR TITLE
[tests] Add non-null assertions for session.get results

### DIFF
--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -102,6 +102,8 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with TestSession() as session:
         updated = session.get(Entry, entry_id)
+        assert updated is not None
+        updated: Entry = updated
         assert updated.dose == 5.0
 
     assert field_query.answer_texts[-1] == "Изменено"

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -205,6 +205,8 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with TestSession() as session:
         updated = session.get(Entry, entry_id)
+        assert updated is not None
+        updated: Entry = updated
         assert updated.xe == 3
         assert updated.carbs_g == 10
         assert updated.dose == 2


### PR DESCRIPTION
## Summary
- Assert session.get returns a value before reading dose fields in tests
- Annotate retrieved entries with Entry for clearer typing

## Testing
- `ruff check services/api/app tests` *(fails: Undefined name DBUser in services/api/app/main.py)*
- `pytest tests/test_edit_record.py tests/test_handlers_history_edit.py`

------
https://chatgpt.com/codex/tasks/task_e_689f879e5254832a973c947bc69dcfd7