### PR TITLE
[tests] Ensure dicts not None before use

### DIFF
--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -43,11 +43,13 @@ async def test_freeform_handler_edits_pending_entry_keeps_state() -> None:
 
     await handlers.freeform_handler(update, context)
 
-    pending = context.user_data.get("pending_entry")
+    user_data = context.user_data
+    assert user_data is not None
+    pending = user_data.get("pending_entry")
     assert pending is not None
     assert pending["dose"] == 3.5
     assert pending["carbs_g"] == 30.0
-    assert "pending_entry" in context.user_data
+    assert "pending_entry" in user_data
     assert message.replies
 
 
@@ -91,10 +93,12 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
 
     await handlers.freeform_handler(update, context)
 
-    pending = context.user_data.get("pending_entry")
+    user_data = context.user_data
+    assert user_data is not None
+    pending = user_data.get("pending_entry")
     assert pending is not None
     assert pending["sugar_before"] == 5.6
-    assert "pending_entry" in context.user_data
+    assert "pending_entry" in user_data
     assert message.replies
     text = message.replies[0]
     assert "5.6 ммоль/л" in text
@@ -123,7 +127,9 @@ async def test_freeform_handler_sugar_only_flow() -> None:
 
     await handlers.freeform_handler(update, context)
 
-    pending = context.user_data.get("pending_entry")
+    user_data = context.user_data
+    assert user_data is not None
+    pending = user_data.get("pending_entry")
     assert pending is not None
     assert pending["sugar_before"] == 4.2
-    assert "pending_entry" in context.user_data
+    assert "pending_entry" in user_data

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -53,7 +53,9 @@ async def test_report_request_and_custom_flow(
     )
 
     await reporting_handlers.report_request(update, context)
-    assert "awaiting_report_date" not in context.user_data
+    user_data = context.user_data
+    assert user_data is not None
+    assert "awaiting_report_date" not in user_data
     assert any("Выберите период" in t for t in message.replies)
     assert message.kwargs
     first_kwargs = message.kwargs[0]
@@ -68,7 +70,9 @@ async def test_report_request_and_custom_flow(
 
     await reporting_handlers.report_period_callback(update_cb, context)
 
-    assert context.user_data.get("awaiting_report_date") is True
+    user_data = context.user_data
+    assert user_data is not None
+    assert user_data.get("awaiting_report_date") is True
     assert query.edited
     assert any("YYYY-MM-DD" in text for text in query.edited)
 
@@ -92,8 +96,11 @@ async def test_report_request_and_custom_flow(
     )
     await dose_handlers.freeform_handler(update2, context)
 
-    assert called.get("called")
-    assert "awaiting_report_date" not in context.user_data
+    called_flag = called.get("called")
+    assert called_flag is not None
+    user_data = context.user_data
+    assert user_data is not None
+    assert "awaiting_report_date" not in user_data
 
 
 @pytest.mark.asyncio

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -358,7 +358,9 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
     assert query.answers
     answer = query.answers[0]
     assert answer == "Готово ✅"
-    assert "pending_entry" in context.user_data
+    user_data = context.user_data
+    assert user_data is not None
+    assert "pending_entry" in user_data
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- guard optional user_data before indexing in report request tests
- assert context user_data exists before working with pending entries in freeform pending tests
- check user_data before accessing pending reminder state

## Testing
- `ruff check services/api/app tests/test_handlers_report_request.py tests/test_handlers_freeform_pending.py tests/test_reminders.py`
- `pytest tests/test_handlers_report_request.py tests/test_handlers_freeform_pending.py tests/test_reminders.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0def29cc4832aa2f702ce504b6e45