### PR TITLE
[webapp] extract normalizeReminderType

### DIFF
--- a/services/webapp/ui/src/lib/reminders.ts
+++ b/services/webapp/ui/src/lib/reminders.ts
@@ -1,0 +1,6 @@
+export type NormalizedReminderType = "sugar" | "insulin" | "meal" | "medicine";
+export type ReminderType = NormalizedReminderType | "meds";
+
+export const normalizeReminderType = (
+  t: ReminderType,
+): NormalizedReminderType => (t === "meds" ? "medicine" : t);

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -8,10 +8,12 @@ import { getReminders, updateReminder, deleteReminder } from '@/api/reminders'
 import MedicalButton from '@/components/MedicalButton'
 import { useTelegramContext } from '@/contexts/TelegramContext'
 import { cn } from '@/lib/utils'
+import {
+  normalizeReminderType,
+  type ReminderType,
+  type NormalizedReminderType,
+} from '@/lib/reminders'
 import { Reminder as ApiReminder } from '@sdk'
-
-type NormalizedReminderType = 'sugar' | 'insulin' | 'meal' | 'medicine'
-type ReminderType = NormalizedReminderType | 'meds'
 
 interface Reminder {
   id: number
@@ -35,9 +37,6 @@ const TYPE_ICON: Record<NormalizedReminderType, string> = {
   meal: '🍽️',
   medicine: '💊',
 }
-
-const normalizeType = (t: ReminderType): NormalizedReminderType =>
-  t === 'meds' ? 'medicine' : t
 
 function parseTimeToMinutes(t: string): number {
   const [h, m] = t.split(':').map(Number)
@@ -77,7 +76,7 @@ function ReminderRow({
   onEdit: (reminder: Reminder) => void
   onDelete: (id: number) => void
 }) {
-  const nt = normalizeType(reminder.type)
+  const nt = normalizeReminderType(reminder.type)
   const icon = TYPE_ICON[nt]
   const label = TYPE_LABEL[nt]
 
@@ -168,7 +167,7 @@ export default function Reminders() {
         const data = await getReminders(user.id)
         if (cancelled) return
         const normalized: Reminder[] = (data || []).map((r: ApiReminder) => {
-          const nt = normalizeType(r.type as ReminderType)
+          const nt = normalizeReminderType(r.type as ReminderType)
           return {
             id: r.id ?? 0,
             type: nt,

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -6,14 +6,11 @@ import { createReminder, updateReminder, getReminder } from "@/api/reminders";
 import { Reminder as ApiReminder } from "@sdk";
 import { useTelegramContext } from "@/contexts/TelegramContext";
 import { useToast } from "@/hooks/use-toast";
-
-// Reminder type returned from API may contain legacy value "meds",
-// normalize it to "medicine" for UI usage
-type ReminderType = "sugar" | "insulin" | "meal" | "medicine" | "meds";
-type NormalizedReminderType = "sugar" | "insulin" | "meal" | "medicine";
-
-const normalizeType = (t: ReminderType): NormalizedReminderType =>
-  t === "meds" ? "medicine" : t;
+import {
+  normalizeReminderType,
+  type ReminderType,
+  type NormalizedReminderType,
+} from "@/lib/reminders";
 
 const TYPES: Record<NormalizedReminderType, { label: string; emoji: string }> = {
   sugar: { label: "Сахар", emoji: "🩸" },
@@ -75,7 +72,7 @@ export default function CreateReminder() {
         try {
           const data = await getReminder(user.id, Number(params.id));
           if (data) {
-            const nt = normalizeType(data.type as ReminderType);
+            const nt = normalizeReminderType(data.type as ReminderType);
             const loaded: Reminder = {
               id: data.id ?? Number(params.id),
               type: nt,


### PR DESCRIPTION
## Summary
- add shared `normalizeReminderType` utility
- use shared reminder type normalizer in reminders pages

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; Unexpected any; A require() style import is forbidden)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a043c0d3f4832a97d4df296908707a