### PR TITLE
[webapp] Validate numeric inputs on new forms

### DIFF
--- a/services/webapp/ui/src/pages/NewMeal.tsx
+++ b/services/webapp/ui/src/pages/NewMeal.tsx
@@ -13,6 +13,15 @@ const NewMeal = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const carbsValue = Number(carbs);
+    if (isNaN(carbsValue) || carbsValue < 0 || carbsValue > 1000) {
+      toast({
+        title: 'Ошибка',
+        description: 'Количество углеводов должно быть от 0 до 1000 г',
+        variant: 'destructive',
+      });
+      return;
+    }
     const now = new Date();
     const record: HistoryRecord = {
       id: Date.now().toString(),
@@ -20,7 +29,7 @@ const NewMeal = () => {
       time: now.toTimeString().slice(0, 5),
       type: 'meal',
       notes: meal,
-      carbs: Number(carbs),
+      carbs: carbsValue,
     };
     try {
       await updateRecord(record);
@@ -57,6 +66,8 @@ const NewMeal = () => {
             Углеводы (г)
             <input
               type="number"
+              min="0"
+              max="1000"
               className="medical-input mt-2"
               value={carbs}
               onChange={(e) => setCarbs(e.target.value)}

--- a/services/webapp/ui/src/pages/NewMeasurement.tsx
+++ b/services/webapp/ui/src/pages/NewMeasurement.tsx
@@ -12,12 +12,21 @@ const NewMeasurement = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const sugarValue = Number(sugar);
+    if (isNaN(sugarValue) || sugarValue < 0 || sugarValue > 50) {
+      toast({
+        title: 'Ошибка',
+        description: 'Уровень сахара должен быть от 0 до 50 ммоль/л',
+        variant: 'destructive',
+      });
+      return;
+    }
     const now = new Date();
     const record: HistoryRecord = {
       id: Date.now().toString(),
       date: now.toISOString().split('T')[0],
       time: now.toTimeString().slice(0, 5),
-      sugar: Number(sugar),
+      sugar: sugarValue,
       type: 'measurement',
     };
     try {
@@ -47,6 +56,8 @@ const NewMeasurement = () => {
             <input
               type="number"
               step="0.1"
+              min="0"
+              max="50"
               className="medical-input mt-2"
               value={sugar}
               onChange={(e) => setSugar(e.target.value)}


### PR DESCRIPTION
## Summary
- add range checks for sugar level in new measurement page
- validate carb amount in new meal page

## Testing
- `npm --workspace services/webapp/ui run lint` (fails: no-empty-object-type & no-require-imports)
- `ruff check services/api/app tests`
- `pytest tests` (fails: assert 401 == 200)


------
https://chatgpt.com/codex/tasks/task_e_68a0a68ac324832aaf9b42bc97eb0962