### PR TITLE
[api] Simplify DB invocation in create_user

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -143,7 +143,7 @@ async def create_user(
             session.add(UserDB(telegram_id=data.telegram_id, thread_id="webapp"))
         session.commit()
 
-    await run_db(lambda session: _create_user(session))
+    await run_db(_create_user)
     return {"status": "ok"}
 
 

--- a/tests/test_webapp_user.py
+++ b/tests/test_webapp_user.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import json
+import time
 import urllib.parse
 
 from typing import Any, Callable
@@ -35,7 +36,7 @@ TOKEN = "test-token"
 
 def build_init_data(user_id: int = 1) -> str:
     user = json.dumps({"id": user_id, "first_name": "A"}, separators=(",", ":"))
-    params = {"auth_date": "123", "query_id": "abc", "user": user}
+    params = {"auth_date": str(int(time.time())), "query_id": "abc", "user": user}
     data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
     secret = hmac.new(b"WebAppData", TOKEN.encode(), hashlib.sha256).digest()
     params["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()


### PR DESCRIPTION
## Summary
- call `run_db` with handler directly in `create_user`
- refresh user creation tests to use current timestamp

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_webapp_user.py`


------
https://chatgpt.com/codex/tasks/task_e_68a09e4a8cec832ab98f216297550311