### PR TITLE
[webapp] Adapt run_db caller to signature

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -126,14 +126,13 @@ async def create_user(
     if data.telegram_id != user["id"]:
         raise HTTPException(status_code=403, detail="telegram id mismatch")
 
-    def _create_user(session: Session, telegram_id: int) -> None:
-        db_user = session.get(UserDB, telegram_id)
+    def _create_user(session: Session) -> None:
+        db_user = session.get(UserDB, data.telegram_id)
         if db_user is None:
-
-            session.add(UserDB(telegram_id=telegram_id, thread_id="webapp"))
+            session.add(UserDB(telegram_id=data.telegram_id, thread_id="webapp"))
         session.commit()
 
-    await run_db(_create_user, data.telegram_id)
+    await run_db(_create_user)
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Summary
- ensure create_user passes only a session-bound callable to run_db

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a037458038832ab708a1970a512e7e