### PR TITLE
[reporting] Cast times to expected type for plot

### DIFF
--- a/services/api/app/diabetes/services/reporting.py
+++ b/services/api/app/diabetes/services/reporting.py
@@ -105,7 +105,7 @@ def make_sugar_plot(entries: Iterable[SugarEntry], period_label: str) -> io.Byte
         return buf
 
     plt.figure(figsize=(7, 3))
-    plt.plot(times, sugars_plot, marker='o', label='Сахар (ммоль/л)')
+    plt.plot(cast(Sequence[float], times), sugars_plot, marker='o', label='Сахар (ммоль/л)')
     plt.title(f'Динамика сахара за {period_label}')
     plt.xlabel('Дата')
     plt.ylabel('Сахар, ммоль/л')


### PR DESCRIPTION
## Summary
- cast `make_sugar_plot` timestamps to the type expected by `matplotlib.pyplot.plot`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a03748f820832aac0d403500186a30