### PR TITLE
[webapp] Sanitize chart colors

### DIFF
--- a/services/webapp/ui/src/components/ui/chart.test.tsx
+++ b/services/webapp/ui/src/components/ui/chart.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { ChartConfig } from './chart'
+import { ChartStyle } from './chart'
+
+describe('ChartStyle', () => {
+  it('ignores invalid color strings', () => {
+    const config: ChartConfig = {
+      safe: { color: '#ff0000' },
+      unsafe: { color: "red; background: url(javascript:alert('xss'))" },
+    }
+
+    const { container } = render(<ChartStyle id="test" config={config} />)
+    const styleTag = container.querySelector('style')
+    expect(styleTag?.innerHTML).toContain('--color-safe: #ff0000')
+    expect(styleTag?.innerHTML).not.toContain('--color-unsafe')
+    expect(styleTag?.innerHTML).not.toContain('javascript')
+  })
+})


### PR DESCRIPTION
## Summary
- sanitize color values before injecting chart styles
- add test ensuring invalid colors are ignored

## Testing
- `npm run lint` (fails: An interface declaring no members is equivalent to its supertype...)
- `npm test` (fails: Missing script: "test")
- `npx vitest run --environment jsdom`


------
https://chatgpt.com/codex/tasks/task_e_68a0943a90b4832aabf711c973eaa9a3