### PR TITLE
[services] Avoid stack trace on missing fonts

### DIFF
--- a/services/api/app/diabetes/services/reporting.py
+++ b/services/api/app/diabetes/services/reporting.py
@@ -37,7 +37,7 @@ def _register_font(name: str, filename: str) -> None:
         if isinstance(e, OSError):
             logging.warning("[PDF] Cannot register font %s at %s: %s", name, path, e)
         else:
-            logging.exception("[PDF] Invalid font %s at %s: %s", name, path, e)
+            logging.warning("[PDF] Invalid font %s at %s: %s", name, path, e)
         if _font_dir != DEFAULT_FONT_DIR:
             fallback = os.path.join(DEFAULT_FONT_DIR, filename)
             try:
@@ -51,7 +51,7 @@ def _register_font(name: str, filename: str) -> None:
                         e2,
                     )
                 else:
-                    logging.exception(
+                    logging.warning(
                         "[PDF] Invalid default font %s at %s: %s",
                         name,
                         fallback,


### PR DESCRIPTION
## Summary
- avoid logging stack traces when PDF fonts fail to register

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: tests/test_webapp_timezone.py::test_timezone_concurrent_writes)*
- `python -m services.bot.main` *(fails: DB_PASSWORD environment variable must be set)*
- `FONT_DIR=/nonexistent python - <<'PY'\nimport logging\nlogging.basicConfig(level=logging.WARNING)\nimport services.api.app.diabetes.services.reporting\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68a00db039d0832a92f1829c37215f63