### PR TITLE
[handlers] Export profile state constants

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -877,4 +877,11 @@ __all__ = [
     "profile_conv",
     "profile_webapp_save",
     "profile_webapp_handler",
+    "PROFILE_ICR",
+    "PROFILE_CF",
+    "PROFILE_TARGET",
+    "PROFILE_LOW",
+    "PROFILE_HIGH",
+    "PROFILE_TZ",
+    "END",
 ]

--- a/tests/test_profile_constants.py
+++ b/tests/test_profile_constants.py
@@ -15,3 +15,14 @@ def test_profile_state_constants() -> None:
     assert states == list(range(6))
     # ensure END constant matches ConversationHandler.END
     assert profile_handlers.END == ConversationHandler.END
+    # ensure constants are exported via __all__
+    exported = {
+        "PROFILE_ICR",
+        "PROFILE_CF",
+        "PROFILE_TARGET",
+        "PROFILE_LOW",
+        "PROFILE_HIGH",
+        "PROFILE_TZ",
+        "END",
+    }
+    assert exported <= set(profile_handlers.__all__)


### PR DESCRIPTION
## Summary
- expose profile conversation state constants via __all__
- add test coverage ensuring constants exported and sequential

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_profile_constants.py -q`
- `pytest tests -q` *(fails: assert 401 == 200)*


------
https://chatgpt.com/codex/tasks/task_e_68a0dee7562c832a83ccf91e36be04eb