### PR TITLE
[tests] use getattr for profile edit handler

### DIFF
--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -107,7 +107,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch: pytest.Monkey
         ep
         for ep in profile_handlers.profile_conv.entry_points
         if isinstance(ep, CallbackQueryNoWarnHandler)
-        and ep.callback is profile_handlers._profile_edit_entry
+        and ep.callback is getattr(profile_handlers, "_profile_edit_entry")
     ]
     assert profile_conv_cb
 


### PR DESCRIPTION
## Summary
- use `getattr` to access the profile edit entry handler in tests

## Testing
- `ruff check tests/test_register_handlers.py`
- `pytest tests/test_register_handlers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0bc317538832a94937449d76b92c8