### PR TITLE
[webapp] encode history id in API path

### DIFF
--- a/services/webapp/ui/src/api/history.ts
+++ b/services/webapp/ui/src/api/history.ts
@@ -49,7 +49,7 @@ export async function updateRecord(record: HistoryRecord) {
 
 export async function deleteRecord(id: string) {
   try {
-    const res = await tgFetch(`/api/history/${id}`, { method: 'DELETE' });
+    const res = await tgFetch(`/api/history/${encodeURIComponent(id)}`, { method: 'DELETE' });
     const data = await res.json().catch(() => ({}));
     if (!res.ok || data.status !== 'ok') {
       throw new Error(data.detail || 'Не удалось удалить запись');


### PR DESCRIPTION
## Summary
- encode history record id with `encodeURIComponent` when forming API path

## Testing
- `pytest tests/test_webapp_history.py`
- `npm run lint` *(fails: Unexpected any, no-empty-object-type, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a0472fdf84832a87500d6caca95906