### PR TITLE
[typing] Parameterize Application and CallbackContext

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -9,7 +9,6 @@ from telegram.ext import (
     CommandHandler,
     ContextTypes,
     ExtBot,
-    JobQueue,
     MessageHandler,
     PollAnswerHandler,
     filters,
@@ -27,11 +26,9 @@ logger = logging.getLogger(__name__)
 def register_handlers(
     app: Application[
         ExtBot[None],
-        ContextTypes.DEFAULT_TYPE,
         dict[str, Any],
         dict[str, Any],
         dict[str, Any],
-        JobQueue[ContextTypes.DEFAULT_TYPE],
     ]
 ) -> None:
 

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -8,14 +8,13 @@ import sys
 from typing import Any
 
 from telegram import BotCommand
-from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
+from telegram.ext import Application, ContextTypes, ExtBot
 from sqlalchemy.exc import SQLAlchemyError
 
 from services.api.app.diabetes.services.db import init_db
 
 from services.api.app.config import settings
 
-DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]
 logger = logging.getLogger(__name__)
 
 
@@ -70,22 +69,18 @@ def main() -> None:
     async def post_init(
         app: Application[
             ExtBot[None],
-            ContextTypes.DEFAULT_TYPE,
             dict[str, Any],
             dict[str, Any],
             dict[str, Any],
-            DefaultJobQueue,
         ]
     ) -> None:
         await app.bot.set_my_commands(commands)
 
     application: Application[
         ExtBot[None],
-        ContextTypes.DEFAULT_TYPE,
         dict[str, Any],
         dict[str, Any],
         dict[str, Any],
-        DefaultJobQueue,
     ] = (
         Application.builder()
         .token(BOT_TOKEN)

--- a/tests/test_alert_stats.py
+++ b/tests/test_alert_stats.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 from services.api.app.diabetes.services.db import Base, Alert, User
 import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
@@ -93,7 +93,7 @@ async def test_alert_stats_counts(monkeypatch: pytest.MonkeyPatch) -> None:
 
     update = cast("Update", DummyUpdate(message=msg, effective_user=DummyUser(id=1)))
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         DummyContext(),
     )
 
@@ -110,7 +110,7 @@ async def test_alert_stats_returns_early(monkeypatch: pytest.MonkeyPatch) -> Non
 
     msg = DummyMessage()
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         DummyContext(),
     )
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, Optional, cast
 
 from telegram import Update
-from telegram.ext import CallbackContext, Job, JobQueue
+from telegram.ext import ExtBot, CallbackContext, Job, JobQueue
 
 from .context_stub import AlertContext, ContextStub
 
@@ -125,7 +125,7 @@ async def test_repeat_logic(monkeypatch: pytest.MonkeyPatch) -> None:
         )
         await handlers.alert_job(
             cast(
-                CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+                CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
                 context,
             )
         )
@@ -200,7 +200,7 @@ async def test_three_alerts_notify(monkeypatch: pytest.MonkeyPatch) -> None:
         await handlers.check_alert(
             update,
             cast(
-                CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+                CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
                 context,
             ),
             3,
@@ -209,7 +209,7 @@ async def test_three_alerts_notify(monkeypatch: pytest.MonkeyPatch) -> None:
     await handlers.check_alert(
         update,
         cast(
-            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+            CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
             context,
         ),
         3,
@@ -265,7 +265,7 @@ async def test_alert_message_without_coords(monkeypatch: pytest.MonkeyPatch) -> 
         await handlers.check_alert(
             update,
             cast(
-                CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+                CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
                 context,
             ),
             3,

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable, cast
 
 import pytest
 from telegram import Update
-from telegram.ext import BaseHandler, CallbackContext, MessageHandler
+from telegram.ext import BaseHandler, CallbackContext, ExtBot, MessageHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -48,7 +48,7 @@ async def test_photo_button_cancels_and_prompts_photo() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
     await handler.callback(update, context)

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -53,7 +53,7 @@ async def test_entry_without_dose_has_no_unit(
         "xe": 2.0,
     }
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         DummyContext(
             user_data={"pending_entry": pending_entry, "pending_fields": ["sugar"]}
         ),
@@ -104,7 +104,7 @@ async def test_entry_without_sugar_has_placeholder(
         "event_time": datetime.datetime.now(datetime.timezone.utc),
     }
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         DummyContext(
             user_data={"pending_entry": pending_entry, "pending_fields": ["dose"]}
         ),

--- a/tests/test_dose_sugar_missing.py
+++ b/tests/test_dose_sugar_missing.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext, ConversationHandler
+from telegram.ext import ExtBot, CallbackContext, ConversationHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -35,7 +35,7 @@ async def test_dose_sugar_requires_carbs_or_xe() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -84,7 +84,7 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, bot=DummyBot()),
     )
 

--- a/tests/test_freeform_handler_unknown.py
+++ b/tests/test_freeform_handler_unknown.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock
 
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
@@ -30,7 +30,7 @@ async def test_freeform_handler_unknown_command(
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={})
     )
 

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 
 class DummyMessage:
@@ -44,7 +44,7 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     query = DummyQuery(DummyMessage(), "cancel_entry")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"telegram_id": 1}}),
     )
 
@@ -73,7 +73,7 @@ async def test_callback_router_invalid_entry_id(
     query = DummyQuery(DummyMessage(), "del:abc")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -96,7 +96,7 @@ async def test_callback_router_unknown_data(
     query = DummyQuery(DummyMessage(), "foo")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -117,7 +117,7 @@ async def test_callback_router_ignores_reminder_action() -> None:
     query = DummyQuery(DummyMessage(), "rem_toggle:1")
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {}}),
     )
 

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from telegram import Bot, Update, User
-from telegram.ext import CallbackContext, ConversationHandler, Job, JobQueue
+from telegram.ext import ExtBot, CallbackContext, ConversationHandler, Job, JobQueue
 from services.api.app.diabetes.handlers import profile as profile_handlers
 import services.api.app.diabetes.handlers.router as router
 from services.api.app.diabetes.services.repository import commit
@@ -77,7 +77,7 @@ def make_update(**kwargs: Any) -> MagicMock:
 
 
 def make_context(**kwargs: Any) -> MagicMock:
-    context = MagicMock(spec=CallbackContext)
+    context = MagicMock(spec=CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]])
     for key, value in kwargs.items():
         setattr(context, key, value)
     return context

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 
 import pytest
 from telegram import Message, Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
@@ -54,7 +54,7 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=dummy_bot, user_data={}),
     )
 
@@ -87,7 +87,7 @@ async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> 
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -107,7 +107,7 @@ async def test_photo_handler_handles_typeerror() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -145,7 +145,7 @@ async def test_photo_handler_preserves_file(
 
     dummy_bot = SimpleNamespace(get_file=fake_get_file)
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=dummy_bot, user_data={"thread_id": "tid"}),
     )
 
@@ -238,7 +238,7 @@ async def test_photo_then_freeform_calculates_dose(
         SimpleNamespace(message=photo_msg, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=dummy_bot, user_data={"thread_id": "tid"}),
     )
 

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
@@ -37,7 +37,7 @@ async def test_freeform_handler_edits_pending_entry_keeps_state() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 
@@ -82,7 +82,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 
@@ -111,7 +111,7 @@ async def test_freeform_handler_sugar_only_flow() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 

--- a/tests/test_handlers_freeform_units.py
+++ b/tests/test_handlers_freeform_units.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
@@ -27,7 +27,7 @@ async def test_freeform_handler_warns_on_sugar_unit_mix() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -46,7 +46,7 @@ async def test_freeform_handler_warns_on_dose_unit_mix() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -67,7 +67,7 @@ async def test_freeform_handler_guidance_on_valueerror(
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 import pytest
 from telegram import InlineKeyboardMarkup, Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import sessionmaker
@@ -97,7 +97,7 @@ async def test_history_view_buttons(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -177,7 +177,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, bot=DummyBot()),
     )
 

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 from services.api.app.diabetes.handlers.dose_handlers import SessionLocal as SessionFactory
@@ -86,7 +86,7 @@ async def test_photo_flow_saves_entry(
         SimpleNamespace(message=msg_start, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
     await dose_handlers.freeform_handler(update_start, context)

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from unittest.mock import MagicMock
 from telegram import InlineKeyboardMarkup, Update
-from telegram.ext import CallbackContext, ConversationHandler
+from telegram.ext import ExtBot, CallbackContext, ConversationHandler
 
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
@@ -60,7 +60,7 @@ async def test_profile_command_and_view(monkeypatch: pytest.MonkeyPatch, args: A
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=123))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=args, user_data={}),
     )
 
@@ -77,7 +77,7 @@ async def test_profile_command_and_view(monkeypatch: pytest.MonkeyPatch, args: A
         Update, SimpleNamespace(message=message2, effective_user=SimpleNamespace(id=123))
     )
     context2 = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -124,7 +124,7 @@ async def test_profile_command_invalid_values(monkeypatch: pytest.MonkeyPatch, a
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=args, user_data={}),
     )
 
@@ -150,7 +150,7 @@ async def test_profile_command_help_and_dialog(monkeypatch: pytest.MonkeyPatch) 
         Update, SimpleNamespace(message=help_msg, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=["help"], user_data={}),
     )
     result = await handlers.profile_command(update, context)
@@ -163,7 +163,7 @@ async def test_profile_command_help_and_dialog(monkeypatch: pytest.MonkeyPatch) 
         Update, SimpleNamespace(message=dialog_msg, effective_user=SimpleNamespace(id=1))
     )
     context2 = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=[], user_data={}),
     )
     result2 = await handlers.profile_command(update2, context2)
@@ -197,7 +197,7 @@ async def test_profile_view_preserves_user_data(monkeypatch: pytest.MonkeyPatch)
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"thread_id": "tid", "foo": "bar"}),
     )
 
@@ -224,7 +224,7 @@ async def test_profile_view_missing_profile_shows_webapp_button(monkeypatch: pyt
         Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
     )
 

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 import pytest
 
@@ -31,7 +31,7 @@ async def test_prompt_photo_sends_message() -> None:
     await dose_handlers.prompt_photo(
         update,
         cast(
-            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+            CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
             SimpleNamespace(),
         ),
     )
@@ -45,7 +45,7 @@ async def test_prompt_sugar_sends_message() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
     await dose_handlers.prompt_sugar(update, context)
@@ -60,7 +60,7 @@ async def test_prompt_dose_sends_message() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
     await dose_handlers.prompt_dose(update, context)

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 
 class DummyMessage:
@@ -48,7 +48,7 @@ async def test_report_request_and_custom_flow(
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
 
@@ -126,7 +126,7 @@ async def test_report_period_callback_week(
         SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={})
     )
 

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 
@@ -41,7 +41,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
         pass
 
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(
             user_data={"thread_id": "tid"},
             bot=SimpleNamespace(

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -1,12 +1,11 @@
 from types import SimpleNamespace
 from typing import Any
 
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import cast
 
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 import services.api.app.diabetes.handlers.common_handlers as handlers
 
@@ -28,7 +27,7 @@ async def test_help_includes_new_features() -> None:
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message))
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
     )
 
@@ -49,7 +48,7 @@ async def test_help_includes_security_block() -> None:
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message))
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
     )
 
@@ -71,7 +70,7 @@ async def test_help_lists_reminder_commands_and_menu_button() -> None:
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message))
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
     )
 
@@ -91,7 +90,7 @@ async def test_help_lists_sos_contact_command() -> None:
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message))
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
     )
 

--- a/tests/test_history_view_async.py
+++ b/tests/test_history_view_async.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 import pytest
 
@@ -62,7 +62,7 @@ async def test_history_view_does_not_block_event_loop(monkeypatch: pytest.Monkey
         ),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
     )
 

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 import pytest
 from telegram.ext import CommandHandler
@@ -41,7 +41,7 @@ async def test_sugar_conv_menu_then_photo() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
 
@@ -66,7 +66,7 @@ async def test_dose_conv_menu_then_photo() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
 

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 import pytest
 from sqlalchemy import create_engine
@@ -62,7 +62,7 @@ async def test_onboarding_demo_photo_missing(monkeypatch: pytest.MonkeyPatch, ca
         ),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, bot_data={}),
     )
 

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from telegram import Update
-from telegram.ext import CallbackContext, ConversationHandler
+from telegram.ext import ExtBot, CallbackContext, ConversationHandler
 
 from services.api.app.diabetes.services.db import Base, User
 
@@ -80,7 +80,7 @@ async def test_onboarding_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         ),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, bot_data={}),
     )
 
@@ -140,7 +140,7 @@ async def test_onboarding_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         ),
     )
     context2 = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, bot_data={}),
     )
     state2 = await onboarding.start_command(update2, context2)

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -8,7 +8,7 @@ from typing import Any, Iterable, cast
 from telegram import Update
 
 import pytest
-from telegram.ext import BaseHandler, CallbackContext, MessageHandler
+from telegram.ext import BaseHandler, CallbackContext, ExtBot, MessageHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -25,12 +25,12 @@ def _find_handler(
     fallbacks: Iterable[
         BaseHandler[
             Update,
-            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+            CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         ]
     ],
     regex: str,
 ) -> MessageHandler[
-    CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+    CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]]
 ]:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
@@ -54,7 +54,7 @@ class DummyMessage:
 
 async def _exercise(
     handler: MessageHandler[
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]]
     ]
 ) -> None:
     message = DummyMessage("📷 Фото еды")
@@ -62,7 +62,7 @@ async def _exercise(
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}, "dose_method": "xe"}),
     )
     await handler.callback(update, context)

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -2,12 +2,11 @@ import os
 from types import SimpleNamespace
 from typing import Any
 
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import cast
 
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import ExtBot, CallbackContext
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -54,7 +53,7 @@ async def test_profile_input_not_logged_as_sugar(monkeypatch: pytest.MonkeyPatch
     )
     shared_chat_data: dict[str, Any] = {}
     sugar_context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, chat_data=shared_chat_data),
     )
     await dose_handlers.sugar_start(sugar_update, sugar_context)
@@ -70,7 +69,7 @@ async def test_profile_input_not_logged_as_sugar(monkeypatch: pytest.MonkeyPatch
         ),
     )
     prof_context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=[], user_data={}, chat_data=shared_chat_data),
     )
     result = await profile_handlers.profile_command(prof_update, prof_context)
@@ -89,7 +88,7 @@ async def test_profile_input_not_logged_as_sugar(monkeypatch: pytest.MonkeyPatch
         ),
     )
     icr_context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, chat_data=shared_chat_data),
     )
     result_icr = await profile_handlers.profile_icr(icr_update, icr_context)

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from typing import Any, Callable, cast
 
 from telegram import Message, Update, User
-from telegram.ext import CallbackContext, Job
+from telegram.ext import ExtBot, CallbackContext, Job
 
 from services.api.app.diabetes.services.db import Base, User as DbUser, Reminder, ReminderLog
 import services.api.app.diabetes.handlers.reminder_handlers as handlers
@@ -137,7 +137,7 @@ def make_update(**kwargs: Any) -> MagicMock:
 
 
 def make_context(**kwargs: Any) -> MagicMock:
-    context = MagicMock(spec=CallbackContext)
+    context = MagicMock(spec=CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]])
     for key, value in kwargs.items():
         setattr(context, key, value)
     return context
@@ -337,7 +337,7 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
     query = DummyCallbackQuery("rem_toggle:1", DummyMessage())
     update = make_update(callback_query=query, effective_user=make_user(1))
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         make_context(job_queue=job_queue, user_data={"pending_entry": {}}),
     )
     await handlers.reminder_action_cb(update, context)

--- a/tests/test_security_handlers.py
+++ b/tests/test_security_handlers.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import CallbackContext, ExtBot
 
 import services.api.app.diabetes.handlers.security_handlers as handlers
 
@@ -23,7 +23,7 @@ async def test_hypoalert_faq_returns_message() -> None:
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message))
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
     )
 

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 from telegram import Update
 
 import pytest
-from telegram.ext import CallbackContext, ConversationHandler, MessageHandler
+from telegram.ext import ExtBot, CallbackContext, ConversationHandler, MessageHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -43,7 +43,7 @@ async def test_sugar_back_fallback_cancels() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
     result = await handler.callback(update, context)
@@ -59,7 +59,7 @@ async def test_cancel_command_clears_state() -> None:
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext[ExtBot[None], dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
     result = await dose_handlers.dose_cancel(update, context)


### PR DESCRIPTION
## Summary
- standardize Application typing to use explicit bot/user/chat/bot data generics
- parameterize all CallbackContext usages with ExtBot

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200 in tests/test_profile_self.py::test_profile_self_valid_header, tests/test_webapp_history.py::test_history_persist_and_update, tests/test_webapp_history.py::test_history_concurrent_writes, tests/test_webapp_timezone.py::test_timezone_persist_and_validate, tests/test_webapp_timezone.py::test_timezone_partial_file, tests/test_webapp_timezone.py::test_timezone_concurrent_writes, tests/test_webapp_timezone.py::test_timezone_async_writes)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cc02c1f4832a92ddaabc884779a4