### PR TITLE
[webapp] add medical button style

### DIFF
--- a/services/webapp/public/style.css
+++ b/services/webapp/public/style.css
@@ -108,3 +108,13 @@ form {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* Buttons */
+.medical-button {
+  background: #0b7285;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- style timezone webapp buttons with new `.medical-button` class

## Testing
- `ruff check services/api/app tests` *(fails: redefinition warnings in tests)*
- `pytest tests` *(fails: 7 failing tests)*


------
https://chatgpt.com/codex/tasks/task_e_68a0ce85b5ec832a9b37a33d84ee83bf