### PR TITLE
[handlers] Re-export std modules

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import logging
-# Re-export standard modules for tests and type checkers
-import datetime as datetime
 import asyncio
-import os as os
+import logging
 import re
 from pathlib import Path
+
+# Re-export standard modules for tests and type checkers
+import datetime as datetime
+import os as os
 
 from openai import OpenAIError
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 # Re-export for tests and type checkers
 import datetime as datetime
+import os as os
+
 import html
 import logging
 
@@ -380,6 +382,7 @@ async def send_report(
 
 __all__ = [
     "datetime",
+    "os",
     "send_report",
     "report_request",
     "history_view",


### PR DESCRIPTION
## Summary
- re-export `datetime` and `os` in report and dose handlers for tests and typing

## Testing
- `ruff check services/api/app tests`
- `mypy --ignore-missing-imports services/api/app/diabetes/handlers/reporting_handlers.py services/api/app/diabetes/handlers/dose_handlers.py`
- `pytest tests` *(fails: AssertionError 401 vs 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dee5a4ac832aba9a3efff695ab36