### PR TITLE
[tests] Annotate render_entry tests

### DIFF
--- a/tests/test_render_entry.py
+++ b/tests/test_render_entry.py
@@ -1,41 +1,51 @@
 import datetime
 from types import SimpleNamespace
+from typing import Any, Protocol, cast
 
 from services.api.app.diabetes.handlers.reporting_handlers import render_entry
 
 
-def make_entry(**kwargs):
-    defaults = dict(
-        event_time=datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
-        sugar_before=5.5,
-        carbs_g=None,
-        xe=None,
-        dose=1.0,
-    )
+class EntryLike(Protocol):
+    event_time: datetime.datetime
+    sugar_before: float | None
+    carbs_g: float | None
+    xe: float | None
+    dose: float | str | None
+
+
+def make_entry(**kwargs: Any) -> EntryLike:
+    defaults: dict[str, Any] = {
+        "event_time": datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+        "sugar_before": 5.5,
+        "carbs_g": None,
+        "xe": None,
+        "dose": 1.0,
+    }
     defaults.update(kwargs)
-    return SimpleNamespace(**defaults)
+    return cast(EntryLike, SimpleNamespace(**defaults))
 
 
 def test_render_entry_with_xe_and_carbs() -> None:
-    entry = make_entry(carbs_g=50, xe=4.1)
+    entry: EntryLike = make_entry(carbs_g=50, xe=4.1)
     text = render_entry(entry)
     assert "🍞 Углеводы: <b>50 г (4.1 ХЕ)</b>" in text
 
 
 def test_render_entry_with_xe_only() -> None:
-    entry = make_entry(carbs_g=None, xe=3.0)
+    entry: EntryLike = make_entry(carbs_g=None, xe=3.0)
     text = render_entry(entry)
     assert "🍞 Углеводы: <b>3.0 ХЕ</b>" in text
 
 
 def test_render_entry_without_xe() -> None:
-    entry = make_entry(carbs_g=30, xe=None)
+    entry: EntryLike = make_entry(carbs_g=30, xe=None)
     text = render_entry(entry)
     assert "🍞 Углеводы: <b>30 г</b>" in text
     assert "ХЕ" not in text
 
 
 def test_render_entry_escapes_html() -> None:
-    entry = make_entry(dose="<script>")
+    entry: EntryLike = make_entry(dose="<script>")
     text = render_entry(entry)
     assert "&lt;script&gt;" in text
+


### PR DESCRIPTION
## Summary
- define an `EntryLike` protocol and type a helper `make_entry`
- annotate local variables in render entry tests

## Testing
- `ruff check services/api/app tests/test_render_entry.py`
- `pytest tests/test_render_entry.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0510692d0832a962061597f381820