### PR TITLE
[tests] type CallbackContext user data

### DIFF
--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -44,7 +44,7 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     query = DummyQuery(DummyMessage(), "cancel_entry")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"telegram_id": 1}}),
     )
 
@@ -73,7 +73,7 @@ async def test_callback_router_invalid_entry_id(
     query = DummyQuery(DummyMessage(), "del:abc")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -96,7 +96,7 @@ async def test_callback_router_unknown_data(
     query = DummyQuery(DummyMessage(), "foo")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -117,7 +117,7 @@ async def test_callback_router_ignores_reminder_action() -> None:
     query = DummyQuery(DummyMessage(), "rem_toggle:1")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
-        CallbackContext[Any, Any, Any, Any],
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {}}),
     )
 


### PR DESCRIPTION
## Summary
- use dict-typed CallbackContext casts in cancel entry handler tests

## Testing
- `ruff check tests/test_handlers_cancel_entry.py`
- `pytest tests/test_handlers_cancel_entry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0bc2b9920832ab092584af281f94f