### PR TITLE
[webapp] Add ts-sdk path alias

### DIFF
--- a/services/webapp/ui/tsconfig.app.json
+++ b/services/webapp/ui/tsconfig.app.json
@@ -23,7 +23,8 @@
 
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@sdk": ["../../../libs/ts-sdk"]
     }
   },
   "include": ["src"]

--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -7,7 +7,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@sdk": ["../../../libs/ts-sdk"]
     },
     "noImplicitAny": false,
     "noUnusedParameters": false,


### PR DESCRIPTION
## Summary
- add `@sdk` TypeScript path alias to the webapp

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, etc.)*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a08d62e1ac832ab1698172a6a47f7b