### PR TITLE
[handlers] Remove redundant cast in timezone save

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -387,7 +387,7 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
     user_id = user.id
 
     def db_set_timezone(session: Session) -> tuple[bool, bool]:
-        return cast(tuple[bool, bool], set_timezone(session, user_id, raw))
+        return set_timezone(session, user_id, raw)
 
     exists, ok = await run_db(
         db_set_timezone, sessionmaker=SessionLocal

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -1,7 +1,4 @@
 from types import SimpleNamespace
-from typing import Any
-
-from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -1,8 +1,5 @@
 import os
 from types import SimpleNamespace
-from typing import Any
-
-from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest


### PR DESCRIPTION
## Summary
- remove redundant cast in profile timezone save handler
- clean up duplicate imports in tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: test_profile_self_valid_header, test_history_persist_and_update, test_history_concurrent_writes, test_timezone_persist_and_validate, test_timezone_partial_file, test_timezone_concurrent_writes, test_timezone_async_writes)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cbf71a2c832ab132bb93afe3d0a3