### PR TITLE
[handlers] Tighten callback context typing

### DIFF
--- a/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
+++ b/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
@@ -1,13 +1,15 @@
 import re
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Callable, Coroutine, Optional
 
 from telegram import CallbackQuery, Update
-from telegram.ext import BaseHandler, CallbackContext
+from telegram.ext import BaseHandler, ContextTypes
 
-CallbackQueryHandlerCallback = Callable[[Update, CallbackContext], Awaitable[Any]]
+CallbackQueryHandlerCallback = Callable[
+    [Update, ContextTypes.DEFAULT_TYPE], Coroutine[Any, Any, None]
+]
 
 
-class CallbackQueryNoWarnHandler(BaseHandler[Update, CallbackContext]):
+class CallbackQueryNoWarnHandler(BaseHandler[Update, ContextTypes.DEFAULT_TYPE]):
     """Handle callback queries without triggering ConversationHandler warnings."""
 
     def __init__(


### PR DESCRIPTION
## Summary
- use `ContextTypes.DEFAULT_TYPE` and explicit coroutine returns for `CallbackQueryNoWarnHandler`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a077e67c78832a8c42d64a908c46ee