### PR TITLE
[tests] Guard optional values in handler tests

### DIFF
--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -51,10 +51,13 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     await router.callback_router(update, context)
 
     assert query.edited == ["❌ Запись отменена."]
-    assert not query.edit_kwargs[0] or "reply_markup" not in query.edit_kwargs[0]
+    assert query.edit_kwargs
+    kwargs0 = query.edit_kwargs[0]
+    assert not kwargs0 or "reply_markup" not in kwargs0
     assert len(query.message.replies) == 1
+    assert query.message.kwargs
     kwargs = query.message.kwargs[0]
-    assert kwargs["reply_markup"] == common_handlers.menu_keyboard
+    assert kwargs.get("reply_markup") == common_handlers.menu_keyboard
     assert "pending_entry" not in context.user_data
 
 

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -127,7 +127,9 @@ async def test_history_view_buttons(monkeypatch: pytest.MonkeyPatch) -> None:
         assert f"edit:{eid}" in all_callbacks
         assert f"del:{eid}" in all_callbacks
 
-    back_markup = message.kwargs[-1]["reply_markup"]
+    back_kwargs = message.kwargs[-1]
+    back_markup = back_kwargs.get("reply_markup")
+    assert isinstance(back_markup, InlineKeyboardMarkup)
     back_button = back_markup.inline_keyboard[0][0]
     assert back_button.callback_data == "report_back"
 
@@ -181,6 +183,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         "message_id": 24,
     }
     markup = query.markups[-1]
+    assert markup is not None
     buttons = [b.callback_data for row in markup.inline_keyboard for b in row]
     assert f"edit_field:{entry_id}:sugar" in buttons
     assert f"edit_field:{entry_id}:xe" in buttons
@@ -218,5 +221,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     edited_text, chat_id, message_id, kwargs = context.bot.edited[0]
     assert chat_id == 42 and message_id == 24
-    buttons = [b.callback_data for row in kwargs["reply_markup"].inline_keyboard for b in row]
+    reply_markup = kwargs.get("reply_markup")
+    assert reply_markup is not None
+    buttons = [b.callback_data for row in reply_markup.inline_keyboard for b in row]
     assert f"edit:{entry_id}" in buttons and f"del:{entry_id}" in buttons


### PR DESCRIPTION
## Summary
- ensure reply markup exists before accessing in history edit tests
- guard list and dict access in cancel entry tests

## Testing
- `ruff check tests/test_handlers_history_edit.py tests/test_handlers_cancel_entry.py`
- `pytest tests/test_handlers_history_edit.py tests/test_handlers_cancel_entry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a906d84c832a9a02cd4bd7ee31ec