### PR TITLE
[ui] sanitize chart colors safely

### DIFF
--- a/services/webapp/ui/src/components/ui/chart.test.tsx
+++ b/services/webapp/ui/src/components/ui/chart.test.tsx
@@ -12,8 +12,23 @@ describe('ChartStyle', () => {
 
     const { container } = render(<ChartStyle id="test" config={config} />)
     const styleTag = container.querySelector('style')
-    expect(styleTag?.innerHTML).toContain('--color-safe: #ff0000')
-    expect(styleTag?.innerHTML).not.toContain('--color-unsafe')
-    expect(styleTag?.innerHTML).not.toContain('javascript')
+    const option = new Option()
+    option.style.color = '#ff0000'
+    expect(styleTag?.textContent).toContain(`--color-safe: ${option.style.color}`)
+    expect(styleTag?.textContent).not.toContain('--color-unsafe')
+    expect(styleTag?.textContent).not.toContain('javascript')
+  })
+
+  it('blocks style injections', () => {
+    const config: ChartConfig = {
+      safe: { color: '#00ff00' },
+      inject: { color: "</style><script>window.xss=true</script>" },
+    }
+
+    const { container } = render(<ChartStyle id="test" config={config} />)
+    const styleTag = container.querySelector('style')
+    expect(styleTag?.textContent).toContain('--color-safe')
+    expect(styleTag?.textContent).not.toContain('--color-inject')
+    expect(container.querySelector('script')).toBeNull()
   })
 })

--- a/services/webapp/ui/src/components/ui/chart.tsx
+++ b/services/webapp/ui/src/components/ui/chart.tsx
@@ -12,9 +12,8 @@ function sanitizeColor(color?: string): string | null {
   }
 
   const option = new Option()
-  option.style.color = ""
   option.style.color = color
-  return option.style.color ? color : null
+  return option.style.color || null
 }
 
 function buildStyleContent(id: string, config: ChartConfig): string {
@@ -106,7 +105,7 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
     return null
   }
 
-  return <style dangerouslySetInnerHTML={{ __html: styleContent }} />
+  return <style>{styleContent}</style>
 }
 
 const ChartTooltip = RechartsPrimitive.Tooltip


### PR DESCRIPTION
## Summary
- avoid returning unsanitized color strings in `sanitizeColor`
- drop `dangerouslySetInnerHTML` for style injection
- test that unsafe color values and style injections are ignored

## Testing
- `npx vitest run --environment jsdom src/components/ui/chart.test.tsx`
- `npx eslint src/components/ui/chart.tsx src/components/ui/chart.test.tsx`
- `ruff check services/api/app tests` *(fails: F811 Redefinition of unused `Any`)*
- `pytest tests/test_profile_ignores_sugar_conv.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0cbed6c5c832a80e13eb08dc7f6bb