### PR TITLE
[gpt] Make thread creation async

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -835,7 +835,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
                 if user:
                     thread_id = user.thread_id
                 else:
-                    thread_id = create_thread()
+                    thread_id = await create_thread()
                     session.add(User(telegram_id=user_id, thread_id=thread_id))
                     if not commit(session):
                         await message.reply_text(

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -76,7 +76,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
             from services.api.app.diabetes.services.gpt_client import create_thread
 
             try:
-                thread_id = create_thread()
+                thread_id = await create_thread()
             except OpenAIError as exc:  # pragma: no cover - network errors
                 logger.exception("Failed to create thread for user %s: %s", user_id, exc)
                 await message.reply_text(

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -245,7 +245,7 @@ async def send_report(
             user = session.get(User, user_id)
             thread_id = getattr(user, "thread_id", None)
             if thread_id is None:
-                thread_id = create_thread()
+                thread_id = await create_thread()
                 if user:
                     user.thread_id = thread_id
                 else:

--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -26,10 +26,16 @@ def _get_client():
     return _client
 
 
-def create_thread() -> str:
-    """Создаём пустой thread (ассистент задаётся позже, в runs.create)."""
+async def create_thread() -> str:
+    """Создаём пустой thread (ассистент задаётся позже, в runs.create).
+
+    Returns
+    -------
+    str
+        Идентификатор созданного thread.
+    """
     try:
-        thread = _get_client().beta.threads.create()
+        thread = await asyncio.to_thread(_get_client().beta.threads.create)
     except OpenAIError as exc:
         logger.exception("[OpenAI] Failed to create thread: %s", exc)
         raise

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -62,17 +62,22 @@ async def test_send_message_openaierror(monkeypatch: pytest.MonkeyPatch, caplog:
     assert any("Failed to create message" in r.message for r in caplog.records)
 
 
-def test_create_thread_openaierror(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+@pytest.mark.asyncio
+async def test_create_thread_openaierror(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     def raise_error():
         raise OpenAIError("boom")
 
-    fake_client = SimpleNamespace(beta=SimpleNamespace(threads=SimpleNamespace(create=raise_error)))
+    fake_client = SimpleNamespace(
+        beta=SimpleNamespace(threads=SimpleNamespace(create=raise_error))
+    )
 
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
 
     with caplog.at_level(logging.ERROR):
         with pytest.raises(OpenAIError):
-            gpt_client.create_thread()
+            await gpt_client.create_thread()
 
     assert any("Failed to create thread" in r.message for r in caplog.records)
 

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -42,7 +42,10 @@ async def test_onboarding_demo_photo_missing(monkeypatch: pytest.MonkeyPatch, ca
     import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
     import services.api.app.diabetes.services.gpt_client as gpt_client
 
-    monkeypatch.setattr(gpt_client, "create_thread", lambda: "tid")
+    async def fake_create_thread() -> str:
+        return "tid"
+
+    monkeypatch.setattr(gpt_client, "create_thread", fake_create_thread)
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -61,7 +61,10 @@ async def test_onboarding_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
     import services.api.app.diabetes.services.gpt_client as gpt_client
 
-    monkeypatch.setattr(gpt_client, "create_thread", lambda: "tid")
+    async def fake_create_thread() -> str:
+        return "tid"
+
+    monkeypatch.setattr(gpt_client, "create_thread", fake_create_thread)
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)


### PR DESCRIPTION
## Summary
- use asyncio.to_thread for thread creation and expose async API
- await create_thread in dose, reporting, and onboarding handlers

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a0232484e4832a970d5609192d8315