### PR TITLE
[tests] Add type hints to profile self tests

### DIFF
--- a/tests/test_profile_self.py
+++ b/tests/test_profile_self.py
@@ -3,6 +3,7 @@ import hmac
 import json
 import urllib.parse
 
+import pytest
 from fastapi.testclient import TestClient
 
 from services.api.app.config import settings
@@ -21,7 +22,7 @@ def build_init_data(user_id: int = 1) -> str:
     return urllib.parse.urlencode(params)
 
 
-def test_profile_self_valid_header(monkeypatch) -> None:
+def test_profile_self_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     init_data = build_init_data(42)
     resp = client.get("/api/profile/self", headers={"X-Telegram-Init-Data": init_data})
@@ -34,7 +35,7 @@ def test_profile_self_missing_header() -> None:
     assert resp.status_code == 401
 
 
-def test_profile_self_invalid_header(monkeypatch) -> None:
+def test_profile_self_invalid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     resp = client.get("/api/profile/self", headers={"X-Telegram-Init-Data": "bad"})
     assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add pytest import
- annotate monkeypatch fixture types in profile self tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_profile_self.py`


------
https://chatgpt.com/codex/tasks/task_e_68a041c13ea0832a8ae66ed7ef9541a9