### PR TITLE
[api] Fix unused user import in main module

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import Session
 from .diabetes.services.db import (
     HistoryRecord as HistoryRecordDB,
     Timezone as TimezoneDB,
-    User as DBUser,
+    User as UserDB,
     run_db,
 )
 from .legacy import router


### PR DESCRIPTION
## Summary
- align User DB model alias usage to prevent undefined reference and unused import warnings

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689f999fc470832a8fb97a466623fa28