### PR TITLE
[api] handle missing telegram token

### DIFF
--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -57,3 +57,10 @@ def test_require_tg_user_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     with pytest.raises(HTTPException):
         require_tg_user("bad")
+
+
+def test_require_tg_user_empty_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "telegram_token", "")
+    with pytest.raises(HTTPException) as exc:
+        require_tg_user("whatever")
+    assert exc.value.status_code == 500


### PR DESCRIPTION
## Summary
- guard webapp auth when Telegram token isn't configured and return 500
- add test for missing token

## Testing
- `ruff check services/api/app tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a088fa3cd8832a8b4bb33750a383a5