### PR TITLE
[telegram-auth] validate user json

### DIFF
--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -38,7 +38,10 @@ def parse_and_verify_init_data(init_data: str, token: str) -> dict[str, Any]:
         raise HTTPException(status_code=401, detail="invalid hash")
 
     if "user" in params:
-        params["user"] = json.loads(params["user"])
+        try:
+            params["user"] = json.loads(params["user"])
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=401, detail="invalid user data") from exc
     return params
 
 


### PR DESCRIPTION
## Summary
- validate `user` field parsing in Telegram init data
- add test for invalid `user` JSON string

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_telegram_auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68a09964eb44832aa936df6075c3a623