### PR TITLE
webapp: add tgFetch util for API requests

### DIFF
--- a/services/webapp/ui/src/api/history.ts
+++ b/services/webapp/ui/src/api/history.ts
@@ -1,3 +1,5 @@
+import { tgFetch } from '../lib/tgFetch';
+
 export interface HistoryRecord {
   id: string;
   date: string;
@@ -12,7 +14,7 @@ export interface HistoryRecord {
 
 export async function getHistory(): Promise<HistoryRecord[]> {
   try {
-    const res = await fetch('/api/history');
+    const res = await tgFetch('/api/history');
     if (!res.ok) {
       throw new Error('Не удалось загрузить историю');
     }
@@ -29,7 +31,7 @@ export async function getHistory(): Promise<HistoryRecord[]> {
 
 export async function updateRecord(record: HistoryRecord) {
   try {
-    const res = await fetch('/api/history', {
+    const res = await tgFetch('/api/history', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(record),
@@ -47,7 +49,7 @@ export async function updateRecord(record: HistoryRecord) {
 
 export async function deleteRecord(id: string) {
   try {
-    const res = await fetch(`/api/history/${id}`, { method: 'DELETE' });
+    const res = await tgFetch(`/api/history/${id}`, { method: 'DELETE' });
     const data = await res.json().catch(() => ({}));
     if (!res.ok || data.status !== 'ok') {
       throw new Error(data.detail || 'Не удалось удалить запись');

--- a/services/webapp/ui/src/api/stats.ts
+++ b/services/webapp/ui/src/api/stats.ts
@@ -1,3 +1,5 @@
+import { tgFetch } from '../lib/tgFetch';
+
 export interface AnalyticsPoint {
   date: string;
   sugar: number;
@@ -24,7 +26,7 @@ export const fallbackDayStats: DayStats = {
 };
 
 export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint[]> {
-  const res = await fetch(`/api/analytics?telegramId=${telegramId}`);
+  const res = await tgFetch(`/api/analytics?telegramId=${telegramId}`);
   if (!res.ok) {
     throw new Error('Failed to fetch analytics');
   }
@@ -36,7 +38,7 @@ export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint
 }
 
 export async function fetchDayStats(telegramId: number): Promise<DayStats> {
-  const res = await fetch(`/api/stats?telegramId=${telegramId}`);
+  const res = await tgFetch(`/api/stats?telegramId=${telegramId}`);
   if (!res.ok) {
     throw new Error('Failed to fetch stats');
   }

--- a/services/webapp/ui/src/lib/tgFetch.test.ts
+++ b/services/webapp/ui/src/lib/tgFetch.test.ts
@@ -25,7 +25,7 @@ describe('tgFetch', () => {
 
   it('attaches X-Telegram-Init-Data header when init data is present', async () => {
     (window as TelegramWindow).Telegram = { WebApp: { initData: 'test-data' } };
-    await tgFetch('/api/test', { credentials: 'include' });
+    await tgFetch('/api/profile/self', { credentials: 'include' });
     const [, options] = (global.fetch as Mock).mock.calls[0] as [unknown, RequestInit];
     const headers = options.headers as Headers;
     expect(headers.get('X-Telegram-Init-Data')).toBe('test-data');
@@ -33,7 +33,7 @@ describe('tgFetch', () => {
 
   it('does not set header when init data is absent', async () => {
     (window as TelegramWindow).Telegram = { WebApp: {} };
-    await tgFetch('/api/test', { credentials: 'include' });
+    await tgFetch('/api/profile/self', { credentials: 'include' });
     const [, options] = (global.fetch as Mock).mock.calls[0] as [unknown, RequestInit];
     const headers = options.headers as Headers;
     expect(headers.has('X-Telegram-Init-Data')).toBe(false);

--- a/services/webapp/ui/src/lib/tgFetch.ts
+++ b/services/webapp/ui/src/lib/tgFetch.ts
@@ -1,21 +1,8 @@
-interface TelegramWebApp {
-  initData?: string;
-}
-
-interface TelegramWindow extends Window {
-  Telegram?: { WebApp?: TelegramWebApp };
-}
-
-export async function tgFetch(
-  input: RequestInfo | URL,
-  init: RequestInit = {},
-): Promise<Response> {
-  const initData = typeof window !== 'undefined'
-    ? (window as TelegramWindow).Telegram?.WebApp?.initData
-    : undefined;
-  const headers = new Headers(init.headers ?? {});
-  if (initData) {
-    headers.set("X-Telegram-Init-Data", initData);
+export function tgFetch(input: RequestInfo | URL, init: RequestInit = {}) {
+  const headers = new Headers(init.headers || {});
+  const tg = (window as any).Telegram?.WebApp;
+  if (tg?.initData) {
+    headers.set("X-Telegram-Init-Data", tg.initData);
   }
   return fetch(input, { ...init, headers });
 }


### PR DESCRIPTION
## Summary
- add tgFetch wrapper to send Telegram init data header
- use tgFetch in webapp API modules
- test tgFetch to ensure header on /api/profile/self

## Testing
- `ruff check services/api/app tests` *(fails: Undefined name `UserDB`)*
- `pytest tests` *(fails: NameError: UserDB not defined)*
- `npm --workspace services/webapp/ui exec vitest run src/lib/tgFetch.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689f9929b728832aa2ab8292fb713b31