### PR TITLE
[reporting] Use typed date2num wrapper

### DIFF
--- a/services/api/app/diabetes/services/reporting.py
+++ b/services/api/app/diabetes/services/reporting.py
@@ -5,7 +5,7 @@ import io
 import logging
 import textwrap
 from datetime import datetime
-from typing import Iterable, Protocol, Sequence, cast
+from typing import Callable, Iterable, Protocol, Sequence, cast
 
 import matplotlib.pyplot as plt
 from matplotlib.dates import date2num
@@ -17,6 +17,8 @@ from reportlab.pdfbase.ttfonts import TTFont, TTFError
 from reportlab.pdfgen import canvas
 
 from services.api.app.config import settings
+
+date2num_typed = cast(Callable[[datetime], float], date2num)
 
 # Регистрация шрифтов для поддержки кириллицы и жирного начертания
 DEFAULT_FONT_DIR = '/usr/share/fonts/truetype/dejavu'
@@ -80,16 +82,11 @@ def make_sugar_plot(entries: Iterable[SugarEntry], period_label: str) -> io.Byte
         Логирует отсутствие данных и использует глобальное состояние
         ``matplotlib``.
     """
-    def _date_to_num(dt: datetime) -> float:
-        """Typed wrapper around ``matplotlib.dates.date2num``."""
-
-        return cast(float, date2num(dt))
-
     entries_sorted = sorted(
         (e for e in entries if e.sugar_before is not None),
         key=lambda e: e.event_time,
     )
-    times: list[float] = [_date_to_num(e.event_time) for e in entries_sorted]
+    times: list[float] = [date2num_typed(e.event_time) for e in entries_sorted]
     sugars_plot: list[float] = [cast(float, e.sugar_before) for e in entries_sorted]
 
     if not sugars_plot:


### PR DESCRIPTION
## Summary
- cast `date2num` to a typed callable
- use typed wrapper when creating sugar plot

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a077df5070832a922086e503506f93