### PR TITLE
[webapp] validate reminder id before fetching

### DIFF
--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -69,13 +69,20 @@ export default function CreateReminder() {
 
   useEffect(() => {
     if (!editing && params.id && user?.id) {
+      const id = Number(params.id);
+      if (Number.isNaN(id)) {
+        const message = "Некорректный ID напоминания";
+        setError(message);
+        toast({ title: "Ошибка", description: message, variant: "destructive" });
+        return;
+      }
       (async () => {
         try {
-          const data = await getReminder(user.id, Number(params.id));
+          const data = await getReminder(user.id, id);
           if (data) {
             const nt = normalizeReminderType(data.type as ReminderType);
             const loaded: Reminder = {
-              id: data.id ?? Number(params.id),
+              id: data.id ?? id,
               type: nt,
               title: data.title ?? TYPES[nt].label,
               time: data.time || "",


### PR DESCRIPTION
## Summary
- check reminder route param is numeric before fetching and show error toast when invalid

## Testing
- `npm --workspace services/webapp/ui test` *(fails: Missing script "test")*
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a4e0e74c832a99e7269bd89980b6