### PR TITLE
[handlers] Export SessionLocal for tests

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -1147,6 +1147,7 @@ dose_conv = ConversationHandler(
 
 
 __all__ = [
+    "SessionLocal",
     "DOSE_METHOD",
     "DOSE_XE",
     "DOSE_CARBS",

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -7,6 +7,7 @@ from telegram import Update
 from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
+from services.api.app.diabetes.handlers.dose_handlers import SessionLocal as SessionFactory
 import services.api.app.diabetes.handlers.router as router
 
 
@@ -153,11 +154,12 @@ async def test_photo_flow_saves_entry(
         Update,
         SimpleNamespace(message=msg_sugar, effective_user=SimpleNamespace(id=1)),
     )
-    dose_handlers.SessionLocal = lambda: session
+    session_factory = cast(type(SessionFactory), lambda: session)
+    dose_handlers.SessionLocal = session_factory
     await dose_handlers.freeform_handler(update_sugar, context)
     assert context.user_data["pending_entry"]["sugar_before"] == 5.5
 
-    monkeypatch.setattr(router, "SessionLocal", lambda: session)
+    monkeypatch.setattr(router, "SessionLocal", session_factory)
     import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
 
     async def noop(*args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
## Summary
- re-export `SessionLocal` from `dose_handlers` so tests can patch the database session factory
- update photo-sugar save handler test to import and patch `SessionLocal` with proper type casting

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: 7 failed, 243 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a905a01c832aafddef66ec84dc2e