### PR TITLE
[tests] Use int HTTP status in doc handler test

### DIFF
--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from types import SimpleNamespace, TracebackType
+from http import HTTPStatus
 from typing import Any, cast
 
 import pytest
@@ -30,9 +31,9 @@ class DummyMessage(Message):
 async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) -> None:
     called = SimpleNamespace(flag=False)
 
-    async def fake_photo_handler(update, context) -> str:
+    async def fake_photo_handler(update, context) -> int:
         called.flag = True
-        return "OK"
+        return HTTPStatus.OK.value
 
     class DummyFile:
         async def download_to_drive(self, path) -> None:
@@ -63,7 +64,7 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
 
     result = await handlers.doc_handler(update, context)
 
-    assert result == "OK"
+    assert result == HTTPStatus.OK.value
     assert called.flag
     assert context.user_data["__file_path"] == "photos/1_uid.png"
     assert update.message.photo == ()


### PR DESCRIPTION
## Summary
- ensure doc handler test compares numeric HTTP status codes

## Testing
- `ruff check services/api/app tests/test_handlers_doc.py`
- `pytest tests/test_handlers_doc.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0d9760aac832aac49991a7e413065