### PR TITLE
[handlers] support EntryLike protocol for render_entry

### DIFF
--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -7,7 +7,7 @@ import datetime
 import html
 import logging
 
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 from openai import OpenAIError
 from telegram import (
@@ -34,7 +34,17 @@ LOW_SUGAR_THRESHOLD = 3.0
 HIGH_SUGAR_THRESHOLD = 13.0
 
 
-def render_entry(entry: Entry) -> str:
+class EntryLike(Protocol):
+    """Protocol describing the fields required for ``render_entry``."""
+
+    event_time: datetime.datetime
+    sugar_before: float | None
+    carbs_g: float | None
+    xe: float | None
+    dose: float | str | None
+
+
+def render_entry(entry: EntryLike) -> str:
     """Render a single diary entry as HTML-formatted text."""
     day_str = html.escape(entry.event_time.strftime("%d.%m %H:%M"))
     sugar = (

--- a/tests/test_render_entry.py
+++ b/tests/test_render_entry.py
@@ -1,16 +1,8 @@
 import datetime
 from types import SimpleNamespace
-from typing import Any, Protocol, cast
+from typing import Any, cast
 
-from services.api.app.diabetes.handlers.reporting_handlers import render_entry
-
-
-class EntryLike(Protocol):
-    event_time: datetime.datetime
-    sugar_before: float | None
-    carbs_g: float | None
-    xe: float | None
-    dose: float | str | None
+from services.api.app.diabetes.handlers.reporting_handlers import EntryLike, render_entry
 
 
 def make_entry(**kwargs: Any) -> EntryLike:


### PR DESCRIPTION
## Summary
- add `EntryLike` protocol describing diary entries
- allow `render_entry` to accept `EntryLike`
- update tests to use the protocol

## Testing
- `pytest`
- `ruff check services/api/app tests`


------
https://chatgpt.com/codex/tasks/task_e_68a077f5acd4832a9af43cda0e98f0c7