### PR TITLE
[tests] add type hints for telegram auth monkeypatch

### DIFF
--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -40,7 +40,7 @@ def test_parse_and_verify_init_data_invalid_hash() -> None:
         parse_and_verify_init_data(tampered, TOKEN)
 
 
-def test_require_tg_user_valid(monkeypatch) -> None:
+def test_require_tg_user_valid(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     init_data = build_init_data()
     user = require_tg_user(init_data)
@@ -52,7 +52,7 @@ def test_require_tg_user_missing() -> None:
         require_tg_user(None)
 
 
-def test_require_tg_user_invalid(monkeypatch) -> None:
+def test_require_tg_user_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     with pytest.raises(HTTPException):
         require_tg_user("bad")


### PR DESCRIPTION
## Summary
- add MonkeyPatch type hints to telegram auth tests

## Testing
- `ruff check tests/test_telegram_auth.py`
- `pytest tests/test_telegram_auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0373cf790832a9d15c3cae132b45c