### PR TITLE
[webapp] add sdk path alias

### DIFF
--- a/services/webapp/ui/tsconfig.app.json
+++ b/services/webapp/ui/tsconfig.app.json
@@ -23,7 +23,8 @@
 
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@sdk/*": ["../../../libs/ts-sdk/*"]
     }
   },
   "include": ["src"]

--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -7,7 +7,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@sdk/*": ["../../../libs/ts-sdk/*"]
     },
     "noImplicitAny": false,
     "noUnusedParameters": false,


### PR DESCRIPTION
## Summary
- add `@sdk/*` alias pointing to `libs/ts-sdk/*`

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` (fails: assert 401 == 200, etc.)
- `npm run lint` (fails: `no-empty-object-type`)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0b6e92170832abe94f3f18afa1bb5