### PR TITLE
[tests] annotate update and context in reminder limit test

### DIFF
--- a/tests/test_reminder_limit_free_vs_pro.py
+++ b/tests/test_reminder_limit_free_vs_pro.py
@@ -44,8 +44,14 @@ async def test_reminder_limit_free_vs_pro(plan: Any, limit: Any, monkeypatch: py
 
     msg = DummyMessage()
     msg.web_app_data.data = json.dumps({"type": "sugar", "value": "09:00"})
-    update = SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(job_queue=SimpleNamespace(run_daily=lambda *a, **k: None, run_repeating=lambda *a, **k: None, get_jobs_by_name=lambda name: []))
+    update: Any = SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1))
+    context: Any = SimpleNamespace(
+        job_queue=SimpleNamespace(
+            run_daily=lambda *a, **k: None,
+            run_repeating=lambda *a, **k: None,
+            get_jobs_by_name=lambda name: [],
+        )
+    )
 
     await handlers.reminder_webapp_save(update, context)
 


### PR DESCRIPTION
## Summary
- annotate update and context as `Any` when testing reminder limit

## Testing
- `ruff check tests/test_reminder_limit_free_vs_pro.py`
- `pytest tests/test_reminder_limit_free_vs_pro.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a02d3ad4f0832aafcaed02f546c2cb