### PR TITLE
[webapp] ensure timezone page loads Telegram initializer

### DIFF
--- a/services/webapp/public/telegram-init.js
+++ b/services/webapp/public/telegram-init.js
@@ -1,0 +1,28 @@
+(function () {
+    const app = window.Telegram?.WebApp;
+    if (!app) {
+        return;
+    }
+
+    const supportsColorMethods = () => {
+        const [major = 0, minor = 0] = (app.version || '0.0')
+            .split('.')
+            .map((n) => parseInt(n, 10));
+        if (app.platform === 'tdesktop') {
+            return major > 4 || (major === 4 && minor >= 8);
+        }
+        return major > 6 || (major === 6 && minor >= 1);
+    };
+
+    const applyTheme = () => {
+        if (supportsColorMethods()) {
+            if (app.setBackgroundColor) app.setBackgroundColor('#fff');
+            if (app.setHeaderColor) app.setHeaderColor('#fff');
+        }
+    };
+
+    app.expand?.();
+    applyTheme();
+    app.onEvent?.('themeChanged', applyTheme);
+})();
+

--- a/services/webapp/public/timezone.html
+++ b/services/webapp/public/timezone.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
     <title>Часовой пояс</title>
-    <script src="/ui/telegram-init.js"></script>
+    <script src="/telegram-init.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;


### PR DESCRIPTION
## Summary
- fix timezone webapp to reference telegram-init.js from public root
- add telegram-init.js to public directory

## Testing
- `curl -I http://localhost:8001/timezone.html`
- `curl -I http://localhost:8001/telegram-init.js`
- `pytest tests/test_timezone_button_webapp.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d59cd87c832aa8da1b3145254826