### PR TITLE
[tests] add None checks before dict usage

### DIFF
--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -43,8 +43,10 @@ async def test_freeform_handler_edits_pending_entry_keeps_state() -> None:
 
     await handlers.freeform_handler(update, context)
 
-    assert context.user_data["pending_entry"]["dose"] == 3.5
-    assert context.user_data["pending_entry"]["carbs_g"] == 30.0
+    pending = context.user_data.get("pending_entry")
+    assert pending is not None
+    assert pending["dose"] == 3.5
+    assert pending["carbs_g"] == 30.0
     assert "pending_entry" in context.user_data
     assert message.replies
 
@@ -88,8 +90,11 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
 
     await handlers.freeform_handler(update, context)
 
-    assert context.user_data["pending_entry"]["sugar_before"] == 5.6
+    pending = context.user_data.get("pending_entry")
+    assert pending is not None
+    assert pending["sugar_before"] == 5.6
     assert "pending_entry" in context.user_data
+    assert message.replies
     text = message.replies[0]
     assert "5.6 ммоль/л" in text
 
@@ -117,5 +122,7 @@ async def test_freeform_handler_sugar_only_flow() -> None:
 
     await handlers.freeform_handler(update, context)
 
-    assert context.user_data["pending_entry"]["sugar_before"] == 4.2
+    pending = context.user_data.get("pending_entry")
+    assert pending is not None
+    assert pending["sugar_before"] == 4.2
     assert "pending_entry" in context.user_data

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -55,7 +55,10 @@ async def test_report_request_and_custom_flow(
     await reporting_handlers.report_request(update, context)
     assert "awaiting_report_date" not in context.user_data
     assert any("Выберите период" in t for t in message.replies)
-    assert message.kwargs[0].get("reply_markup") is not None
+    assert message.kwargs
+    first_kwargs = message.kwargs[0]
+    assert first_kwargs is not None
+    assert first_kwargs.get("reply_markup") is not None
 
     query = DummyQuery(DummyMessage(), "report_period:custom")
     update_cb = cast(
@@ -66,6 +69,7 @@ async def test_report_request_and_custom_flow(
     await reporting_handlers.report_period_callback(update_cb, context)
 
     assert context.user_data.get("awaiting_report_date") is True
+    assert query.edited
     assert any("YYYY-MM-DD" in text for text in query.edited)
 
     called = {}
@@ -135,5 +139,9 @@ async def test_report_period_callback_week(
     expected = (fixed_now - dt.timedelta(days=7)).replace(
         hour=0, minute=0, second=0, microsecond=0
     )
-    assert called["date_from"] == expected
-    assert called["period_label"] == "последнюю неделю"
+    date_from = called.get("date_from")
+    assert date_from is not None
+    assert date_from == expected
+    period_label = called.get("period_label")
+    assert period_label is not None
+    assert period_label == "последнюю неделю"

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -311,8 +311,12 @@ async def test_reminders_list_no_keyboard(monkeypatch: pytest.MonkeyPatch) -> No
     update = make_update(effective_user=make_user(1), message=message)
     context = make_context()
     await handlers.reminders_list(update, context)
-    assert "У вас нет напоминаний" in captured["text"]
-    assert "reply_markup" not in captured["kwargs"]
+    text = captured.get("text")
+    assert text is not None
+    assert "У вас нет напоминаний" in text
+    kwargs = captured.get("kwargs")
+    assert kwargs is not None
+    assert "reply_markup" not in kwargs
 
 
 @pytest.mark.asyncio
@@ -460,6 +464,7 @@ async def test_trigger_job_logs(monkeypatch: pytest.MonkeyPatch) -> None:
     await handlers.reminder_job(context)
     assert bot.messages
     _, text_msg, kwargs = bot.messages[0]
+    assert kwargs is not None
     assert text_msg.startswith("🔔 Замерить сахар")
     reply_markup = kwargs.get("reply_markup")
     assert reply_markup is not None


### PR DESCRIPTION
## Summary
- guard reply_markup kwargs in report request tests
- ensure pending_entry is present before indexing in freeform handler tests
- validate captured kwargs and job data in reminders tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_handlers_report_request.py tests/test_handlers_freeform_pending.py tests/test_reminders.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0d9741b0c832abc3989a199c7ce46