### PR TITLE
[tests] Remove redundant Message casts

### DIFF
--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -3,7 +3,7 @@ import os
 from types import SimpleNamespace
 from typing import Any, cast
 
-from telegram import Message, Update
+from telegram import Update
 from telegram.ext import CallbackContext
 
 import pytest
@@ -68,13 +68,13 @@ async def test_onboarding_demo_photo_missing(monkeypatch: pytest.MonkeyPatch, ca
 
     await onboarding.start_command(update, context)
     assert update.message
-    cast(Message, update.message).text = "10"
+    update.message.text = "10"
     await onboarding.onboarding_icr(update, context)
     assert update.message
-    cast(Message, update.message).text = "3"
+    update.message.text = "3"
     await onboarding.onboarding_cf(update, context)
     assert update.message
-    cast(Message, update.message).text = "6"
+    update.message.text = "6"
     await onboarding.onboarding_target(update, context)
 
     import pathlib
@@ -89,7 +89,7 @@ async def test_onboarding_demo_photo_missing(monkeypatch: pytest.MonkeyPatch, ca
     monkeypatch.setattr(pathlib.Path, "open", fake_open)
 
     assert update.message
-    cast(Message, update.message).text = "Europe/Moscow"
+    update.message.text = "Europe/Moscow"
     with caplog.at_level(logging.ERROR):
         state = await onboarding.onboarding_timezone(update, context)
 

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from telegram import Message, Update
+from telegram import Update
 from telegram.ext import CallbackContext, ConversationHandler
 
 from services.api.app.diabetes.services.db import Base, User
@@ -89,22 +89,22 @@ async def test_onboarding_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "1/3" in message.texts[-1]
 
     assert update.message
-    cast(Message, update.message).text = "10"
+    update.message.text = "10"
     state = await onboarding.onboarding_icr(update, context)
     assert state == onboarding.ONB_PROFILE_CF
 
     assert update.message
-    cast(Message, update.message).text = "3"
+    update.message.text = "3"
     state = await onboarding.onboarding_cf(update, context)
     assert state == onboarding.ONB_PROFILE_TARGET
 
     assert update.message
-    cast(Message, update.message).text = "6"
+    update.message.text = "6"
     state = await onboarding.onboarding_target(update, context)
     assert state == onboarding.ONB_PROFILE_TZ
 
     assert update.message
-    cast(Message, update.message).text = "Europe/Moscow"
+    update.message.text = "Europe/Moscow"
     state = await onboarding.onboarding_timezone(update, context)
     assert state == onboarding.ONB_DEMO
     assert message.photos


### PR DESCRIPTION
## Summary
- drop unnecessary Message casts in onboarding test suites

## Testing
- `ruff check tests/test_onboarding_flow.py tests/test_onboarding_demo_photo_missing.py`
- `pytest tests/test_onboarding_flow.py tests/test_onboarding_demo_photo_missing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a902c384832a994268c56693b31f