### PR TITLE
[ui] Sanitize chart styles

### DIFF
--- a/services/webapp/ui/src/components/ui/chart.test.tsx
+++ b/services/webapp/ui/src/components/ui/chart.test.tsx
@@ -10,13 +10,18 @@ describe('ChartStyle', () => {
       unsafe: { color: "red; background: url(javascript:alert('xss'))" },
     }
 
-    const { container } = render(<ChartStyle id="test" config={config} />)
-    const styleTag = container.querySelector('style')
+    const { unmount } = render(<ChartStyle id="test" config={config} />)
+    const styleTag = document.head.querySelector(
+      'style[data-chart-style="test"]'
+    )
     const option = new Option()
     option.style.color = '#ff0000'
-    expect(styleTag?.textContent).toContain(`--color-safe: ${option.style.color}`)
+    expect(styleTag?.textContent).toContain(
+      `--color-safe: ${option.style.color}`
+    )
     expect(styleTag?.textContent).not.toContain('--color-unsafe')
     expect(styleTag?.textContent).not.toContain('javascript')
+    unmount()
   })
 
   it('blocks style injections', () => {
@@ -25,10 +30,13 @@ describe('ChartStyle', () => {
       inject: { color: "</style><script>window.xss=true</script>" },
     }
 
-    const { container } = render(<ChartStyle id="test" config={config} />)
-    const styleTag = container.querySelector('style')
+    const { unmount } = render(<ChartStyle id="test" config={config} />)
+    const styleTag = document.head.querySelector(
+      'style[data-chart-style="test"]'
+    )
     expect(styleTag?.textContent).toContain('--color-safe')
     expect(styleTag?.textContent).not.toContain('--color-inject')
-    expect(container.querySelector('script')).toBeNull()
+    expect(document.head.querySelector('script')).toBeNull()
+    unmount()
   })
 })

--- a/services/webapp/ui/src/components/ui/chart.tsx
+++ b/services/webapp/ui/src/components/ui/chart.tsx
@@ -6,13 +6,24 @@ import { cn } from "@/lib/utils"
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const
 
+const COLOR_REGEX = /^[-#a-zA-Z0-9(),.%\s]+$/
+
 function sanitizeColor(color?: string): string | null {
   if (!color) {
     return null
   }
+  const value = color.trim()
+
+  if (!COLOR_REGEX.test(value)) {
+    return null
+  }
+
+  if (value.includes("var(")) {
+    return value
+  }
 
   const option = new Option()
-  option.style.color = color
+  option.style.color = value
   return option.style.color || null
 }
 
@@ -99,13 +110,22 @@ const ChartContainer = React.forwardRef<
 ChartContainer.displayName = "Chart"
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
-  const styleContent = buildStyleContent(id, config)
+  React.useEffect(() => {
+    const styleContent = buildStyleContent(id, config)
+    if (!styleContent) {
+      return
+    }
 
-  if (!styleContent) {
-    return null
-  }
+    const style = document.createElement("style")
+    style.setAttribute("data-chart-style", id)
+    style.textContent = styleContent
+    document.head.appendChild(style)
+    return () => {
+      style.remove()
+    }
+  }, [id, config])
 
-  return <style>{styleContent}</style>
+  return null
 }
 
 const ChartTooltip = RechartsPrimitive.Tooltip


### PR DESCRIPTION
## Summary
- use DOM APIs to inject chart styles safely
- validate chart color values before applying CSS variables
- test style injection safeguards

## Testing
- `npx eslint src/components/ui/chart.tsx src/components/ui/chart.test.tsx`
- `npx vitest run src/components/ui/chart.test.tsx --environment jsdom`
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200)*


------
https://chatgpt.com/codex/tasks/task_e_68a0d202b7fc832a9bd189f11b460d82