### PR TITLE
[webapp] add default API base fallback

### DIFF
--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -19,7 +19,8 @@ JWT_EXPIRE_DAYS=7
 # Optional service URLs
 WEBAPP_URL=http://localhost:3000
 API_URL=http://localhost:8000
-VITE_API_BASE=http://localhost:8000  # base API URL for webapp
+# Optional base API URL for webapp; defaults to '/api'
+# VITE_API_BASE=http://localhost:8000
 
 # OpenAI configuration
 OPENAI_API_KEY=your-openai-api-key

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -2,7 +2,11 @@ import { DefaultApi, Profile } from '@sdk';
 import { Configuration, ResponseError } from '@sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 
-const API_BASE = import.meta.env.VITE_API_BASE;
+const API_BASE = import.meta.env.VITE_API_BASE || '/api';
+if (!API_BASE) {
+  throw new Error('VITE_API_BASE is not set and no default is provided');
+}
+
 const api = new DefaultApi(
   new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
 );

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -2,7 +2,11 @@ import { DefaultApi, Reminder } from '@sdk';
 import { Configuration } from '@sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 
-const API_BASE = import.meta.env.VITE_API_BASE;
+const API_BASE = import.meta.env.VITE_API_BASE || '/api';
+if (!API_BASE) {
+  throw new Error('VITE_API_BASE is not set and no default is provided');
+}
+
 const api = new DefaultApi(
   new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
 );


### PR DESCRIPTION
## Summary
- provide default '/api' when VITE_API_BASE is missing in API modules
- validate environment setup and throw when base URL is undefined
- document optional VITE_API_BASE with default in env example

## Testing
- `npm --workspace services/webapp/ui run lint` (fails: An interface declaring no members is equivalent to its supertype, A `require()` style import is forbidden)
- `npm --workspace services/webapp/ui exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a08680dcd8832ab2110e78bb581a7b