### PR TITLE
[tests] Type BaseHandler generics in photo fallback tests

### DIFF
--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -7,8 +7,7 @@ from typing import Any, Iterable, cast
 
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext, MessageHandler
-from telegram.ext._basehandler import BaseHandler
+from telegram.ext import BaseHandler, CallbackContext, MessageHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -17,16 +16,9 @@ from services.api.app.diabetes.handlers import dose_handlers
 
 
 def _find_handler(
-    fallbacks: Iterable[
-        BaseHandler[
-            Update,
-            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        ]
-    ],
+    fallbacks: Iterable[BaseHandler[Update, CallbackContext]],
     regex: str,
-) -> MessageHandler[
-    CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
-]:
+) -> MessageHandler[CallbackContext]:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)
@@ -56,7 +48,7 @@ async def test_photo_button_cancels_and_prompts_photo() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext,
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
     await handler.callback(update, context)

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -8,8 +8,7 @@ from typing import Any, Iterable, cast
 from telegram import Update
 
 import pytest
-from telegram.ext import CallbackContext, MessageHandler
-from telegram.ext._basehandler import BaseHandler
+from telegram.ext import BaseHandler, CallbackContext, MessageHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -23,16 +22,9 @@ from services.api.app.diabetes.handlers import (
 
 
 def _find_handler(
-    fallbacks: Iterable[
-        BaseHandler[
-            Update,
-            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        ]
-    ],
+    fallbacks: Iterable[BaseHandler[Update, CallbackContext]],
     regex: str,
-) -> MessageHandler[
-    CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
-]:
+) -> MessageHandler[CallbackContext]:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)
@@ -53,17 +45,13 @@ class DummyMessage:
         self.kwargs.append(kwargs)
 
 
-async def _exercise(
-    handler: MessageHandler[
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
-    ]
-) -> None:
+async def _exercise(handler: MessageHandler[CallbackContext]) -> None:
     message = DummyMessage("📷 Фото еды")
     update = cast(
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        CallbackContext,
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}, "dose_method": "xe"}),
     )
     await handler.callback(update, context)


### PR DESCRIPTION
## Summary
- Import BaseHandler from telegram.ext and type it with Update and CallbackContext
- Simplify handler and context type hints in photo fallback tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_dose_conv_photo_fallback.py tests/test_photo_fallbacks.py`
- `pytest tests` *(fails: assert 401 == 200 in several webapp timezone tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0def10af4832a825aa13f6665db0f