### PR TITLE
[tests] Annotate failing_commit session type

### DIFF
--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 from telegram import Bot, Update, User
 from telegram.ext import CallbackContext, ConversationHandler, Job, JobQueue
 from services.api.app.diabetes.handlers import profile as profile_handlers
@@ -293,7 +294,7 @@ async def test_reminder_callback_commit_failure(monkeypatch: pytest.MonkeyPatch,
     monkeypatch.setattr(reminder_handlers, "SessionLocal", lambda: session)
     reminder_handlers.commit = commit
 
-    def failing_commit(sess):
+    def failing_commit(sess: Session) -> bool:
         sess.rollback()
         return False
 


### PR DESCRIPTION
## Summary
- annotate failing_commit with Session type in reminder callback commit failure test

## Testing
- `ruff check tests/test_handlers_commit_failures.py`
- `mypy tests/test_handlers_commit_failures.py --follow-imports=skip`
- `pytest tests/test_handlers_commit_failures.py::test_reminder_callback_commit_failure -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0bc28e724832ab3488bc544b1c580