### PR TITLE
[handlers] Guard reply_text against missing message

### DIFF
--- a/services/api/app/diabetes/handlers/security_handlers.py
+++ b/services/api/app/diabetes/handlers/security_handlers.py
@@ -14,7 +14,8 @@ async def hypo_alert_faq(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         "Раннее предупреждение даёт шанс быстро принять углеводы и привлечь помощь, "
         "предотвращая тяжёлые последствия."
     )
-    await update.message.reply_text(text)
+    if update.message:
+        await update.message.reply_text(text)
 
 
 __all__ = ["hypo_alert_faq"]


### PR DESCRIPTION
## Summary
- Check that update.message exists before sending a reply in security handler

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68a041c87f38832abc4838e6cb0e40ff