### PR TITLE
[tests] Type failing_commit and fix DBUser reference

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -122,9 +122,9 @@ async def create_user(data: WebUser) -> dict:
     """Ensure a user exists in the database."""
 
     def _create_user(session, telegram_id: int) -> None:
-        user = session.get(DBUser, telegram_id)
+        user = session.get(UserDB, telegram_id)
         if user is None:
-            session.add(DBUser(telegram_id=telegram_id, thread_id="webapp"))
+            session.add(UserDB(telegram_id=telegram_id, thread_id="webapp"))
         session.commit()
 
     await run_db(_create_user, data.telegram_id)

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 from telegram.ext import ConversationHandler
 from services.api.app.diabetes.handlers import profile as profile_handlers
 import services.api.app.diabetes.handlers.router as router
@@ -256,7 +257,7 @@ async def test_reminder_callback_commit_failure(monkeypatch: pytest.MonkeyPatch,
     monkeypatch.setattr(reminder_handlers, "SessionLocal", lambda: session)
     reminder_handlers.commit = commit
 
-    def failing_commit(sess):
+    def failing_commit(sess: Session) -> bool:
         sess.rollback()
         return False
 


### PR DESCRIPTION
## Summary
- add Session import and typing for `failing_commit`
- replace undefined `DBUser` with `UserDB` in API user creation helper

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689f879544c8832a82f082e08fefcd3d