### PR TITLE
[handlers] Specify concrete type arguments

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
 
 from telegram.ext import (
     Application,
+    CallbackContext,
     CallbackQueryHandler,
     CommandHandler,
-
-
     MessageHandler,
     PollAnswerHandler,
     filters,
@@ -23,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 
-def register_handlers(app: Application) -> None:
+def register_handlers(app: Application[CallbackContext]) -> None:
 
     """Register bot handlers on the provided ``Application`` instance."""
 
@@ -39,10 +37,9 @@ def register_handlers(app: Application) -> None:
         security_handlers,
     )
 
-    app = cast(Any, app)
     app.add_handler(onboarding_conv)
-    app.add_handler(CommandHandler("menu", menu_command))
-    app.add_handler(CommandHandler("report", reporting_handlers.report_request))
+    app.add_handler(CommandHandler[CallbackContext]("menu", menu_command))
+    app.add_handler(CommandHandler[CallbackContext]("report", reporting_handlers.report_request))
     app.add_handler(dose_handlers.dose_conv)
     # Register profile conversation before sugar conversation so that numeric
     # inputs for profile aren't captured by sugar logging
@@ -50,72 +47,74 @@ def register_handlers(app: Application) -> None:
     app.add_handler(profile.profile_webapp_handler)
     app.add_handler(dose_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
-    app.add_handler(CommandHandler("cancel", dose_handlers.dose_cancel))
-    app.add_handler(CommandHandler("help", help_command))
-    app.add_handler(CommandHandler("gpt", dose_handlers.chat_with_gpt))
-    app.add_handler(CommandHandler("reminders", reminder_handlers.reminders_list))
-    app.add_handler(CommandHandler("addreminder", reminder_handlers.add_reminder))
+    app.add_handler(CommandHandler[CallbackContext]("cancel", dose_handlers.dose_cancel))
+    app.add_handler(CommandHandler[CallbackContext]("help", help_command))
+    app.add_handler(CommandHandler[CallbackContext]("gpt", dose_handlers.chat_with_gpt))
+    app.add_handler(CommandHandler[CallbackContext]("reminders", reminder_handlers.reminders_list))
+    app.add_handler(CommandHandler[CallbackContext]("addreminder", reminder_handlers.add_reminder))
     app.add_handler(reminder_handlers.reminder_action_handler)
     app.add_handler(reminder_handlers.reminder_webapp_handler)
-    app.add_handler(CommandHandler("delreminder", reminder_handlers.delete_reminder))
-    app.add_handler(CommandHandler("alertstats", alert_handlers.alert_stats))
-    app.add_handler(CommandHandler("hypoalert", security_handlers.hypo_alert_faq))
-    app.add_handler(PollAnswerHandler(onboarding_poll_answer))
+    app.add_handler(CommandHandler[CallbackContext]("delreminder", reminder_handlers.delete_reminder))
+    app.add_handler(CommandHandler[CallbackContext]("alertstats", alert_handlers.alert_stats))
+    app.add_handler(CommandHandler[CallbackContext]("hypoalert", security_handlers.hypo_alert_faq))
+    app.add_handler(PollAnswerHandler[CallbackContext](onboarding_poll_answer))
     app.add_handler(
-        MessageHandler(filters.Regex("^📄 Мой профиль$"), profile.profile_view)
+        MessageHandler[CallbackContext](filters.Regex("^📄 Мой профиль$"), profile.profile_view)
     )
     app.add_handler(
-        MessageHandler(filters.Regex("^📈 Отчёт$"), reporting_handlers.report_request)
+        MessageHandler[CallbackContext](filters.Regex("^📈 Отчёт$"), reporting_handlers.report_request)
     )
     app.add_handler(
-        MessageHandler(filters.Regex("^📊 История$"), reporting_handlers.history_view)
+        MessageHandler[CallbackContext](filters.Regex("^📊 История$"), reporting_handlers.history_view)
     )
     app.add_handler(
-        MessageHandler(filters.Regex("^📷 Фото еды$"), dose_handlers.photo_prompt)
+        MessageHandler[CallbackContext](filters.Regex("^📷 Фото еды$"), dose_handlers.photo_prompt)
     )
     app.add_handler(
-        MessageHandler(filters.Regex("^🕹 Быстрый ввод$"), smart_input_help)
+        MessageHandler[CallbackContext](filters.Regex("^🕹 Быстрый ввод$"), smart_input_help)
     )
     app.add_handler(
-        MessageHandler(
+        MessageHandler[CallbackContext](
             filters.Regex("^⏰ Напоминания$"), reminder_handlers.reminders_list
         )
     )
     app.add_handler(
-        MessageHandler(filters.Regex("^ℹ️ Помощь$"), help_command)
+        MessageHandler[CallbackContext](filters.Regex("^ℹ️ Помощь$"), help_command)
     )
     app.add_handler(
-        MessageHandler(
+        MessageHandler[CallbackContext](
             filters.Regex("^🆘 SOS контакт$"), sos_handlers.sos_contact_start
         )
     )
     app.add_handler(
-        MessageHandler(filters.TEXT & ~filters.COMMAND, dose_handlers.freeform_handler)
+        MessageHandler[CallbackContext](
+            filters.TEXT & ~filters.COMMAND, dose_handlers.freeform_handler
+        )
     )
-    app.add_handler(MessageHandler(filters.PHOTO, dose_handlers.photo_handler))
+    app.add_handler(MessageHandler[CallbackContext](filters.PHOTO, dose_handlers.photo_handler))
     app.add_handler(
-        MessageHandler(filters.Document.IMAGE, dose_handlers.doc_handler)
+        MessageHandler[CallbackContext](filters.Document.IMAGE, dose_handlers.doc_handler)
     )
     app.add_handler(
-        CallbackQueryHandler(
+        CallbackQueryHandler[CallbackContext](
             reporting_handlers.report_period_callback, pattern="^report_back$"
         )
     )
     app.add_handler(
-        CallbackQueryHandler(
+        CallbackQueryHandler[CallbackContext](
             reporting_handlers.report_period_callback, pattern="^report_period:"
         )
     )
     app.add_handler(
-        CallbackQueryHandler(
+        CallbackQueryHandler[CallbackContext](
             profile.profile_security, pattern="^profile_security"
         )
     )
     app.add_handler(
-        CallbackQueryHandler(profile.profile_back, pattern="^profile_back$")
+        CallbackQueryHandler[CallbackContext](profile.profile_back, pattern="^profile_back$")
     )
-    app.add_handler(CallbackQueryHandler(reminder_handlers.reminder_callback, pattern="^remind_"))
-    app.add_handler(CallbackQueryHandler(callback_router))
+    app.add_handler(CallbackQueryHandler[CallbackContext](reminder_handlers.reminder_callback, pattern="^remind_"))
+    app.add_handler(CallbackQueryHandler[CallbackContext](callback_router))
 
     job_queue = app.job_queue
     if job_queue:

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -22,9 +22,9 @@ from services.api.app.diabetes.handlers import (
 
 
 def _find_handler(
-    fallbacks: Iterable[BaseHandler[Any]],
+    fallbacks: Iterable[BaseHandler[Update, CallbackContext]],
     regex: str,
-) -> MessageHandler[Any]:
+) -> MessageHandler[CallbackContext]:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)
@@ -45,13 +45,13 @@ class DummyMessage:
         self.kwargs.append(kwargs)
 
 
-async def _exercise(handler: MessageHandler[Any]) -> None:
+async def _exercise(handler: MessageHandler[CallbackContext]) -> None:
     message = DummyMessage("📷 Фото еды")
     update = cast(
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}, "dose_method": "xe"}),
     )
     await handler.callback(update, context)


### PR DESCRIPTION
## Summary
- use explicit Update/CallbackContext generics in photo fallback tests
- register handlers with Application[CallbackContext] and typed handler classes

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a905b7f8832a85d4fa90de719806