### PR TITLE
[ui] ensure tgFetch credentials default

### DIFF
--- a/services/webapp/ui/src/lib/tgFetch.ts
+++ b/services/webapp/ui/src/lib/tgFetch.ts
@@ -23,9 +23,9 @@ export async function tgFetch(
 
   try {
     return await fetch(input, {
-      credentials: "include",
       ...init,
       headers,
+      credentials: init.credentials ?? "include",
       signal: controller.signal,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- ensure tgFetch defaults to `credentials: "include"` unless overridden

## Testing
- `npm --workspace services/webapp/ui run lint` *(fails: rule violations in unrelated files)*
- `npm --workspace services/webapp/ui exec eslint src/lib/tgFetch.ts`
- `npm --workspace services/webapp/ui exec vitest run` *(fails: `document is not defined` in `src/components/ui/chart.test.tsx`)*
- `npm --workspace services/webapp/ui exec vitest run src/lib/tgFetch.test.ts src/api/tgFetch.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a0dd7649e8832ab7a4bcecef06f003