### PR TITLE
[webapp] Centralize API base configuration

### DIFF
--- a/services/webapp/ui/src/api/base.ts
+++ b/services/webapp/ui/src/api/base.ts
@@ -1,0 +1,1 @@
+export const API_BASE = import.meta.env.VITE_API_BASE || '/api';

--- a/services/webapp/ui/src/api/history.ts
+++ b/services/webapp/ui/src/api/history.ts
@@ -1,4 +1,5 @@
 import { tgFetch } from '../lib/tgFetch';
+import { API_BASE } from './base';
 
 export interface HistoryRecord {
   id: string;
@@ -14,7 +15,7 @@ export interface HistoryRecord {
 
 export async function getHistory(): Promise<HistoryRecord[]> {
   try {
-    const res = await tgFetch('/api/history');
+    const res = await tgFetch(`${API_BASE}/history`);
     if (!res.ok) {
       throw new Error('Не удалось загрузить историю');
     }
@@ -34,7 +35,7 @@ export async function getHistory(): Promise<HistoryRecord[]> {
 
 export async function updateRecord(record: HistoryRecord) {
   try {
-    const res = await tgFetch('/api/history', {
+    const res = await tgFetch(`${API_BASE}/history`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(record),
@@ -55,7 +56,7 @@ export async function updateRecord(record: HistoryRecord) {
 
 export async function deleteRecord(id: string) {
   try {
-    const res = await tgFetch(`/api/history/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    const res = await tgFetch(`${API_BASE}/history/${encodeURIComponent(id)}`, { method: 'DELETE' });
     const data = await res.json().catch(() => ({}));
     if (!res.ok || data.status !== 'ok') {
       throw new Error(data.detail || 'Не удалось удалить запись');

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,11 +1,7 @@
 import { DefaultApi, Profile } from '@sdk';
 import { Configuration, ResponseError } from '@sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
-
-const API_BASE = import.meta.env.VITE_API_BASE || '/api';
-if (!API_BASE) {
-  throw new Error('VITE_API_BASE is not set and no default is provided');
-}
+import { API_BASE } from './base';
 
 const api = new DefaultApi(
   new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,11 +1,7 @@
 import { DefaultApi, Reminder } from '@sdk';
 import { Configuration } from '@sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
-
-const API_BASE = import.meta.env.VITE_API_BASE || '/api';
-if (!API_BASE) {
-  throw new Error('VITE_API_BASE is not set and no default is provided');
-}
+import { API_BASE } from './base';
 
 const api = new DefaultApi(
   new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),

--- a/services/webapp/ui/src/api/stats.ts
+++ b/services/webapp/ui/src/api/stats.ts
@@ -1,4 +1,5 @@
 import { tgFetch } from '../lib/tgFetch';
+import { API_BASE } from './base';
 
 export interface AnalyticsPoint {
   date: string;
@@ -27,7 +28,7 @@ export const fallbackDayStats: DayStats = {
 
 export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint[]> {
   try {
-    const res = await tgFetch(`/api/analytics?telegramId=${telegramId}`);
+    const res = await tgFetch(`${API_BASE}/analytics?telegramId=${telegramId}`);
     if (!res.ok) {
       console.error('Analytics API request failed:', res.status);
       return fallbackAnalytics;
@@ -46,7 +47,7 @@ export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint
 
 export async function fetchDayStats(telegramId: number): Promise<DayStats> {
   try {
-    const res = await tgFetch(`/api/stats?telegramId=${telegramId}`);
+    const res = await tgFetch(`${API_BASE}/stats?telegramId=${telegramId}`);
     if (!res.ok) {
       console.error('Stats API request failed:', res.status);
       return fallbackDayStats;


### PR DESCRIPTION
## Summary
- add shared API_BASE constant for webapp API modules
- update history and stats API calls to use API_BASE
- refactor profile and reminders APIs to import shared base

## Testing
- `npm --workspace services/webapp/ui run lint` *(fails: interface declares no members in components, require() import in tailwind.config.ts)*
- `npx eslint src/api/base.ts src/api/history.ts src/api/stats.ts src/api/profile.ts src/api/reminders.ts && echo "eslint: no problems"`


------
https://chatgpt.com/codex/tasks/task_e_68a08f8afd24832aae91eef811867251