### PR TITLE
[handlers] Guard reply_text calls when message missing

### DIFF
--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -10,9 +10,11 @@ from services.api.app.diabetes.utils.ui import menu_keyboard
 
 async def menu_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Display the main menu keyboard using ``menu_keyboard``."""
-    await update.message.reply_text(
-        "📋 Выберите действие:", reply_markup=menu_keyboard
-    )
+    message = update.message
+    if message:
+        await message.reply_text(
+            "📋 Выберите действие:", reply_markup=menu_keyboard
+        )
 
 
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -61,7 +63,9 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "⏰ Напоминания\n"
         "ℹ️ Помощь"
     )
-    await update.message.reply_text(text, reply_markup=menu_keyboard)
+    message = update.message
+    if message:
+        await message.reply_text(text, reply_markup=menu_keyboard)
 
 
 async def smart_input_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -72,7 +76,9 @@ async def smart_input_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         "Используйте формат: `сахар=<ммоль/л> xe=<ХЕ> dose=<ед>` или свободный текст,\n"
         "например: `5 ммоль/л 3хе 2ед`. Можно указывать только нужные значения."
     )
-    await update.message.reply_text(text, parse_mode="Markdown")
+    message = update.message
+    if message:
+        await message.reply_text(text, parse_mode="Markdown")
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Ensure menu, help, and smart-input handlers verify `update.message` before replying

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68a050f9e4cc832aa7a78f9645a0b3dc