### PR TITLE
[tests] Add type annotations for webapp tests

### DIFF
--- a/tests/test_webapp_user.py
+++ b/tests/test_webapp_user.py
@@ -3,10 +3,12 @@ import hmac
 import json
 import urllib.parse
 
+from typing import Any, Callable
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 import services.api.app.main as server
@@ -14,18 +16,18 @@ from services.api.app.config import settings
 from services.api.app.diabetes.services import db
 
 
-def setup_db(monkeypatch):
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
     )
-    Session = sessionmaker(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
     db.Base.metadata.create_all(bind=engine)
 
-    async def run_db_wrapper(fn, *args, **kwargs):
-        return await db.run_db(fn, *args, sessionmaker=Session, **kwargs)
+    async def run_db_wrapper(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        return await db.run_db(fn, *args, sessionmaker=SessionLocal, **kwargs)
 
     monkeypatch.setattr(server, "run_db", run_db_wrapper)
-    return Session
+    return SessionLocal
 
 
 TOKEN = "test-token"


### PR DESCRIPTION
## Summary
- Type-annotate setup_db helpers and nested wrappers for webapp user, timezone, and history tests
- Ensure DB lookups handle None results and use typed records
- Use `dict[str, Any]` for history post_record helper

## Testing
- `mypy tests/test_webapp_user.py tests/test_webapp_timezone.py tests/test_webapp_history.py`
- `ruff check services/api/app tests`
- `pytest tests/test_webapp_user.py tests/test_webapp_timezone.py tests/test_webapp_history.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a041bc610c832a84db7ff11781b288