### PR TITLE
[handlers] Default profile args to empty list

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -54,7 +54,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     * ``/profile <args>`` → set profile directly
     """
 
-    args = context.args
+    args = context.args or []
     api, ApiException, ProfileModel = get_api()
     if api is None:
         await update.message.reply_text(


### PR DESCRIPTION
## Summary
- Ensure `/profile` command handles missing arguments gracefully

## Testing
- `pytest tests/`
- `ruff check services/api/app tests`

------
https://chatgpt.com/codex/tasks/task_e_68a08b1f1e90832aa4b3004d1936ac34