### PR TITLE
[handlers] Guard against missing user/message in alert_stats

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -266,7 +266,11 @@ async def alert_stats(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     """Отправить статистику предупреждений за последние 7 дней."""
-    user_id = update.effective_user.id
+    user = update.effective_user
+    message = update.message
+    if user is None or message is None:
+        return
+    user_id = user.id
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     week_ago = now - datetime.timedelta(days=7)
 
@@ -281,7 +285,7 @@ async def alert_stats(
     hyper = sum(1 for a in alerts if a.type == "hyper")
 
     text = f"За 7\u202Fдн.: гипо\u202F{hypo}, гипер\u202F{hyper}"
-    await update.message.reply_text(text)
+    await message.reply_text(text)
 
 
 __all__ = [

--- a/tests/test_alert_stats.py
+++ b/tests/test_alert_stats.py
@@ -25,6 +25,22 @@ class DummyMessage:
         self.kwargs.append(kwargs)
 
 
+@dataclass
+class DummyUser:
+    id: int
+
+
+@dataclass
+class DummyUpdate:
+    message: DummyMessage | None
+    effective_user: DummyUser | None
+
+
+@dataclass
+class DummyContext:
+    pass
+
+
 @pytest.mark.asyncio
 async def test_alert_stats_counts(monkeypatch: pytest.MonkeyPatch) -> None:
     engine = create_engine("sqlite:///:memory:")
@@ -75,21 +91,28 @@ async def test_alert_stats_counts(monkeypatch: pytest.MonkeyPatch) -> None:
 
     msg = DummyMessage()
 
-    @dataclass
-    class DummyUser:
-        id: int
-
-    @dataclass
-    class DummyUpdate:
-        message: DummyMessage
-        effective_user: DummyUser
-
-    @dataclass
-    class DummyContext:
-        pass
-
     update = cast("Update", DummyUpdate(message=msg, effective_user=DummyUser(id=1)))
     context = cast(CallbackContext[Any, Any, Any, Any], DummyContext())
 
     await alert_handlers.alert_stats(update, context)
     assert msg.texts == ["За 7\u202Fдн.: гипо\u202F1, гипер\u202F1"]
+
+
+@pytest.mark.asyncio
+async def test_alert_stats_returns_early(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_session_local(*args: Any, **kwargs: Any) -> None:  # pragma: no cover - used to ensure early return
+        raise AssertionError("SessionLocal should not be called")
+
+    monkeypatch.setattr(alert_handlers, "SessionLocal", fail_session_local)
+
+    msg = DummyMessage()
+    context = cast(CallbackContext[Any, Any, Any, Any], DummyContext())
+
+    update_no_user = cast("Update", DummyUpdate(message=msg, effective_user=None))
+    await alert_handlers.alert_stats(update_no_user, context)
+    assert msg.texts == []
+
+    update_no_message = cast(
+        "Update", DummyUpdate(message=None, effective_user=DummyUser(id=1))
+    )
+    await alert_handlers.alert_stats(update_no_message, context)


### PR DESCRIPTION
## Summary
- Avoid `None` access in alert_stats by checking for user and message
- Cover alert_stats early returns with tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a08b12c7d0832a8833485d8f99adff