### PR TITLE
[tests] Guard web_app exists in timezone button test

### DIFF
--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -16,7 +16,9 @@ def test_timezone_button_webapp_url(monkeypatch: pytest.MonkeyPatch) -> None:
 
     button = ui.build_timezone_webapp_button()
     assert button is not None
-    assert urlparse(button.web_app.url).path == "/ui/timezone"
+    web_app = button.web_app
+    assert web_app is not None
+    assert urlparse(web_app.url).path == "/ui/timezone"
 
     monkeypatch.delenv("WEBAPP_URL", raising=False)
     importlib.reload(config)


### PR DESCRIPTION
## Summary
- ensure timezone webapp button test checks `web_app` is not `None` before accessing `url`

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_timezone_button_webapp.py`


------
https://chatgpt.com/codex/tasks/task_e_68a041beef4c832a8ef2fc46df7ccbdb