### PR TITLE
[utils] Place json and logging imports at top

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -1,5 +1,3 @@
-# utils.py
-
 import json
 import logging
 import asyncio
@@ -9,6 +7,8 @@ from urllib.request import urlopen
 
 from reportlab.pdfbase.pdfmetrics import stringWidth
 from reportlab.lib.units import mm
+
+# utils.py
 
 
 def clean_markdown(text: str) -> str:


### PR DESCRIPTION
## Summary
- move json and logging imports to the very beginning of helpers module

## Testing
- `ruff check services/api/app tests`

------
https://chatgpt.com/codex/tasks/task_e_68a02471e448832ab1f66c25d347e7c7