### PR TITLE
[tests] use typed session factory

### DIFF
--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -81,7 +81,8 @@ async def test_entry_without_dose_has_no_unit(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    monkeypatch.setattr(dose_handlers, "SessionLocal", lambda: DummySession())
+    session_factory = cast(type(dose_handlers.SessionLocal), lambda: DummySession())
+    monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
@@ -132,7 +133,8 @@ async def test_entry_without_sugar_has_placeholder(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    monkeypatch.setattr(dose_handlers, "SessionLocal", lambda: DummySession())
+    session_factory = cast(type(dose_handlers.SessionLocal), lambda: DummySession())
+    monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -259,7 +259,8 @@ async def test_photo_then_freeform_calculates_dose(
         def get(self, model, user_id):
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    handlers.SessionLocal = lambda: DummySession()
+    session_factory = cast(type(handlers.SessionLocal), lambda: DummySession())
+    handlers.SessionLocal = session_factory
 
     sugar_msg = DummyMessage(text="5")
     update_sugar = cast(

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -75,7 +75,8 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         def get(self, model, user_id):
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    handlers.SessionLocal = lambda: DummySession()
+    session_factory = cast(type(handlers.SessionLocal), lambda: DummySession())
+    handlers.SessionLocal = session_factory
     message = DummyMessage("5,6")
     update = cast(
         Update,


### PR DESCRIPTION
## Summary
- fix DummySession overrides by casting to SessionLocal type in tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: 7 failed, 243 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d96b262c832ab9cdced3601c3301