### PR TITLE
[tests] Annotate test function signatures

### DIFF
--- a/tests/test_history_view_async.py
+++ b/tests/test_history_view_async.py
@@ -25,26 +25,26 @@ class DummyMessage:
 async def test_history_view_does_not_block_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
     """The database query is executed in a thread and doesn't block."""
 
-    def slow_session():
+    def slow_session() -> Any:
         class FakeSession:
-            def __enter__(self):
+            def __enter__(self) -> "FakeSession":
                 return self
 
-            def __exit__(self, exc_type, exc, tb):
+            def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
                 pass
 
-            def query(self, *args, **kwargs):
+            def query(self, *args: Any, **kwargs: Any) -> Any:
                 class Q:
-                    def filter(self, *args, **kwargs):
+                    def filter(self, *args: Any, **kwargs: Any) -> "Q":
                         return self
 
-                    def order_by(self, *args, **kwargs):
+                    def order_by(self, *args: Any, **kwargs: Any) -> "Q":
                         return self
 
-                    def limit(self, *args, **kwargs):
+                    def limit(self, *args: Any, **kwargs: Any) -> "Q":
                         return self
 
-                    def all(self):
+                    def all(self) -> list[Any]:
                         time.sleep(0.5)  # Blocking call executed in to_thread
                         return []
 

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -25,7 +25,9 @@ class DummyMessage:
         self.kwargs.append(kwargs)
 
 
-def _get_menu_handler(fallbacks):
+def _get_menu_handler(
+    fallbacks: list[CommandHandler[Any]],
+) -> CommandHandler[Any]:
     return next(
         h
         for h in fallbacks

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -221,7 +221,7 @@ async def test_profile_security_add_delete_calls_handlers(monkeypatch: pytest.Mo
 
     called = {"del": False}
 
-    async def fake_del(update, context) -> None:
+    async def fake_del(update: Any, context: Any) -> None:
         called["del"] = True
 
     monkeypatch.setattr(reminder_handlers, "delete_reminder", fake_del)
@@ -260,7 +260,7 @@ async def test_profile_security_sos_contact_calls_handler(monkeypatch: pytest.Mo
 
     called = False
 
-    async def fake_sos(update, context) -> None:
+    async def fake_sos(update: Any, context: Any) -> None:
         nonlocal called
         called = True
 


### PR DESCRIPTION
## Summary
- add explicit parameter and return type hints in menu fallback, history view async, and profile security tests

## Testing
- `ruff check tests/test_profile_security.py tests/test_menu_fallbacks.py tests/test_history_view_async.py`
- `pytest tests/test_profile_security.py tests/test_menu_fallbacks.py tests/test_history_view_async.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0d963d948832ab3c796a74518b0ac