### PR TITLE
tests: type annotate helper functions

### DIFF
--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -31,12 +31,15 @@ class DummyMessage(Message):
 async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) -> None:
     called = SimpleNamespace(flag=False)
 
-    async def fake_photo_handler(update, context) -> int:
+    async def fake_photo_handler(
+        update: Update,
+        context: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+    ) -> int:
         called.flag = True
         return HTTPStatus.OK.value
 
     class DummyFile:
-        async def download_to_drive(self, path) -> None:
+        async def download_to_drive(self, path: str) -> None:
             self.path = path
 
     async def fake_get_file(file_id: str) -> DummyFile:
@@ -74,7 +77,10 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
 async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> None:
     called = SimpleNamespace(flag=False)
 
-    async def fake_photo_handler(update, context) -> None:
+    async def fake_photo_handler(
+        update: Update,
+        context: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+    ) -> None:
         called.flag = True
 
     document = SimpleNamespace(
@@ -138,7 +144,7 @@ async def test_photo_handler_preserves_file(
     )
 
     class DummyFile:
-        async def download_to_drive(self, path) -> None:
+        async def download_to_drive(self, path: str) -> None:
             Path(path).write_bytes(b"img")
 
     async def fake_get_file(file_id: str) -> DummyFile:
@@ -152,7 +158,7 @@ async def test_photo_handler_preserves_file(
 
     call = {}
 
-    async def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs: Any) -> Any:
         call.update(kwargs)
 
         class Run:
@@ -202,7 +208,7 @@ async def test_photo_then_freeform_calculates_dose(
         file_unique_id = "uid"
 
     class DummyFile:
-        async def download_to_drive(self, path) -> None:
+        async def download_to_drive(self, path: str) -> None:
             Path(path).write_bytes(b"img")
 
     async def fake_get_file(file_id: str) -> DummyFile:
@@ -216,7 +222,7 @@ async def test_photo_then_freeform_calculates_dose(
         thread_id = "tid"
         id = "runid"
 
-    async def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs: Any) -> Run:
         return Run()
 
     class DummyClient:
@@ -257,7 +263,7 @@ async def test_photo_then_freeform_calculates_dose(
         ) -> None:
             pass
 
-        def get(self, model, user_id):
+        def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
     session_factory = cast(type(handlers.SessionLocal), lambda: DummySession())

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -74,7 +74,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         ) -> None:
             pass
 
-        def get(self, model, user_id):
+        def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
     session_factory = cast(type(handlers.SessionLocal), lambda: DummySession())

--- a/tests/test_handlers_freeform_units.py
+++ b/tests/test_handlers_freeform_units.py
@@ -1,6 +1,6 @@
 import pytest
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, cast, NoReturn
 
 from telegram import Update
 from telegram.ext import CallbackContext
@@ -71,7 +71,7 @@ async def test_freeform_handler_guidance_on_valueerror(
         SimpleNamespace(user_data={}),
     )
 
-    def fake_smart_input(_):
+    def fake_smart_input(_: str) -> NoReturn:
         raise ValueError("boom")
 
     monkeypatch.setattr(handlers, "smart_input", fake_smart_input)

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -60,10 +60,10 @@ class DummySession:
     def add(self, entry: Any) -> None:
         self.added.append(entry)
 
-    def commit(self):
+    def commit(self) -> None:
         pass
 
-    def get(self, model, user_id):
+    def get(self, model: Any, user_id: int) -> SimpleNamespace:
         return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
 
@@ -113,7 +113,7 @@ async def test_photo_flow_saves_entry(
         thread_id = "tid"
         id = "runid"
 
-    async def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs: Any) -> Run:
         return Run()
 
     class DummyClient:

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -57,7 +57,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
         thread_id = "tid"
         id = "runid"
 
-    async def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs: Any) -> Run:
         captured["content"] = kwargs["content"]
         return Run()
 


### PR DESCRIPTION
## Summary
- add missing parameter and return annotations to test helpers

## Testing
- `ruff check tests`
- `pytest tests` *(fails: 7 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dee244b8832a827c804c5ef1d5f5