### PR TITLE
[api] Remove blank line before profile_self

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -104,7 +104,6 @@ async def put_timezone(
 
 
 @app.get("/api/profile/self")
-
 async def profile_self(user: dict[str, Any] = Depends(require_tg_user)) -> dict[str, Any]:
     return user
 


### PR DESCRIPTION
## Summary
- remove stray blank line so `/api/profile/self` decorator directly precedes `profile_self`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a097a08588832a917e2c272b6e1a77