### PR TITLE
[tests] type session factories

### DIFF
--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
+from sqlalchemy.orm import sessionmaker
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -81,7 +82,7 @@ async def test_entry_without_dose_has_no_unit(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(type(dose_handlers.SessionLocal), lambda: DummySession())
+    session_factory = cast(sessionmaker, lambda: DummySession())
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
@@ -133,7 +134,7 @@ async def test_entry_without_sugar_has_placeholder(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(type(dose_handlers.SessionLocal), lambda: DummySession())
+    session_factory = cast(sessionmaker, lambda: DummySession())
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -3,6 +3,8 @@ from types import SimpleNamespace, TracebackType
 from http import HTTPStatus
 from typing import Any, cast
 
+from sqlalchemy.orm import sessionmaker
+
 import pytest
 from telegram import Message, Update
 from telegram.ext import CallbackContext
@@ -260,7 +262,7 @@ async def test_photo_then_freeform_calculates_dose(
         def get(self, model, user_id):
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(type(handlers.SessionLocal), lambda: DummySession())
+    session_factory = cast(sessionmaker, lambda: DummySession())
     handlers.SessionLocal = session_factory
 
     sugar_msg = DummyMessage(text="5")

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -2,6 +2,8 @@ import datetime
 from types import SimpleNamespace, TracebackType
 from typing import Any, cast
 
+from sqlalchemy.orm import sessionmaker
+
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
@@ -77,7 +79,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         def get(self, model, user_id):
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(type(handlers.SessionLocal), lambda: DummySession())
+    session_factory = cast(sessionmaker, lambda: DummySession())
     handlers.SessionLocal = session_factory
     message = DummyMessage("5,6")
     update = cast(

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from types import SimpleNamespace, TracebackType
 from typing import Any, cast
+
+from sqlalchemy.orm import sessionmaker
 from unittest.mock import Mock, PropertyMock
 
 import pytest
@@ -8,7 +10,6 @@ from telegram import Update
 from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
-from services.api.app.diabetes.handlers.dose_handlers import SessionLocal as SessionFactory
 import services.api.app.diabetes.handlers.router as router
 
 
@@ -161,7 +162,7 @@ async def test_photo_flow_saves_entry(
         Update,
         SimpleNamespace(message=msg_sugar, effective_user=SimpleNamespace(id=1)),
     )
-    session_factory = cast(type(SessionFactory), lambda: session)
+    session_factory = cast(sessionmaker, lambda: session)
     dose_handlers.SessionLocal = session_factory
     await dose_handlers.freeform_handler(update_sugar, context)
     assert context.user_data["pending_entry"]["sugar_before"] == 5.5


### PR DESCRIPTION
## Summary
- use sessionmaker factories in tests instead of assigning DummySession objects
- clean up unused imports in tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: 7 tests due to unauthorized responses)*
- `pytest tests/test_handlers_freeform_pending.py tests/test_dose_info_unit.py tests/test_handlers_photo_sugar_save.py tests/test_handlers_doc.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0dee831f8832a902fd340f146a8e3