### PR TITLE
[handlers] enforce typed run_db and user_data init

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -279,9 +279,9 @@ async def dose_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     message = update.message
     if message is None:
         return ConversationHandler.END
+    if context.user_data is None:
+        context.user_data = {}
     user_data = context.user_data
-    if user_data is None:
-        return ConversationHandler.END
     await message.reply_text("Отменено.", reply_markup=menu_keyboard)
     user_data.pop("pending_entry", None)
     user_data.pop("dose_method", None)

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -119,9 +119,9 @@ async def onboarding_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     message = update.message
     if message is None or message.text is None:
         return ConversationHandler.END
+    if context.user_data is None:
+        context.user_data = {}
     user_data = context.user_data
-    if user_data is None:
-        return ConversationHandler.END
     try:
         icr = float(message.text.replace(",", "."))
     except ValueError:
@@ -143,9 +143,9 @@ async def onboarding_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     message = update.message
     if message is None or message.text is None:
         return ConversationHandler.END
+    if context.user_data is None:
+        context.user_data = {}
     user_data = context.user_data
-    if user_data is None:
-        return ConversationHandler.END
     try:
         cf = float(message.text.replace(",", "."))
     except ValueError:
@@ -166,8 +166,10 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     """Handle target BG input and proceed to demo."""
     message = update.message
     user = update.effective_user
+    if context.user_data is None:
+        context.user_data = {}
     user_data = context.user_data
-    if message is None or message.text is None or user is None or user_data is None:
+    if message is None or message.text is None or user is None:
         return ConversationHandler.END
     try:
         target = float(message.text.replace(",", "."))
@@ -448,8 +450,10 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     from .dose_handlers import photo_prompt
 
     message = update.message
+    if context.user_data is None:
+        context.user_data = {}
     user_data = context.user_data
-    if message is None or user_data is None:
+    if message is None:
         return ConversationHandler.END
 
     handler: Callable[[Update, ContextTypes.DEFAULT_TYPE], Awaitable[int]] = _cancel_then(

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -174,6 +174,8 @@ async def report_period_callback(
         )
         await send_report(update, context, date_from, "последний месяц", query=query)
     elif period == "custom":
+        if context.user_data is None:
+            context.user_data = {}
         user_data: dict[str, Any] = context.user_data
         user_data["awaiting_report_date"] = True
         await query.edit_message_text(
@@ -254,6 +256,8 @@ async def send_report(
 
     default_gpt_text = "Не удалось получить рекомендации."
     gpt_text = default_gpt_text
+    if context.user_data is None:
+        context.user_data = {}
     user_data: dict[str, Any] = context.user_data
     thread_id = cast(str | None, user_data.get("thread_id"))
     if thread_id is None:

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -144,7 +144,7 @@ async def create_user(
             session.add(UserDB(telegram_id=data.telegram_id, thread_id="webapp"))
         session.commit()
 
-    await run_db(lambda session: _create_user(session))
+    await run_db(_create_user)
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Summary
- wrap run_db usage with typed session functions in reminder handlers
- initialize context.user_data dictionaries before indexing
- simplify run_db invocation in main by removing lambda

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a077f9d4ac832aa15112bc9fb534c7