### PR TITLE
[handlers] allow CallbackQueryNoWarnHandler callbacks to return state

### DIFF
--- a/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
+++ b/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
@@ -5,7 +5,7 @@ from telegram import CallbackQuery, Update
 from telegram.ext import BaseHandler, ContextTypes
 
 CallbackQueryHandlerCallback = Callable[
-    [Update, ContextTypes.DEFAULT_TYPE], Coroutine[Any, Any, int]
+    [Update, ContextTypes.DEFAULT_TYPE], Coroutine[Any, Any, int | None]
 ]
 
 

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -1,7 +1,4 @@
 from types import SimpleNamespace
-from typing import Any
-
-from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -1,8 +1,5 @@
 import os
 from types import SimpleNamespace
-from typing import Any
-
-from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest


### PR DESCRIPTION
## Summary
- allow `CallbackQueryNoWarnHandler` callbacks to return optional conversation state
- deduplicate imports in tests to satisfy lint checks

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cc111c24832a9a33cecf31ab9f3b