### PR TITLE
[webapp] Use medical success colors for reminders

### DIFF
--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -103,7 +103,7 @@ function ReminderRow({
         <MedicalButton
           size="icon"
           variant="ghost"
-          className={cn(reminder.active ? 'bg-success/10 text-success' : 'bg-secondary text-muted-foreground')}
+          className={cn(reminder.active ? 'bg-medical-success/10 text-medical-success' : 'bg-secondary text-muted-foreground')}
           onClick={() => onToggle(reminder.id)}
           aria-label=
             {reminder.active ? 'Отключить напоминание' : 'Включить напоминание'}


### PR DESCRIPTION
## Summary
- use medical success colors for active reminder toggle

## Testing
- `pytest tests/` (fails: assert 401 == 200)
- `ruff check services/api/app tests`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a0a8387824832a9723b17d5de01705