### PR TITLE
test: ensure timers restored in tgFetch tests

### DIFF
--- a/services/webapp/ui/src/api/tgFetch.api.test.ts
+++ b/services/webapp/ui/src/api/tgFetch.api.test.ts
@@ -18,6 +18,7 @@ describe('tgFetch', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     global.fetch = originalFetch;
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -50,6 +51,5 @@ describe('tgFetch', () => {
     const promise = tgFetch('/api/profile');
     vi.advanceTimersByTime(10_000);
     await expect(promise).rejects.toThrow('Превышено время ожидания');
-    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- restore real timers in tgFetch tests after each test to avoid lingering fake timers

## Testing
- `npx vitest run --environment jsdom`
- `npm run lint` (fails: `A 'require()' style import is forbidden`)


------
https://chatgpt.com/codex/tasks/task_e_68a0bc04fe3c832abc7171471988689b