### PR TITLE
[webapp] Add auth fetch wrapper for API

### DIFF
--- a/services/webapp/ui/src/api/authFetch.test.ts
+++ b/services/webapp/ui/src/api/authFetch.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { authFetch } from './authFetch';
+
+interface TelegramWebApp {
+  initData?: string;
+}
+
+interface TelegramWindow extends Window {
+  Telegram?: { WebApp?: TelegramWebApp };
+}
+
+const originalFetch = global.fetch;
+
+describe('authFetch', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue(new Response());
+    vi.stubGlobal('window', {} as TelegramWindow);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('sets credentials and attaches init data header', async () => {
+    (window as TelegramWindow).Telegram = { WebApp: { initData: 'test-data' } };
+    await authFetch('/api/profile');
+    const [, options] = (global.fetch as Mock).mock.calls[0] as [unknown, RequestInit];
+    const headers = options.headers as Headers;
+    expect(options.credentials).toBe('include');
+    expect(headers.get('X-Telegram-Init-Data')).toBe('test-data');
+  });
+});

--- a/services/webapp/ui/src/api/authFetch.ts
+++ b/services/webapp/ui/src/api/authFetch.ts
@@ -1,0 +1,8 @@
+import { tgFetch } from '../lib/tgFetch';
+
+/**
+ * A fetch wrapper that ensures Telegram init data headers and cookies are sent.
+ */
+export function authFetch(input: RequestInfo | URL, init: RequestInit = {}) {
+  return tgFetch(input, { ...init, credentials: 'include' });
+}

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,8 +1,11 @@
 import { DefaultApi, Profile } from '@sdk';
 import { Configuration, ResponseError } from '@sdk/runtime';
+import { authFetch } from './authFetch';
 
 const API_BASE = import.meta.env.VITE_API_BASE;
-const api = new DefaultApi(new Configuration({ basePath: API_BASE }));
+const api = new DefaultApi(
+  new Configuration({ basePath: API_BASE, fetchApi: authFetch }),
+);
 
 export async function getProfile(telegramId: number): Promise<Profile | null> {
   try {

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,8 +1,11 @@
 import { DefaultApi, Reminder } from '@sdk';
 import { Configuration } from '@sdk/runtime';
+import { authFetch } from './authFetch';
 
 const API_BASE = import.meta.env.VITE_API_BASE;
-const api = new DefaultApi(new Configuration({ basePath: API_BASE }));
+const api = new DefaultApi(
+  new Configuration({ basePath: API_BASE, fetchApi: authFetch }),
+);
 
 export async function getReminders(telegramId: number): Promise<Reminder[]> {
   try {


### PR DESCRIPTION
## Summary
- ensure API client requests include Telegram init data and cookies
- use authenticated fetch wrapper in profile and reminders APIs
- add unit test for auth fetch wrapper

## Testing
- `npm --workspace services/webapp/ui run lint` *(fails: Unexpected any and no-require-imports)*
- `(cd services/webapp/ui && npx vitest run)`
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a032624cb4832aac03d69cd46035ea