### PR TITLE
[handlers] Guard check_alert against missing user

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -200,12 +200,15 @@ async def check_alert(
             DefaultJobQueue | None,
             getattr(getattr(context, "application", None), "job_queue", None),
         )
+    user = update.effective_user
+    if user is None:
+        return
     await evaluate_sugar(
-        update.effective_user.id,
+        user.id,
         sugar,
         job_queue,
         context=context,
-        first_name=update.effective_user.first_name or "",
+        first_name=user.first_name or "",
     )
 
 


### PR DESCRIPTION
## Summary
- Guard `check_alert` against missing `effective_user`
- Replace direct `update.effective_user` references with local `user`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a08b1043a8832aa31acfd9e072cd6e