### PR TITLE
[api] Add history retrieval and deletion with auth

### DIFF
--- a/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
+++ b/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
@@ -34,6 +34,7 @@ def upgrade() -> None:
         op.create_table(
             "history_records",
             sa.Column("id", sa.String(), primary_key=True),
+            sa.Column("telegram_id", sa.BigInteger(), nullable=False),
             sa.Column("date", sa.String(), nullable=False),
             sa.Column("time", sa.String(), nullable=False),
             sa.Column("sugar", sa.Float(), nullable=True),

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -209,6 +209,7 @@ class Timezone(Base):
 class HistoryRecord(Base):
     __tablename__ = "history_records"
     id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
+    telegram_id: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
     date: Mapped[str] = mapped_column(String, nullable=False)
     time: Mapped[str] = mapped_column(String, nullable=False)
     sugar: Mapped[float | None] = mapped_column(Float)


### PR DESCRIPTION
## Summary
- secure history record updates with Telegram auth and ownership checks
- add GET and DELETE endpoints for user history
- track record ownership via new `telegram_id` column
- test history API auth and new endpoints

## Testing
- `ruff check services/api/app tests`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68a030bcf2f8832a92c6fbad47c1b8e6