### PR TITLE
[webapp] Prefix web app button URLs with /ui

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -176,7 +176,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                     [
                         InlineKeyboardButton(
                             "📝 Заполнить форму",
-                            web_app=WebAppInfo(f"{settings.webapp_url}/profile"),
+                            web_app=WebAppInfo(f"{settings.webapp_url}/ui/profile"),
                         )
                     ]
                 ]
@@ -215,7 +215,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             [
                 InlineKeyboardButton(
                     "📝 Заполнить форму",
-                    web_app=WebAppInfo(f"{settings.webapp_url}/profile"),
+                    web_app=WebAppInfo(f"{settings.webapp_url}/ui/profile"),
                 )
             ],
         )
@@ -450,7 +450,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         return
     if action == "add" and settings.webapp_url:
         button = InlineKeyboardButton(
-            "📝 Новое", web_app=WebAppInfo(f"{settings.webapp_url}/reminders")
+            "📝 Новое", web_app=WebAppInfo(f"{settings.webapp_url}/ui/reminders")
         )
         keyboard = InlineKeyboardMarkup([[button]])
         await query.message.reply_text("Создать напоминание:", reply_markup=keyboard)

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -141,7 +141,7 @@ def _render_reminders(
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
-                web_app=WebAppInfo(f"{settings.webapp_url}/reminders"),
+                web_app=WebAppInfo(f"{settings.webapp_url}/ui/reminders"),
             )
         ]
     if not rems:
@@ -167,7 +167,7 @@ def _render_reminders(
             row.append(
                 InlineKeyboardButton(
                     "✏️",
-                    web_app=WebAppInfo(f"{settings.webapp_url}/reminders?id={r.id}"),
+                    web_app=WebAppInfo(f"{settings.webapp_url}/ui/reminders?id={r.id}"),
                 )
             )
         row.extend(

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -29,14 +29,14 @@ __all__ = (
 # Create WebApp buttons when WebApp is configured, fall back to text buttons otherwise
 profile_button = (
     KeyboardButton(
-        "📄 Мой профиль", web_app=WebAppInfo(f"{settings.webapp_url}/profile")
+        "📄 Мой профиль", web_app=WebAppInfo(f"{settings.webapp_url}/ui/profile")
     )
     if settings.webapp_url
     else KeyboardButton("📄 Мой профиль")
 )
 reminders_button = (
     KeyboardButton(
-        "⏰ Напоминания", web_app=WebAppInfo(f"{settings.webapp_url}/reminders")
+        "⏰ Напоминания", web_app=WebAppInfo(f"{settings.webapp_url}/ui/reminders")
     )
     if settings.webapp_url
     else KeyboardButton("⏰ Напоминания")
@@ -122,5 +122,5 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
 
     return InlineKeyboardButton(
         "Определить автоматически",
-        web_app=WebAppInfo(f"{settings.webapp_url}/timezone"),
+        web_app=WebAppInfo(f"{settings.webapp_url}/ui/timezone"),
     )

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -200,4 +200,4 @@ async def test_profile_view_missing_profile_shows_webapp_button(monkeypatch: pyt
     button = markup.inline_keyboard[0][0]
     assert button.text == "📝 Заполнить форму"
     assert button.web_app is not None
-    assert urlparse(button.web_app.url).path == "/profile"
+    assert urlparse(button.web_app.url).path == "/ui/profile"

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -19,10 +19,11 @@ def test_menu_keyboard_webapp_urls(monkeypatch: pytest.MonkeyPatch) -> None:
     reminders_btn = next(b for b in buttons if b.text == "⏰ Напоминания")
 
     assert profile_btn.web_app is not None
-    assert urlparse(profile_btn.web_app.url).path == "/profile"
+    assert urlparse(profile_btn.web_app.url).path == "/ui/profile"
     assert reminders_btn.web_app is not None
-    assert urlparse(reminders_btn.web_app.url).path == "/reminders"
+    assert urlparse(reminders_btn.web_app.url).path == "/ui/reminders"
 
     monkeypatch.delenv("WEBAPP_URL", raising=False)
     importlib.reload(config)
     importlib.reload(ui)
+

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -191,7 +191,7 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "📸 Триггер-фото" in text
     assert "2. <s>🔕title2</s>" in text
     btn = markup.inline_keyboard[-1][0]
-    assert btn.web_app and btn.web_app.url.endswith("/reminders")
+    assert btn.web_app and btn.web_app.url.endswith("/ui/reminders")
 
 
 def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -16,7 +16,7 @@ def test_timezone_button_webapp_url(monkeypatch: pytest.MonkeyPatch) -> None:
 
     button = ui.build_timezone_webapp_button()
     assert button is not None
-    assert urlparse(button.web_app.url).path == "/timezone"
+    assert urlparse(button.web_app.url).path == "/ui/timezone"
 
     monkeypatch.delenv("WEBAPP_URL", raising=False)
     importlib.reload(config)


### PR DESCRIPTION
## Summary
- point web app buttons to `/ui/*` paths for profile, reminders, and timezone
- adjust tests to expect new `/ui` paths

## Testing
- `python -m pytest tests/test_menu_keyboard_webapp.py tests/test_timezone_button_webapp.py tests/test_handlers_profile.py tests/test_reminders.py`
- `python -m pytest tests` *(fails: NameError: name 'UserDB' is not defined)*
- `ruff check services/api/app tests` *(fails: F821 Undefined name `UserDB`)*

------
https://chatgpt.com/codex/tasks/task_e_689f95e0f9ec832a93d445da06aa541e