### PR TITLE
[profile] Ensure conversation callbacks return None

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -762,17 +762,24 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     from .. import _cancel_then
     from ..dose_handlers import photo_prompt
 
-    handler: Callable[[Update, ContextTypes.DEFAULT_TYPE], Awaitable[int]] = _cancel_then(
-        photo_prompt
-    )
-    return await handler(update, context)
+    handler = _cancel_then(photo_prompt)
+    await handler(update, context)
+    return ConversationHandler.END
+
+
+async def _profile_edit_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await profile_edit(update, context)
+
+
+async def _profile_timezone_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await profile_timezone(update, context)
 
 
 profile_conv = ConversationHandler(
     entry_points=[
         CommandHandler("profile", profile_command),
-        CallbackQueryNoWarnHandler(profile_edit, pattern="^profile_edit$"),
-        CallbackQueryNoWarnHandler(profile_timezone, pattern="^profile_timezone$"),
+        CallbackQueryNoWarnHandler(_profile_edit_entry, pattern="^profile_edit$"),
+        CallbackQueryNoWarnHandler(_profile_timezone_entry, pattern="^profile_timezone$"),
     ],
     states={
         PROFILE_ICR: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_icr)],

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -107,7 +107,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch: pytest.Monkey
         ep
         for ep in profile_handlers.profile_conv.entry_points
         if isinstance(ep, CallbackQueryNoWarnHandler)
-        and ep.callback is profile_handlers.profile_edit
+        and ep.callback is profile_handlers._profile_edit_entry
     ]
     assert profile_conv_cb
 


### PR DESCRIPTION
## Summary
- ensure profile conversation fallback ends session and discard handler result
- wrap profile edit/timezone callbacks for `CallbackQueryNoWarnHandler`
- adjust handler registration test for wrapped callbacks

## Testing
- `ruff check services/api/app/diabetes/handlers/profile/conversation.py`
- `ruff check tests/test_register_handlers.py`
- `mypy --strict services/api/app/diabetes/handlers/profile/conversation.py`
- `pytest tests/test_register_handlers.py::test_register_handlers_attaches_expected_handlers -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09a623470832ab6108169f8c6d2e4