### PR TITLE
[api] Improve type hints for history endpoints

### DIFF
--- a/services/api/app/schemas/history.py
+++ b/services/api/app/schemas/history.py
@@ -5,6 +5,9 @@ from typing import Literal, Optional
 from pydantic import BaseModel
 
 
+HistoryType = Literal["measurement", "meal", "insulin"]
+
+
 class HistoryRecordSchema(BaseModel):
     """Schema for user history records."""
 
@@ -16,4 +19,4 @@ class HistoryRecordSchema(BaseModel):
     breadUnits: Optional[float] = None
     insulin: Optional[float] = None
     notes: Optional[str] = None
-    type: Literal["measurement", "meal", "insulin"]
+    type: HistoryType


### PR DESCRIPTION
## Summary
- add explicit `dict[str, Any]` annotations for telegram user dependencies
- wrap `run_db` callback with lambda to satisfy callable signature
- introduce `HistoryType` literal and use it in `HistoryRecordSchema`

## Testing
- `ruff check services/api/app tests`
- `pytest tests/ -q`

------
https://chatgpt.com/codex/tasks/task_e_68a041b71680832ab5c5778bffc817db