### PR TITLE
[handlers] Cast entries to EntryLike in history view

### DIFF
--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -132,7 +132,7 @@ async def history_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
     await message.reply_text("📊 Последние записи:")
     for entry in entries:
-        text = render_entry(entry)
+        text = render_entry(cast(EntryLike, entry))
         markup = InlineKeyboardMarkup(
             [
                 [


### PR DESCRIPTION
## Summary
- cast diary entries to `EntryLike` before rendering history view

## Testing
- `ruff check services/api/app tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68a08b1782cc832a99ccd03e6587e5ca