### PR TITLE
[ui] Simplify error handling in Reminders

### DIFF
--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -1,5 +1,5 @@
 // Файл: webapp/ui/src/pages/Reminders.tsx
-import { useState, useEffect, type ReactNode } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Plus, Clock, Edit2, Trash2, Bell } from 'lucide-react'
 import { MedicalHeader } from '@/components/MedicalHeader'
@@ -138,29 +138,13 @@ export default function Reminders() {
 
   const [reminders, setReminders] = useState<Reminder[]>([])
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<ReactNode | null>(null)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!isReady) return
     if (!user?.id) {
       setLoading(false)
-      setError(
-        <div className="space-y-4">
-          <p className="text-destructive">Не удалось получить данные пользователя.</p>
-          <div className="flex flex-col items-center gap-2">
-            <MedicalButton onClick={() => window.location.reload()}>Повторить</MedicalButton>
-            <MedicalButton asChild variant="outline">
-              <a
-                href={`https://t.me/${import.meta.env.VITE_TELEGRAM_BOT}?startapp=reminders`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Открыть в Telegram
-              </a>
-            </MedicalButton>
-          </div>
-        </div>,
-      )
+      setError('Не удалось получить данные пользователя.')
       return
     }
     setLoading(true)
@@ -201,7 +185,7 @@ export default function Reminders() {
       } catch (err) {
         if (!cancelled) {
           const message = err instanceof Error ? err.message : 'Не удалось загрузить напоминания'
-          setError(<p className="text-destructive mb-4">{message}</p>)
+          setError(message)
           toast({ title: 'Ошибка', description: message, variant: 'destructive' })
         }
       } finally {
@@ -277,7 +261,23 @@ export default function Reminders() {
       </div>
     )
   } else if (error) {
-    content = <div className="text-center py-12">{error}</div>
+    content = (
+      <div className="text-center py-12 space-y-4">
+        <p className="text-destructive mb-4">{error}</p>
+        <div className="flex flex-col items-center gap-2">
+          <MedicalButton onClick={() => window.location.reload()}>Повторить</MedicalButton>
+          <MedicalButton asChild variant="outline">
+            <a
+              href={`https://t.me/${import.meta.env.VITE_TELEGRAM_BOT}?startapp=reminders`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Открыть в Telegram
+            </a>
+          </MedicalButton>
+        </div>
+      </div>
+    )
   } else if (reminders.length === 0) {
     content = (
       <div className="text-center py-12">


### PR DESCRIPTION
## Summary
- store reminder errors as strings instead of JSX
- display error message separately in markup with retry/open buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: command sh -c eslint .)*

------
https://chatgpt.com/codex/tasks/task_e_68a07e398f20832a87747d364e16a6c3