### PR TITLE
[bot] Align Application context generics

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -8,7 +8,7 @@ import sys
 from typing import Any
 
 from telegram import BotCommand
-from telegram.ext import Application, ContextTypes, ExtBot
+from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
 from sqlalchemy.exc import SQLAlchemyError
 
 from services.api.app.diabetes.services.db import init_db
@@ -68,22 +68,22 @@ def main() -> None:
     async def post_init(
         app: Application[
             ExtBot[None],
+            ContextTypes.DEFAULT_TYPE,
             dict[str, Any],
             dict[str, Any],
             dict[str, Any],
-            Any,
-            Any,
+            JobQueue[ContextTypes.DEFAULT_TYPE],
         ]
     ) -> None:
         await app.bot.set_my_commands(commands)
 
     application: Application[
         ExtBot[None],
+        ContextTypes.DEFAULT_TYPE,
         dict[str, Any],
         dict[str, Any],
         dict[str, Any],
-        Any,
-        Any,
+        JobQueue[ContextTypes.DEFAULT_TYPE],
     ] = (
         Application.builder()
         .token(BOT_TOKEN)


### PR DESCRIPTION
## Summary
- use `ContextTypes.DEFAULT_TYPE` for application context generics
- ensure error handler registration matches context type

## Testing
- `ruff check services/bot/main.py`
- `mypy --follow-imports=skip services/bot/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a013ad43a4832a9210e84786b30ad4