### PR TITLE
tests: annotate updates and contexts

### DIFF
--- a/tests/test_alert_stats.py
+++ b/tests/test_alert_stats.py
@@ -92,7 +92,10 @@ async def test_alert_stats_counts(monkeypatch: pytest.MonkeyPatch) -> None:
     msg = DummyMessage()
 
     update = cast("Update", DummyUpdate(message=msg, effective_user=DummyUser(id=1)))
-    context = cast(CallbackContext[Any, Any, Any, Any], DummyContext())
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        DummyContext(),
+    )
 
     await alert_handlers.alert_stats(update, context)
     assert msg.texts == ["За 7\u202Fдн.: гипо\u202F1, гипер\u202F1"]
@@ -106,7 +109,10 @@ async def test_alert_stats_returns_early(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(alert_handlers, "SessionLocal", fail_session_local)
 
     msg = DummyMessage()
-    context = cast(CallbackContext[Any, Any, Any, Any], DummyContext())
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        DummyContext(),
+    )
 
     update_no_user = cast("Update", DummyUpdate(message=msg, effective_user=None))
     await alert_handlers.alert_stats(update_no_user, context)

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -48,7 +48,7 @@ async def test_photo_button_cancels_and_prompts_photo() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
     await handler.callback(update, context)

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -53,7 +53,7 @@ async def test_entry_without_dose_has_no_unit(
         "xe": 2.0,
     }
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         DummyContext(
             user_data={"pending_entry": pending_entry, "pending_fields": ["sugar"]}
         ),
@@ -104,7 +104,7 @@ async def test_entry_without_sugar_has_placeholder(
         "event_time": datetime.datetime.now(datetime.timezone.utc),
     }
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         DummyContext(
             user_data={"pending_entry": pending_entry, "pending_fields": ["dose"]}
         ),

--- a/tests/test_dose_sugar_missing.py
+++ b/tests/test_dose_sugar_missing.py
@@ -35,7 +35,7 @@ async def test_dose_sugar_requires_carbs_or_xe() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -79,18 +79,22 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
 
     entry_message = DummyMessage(chat_id=42, message_id=24)
     query = DummyQuery(entry_message, f"edit:{entry_id}")
-    update_cb = SimpleNamespace(
-        callback_query=query, effective_user=SimpleNamespace(id=1)
+    update_cb = cast(
+        Update,
+        SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, bot=DummyBot()),
     )
 
     await router.callback_router(update_cb, context)
 
     field_query = DummyQuery(entry_message, f"edit_field:{entry_id}:dose")
-    update_cb2 = SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1))
+    update_cb2 = cast(
+        Update,
+        SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1)),
+    )
     await router.callback_router(update_cb2, context)
     assert context.user_data["edit_field"] == "dose"
 
@@ -101,12 +105,12 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
     await dose_handlers.freeform_handler(update_msg, context)
 
     with TestSession() as session:
-        updated = session.get(Entry, entry_id)
-        assert updated is not None
-        updated: Entry = updated
-        assert updated.dose == 5.0
+        entry_obj = session.get(Entry, entry_id)
+        assert entry_obj is not None
+        entry_db: Entry = entry_obj
+        assert entry_db.dose == 5.0
 
     assert field_query.answer_texts[-1] == "Изменено"
     edited_text, chat_id, message_id, kwargs = context.bot.edited[0]
     assert chat_id == 42 and message_id == 24
-    assert f"💉 Доза: <b>{updated.dose}</b>" in edited_text
+    assert f"💉 Доза: <b>{entry_db.dose}</b>" in edited_text

--- a/tests/test_freeform_handler_unknown.py
+++ b/tests/test_freeform_handler_unknown.py
@@ -30,7 +30,8 @@ async def test_freeform_handler_unknown_command(
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={})
     )
 
     monkeypatch.setattr(handlers, "parse_command", AsyncMock(return_value=None))

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -44,7 +44,7 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     query = DummyQuery(DummyMessage(), "cancel_entry")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"telegram_id": 1}}),
     )
 
@@ -73,7 +73,7 @@ async def test_callback_router_invalid_entry_id(
     query = DummyQuery(DummyMessage(), "del:abc")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -96,7 +96,7 @@ async def test_callback_router_unknown_data(
     query = DummyQuery(DummyMessage(), "foo")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -117,7 +117,7 @@ async def test_callback_router_ignores_reminder_action() -> None:
     query = DummyQuery(DummyMessage(), "rem_toggle:1")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {}}),
     )
 

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -50,8 +50,13 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
         mime_type="image/png",
     )
     message = SimpleNamespace(document=document, photo=None)
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(bot=dummy_bot, user_data={})
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(bot=dummy_bot, user_data={}),
+    )
 
     monkeypatch.setattr(handlers, "photo_handler", fake_photo_handler)
     monkeypatch.setattr(handlers.os, "makedirs", lambda *args, **kwargs: None)
@@ -61,7 +66,7 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
     assert result == "OK"
     assert called.flag
     assert context.user_data["__file_path"] == "photos/1_uid.png"
-    assert update.message.photo == []
+    assert update.message.photo == ()
 
 
 @pytest.mark.asyncio
@@ -78,8 +83,13 @@ async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> 
         mime_type=None,
     )
     message = SimpleNamespace(document=document, photo=None)
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={})
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
+    )
 
     monkeypatch.setattr(handlers, "photo_handler", fake_photo_handler)
 
@@ -93,8 +103,13 @@ async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> 
 @pytest.mark.asyncio
 async def test_photo_handler_handles_typeerror() -> None:
     message = DummyMessage(photo=None)
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={})
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
+    )
 
     result = await handlers.photo_handler(update, context)
 
@@ -117,7 +132,9 @@ async def test_photo_handler_preserves_file(
         pass
 
     message = SimpleNamespace(photo=[DummyPhoto()], reply_text=reply_text)
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
 
     class DummyFile:
         async def download_to_drive(self, path) -> None:
@@ -127,7 +144,10 @@ async def test_photo_handler_preserves_file(
         return DummyFile()
 
     dummy_bot = SimpleNamespace(get_file=fake_get_file)
-    context = SimpleNamespace(bot=dummy_bot, user_data={"thread_id": "tid"})
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(bot=dummy_bot, user_data={"thread_id": "tid"}),
+    )
 
     call = {}
 
@@ -213,11 +233,12 @@ async def test_photo_then_freeform_calculates_dose(
     monkeypatch.setattr(handlers, "confirm_keyboard", lambda: None)
 
     photo_msg = DummyMessage(photo=[DummyPhoto()])
-    update_photo = SimpleNamespace(
-        message=photo_msg, effective_user=SimpleNamespace(id=1)
+    update_photo = cast(
+        Update,
+        SimpleNamespace(message=photo_msg, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=dummy_bot, user_data={"thread_id": "tid"}),
     )
 

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -37,7 +37,7 @@ async def test_freeform_handler_edits_pending_entry_keeps_state() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 
@@ -82,7 +82,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 
@@ -111,7 +111,7 @@ async def test_freeform_handler_sugar_only_flow() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 

--- a/tests/test_handlers_freeform_units.py
+++ b/tests/test_handlers_freeform_units.py
@@ -27,7 +27,8 @@ async def test_freeform_handler_warns_on_sugar_unit_mix() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
     )
 
     await handlers.freeform_handler(update, context)
@@ -45,7 +46,8 @@ async def test_freeform_handler_warns_on_dose_unit_mix() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
     )
 
     await handlers.freeform_handler(update, context)
@@ -65,7 +67,8 @@ async def test_freeform_handler_guidance_on_valueerror(
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
     )
 
     def fake_smart_input(_):

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -92,16 +92,20 @@ async def test_history_view_buttons(monkeypatch: pytest.MonkeyPatch) -> None:
         entry_ids = [e.id for e in session.query(Entry).all()]
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
     )
 
     await reporting_handlers.history_view(update, context)
 
     # First message is header, last is back button
     assert len(message.replies) == len(entry_ids) + 2
-    all_callbacks = []
+    all_callbacks: list[str] = []
     expected_texts = []
     for d in [
         datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc),
@@ -168,11 +172,12 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     entry_message = DummyMessage(chat_id=42, message_id=24)
     query = DummyQuery(entry_message, f"edit:{entry_id}")
-    update_cb = SimpleNamespace(
-        callback_query=query, effective_user=SimpleNamespace(id=1)
+    update_cb = cast(
+        Update,
+        SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, bot=DummyBot()),
     )
 
@@ -190,8 +195,9 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert f"edit_field:{entry_id}:dose" in buttons
 
     field_query = DummyQuery(entry_message, f"edit_field:{entry_id}:xe")
-    update_cb2 = SimpleNamespace(
-        callback_query=field_query, effective_user=SimpleNamespace(id=1)
+    update_cb2 = cast(
+        Update,
+        SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1)),
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data["edit_id"] == entry_id
@@ -207,13 +213,13 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     await dose_handlers.freeform_handler(update_msg, context)
 
     with TestSession() as session:
-        updated = session.get(Entry, entry_id)
-        assert updated is not None
-        updated: Entry = updated
-        assert updated.xe == 3
-        assert updated.carbs_g == 10
-        assert updated.dose == 2
-        assert updated.sugar_before == 5
+        entry_obj = session.get(Entry, entry_id)
+        assert entry_obj is not None
+        entry_db: Entry = entry_obj
+        assert entry_db.xe == 3
+        assert entry_db.carbs_g == 10
+        assert entry_db.dose == 2
+        assert entry_db.sugar_before == 5
 
     assert field_query.answer_texts[-1] == "Изменено"
     assert not any(

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -86,7 +86,8 @@ async def test_photo_flow_saves_entry(
         SimpleNamespace(message=msg_start, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
     )
     await dose_handlers.freeform_handler(update_start, context)
 

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -60,7 +60,8 @@ async def test_profile_command_and_view(monkeypatch: pytest.MonkeyPatch, args: A
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=123))
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(args=args, user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(args=args, user_data={}),
     )
 
     await handlers.profile_command(update, context)
@@ -76,7 +77,8 @@ async def test_profile_command_and_view(monkeypatch: pytest.MonkeyPatch, args: A
         Update, SimpleNamespace(message=message2, effective_user=SimpleNamespace(id=123))
     )
     context2 = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
     )
 
     await handlers.profile_view(update2, context2)
@@ -122,7 +124,8 @@ async def test_profile_command_invalid_values(monkeypatch: pytest.MonkeyPatch, a
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(args=args, user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(args=args, user_data={}),
     )
 
     await handlers.profile_command(update, context)
@@ -147,7 +150,8 @@ async def test_profile_command_help_and_dialog(monkeypatch: pytest.MonkeyPatch) 
         Update, SimpleNamespace(message=help_msg, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(args=["help"], user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(args=["help"], user_data={}),
     )
     result = await handlers.profile_command(update, context)
     assert result == ConversationHandler.END
@@ -159,7 +163,8 @@ async def test_profile_command_help_and_dialog(monkeypatch: pytest.MonkeyPatch) 
         Update, SimpleNamespace(message=dialog_msg, effective_user=SimpleNamespace(id=1))
     )
     context2 = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(args=[], user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(args=[], user_data={}),
     )
     result2 = await handlers.profile_command(update2, context2)
     assert result2 == handlers.PROFILE_ICR
@@ -192,7 +197,7 @@ async def test_profile_view_preserves_user_data(monkeypatch: pytest.MonkeyPatch)
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"thread_id": "tid", "foo": "bar"}),
     )
 
@@ -218,7 +223,10 @@ async def test_profile_view_missing_profile_shows_webapp_button(monkeypatch: pyt
     update = cast(
         Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
     )
-    context = cast(CallbackContext[Any, Any, Any, Any], SimpleNamespace())
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
 
     await handlers.profile_view(update, context)
 

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -29,7 +29,11 @@ async def test_prompt_photo_sends_message() -> None:
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message))
     await dose_handlers.prompt_photo(
-        update, cast(CallbackContext[Any, Any, Any, Any], SimpleNamespace())
+        update,
+        cast(
+            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+            SimpleNamespace(),
+        ),
     )
     assert any("фото" in t.lower() for t in message.texts)
 
@@ -41,7 +45,8 @@ async def test_prompt_sugar_sends_message() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
     )
     await dose_handlers.prompt_sugar(update, context)
     assert any("сахар" in t.lower() for t in message.texts)
@@ -55,7 +60,8 @@ async def test_prompt_dose_sends_message() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
     )
     await dose_handlers.prompt_dose(update, context)
     assert any("доз" in t.lower() for t in message.texts)

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -48,7 +48,8 @@ async def test_report_request_and_custom_flow(
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
     )
 
     await reporting_handlers.report_request(update, context)
@@ -125,7 +126,8 @@ async def test_report_period_callback_week(
         SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={})
     )
 
     await reporting_handlers.report_period_callback(update_cb, context)

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -41,7 +41,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
         pass
 
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(
             user_data={"thread_id": "tid"},
             bot=SimpleNamespace(

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -1,7 +1,13 @@
 from types import SimpleNamespace
 from typing import Any
 
+from types import SimpleNamespace
+from typing import Any, cast
+
 import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
 import services.api.app.diabetes.handlers.common_handlers as handlers
 
 
@@ -20,8 +26,11 @@ async def test_help_includes_new_features() -> None:
     """Ensure /help mentions wizard, smart-input and edit features."""
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
 
     await handlers.help_command(update, context)
 
@@ -38,8 +47,11 @@ async def test_help_includes_security_block() -> None:
     """Ensure /help mentions security settings."""
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
 
     await handlers.help_command(update, context)
 
@@ -57,8 +69,11 @@ async def test_help_lists_reminder_commands_and_menu_button() -> None:
     """Ensure reminder commands and menu button are documented."""
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
 
     await handlers.help_command(update, context)
 
@@ -74,8 +89,11 @@ async def test_help_lists_sos_contact_command() -> None:
     """Ensure /help documents SOS contact configuration."""
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
 
     await handlers.help_command(update, context)
 

--- a/tests/test_history_view_async.py
+++ b/tests/test_history_view_async.py
@@ -1,7 +1,10 @@
 import asyncio
 import time
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
+
+from telegram import Update
+from telegram.ext import CallbackContext
 
 import pytest
 
@@ -51,11 +54,17 @@ async def test_history_view_does_not_block_event_loop(monkeypatch: pytest.Monkey
 
     monkeypatch.setattr(reporting_handlers, "SessionLocal", slow_session)
 
-    update = SimpleNamespace(
-        effective_user=SimpleNamespace(id=1),
-        message=DummyMessage(),
+    update = cast(
+        Update,
+        SimpleNamespace(
+            effective_user=SimpleNamespace(id=1),
+            message=DummyMessage(),
+        ),
     )
-    context = SimpleNamespace()
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
 
     flag = False
 

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -41,7 +41,7 @@ async def test_sugar_conv_menu_then_photo() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
 
@@ -66,7 +66,7 @@ async def test_dose_conv_menu_then_photo() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
 

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -62,7 +62,7 @@ async def test_onboarding_demo_photo_missing(monkeypatch: pytest.MonkeyPatch, ca
         ),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, bot_data={}),
     )
 

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -80,7 +80,7 @@ async def test_onboarding_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         ),
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, bot_data={}),
     )
 
@@ -140,7 +140,7 @@ async def test_onboarding_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         ),
     )
     context2 = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, bot_data={}),
     )
     state2 = await onboarding.start_command(update2, context2)

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -2,7 +2,12 @@ import os
 from types import SimpleNamespace
 from typing import Any
 
+from types import SimpleNamespace
+from typing import Any, cast
+
 import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -39,23 +44,35 @@ async def test_profile_input_not_logged_as_sugar(monkeypatch: pytest.MonkeyPatch
 
     # Start sugar conversation
     sugar_msg = DummyMessage("/sugar")
-    sugar_update = SimpleNamespace(
-        message=sugar_msg,
-        effective_user=SimpleNamespace(id=1),
-        effective_chat=SimpleNamespace(id=1),
+    sugar_update = cast(
+        Update,
+        SimpleNamespace(
+            message=sugar_msg,
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=1),
+        ),
     )
-    shared_chat_data: dict = {}
-    sugar_context = SimpleNamespace(user_data={}, chat_data=shared_chat_data)
+    shared_chat_data: dict[str, Any] = {}
+    sugar_context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}, chat_data=shared_chat_data),
+    )
     await dose_handlers.sugar_start(sugar_update, sugar_context)
 
     # Start profile conversation which should cancel sugar conversation
     prof_msg = DummyMessage("/profile")
-    prof_update = SimpleNamespace(
-        message=prof_msg,
-        effective_user=SimpleNamespace(id=1),
-        effective_chat=SimpleNamespace(id=1),
+    prof_update = cast(
+        Update,
+        SimpleNamespace(
+            message=prof_msg,
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=1),
+        ),
     )
-    prof_context = SimpleNamespace(args=[], user_data={}, chat_data=shared_chat_data)
+    prof_context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(args=[], user_data={}, chat_data=shared_chat_data),
+    )
     result = await profile_handlers.profile_command(prof_update, prof_context)
     assert result == profile_handlers.PROFILE_ICR
     assert "ИКХ" in prof_msg.replies[0]
@@ -63,12 +80,18 @@ async def test_profile_input_not_logged_as_sugar(monkeypatch: pytest.MonkeyPatch
 
     # Send ICR value
     icr_msg = DummyMessage("10")
-    icr_update = SimpleNamespace(
-        message=icr_msg,
-        effective_user=SimpleNamespace(id=1),
-        effective_chat=SimpleNamespace(id=1),
+    icr_update = cast(
+        Update,
+        SimpleNamespace(
+            message=icr_msg,
+            effective_user=SimpleNamespace(id=1),
+            effective_chat=SimpleNamespace(id=1),
+        ),
     )
-    icr_context = SimpleNamespace(user_data={}, chat_data=shared_chat_data)
+    icr_context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}, chat_data=shared_chat_data),
+    )
     result_icr = await profile_handlers.profile_icr(icr_update, icr_context)
     assert result_icr == profile_handlers.PROFILE_CF
     assert "КЧ" in icr_msg.replies[0]

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from telegram import Message, Update, User
 from telegram.ext import CallbackContext, Job
@@ -321,7 +321,10 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
 
     query = DummyCallbackQuery("rem_toggle:1", DummyMessage())
     update = make_update(callback_query=query, effective_user=make_user(1))
-    context = make_context(job_queue=job_queue, user_data={"pending_entry": {}})
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        make_context(job_queue=job_queue, user_data={"pending_entry": {}}),
+    )
     await handlers.reminder_action_cb(update, context)
     await router.callback_router(update, context)
 

--- a/tests/test_security_handlers.py
+++ b/tests/test_security_handlers.py
@@ -1,6 +1,9 @@
-import pytest
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.security_handlers as handlers
 
@@ -18,8 +21,11 @@ class DummyMessage:
 @pytest.mark.asyncio
 async def test_hypoalert_faq_returns_message() -> None:
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
 
     await handlers.hypo_alert_faq(update, context)
 

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -43,7 +43,7 @@ async def test_sugar_back_fallback_cancels() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
     result = await handler.callback(update, context)
@@ -59,7 +59,7 @@ async def test_cancel_command_clears_state() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
     result = await dose_handlers.dose_cancel(update, context)


### PR DESCRIPTION
## Summary
- cast updates to `Update` and provide concrete typing for callback contexts
- annotate test collections like `all_callbacks` and rename temporary DB results
- ensure `user_data` is typed before membership checks to prevent `Any` indexing

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200 in webapp tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bc24dd78832aaf2f449b14df88cf