### PR TITLE
[handlers] refine callback query handler typing

### DIFF
--- a/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
+++ b/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
@@ -5,7 +5,7 @@ from telegram import CallbackQuery, Update
 from telegram.ext import BaseHandler, ContextTypes
 
 CallbackQueryHandlerCallback = Callable[
-    [Update, ContextTypes.DEFAULT_TYPE], Coroutine[Any, Any, None]
+    [Update, ContextTypes.DEFAULT_TYPE], Coroutine[Any, Any, int]
 ]
 
 

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -458,7 +458,6 @@ async def onboarding_poll_answer(
 async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     from . import _cancel_then
     from .dose_handlers import photo_prompt
-
     message = update.message
     user_data_raw = context.user_data
     if user_data_raw is None:
@@ -469,10 +468,9 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     if message is None:
         return ConversationHandler.END
 
-    handler: Callable[[Update, ContextTypes.DEFAULT_TYPE], Awaitable[int]] = _cancel_then(
-        photo_prompt
-    )
-    return await handler(update, context)
+    handler = _cancel_then(photo_prompt)
+    await handler(update, context)
+    return ConversationHandler.END
 
 
 onboarding_conv = ConversationHandler(

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -810,12 +810,12 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return END
 
 
-async def _profile_edit_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    await profile_edit(update, context)
+async def _profile_edit_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    return await profile_edit(update, context)
 
 
-async def _profile_timezone_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    await profile_timezone(update, context)
+async def _profile_timezone_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    return await profile_timezone(update, context)
 
 
 profile_conv = ConversationHandler(


### PR DESCRIPTION
## Summary
- refine callback query handler callback to require int return value
- return state from profile entry callbacks via wrapper functions
- ensure photo fallback in onboarding returns ConversationHandler.END

## Testing
- `mypy --follow-imports=skip services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py services/api/app/diabetes/handlers/onboarding_handlers.py services/api/app/diabetes/handlers/profile/conversation.py`
- `ruff check services/api/app tests`
- `pytest tests/` *(fails: doc handler call, profile self auth, webapp timezone/history authorization)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bc155f6c832aadc2eec380aa2644