### PR TITLE
[handlers] Type annotate callback query no warn handler

### DIFF
--- a/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
+++ b/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
@@ -1,14 +1,20 @@
 import re
-from typing import Optional
+from typing import Any, Awaitable, Callable, Optional
 
 from telegram import CallbackQuery, Update
-from telegram.ext import BaseHandler
+from telegram.ext import BaseHandler, CallbackContext
+
+CallbackQueryHandlerCallback = Callable[[Update, CallbackContext], Awaitable[Any]]
 
 
-class CallbackQueryNoWarnHandler(BaseHandler):
+class CallbackQueryNoWarnHandler(BaseHandler[Update, CallbackContext]):
     """Handle callback queries without triggering ConversationHandler warnings."""
 
-    def __init__(self, callback, pattern: str | None = None):
+    def __init__(
+        self,
+        callback: CallbackQueryHandlerCallback,
+        pattern: str | None = None,
+    ) -> None:
         super().__init__(callback)
         self.pattern: Optional[re.Pattern[str]] = re.compile(pattern) if pattern else None
 


### PR DESCRIPTION
## Summary
- add `CallbackQueryHandlerCallback` alias and apply `BaseHandler[Update, CallbackContext]`
- fully annotate `CallbackQueryNoWarnHandler.__init__` parameters and return type

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a050fb8894832a9574404599b089f2