### PR TITLE
[handlers] Type Application with CallbackContext

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -7,6 +7,7 @@ from telegram.ext import (
     Application,
     CallbackQueryHandler,
     CommandHandler,
+    ContextTypes,
     ExtBot,
     MessageHandler,
     PollAnswerHandler,
@@ -24,7 +25,7 @@ logger = logging.getLogger(__name__)
 def register_handlers(
     app: Application[
         ExtBot[None],
-        dict[str, Any],
+        ContextTypes.DEFAULT_TYPE,
         dict[str, Any],
         dict[str, Any],
         Any,


### PR DESCRIPTION
## Summary
- ensure `register_handlers` accepts `Application` typed with default `CallbackContext`
- import `ContextTypes` for `Application`

## Testing
- `ruff check services/api/app tests`
- `mypy --follow-imports=skip services/api/app/diabetes/handlers/registration.py`
- `pytest tests/test_register_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0137b7468832a81d7eb6c09cd24d4