### PR TITLE
[handlers] Cast job and data in alert_job

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -210,10 +210,10 @@ async def check_alert(
 
 
 async def alert_job(context: ContextTypes.DEFAULT_TYPE) -> None:
-    job: Job[CustomContext] | None = context.job
+    job = cast(Job[CustomContext] | None, context.job)
     if job is None:
         return
-    data: AlertJobData | None = job.data
+    data = cast(AlertJobData | None, job.data)
     if not data:
         job.schedule_removal()
         return


### PR DESCRIPTION
## Summary
- use `typing.cast` for `context.job` and `job.data` in `alert_job`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a08b11972c832a842dde2b854aa648