### PR TITLE
tests: parameterize CallbackContext in photo fallback tests

### DIFF
--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -22,9 +22,16 @@ from services.api.app.diabetes.handlers import (
 
 
 def _find_handler(
-    fallbacks: Iterable[BaseHandler[Update, CallbackContext]],
+    fallbacks: Iterable[
+        BaseHandler[
+            Update,
+            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        ]
+    ],
     regex: str,
-) -> MessageHandler[CallbackContext]:
+) -> MessageHandler[
+    CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+]:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)
@@ -45,7 +52,11 @@ class DummyMessage:
         self.kwargs.append(kwargs)
 
 
-async def _exercise(handler: MessageHandler[CallbackContext]) -> None:
+async def _exercise(
+    handler: MessageHandler[
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+    ]
+) -> None:
     message = DummyMessage("📷 Фото еды")
     update = cast(
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))


### PR DESCRIPTION
## Summary
- parameterize `CallbackContext` usages in photo fallback tests to avoid missing type parameters

## Testing
- `python -m mypy tests/test_photo_fallbacks.py --ignore-missing-imports --follow-imports=skip`
- `ruff check tests/test_photo_fallbacks.py`
- `pytest tests/test_photo_fallbacks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0bc20433c832abde3f39bdf320429