### PR TITLE
[handlers] Use closure for timezone update

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -15,6 +15,8 @@ import json
 import logging
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from sqlalchemy.orm import Session
+
 from services.api.app.diabetes.services.db import (
     SessionLocal,
     Profile,
@@ -355,8 +357,12 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
             )
         return PROFILE_TZ
     user_id = update.effective_user.id
+
+    def db_set_timezone(session: Session) -> tuple[bool, bool]:
+        return set_timezone(session, user_id, raw)
+
     exists, ok = await run_db(
-        set_timezone, user_id, raw, sessionmaker=SessionLocal
+        db_set_timezone, sessionmaker=SessionLocal
     )
     if not exists:
         await update.message.reply_text(


### PR DESCRIPTION
## Summary
- refactor timezone handler to pass closure capturing timezone data to `run_db`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a08b225d10832a8921bb91475ab077