### PR TITLE
[webapp] Replace authFetch with tgFetch

### DIFF
--- a/services/webapp/ui/src/api/authFetch.ts
+++ b/services/webapp/ui/src/api/authFetch.ts
@@ -1,8 +1,0 @@
-import { tgFetch } from '../lib/tgFetch';
-
-/**
- * A fetch wrapper that ensures Telegram init data headers and cookies are sent.
- */
-export function authFetch(input: RequestInfo | URL, init: RequestInit = {}) {
-  return tgFetch(input, { ...init, credentials: 'include' });
-}

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,10 +1,10 @@
 import { DefaultApi, Profile } from '@sdk';
 import { Configuration, ResponseError } from '@sdk/runtime';
-import { authFetch } from './authFetch';
+import { tgFetch } from '../lib/tgFetch';
 
 const API_BASE = import.meta.env.VITE_API_BASE;
 const api = new DefaultApi(
-  new Configuration({ basePath: API_BASE, fetchApi: authFetch }),
+  new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
 );
 
 export async function getProfile(telegramId: number): Promise<Profile | null> {

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,10 +1,10 @@
 import { DefaultApi, Reminder } from '@sdk';
 import { Configuration } from '@sdk/runtime';
-import { authFetch } from './authFetch';
+import { tgFetch } from '../lib/tgFetch';
 
 const API_BASE = import.meta.env.VITE_API_BASE;
 const api = new DefaultApi(
-  new Configuration({ basePath: API_BASE, fetchApi: authFetch }),
+  new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
 );
 
 export async function getReminders(telegramId: number): Promise<Reminder[]> {

--- a/services/webapp/ui/src/api/tgFetch.api.test.ts
+++ b/services/webapp/ui/src/api/tgFetch.api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import { authFetch } from './authFetch';
+import { tgFetch } from '../lib/tgFetch';
 
 interface TelegramWebApp {
   initData?: string;
@@ -11,7 +11,7 @@ interface TelegramWindow extends Window {
 
 const originalFetch = global.fetch;
 
-describe('authFetch', () => {
+describe('tgFetch', () => {
   beforeEach(() => {
     global.fetch = vi.fn().mockResolvedValue(new Response());
     vi.stubGlobal('window', {} as TelegramWindow);
@@ -25,7 +25,7 @@ describe('authFetch', () => {
 
   it('sets credentials and attaches init data header', async () => {
     (window as TelegramWindow).Telegram = { WebApp: { initData: 'test-data' } };
-    await authFetch('/api/profile');
+    await tgFetch('/api/profile');
     const [, options] = (global.fetch as Mock).mock.calls[0] as [unknown, RequestInit];
     const headers = options.headers as Headers;
     expect(options.credentials).toBe('include');


### PR DESCRIPTION
## Summary
- use tgFetch directly in API clients
- drop authFetch wrapper and migrate tests

## Testing
- `pre-commit run --files services/webapp/ui/src/api/profile.ts services/webapp/ui/src/api/reminders.ts services/webapp/ui/src/api/tgFetch.api.test.ts`
- `pytest tests/`
- `npx vitest run`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, A require() style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a053541d20832a9973f8d64af0fa8f