### PR TITLE
tests: type-safe update placeholders

### DIFF
--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -137,8 +137,9 @@ async def test_photo_flow_saves_entry(
     context.user_data["thread_id"] = "tid"
 
     msg_photo = DummyMessage(photo=[DummyPhoto()])
-    update_photo = SimpleNamespace(
-        message=msg_photo, effective_user=SimpleNamespace(id=1)
+    update_photo = cast(
+        Update,
+        SimpleNamespace(message=msg_photo, effective_user=SimpleNamespace(id=1)),
     )
     await dose_handlers.photo_handler(update_photo, context)
 
@@ -165,7 +166,7 @@ async def test_photo_flow_saves_entry(
     monkeypatch.setattr(alert_handlers, "check_alert", noop)
 
     query = DummyQuery(DummyMessage(), "confirm_entry")
-    update_confirm = SimpleNamespace(callback_query=query)
+    update_confirm = cast(Update, SimpleNamespace(callback_query=query))
     await router.callback_router(update_confirm, context)
 
     assert len(session.added) == 1

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -1,11 +1,11 @@
 import pytest
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from unittest.mock import MagicMock
-from telegram import InlineKeyboardMarkup
-from telegram.ext import ConversationHandler
+from telegram import InlineKeyboardMarkup, Update
+from telegram.ext import CallbackContext, ConversationHandler
 
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
@@ -56,8 +56,12 @@ async def test_profile_command_and_view(monkeypatch: pytest.MonkeyPatch, args: A
         session.commit()
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=123))
-    context = SimpleNamespace(args=args, user_data={})
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=123))
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(args=args, user_data={})
+    )
 
     await handlers.profile_command(update, context)
     assert message.markups[0] is menu_keyboard
@@ -68,8 +72,12 @@ async def test_profile_command_and_view(monkeypatch: pytest.MonkeyPatch, args: A
     assert f"• Высокий порог: {expected_high} ммоль/л" in message.texts[0]
 
     message2 = DummyMessage()
-    update2 = SimpleNamespace(message=message2, effective_user=SimpleNamespace(id=123))
-    context2 = SimpleNamespace(user_data={})
+    update2 = cast(
+        Update, SimpleNamespace(message=message2, effective_user=SimpleNamespace(id=123))
+    )
+    context2 = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+    )
 
     await handlers.profile_view(update2, context2)
     assert f"• ИКХ: {expected_icr} г/ед." in message2.texts[0]
@@ -110,8 +118,12 @@ async def test_profile_command_invalid_values(monkeypatch: pytest.MonkeyPatch, a
     monkeypatch.setattr(handlers, "SessionLocal", session_local_mock)
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(args=args, user_data={})
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(args=args, user_data={})
+    )
 
     await handlers.profile_command(update, context)
 
@@ -131,16 +143,24 @@ async def test_profile_command_help_and_dialog(monkeypatch: pytest.MonkeyPatch) 
 
     # Test /profile help
     help_msg = DummyMessage()
-    update = SimpleNamespace(message=help_msg, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(args=["help"], user_data={})
+    update = cast(
+        Update, SimpleNamespace(message=help_msg, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(args=["help"], user_data={})
+    )
     result = await handlers.profile_command(update, context)
     assert result == ConversationHandler.END
     assert "Формат команды" in help_msg.texts[0]
 
     # Test starting dialog with empty args
     dialog_msg = DummyMessage()
-    update2 = SimpleNamespace(message=dialog_msg, effective_user=SimpleNamespace(id=1))
-    context2 = SimpleNamespace(args=[], user_data={})
+    update2 = cast(
+        Update, SimpleNamespace(message=dialog_msg, effective_user=SimpleNamespace(id=1))
+    )
+    context2 = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(args=[], user_data={})
+    )
     result2 = await handlers.profile_command(update2, context2)
     assert result2 == handlers.PROFILE_ICR
     assert dialog_msg.texts[0].startswith("Введите коэффициент ИКХ")
@@ -168,8 +188,13 @@ async def test_profile_view_preserves_user_data(monkeypatch: pytest.MonkeyPatch)
         session.commit()
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={"thread_id": "tid", "foo": "bar"})
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any],
+        SimpleNamespace(user_data={"thread_id": "tid", "foo": "bar"}),
+    )
 
     await handlers.profile_view(update, context)
 
@@ -190,8 +215,10 @@ async def test_profile_view_missing_profile_shows_webapp_button(monkeypatch: pyt
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: None)
 
     msg = DummyMessage()
-    update = SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace()
+    update = cast(
+        Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(CallbackContext[Any, Any, Any, Any], SimpleNamespace())
 
     await handlers.profile_view(update, context)
 

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -1,6 +1,9 @@
 import os
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
+
+from telegram import Update
+from telegram.ext import CallbackContext
 
 import pytest
 
@@ -24,16 +27,22 @@ class DummyMessage:
 @pytest.mark.asyncio
 async def test_prompt_photo_sends_message() -> None:
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    await dose_handlers.prompt_photo(update, SimpleNamespace())
+    update = cast(Update, SimpleNamespace(message=message))
+    await dose_handlers.prompt_photo(
+        update, cast(CallbackContext[Any, Any, Any, Any], SimpleNamespace())
+    )
     assert any("фото" in t.lower() for t in message.texts)
 
 
 @pytest.mark.asyncio
 async def test_prompt_sugar_sends_message() -> None:
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={})
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+    )
     await dose_handlers.prompt_sugar(update, context)
     assert any("сахар" in t.lower() for t in message.texts)
     assert message.kwargs and message.kwargs[0].get("reply_markup") is sugar_keyboard
@@ -42,7 +51,11 @@ async def test_prompt_sugar_sends_message() -> None:
 @pytest.mark.asyncio
 async def test_prompt_dose_sends_message() -> None:
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={})
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+    )
     await dose_handlers.prompt_dose(update, context)
     assert any("доз" in t.lower() for t in message.texts)

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -43,8 +43,9 @@ async def test_report_request_and_custom_flow(
     import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 
     message = DummyMessage()
-    update = SimpleNamespace(
-        message=message, effective_user=SimpleNamespace(id=1)
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
         CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
@@ -56,8 +57,9 @@ async def test_report_request_and_custom_flow(
     assert message.kwargs[0].get("reply_markup") is not None
 
     query = DummyQuery(DummyMessage(), "report_period:custom")
-    update_cb = SimpleNamespace(
-        callback_query=query, effective_user=SimpleNamespace(id=1)
+    update_cb = cast(
+        Update,
+        SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1)),
     )
 
     await reporting_handlers.report_period_callback(update_cb, context)
@@ -118,8 +120,9 @@ async def test_report_period_callback_week(
     monkeypatch.setattr(reporting_handlers.datetime, "datetime", DummyDateTime)
 
     query = DummyQuery(DummyMessage(), "report_period:week")
-    update_cb = SimpleNamespace(
-        callback_query=query, effective_user=SimpleNamespace(id=1)
+    update_cb = cast(
+        Update,
+        SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
         CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -1,7 +1,10 @@
 import pytest
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
+
+from telegram import Update
+from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 
@@ -37,9 +40,14 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
     async def fake_send_chat_action(*args: Any, **kwargs: Any) -> None:
         pass
 
-    context = SimpleNamespace(
-        user_data={"thread_id": "tid"},
-        bot=SimpleNamespace(get_file=fake_get_file, send_chat_action=fake_send_chat_action),
+    context = cast(
+        CallbackContext[Any, Any, Any, Any],
+        SimpleNamespace(
+            user_data={"thread_id": "tid"},
+            bot=SimpleNamespace(
+                get_file=fake_get_file, send_chat_action=fake_send_chat_action
+            ),
+        ),
     )
 
     captured = {}
@@ -81,7 +89,10 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
     msg_photo = DummyMessage(photo=[DummyPhoto()])
-    update = SimpleNamespace(message=msg_photo, effective_user=SimpleNamespace(id=1))
+    update = cast(
+        Update,
+        SimpleNamespace(message=msg_photo, effective_user=SimpleNamespace(id=1)),
+    )
 
     await dose_handlers.photo_handler(update, context)
 

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -1,6 +1,9 @@
 import os
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
+
+from telegram import Update
+from telegram.ext import CallbackContext
 
 import pytest
 from telegram.ext import CommandHandler
@@ -34,8 +37,13 @@ def _get_menu_handler(fallbacks):
 async def test_sugar_conv_menu_then_photo() -> None:
     handler = _get_menu_handler(dose_handlers.sugar_conv.fallbacks)
     message = DummyMessage("/menu")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}})
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any],
+        SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
+    )
 
     await handler.callback(update, context)
 
@@ -44,8 +52,8 @@ async def test_sugar_conv_menu_then_photo() -> None:
     assert context.user_data == {}
 
     next_message = DummyMessage("📷 Фото еды")
-    next_update = SimpleNamespace(
-        message=next_message, effective_user=SimpleNamespace(id=1)
+    next_update = cast(
+        Update, SimpleNamespace(message=next_message, effective_user=SimpleNamespace(id=1))
     )
     await dose_handlers.photo_prompt(next_update, context)
     assert any("фото" in r.lower() for r in next_message.replies)
@@ -54,8 +62,13 @@ async def test_sugar_conv_menu_then_photo() -> None:
 async def test_dose_conv_menu_then_photo() -> None:
     handler = _get_menu_handler(dose_handlers.dose_conv.fallbacks)
     message = DummyMessage("/menu")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}})
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, Any, Any, Any],
+        SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
+    )
 
     await handler.callback(update, context)
 
@@ -64,8 +77,8 @@ async def test_dose_conv_menu_then_photo() -> None:
     assert context.user_data == {}
 
     next_message = DummyMessage("📷 Фото еды")
-    next_update = SimpleNamespace(
-        message=next_message, effective_user=SimpleNamespace(id=1)
+    next_update = cast(
+        Update, SimpleNamespace(message=next_message, effective_user=SimpleNamespace(id=1))
     )
     await dose_handlers.photo_prompt(next_update, context)
     assert any("фото" in r.lower() for r in next_message.replies)

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -5,6 +5,8 @@ from re import Pattern
 from types import SimpleNamespace
 from typing import Any, Iterable, cast
 
+from telegram import Update
+
 import pytest
 from telegram.ext import BaseHandler, CallbackContext, MessageHandler
 
@@ -45,7 +47,9 @@ class DummyMessage:
 
 async def _exercise(handler: MessageHandler[Any, Any]) -> None:
     message = DummyMessage("📷 Фото еды")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, Any, Any, Any],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}, "dose_method": "xe"}),

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -3,6 +3,8 @@ from re import Pattern
 from types import SimpleNamespace
 from typing import Any, cast
 
+from telegram import Update
+
 import pytest
 from telegram.ext import CallbackContext, ConversationHandler, MessageHandler
 
@@ -37,7 +39,9 @@ async def test_sugar_back_fallback_cancels() -> None:
         if isinstance(h, MessageHandler) and _filter_pattern_equals(h, "^↩️ Назад$")
     )
     message = DummyMessage("↩️ Назад")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, Any, Any, Any],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
@@ -51,7 +55,9 @@ async def test_sugar_back_fallback_cancels() -> None:
 @pytest.mark.asyncio
 async def test_cancel_command_clears_state() -> None:
     message = DummyMessage("/cancel")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, Any, Any, Any],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),


### PR DESCRIPTION
## Summary
- replace SimpleNamespace update/context placeholders in tests with typed casts

## Testing
- `ruff check services/api/app tests/test_handlers_vision_prompt.py tests/test_handlers_prompts.py tests/test_photo_fallbacks.py tests/test_handlers_photo_sugar_save.py tests/test_menu_fallbacks.py tests/test_sugar_exit.py tests/test_handlers_profile.py tests/test_handlers_report_request.py`
- `pytest tests/test_handlers_vision_prompt.py tests/test_handlers_prompts.py tests/test_photo_fallbacks.py tests/test_handlers_photo_sugar_save.py tests/test_menu_fallbacks.py tests/test_sugar_exit.py tests/test_handlers_profile.py tests/test_handlers_report_request.py`


------
https://chatgpt.com/codex/tasks/task_e_689f87935e30832ab0a642975c63769f