### PR TITLE
[ui] Validate profile inputs before save

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -71,15 +71,29 @@ const Profile = () => {
       });
       return;
     }
+    const icr = parseFloat(profile.icr);
+    const cf = parseFloat(profile.correctionFactor);
+    const target = parseFloat(profile.targetSugar);
+    const low = parseFloat(profile.lowThreshold);
+    const high = parseFloat(profile.highThreshold);
+
+    if (![icr, cf, target, low, high].every(Number.isFinite)) {
+      toast({
+        title: 'Ошибка',
+        description: 'Пожалуйста, введите корректные числовые значения',
+        variant: 'destructive',
+      });
+      return;
+    }
 
     try {
       await saveProfile({
         telegramId: user.id,
-        icr: Number(profile.icr),
-        cf: Number(profile.correctionFactor),
-        target: Number(profile.targetSugar),
-        low: Number(profile.lowThreshold),
-        high: Number(profile.highThreshold),
+        icr,
+        cf,
+        target,
+        low,
+        high,
       });
       toast({
         title: 'Профиль сохранен',


### PR DESCRIPTION
## Summary
- validate profile numeric inputs before saving
- ensure saveProfile sends only finite numbers

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npx eslint src/pages/Profile.tsx`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a04198e864832ab4c0eec44d48093a