### PR TITLE
[webapp] Use safe defaults when loading profile

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -32,11 +32,11 @@ const Profile = () => {
         const data = await getProfile(user.id);
         if (data && active) {
           setProfile({
-            icr: data.icr.toString(),
-            correctionFactor: data.cf.toString(),
-            targetSugar: data.target.toString(),
-            lowThreshold: data.low.toString(),
-            highThreshold: data.high.toString(),
+            icr: String(data.icr ?? ''),
+            correctionFactor: String(data.cf ?? ''),
+            targetSugar: String(data.target ?? ''),
+            lowThreshold: String(data.low ?? ''),
+            highThreshold: String(data.high ?? ''),
           });
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- Use String() with nullish coalescing to safely map profile data fields

## Testing
- `npm --workspace services/webapp/ui exec eslint src/pages/Profile.tsx`
- `pre-commit run --files services/webapp/ui/src/pages/Profile.tsx`
- `pytest`
- `npm --workspace services/webapp/ui test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a04d034670832aa62fde4b32a2e26d