### PR TITLE
[reporting] Convert datetime to numeric for plotting

### DIFF
--- a/services/api/app/diabetes/services/reporting.py
+++ b/services/api/app/diabetes/services/reporting.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Iterable, Protocol, Sequence, cast
 
 import matplotlib.pyplot as plt
+from matplotlib.dates import date2num
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import mm
 from reportlab.lib.utils import ImageReader
@@ -83,7 +84,7 @@ def make_sugar_plot(entries: Iterable[SugarEntry], period_label: str) -> io.Byte
         (e for e in entries if e.sugar_before is not None),
         key=lambda e: e.event_time,
     )
-    times: list[datetime] = [e.event_time for e in entries_sorted]
+    times: list[float] = [date2num(e.event_time) for e in entries_sorted]
     sugars_plot: list[float] = [cast(float, e.sugar_before) for e in entries_sorted]
 
     if not sugars_plot:
@@ -105,7 +106,9 @@ def make_sugar_plot(entries: Iterable[SugarEntry], period_label: str) -> io.Byte
         return buf
 
     plt.figure(figsize=(7, 3))
-    plt.plot(cast(Sequence[float], times), sugars_plot, marker='o', label='Сахар (ммоль/л)')
+    plt.plot(times, sugars_plot, marker='o', label='Сахар (ммоль/л)')
+    plt.gca().xaxis_date()
+    plt.gcf().autofmt_xdate()
     plt.title(f'Динамика сахара за {period_label}')
     plt.xlabel('Дата')
     plt.ylabel('Сахар, ммоль/л')

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import matplotlib.pyplot as plt
+from matplotlib.dates import date2num
 import pytest
 from pypdf import PdfReader
 from sqlalchemy import create_engine
@@ -77,7 +78,7 @@ def test_make_sugar_plot_sorts_entries(monkeypatch: pytest.MonkeyPatch) -> None:
     captured = {}
 
     def fake_plot(
-        x: list[datetime.datetime],
+        x: list[float],
         y: list[float],
         **kwargs: Any,
     ) -> None:
@@ -88,8 +89,8 @@ def test_make_sugar_plot_sorts_entries(monkeypatch: pytest.MonkeyPatch) -> None:
     make_sugar_plot(entries, "период")
 
     assert captured["x"] == [
-        datetime.datetime(2025, 7, 1, 9, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2025, 7, 1, 14, tzinfo=datetime.timezone.utc),
+        date2num(datetime.datetime(2025, 7, 1, 9, tzinfo=datetime.timezone.utc)),
+        date2num(datetime.datetime(2025, 7, 1, 14, tzinfo=datetime.timezone.utc)),
     ]
     assert captured["y"] == [7.0, 9.0]
 


### PR DESCRIPTION
## Summary
- use matplotlib.dates.date2num to convert timestamps before plotting
- adjust plotting call to format x-axis as dates
- update report plot tests for numeric timestamps

## Testing
- `ruff check services/api/app tests`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_68a041b9888c832a93e07aa34b8e4091