### PR TITLE
[profile] Cast job queue before evaluate sugar

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from typing import cast
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
 from telegram.ext import (
     CommandHandler,
@@ -24,7 +25,10 @@ from services.api.app.diabetes.services.db import (
     run_db,
 )
 
-from services.api.app.diabetes.handlers.alert_handlers import evaluate_sugar
+from services.api.app.diabetes.handlers.alert_handlers import (
+    evaluate_sugar,
+    DefaultJobQueue,
+)
 from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import (
     CallbackQueryNoWarnHandler,
 )
@@ -471,9 +475,8 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         return
     alert_sugar = result.get("alert_sugar")
     if alert_sugar is not None:
-        await evaluate_sugar(
-            user_id, alert_sugar, context.application.job_queue
-        )
+        job_queue = cast(DefaultJobQueue, context.application.job_queue)
+        await evaluate_sugar(user_id, alert_sugar, job_queue)
 
     low = result["low"]
     high = result["high"]


### PR DESCRIPTION
## Summary
- cast Application job queue to DefaultJobQueue in profile_security
- pass typed job queue to evaluate_sugar

## Testing
- `ruff check services/api/app tests`
- `pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68a08b255aa4832a810e1a5b043361f8