### PR TITLE
[handlers] expose profile helper functions

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -784,6 +784,12 @@ profile_webapp_handler = MessageHandler(
 
 
 __all__ = [
+    "get_api",
+    "save_profile",
+    "set_timezone",
+    "fetch_profile",
+    "post_profile",
+    "parse_profile_args",
     "profile_command",
     "profile_view",
     "profile_cancel",


### PR DESCRIPTION
## Summary
- export profile helper functions from conversation module

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a077fd3950832a8f5d1d4852e592ef