### PR TITLE
[handlers] Re-export stdlib modules

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
-import datetime
+# Re-export standard modules for tests and type checkers
+import datetime as datetime
 import asyncio
-import os
+import os as os
 import re
 from pathlib import Path
 
@@ -1172,6 +1173,8 @@ __all__ = [
     "PHOTO_SUGAR",
     "SUGAR_VAL",
     "WAITING_GPT_FLAG",
+    "datetime",
+    "os",
 
     "photo_prompt",
     "sugar_start",

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import datetime
+# Re-export for tests and type checkers
+import datetime as datetime
 import html
 import logging
 
@@ -378,6 +379,7 @@ async def send_report(
 
 
 __all__ = [
+    "datetime",
     "send_report",
     "report_request",
     "history_view",


### PR DESCRIPTION
## Summary
- re-export `datetime` in `reporting_handlers` so tests and mypy can access it
- re-export `datetime` and `os` in `dose_handlers` and expose them through `__all__`

## Testing
- `ruff check services/api/app tests`
- `mypy services/api/app/diabetes/handlers/reporting_handlers.py services/api/app/diabetes/handlers/dose_handlers.py`
- `pytest` *(fails: assert 401 == 200 in webapp timezone tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d9654dfc832aa66c76e51ecd5340