### PR TITLE
[webapp] Ensure timers reset in tgFetch tests

### DIFF
--- a/services/webapp/ui/src/api/tgFetch.api.test.ts
+++ b/services/webapp/ui/src/api/tgFetch.api.test.ts
@@ -18,10 +18,13 @@ describe('tgFetch', () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
-    global.fetch = originalFetch;
-    vi.restoreAllMocks();
-    vi.unstubAllGlobals();
+    try {
+      global.fetch = originalFetch;
+      vi.restoreAllMocks();
+      vi.unstubAllGlobals();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('sets credentials and attaches init data header', async () => {


### PR DESCRIPTION
## Summary
- guarantee timers are restored in tgFetch tests using try/finally during cleanup

## Testing
- `pre-commit run --files services/webapp/ui/src/api/tgFetch.api.test.ts`
- `npm --workspace services/webapp/ui exec vitest run` *(fails: ReferenceError: document is not defined)*
- `npm --workspace services/webapp/ui exec vitest run src/api/tgFetch.api.test.ts`
- `pytest tests` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a0beaed2d4832a9ea315868cbf1bd8