### PR TITLE
[webapp] include credentials by default in tgFetch

### DIFF
--- a/services/webapp/ui/src/lib/tgFetch.test.ts
+++ b/services/webapp/ui/src/lib/tgFetch.test.ts
@@ -25,17 +25,25 @@ describe('tgFetch', () => {
 
   it('attaches X-Telegram-Init-Data header when init data is present', async () => {
     (window as TelegramWindow).Telegram = { WebApp: { initData: 'test-data' } };
-    await tgFetch('/api/profile/self', { credentials: 'include' });
+    await tgFetch('/api/profile/self');
     const [, options] = (global.fetch as Mock).mock.calls[0] as [unknown, RequestInit];
     const headers = options.headers as Headers;
     expect(headers.get('X-Telegram-Init-Data')).toBe('test-data');
+    expect(options.credentials).toBe('include');
   });
 
   it('does not set header when init data is absent', async () => {
     (window as TelegramWindow).Telegram = { WebApp: {} };
-    await tgFetch('/api/profile/self', { credentials: 'include' });
+    await tgFetch('/api/profile/self');
     const [, options] = (global.fetch as Mock).mock.calls[0] as [unknown, RequestInit];
     const headers = options.headers as Headers;
     expect(headers.has('X-Telegram-Init-Data')).toBe(false);
+    expect(options.credentials).toBe('include');
+  });
+
+  it('allows overriding credentials', async () => {
+    await tgFetch('/api/profile/self', { credentials: 'omit' });
+    const [, options] = (global.fetch as Mock).mock.calls[0] as [unknown, RequestInit];
+    expect(options.credentials).toBe('omit');
   });
 });

--- a/services/webapp/ui/src/lib/tgFetch.ts
+++ b/services/webapp/ui/src/lib/tgFetch.ts
@@ -4,5 +4,5 @@ export function tgFetch(input: RequestInfo | URL, init: RequestInit = {}) {
   if (tg?.initData) {
     headers.set("X-Telegram-Init-Data", tg.initData);
   }
-  return fetch(input, { ...init, headers });
+  return fetch(input, { credentials: "include", ...init, headers });
 }


### PR DESCRIPTION
## Summary
- include cookies by default in `tgFetch` requests
- ensure callers can override credentials
- test default session credential behavior

## Testing
- `npx vitest run`
- `pytest tests/`
- `ruff check services/api/app tests`

------
https://chatgpt.com/codex/tasks/task_e_68a03c822464832a986252537d6d8b04