### PR TITLE
[webapp] connect new measurement and meal to API

### DIFF
--- a/services/webapp/ui/src/pages/NewMeal.tsx
+++ b/services/webapp/ui/src/pages/NewMeal.tsx
@@ -2,15 +2,37 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import MedicalButton from '@/components/MedicalButton';
+import { useToast } from '@/hooks/use-toast';
+import { updateRecord, HistoryRecord } from '@/api/history';
 
 const NewMeal = () => {
   const navigate = useNavigate();
+  const { toast } = useToast();
   const [meal, setMeal] = useState('');
   const [carbs, setCarbs] = useState('');
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    navigate('/history');
+    const now = new Date();
+    const record: HistoryRecord = {
+      id: Date.now().toString(),
+      date: now.toISOString().split('T')[0],
+      time: now.toTimeString().slice(0, 5),
+      type: 'meal',
+      notes: meal,
+      carbs: Number(carbs),
+    };
+    try {
+      await updateRecord(record);
+      navigate('/history');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Неизвестная ошибка';
+      toast({
+        title: 'Ошибка',
+        description: message,
+        variant: 'destructive',
+      });
+    }
   };
 
   return (

--- a/services/webapp/ui/src/pages/NewMeasurement.tsx
+++ b/services/webapp/ui/src/pages/NewMeasurement.tsx
@@ -2,14 +2,35 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import MedicalButton from '@/components/MedicalButton';
+import { useToast } from '@/hooks/use-toast';
+import { updateRecord, HistoryRecord } from '@/api/history';
 
 const NewMeasurement = () => {
   const navigate = useNavigate();
+  const { toast } = useToast();
   const [sugar, setSugar] = useState('');
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    navigate('/history');
+    const now = new Date();
+    const record: HistoryRecord = {
+      id: Date.now().toString(),
+      date: now.toISOString().split('T')[0],
+      time: now.toTimeString().slice(0, 5),
+      sugar: Number(sugar),
+      type: 'measurement',
+    };
+    try {
+      await updateRecord(record);
+      navigate('/history');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Неизвестная ошибка';
+      toast({
+        title: 'Ошибка',
+        description: message,
+        variant: 'destructive',
+      });
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- hook up new measurement form to history API with toast-based error handling
- hook up new meal form to history API with toast-based error handling

## Testing
- `npm --workspace services/webapp/ui run lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any, A require style import is forbidden)*
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68a07c6505c8832ab5e13847d2a644a6