### PR TITLE
[handlers] Parameterize registration handlers

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from telegram.ext import (
     Application,
-    CallbackContext,
     CallbackQueryHandler,
     CommandHandler,
+    ContextTypes,
+    ExtBot,
+    JobQueue,
     MessageHandler,
     PollAnswerHandler,
     filters,
@@ -21,7 +24,16 @@ logger = logging.getLogger(__name__)
 
 
 
-def register_handlers(app: Application[CallbackContext]) -> None:
+def register_handlers(
+    app: Application[
+        ExtBot[None],
+        ContextTypes.DEFAULT_TYPE,
+        dict[str, Any],
+        dict[str, Any],
+        dict[str, Any],
+        JobQueue[ContextTypes.DEFAULT_TYPE],
+    ]
+) -> None:
 
     """Register bot handlers on the provided ``Application`` instance."""
 
@@ -38,8 +50,8 @@ def register_handlers(app: Application[CallbackContext]) -> None:
     )
 
     app.add_handler(onboarding_conv)
-    app.add_handler(CommandHandler[CallbackContext]("menu", menu_command))
-    app.add_handler(CommandHandler[CallbackContext]("report", reporting_handlers.report_request))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("menu", menu_command))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("report", reporting_handlers.report_request))
     app.add_handler(dose_handlers.dose_conv)
     # Register profile conversation before sugar conversation so that numeric
     # inputs for profile aren't captured by sugar logging
@@ -47,74 +59,74 @@ def register_handlers(app: Application[CallbackContext]) -> None:
     app.add_handler(profile.profile_webapp_handler)
     app.add_handler(dose_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
-    app.add_handler(CommandHandler[CallbackContext]("cancel", dose_handlers.dose_cancel))
-    app.add_handler(CommandHandler[CallbackContext]("help", help_command))
-    app.add_handler(CommandHandler[CallbackContext]("gpt", dose_handlers.chat_with_gpt))
-    app.add_handler(CommandHandler[CallbackContext]("reminders", reminder_handlers.reminders_list))
-    app.add_handler(CommandHandler[CallbackContext]("addreminder", reminder_handlers.add_reminder))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("cancel", dose_handlers.dose_cancel))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("help", help_command))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("gpt", dose_handlers.chat_with_gpt))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("reminders", reminder_handlers.reminders_list))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("addreminder", reminder_handlers.add_reminder))
     app.add_handler(reminder_handlers.reminder_action_handler)
     app.add_handler(reminder_handlers.reminder_webapp_handler)
-    app.add_handler(CommandHandler[CallbackContext]("delreminder", reminder_handlers.delete_reminder))
-    app.add_handler(CommandHandler[CallbackContext]("alertstats", alert_handlers.alert_stats))
-    app.add_handler(CommandHandler[CallbackContext]("hypoalert", security_handlers.hypo_alert_faq))
-    app.add_handler(PollAnswerHandler[CallbackContext](onboarding_poll_answer))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("delreminder", reminder_handlers.delete_reminder))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("alertstats", alert_handlers.alert_stats))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("hypoalert", security_handlers.hypo_alert_faq))
+    app.add_handler(PollAnswerHandler[ContextTypes.DEFAULT_TYPE](onboarding_poll_answer))
     app.add_handler(
-        MessageHandler[CallbackContext](filters.Regex("^📄 Мой профиль$"), profile.profile_view)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📄 Мой профиль$"), profile.profile_view)
     )
     app.add_handler(
-        MessageHandler[CallbackContext](filters.Regex("^📈 Отчёт$"), reporting_handlers.report_request)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📈 Отчёт$"), reporting_handlers.report_request)
     )
     app.add_handler(
-        MessageHandler[CallbackContext](filters.Regex("^📊 История$"), reporting_handlers.history_view)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📊 История$"), reporting_handlers.history_view)
     )
     app.add_handler(
-        MessageHandler[CallbackContext](filters.Regex("^📷 Фото еды$"), dose_handlers.photo_prompt)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📷 Фото еды$"), dose_handlers.photo_prompt)
     )
     app.add_handler(
-        MessageHandler[CallbackContext](filters.Regex("^🕹 Быстрый ввод$"), smart_input_help)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^🕹 Быстрый ввод$"), smart_input_help)
     )
     app.add_handler(
-        MessageHandler[CallbackContext](
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
             filters.Regex("^⏰ Напоминания$"), reminder_handlers.reminders_list
         )
     )
     app.add_handler(
-        MessageHandler[CallbackContext](filters.Regex("^ℹ️ Помощь$"), help_command)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^ℹ️ Помощь$"), help_command)
     )
     app.add_handler(
-        MessageHandler[CallbackContext](
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
             filters.Regex("^🆘 SOS контакт$"), sos_handlers.sos_contact_start
         )
     )
     app.add_handler(
-        MessageHandler[CallbackContext](
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
             filters.TEXT & ~filters.COMMAND, dose_handlers.freeform_handler
         )
     )
-    app.add_handler(MessageHandler[CallbackContext](filters.PHOTO, dose_handlers.photo_handler))
+    app.add_handler(MessageHandler[ContextTypes.DEFAULT_TYPE](filters.PHOTO, dose_handlers.photo_handler))
     app.add_handler(
-        MessageHandler[CallbackContext](filters.Document.IMAGE, dose_handlers.doc_handler)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Document.IMAGE, dose_handlers.doc_handler)
     )
     app.add_handler(
-        CallbackQueryHandler[CallbackContext](
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
             reporting_handlers.report_period_callback, pattern="^report_back$"
         )
     )
     app.add_handler(
-        CallbackQueryHandler[CallbackContext](
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
             reporting_handlers.report_period_callback, pattern="^report_period:"
         )
     )
     app.add_handler(
-        CallbackQueryHandler[CallbackContext](
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
             profile.profile_security, pattern="^profile_security"
         )
     )
     app.add_handler(
-        CallbackQueryHandler[CallbackContext](profile.profile_back, pattern="^profile_back$")
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](profile.profile_back, pattern="^profile_back$")
     )
-    app.add_handler(CallbackQueryHandler[CallbackContext](reminder_handlers.reminder_callback, pattern="^remind_"))
-    app.add_handler(CallbackQueryHandler[CallbackContext](callback_router))
+    app.add_handler(CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](reminder_handlers.reminder_callback, pattern="^remind_"))
+    app.add_handler(CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](callback_router))
 
     job_queue = app.job_queue
     if job_queue:


### PR DESCRIPTION
## Summary
- Replace deprecated CallbackContext type parameters with ContextTypes.DEFAULT_TYPE in registration handlers
- Specify concrete Application generics including ExtBot and JobQueue

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert statements in tests)*
- `mypy services/api/app/diabetes/handlers/registration.py` *(fails: existing errors in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bc195918832aa5b96ba2fea6699a