### PR TITLE
[profile] Filter None from sugar_conv key tuple

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -84,7 +84,10 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 if sugar_conv.per_message
                 else None
             )
-            key = (chat_id, user_id, msg_id)
+            key = cast(
+                tuple[int | str, ...],
+                tuple(i for i in (chat_id, user_id, msg_id) if i is not None),
+            )
             if hasattr(sugar_conv, "_update_state"):
                 sugar_conv._update_state(ConversationHandler.END, key)
             else:


### PR DESCRIPTION
## Summary
- avoid `None` values in `sugar_conv` key when updating conversation state

## Testing
- `ruff check services/api/app tests`
- `pytest tests/`
- `mypy --strict services/api/app/diabetes/handlers/profile/conversation.py`

------
https://chatgpt.com/codex/tasks/task_e_68a09a5db9e0832a87ce1f2617006c02