### PR TITLE
[handlers] Export profile state constants

### DIFF
--- a/services/api/app/diabetes/handlers/profile/__init__.py
+++ b/services/api/app/diabetes/handlers/profile/__init__.py
@@ -13,6 +13,13 @@ from .conversation import (
     profile_conv,
     profile_webapp_save,
     profile_webapp_handler,
+    PROFILE_ICR,
+    PROFILE_CF,
+    PROFILE_TARGET,
+    PROFILE_LOW,
+    PROFILE_HIGH,
+    PROFILE_TZ,
+    END,
 )
 from .validation import parse_profile_args
 
@@ -27,6 +34,13 @@ __all__ = [
     "profile_conv",
     "profile_webapp_save",
     "profile_webapp_handler",
+    "PROFILE_ICR",
+    "PROFILE_CF",
+    "PROFILE_TARGET",
+    "PROFILE_LOW",
+    "PROFILE_HIGH",
+    "PROFILE_TZ",
+    "END",
     "get_api",
     "save_profile",
     "set_timezone",
@@ -43,6 +57,33 @@ _conversation.set_timezone = set_timezone
 _conversation.fetch_profile = fetch_profile
 _conversation.post_profile = post_profile
 _conversation.parse_profile_args = parse_profile_args
+
+# Ensure constants are visible when importing this package
+_conversation.__all__ = [
+    "profile_command",
+    "profile_view",
+    "profile_cancel",
+    "profile_back",
+    "profile_security",
+    "profile_timezone",
+    "profile_edit",
+    "profile_conv",
+    "profile_webapp_save",
+    "profile_webapp_handler",
+    "PROFILE_ICR",
+    "PROFILE_CF",
+    "PROFILE_TARGET",
+    "PROFILE_LOW",
+    "PROFILE_HIGH",
+    "PROFILE_TZ",
+    "END",
+    "get_api",
+    "save_profile",
+    "set_timezone",
+    "fetch_profile",
+    "post_profile",
+    "parse_profile_args",
+]
 
 # Re-export the conversation module as the package itself for backward compatibility.
 import sys as _sys

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from unittest.mock import MagicMock
 from telegram import InlineKeyboardMarkup, Update
-from telegram.ext import CallbackContext, ConversationHandler
+from telegram.ext import CallbackContext
 
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
@@ -154,7 +154,7 @@ async def test_profile_command_help_and_dialog(monkeypatch: pytest.MonkeyPatch) 
         SimpleNamespace(args=["help"], user_data={}),
     )
     result = await handlers.profile_command(update, context)
-    assert result == ConversationHandler.END
+    assert result == handlers.END
     assert "Формат команды" in help_msg.texts[0]
 
     # Test starting dialog with empty args

--- a/tests/test_profile_constants.py
+++ b/tests/test_profile_constants.py
@@ -1,0 +1,17 @@
+from telegram.ext import ConversationHandler
+from services.api.app.diabetes.handlers import profile as profile_handlers
+
+
+def test_profile_state_constants() -> None:
+    states = [
+        profile_handlers.PROFILE_ICR,
+        profile_handlers.PROFILE_CF,
+        profile_handlers.PROFILE_TARGET,
+        profile_handlers.PROFILE_LOW,
+        profile_handlers.PROFILE_HIGH,
+        profile_handlers.PROFILE_TZ,
+    ]
+    # ensure state constants are unique and sequential starting from 0
+    assert states == list(range(6))
+    # ensure END constant matches ConversationHandler.END
+    assert profile_handlers.END == ConversationHandler.END


### PR DESCRIPTION
## Summary
- export profile conversation state constants from handler package
- adjust profile handler tests to rely on exported constants
- add tests ensuring profile state constants remain stable

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_handlers_profile.py tests/test_profile_constants.py tests/test_profile_ignores_sugar_conv.py -q`
- `pytest -q` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d9680ea0832ab3bc5579e5a34762