### PR TITLE
[profile] Fix DB callables and SOS handler usage

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -17,8 +17,6 @@ import logging
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from sqlalchemy.orm import Session
 
-from sqlalchemy.orm import Session
-
 from services.api.app.diabetes.services.db import (
     SessionLocal,
     Profile,
@@ -464,7 +462,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if action == "sos_contact":
         from services.api.app.diabetes.handlers import sos_handlers
 
-        await sos_handlers.sos_contact_start(query, context)
+        await sos_handlers.sos_contact_start(update, context)
         return
     if action == "add" and settings.webapp_url:
         button = InlineKeyboardButton(
@@ -475,8 +473,11 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     elif action == "del":
         await reminder_handlers.delete_reminder(update, context)
 
+    def db_security(session: Session) -> dict[str, object]:
+        return _security_db(session, user_id, action)
+
     result = await run_db(
-        _security_db, user_id, action, sessionmaker=SessionLocal
+        db_security, sessionmaker=SessionLocal
     )
     if not result.get("found"):
         await query.edit_message_text("Профиль не найден.")
@@ -488,9 +489,9 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         )
         return
     alert_sugar = result.get("alert_sugar")
-    if alert_sugar is not None:
+    if isinstance(alert_sugar, (int, float, str)):
         job_queue = cast(DefaultJobQueue, context.application.job_queue)
-        await evaluate_sugar(user_id, alert_sugar, job_queue)
+        await evaluate_sugar(user_id, float(alert_sugar), job_queue)
 
     low = result["low"]
     high = result["high"]
@@ -723,14 +724,19 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         )
         return ConversationHandler.END
     user_id = update.effective_user.id
+    def db_save_profile(session: Session) -> bool:
+        return save_profile(
+            session,
+            user_id,
+            icr,
+            cf,
+            target,
+            low,
+            high,
+        )
+
     ok = await run_db(
-        save_profile,
-        user_id,
-        icr,
-        cf,
-        target,
-        low,
-        high,
+        db_save_profile,
         sessionmaker=SessionLocal,
     )
     if not ok:


### PR DESCRIPTION
## Summary
- ensure `run_db` callbacks only require `Session`
- cast sugar values to float before `evaluate_sugar`
- pass `update` to `sos_contact_start`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`
- `mypy --strict services/api/app/diabetes/handlers/profile/conversation.py` *(fails: Library stubs not installed; 169 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a09a621d14832aac6d72e3f580545d