### PR TITLE
[handlers] Guard attributes for telegram objects

### DIFF
--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -25,7 +25,11 @@ async def sos_contact_start(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> int:
     """Prompt user to enter emergency contact."""
-    await update.message.reply_text(
+    message = update.message
+    if message is None:
+        return ConversationHandler.END
+    assert message is not None
+    await message.reply_text(
         "Введите контакт в Telegram (@username). Телефоны не поддерживаются.",
         reply_markup=back_keyboard,
     )
@@ -46,6 +50,7 @@ async def sos_contact_save(
     message = update.message
     if message is None or message.text is None:
         return ConversationHandler.END
+    assert message is not None
     contact = message.text.strip()
     if not _is_valid_contact(contact):
         await message.reply_text(
@@ -53,8 +58,11 @@ async def sos_contact_save(
             reply_markup=back_keyboard,
         )
         return SOS_CONTACT
-
-    user_id = update.effective_user.id
+    user = update.effective_user
+    if user is None:
+        return ConversationHandler.END
+    assert user is not None
+    user_id = user.id
     with SessionLocal() as session:
         profile = session.get(Profile, user_id)
         if not profile:
@@ -79,7 +87,11 @@ async def sos_contact_cancel(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> int:
     """Cancel SOS contact input."""
-    await update.message.reply_text("Отменено.", reply_markup=menu_keyboard)
+    message = update.message
+    if message is None:
+        return ConversationHandler.END
+    assert message is not None
+    await message.reply_text("Отменено.", reply_markup=menu_keyboard)
     return ConversationHandler.END
 
 


### PR DESCRIPTION
## Summary
- Guard `update.message` and `update.effective_user` before use in SOS contact handlers
- Add None checks for `callback_query`, `context.user_data`, and related message/user accesses in `callback_router`

## Testing
- `ruff check services/api/app tests` *(fails: F811 redefinition warnings in tests)*
- `pytest tests` *(fails: 7 tests - unauthorized responses)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cbffc214832aa3b6418aa6fdbf2c