### PR TITLE
[db] Add SQL script to backfill user profile fields

### DIFF
--- a/scripts/add_user_fields.sql
+++ b/scripts/add_user_fields.sql
@@ -1,0 +1,12 @@
+-- Add missing user profile fields to users table
+-- Ensures new bot features have the required columns.
+ALTER TABLE IF EXISTS users
+    ADD COLUMN IF NOT EXISTS thread_id VARCHAR NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS first_name VARCHAR,
+    ADD COLUMN IF NOT EXISTS last_name VARCHAR,
+    ADD COLUMN IF NOT EXISTS username VARCHAR,
+    ADD COLUMN IF NOT EXISTS onboarding_complete BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS plan VARCHAR NOT NULL DEFAULT 'free',
+    ADD COLUMN IF NOT EXISTS timezone VARCHAR NOT NULL DEFAULT 'UTC',
+    ADD COLUMN IF NOT EXISTS org_id INTEGER,
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();


### PR DESCRIPTION
## Summary
- add SQL script to ensure user table has thread_id, name, plan, timezone, and audit fields

## Testing
- `ruff check services/api/app tests`
- `pytest tests`
- `psql -h localhost -U diabetes_user -d diabetes_bot -f scripts/add_user_fields.sql`
- `python -m services.bot.main` (via timeout for startup)
- `python - <<'PY' ... schedule_reminder ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68a00a1d40d8832ab5b833116c2b4025