### PR TITLE
[tests] Use typed BaseHandler imports

### DIFF
--- a/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
+++ b/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
@@ -2,7 +2,8 @@ import re
 from typing import Any, Callable, Coroutine, Optional
 
 from telegram import CallbackQuery, Update
-from telegram.ext import BaseHandler, ContextTypes
+from telegram.ext import ContextTypes
+from telegram.ext._basehandler import BaseHandler
 
 CallbackQueryHandlerCallback = Callable[
     [Update, ContextTypes.DEFAULT_TYPE], Coroutine[Any, Any, int | None]

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -7,7 +7,8 @@ from typing import Any, Iterable, cast
 
 import pytest
 from telegram import Update
-from telegram.ext import BaseHandler, CallbackContext, MessageHandler
+from telegram.ext import CallbackContext, MessageHandler
+from telegram.ext._basehandler import BaseHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -16,9 +17,16 @@ from services.api.app.diabetes.handlers import dose_handlers
 
 
 def _find_handler(
-    fallbacks: Iterable[BaseHandler[Any]],
+    fallbacks: Iterable[
+        BaseHandler[
+            Update,
+            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        ]
+    ],
     regex: str,
-) -> MessageHandler[Any]:
+) -> MessageHandler[
+    CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+]:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -8,7 +8,8 @@ from typing import Any, Iterable, cast
 from telegram import Update
 
 import pytest
-from telegram.ext import BaseHandler, CallbackContext, MessageHandler
+from telegram.ext import CallbackContext, MessageHandler
+from telegram.ext._basehandler import BaseHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")


### PR DESCRIPTION
## Summary
- Import `BaseHandler` from `telegram.ext._basehandler` for precise typing
- Apply explicit type parameters to `BaseHandler` and `MessageHandler` in tests
- Align custom callback query handler import with typed base handler

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_photo_fallbacks.py tests/test_dose_conv_photo_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0d9724f1c832aa9b6ec2b8f709981