### PR TITLE
[utils] Configure OpenAI proxy via httpx client

### DIFF
--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -1,25 +1,29 @@
 import logging
-import os
+
+import httpx
 from openai import OpenAI
+
 from services.api.app.config import settings
 
 
 def get_openai_client() -> OpenAI:
     """Return a configured OpenAI client.
 
-    Sets proxy environment variables and validates that required
-    credentials are provided.
+    Configures an ``httpx`` client for proxy support and validates that
+    required credentials are provided. The global environment is not
+    mutated, keeping proxy settings local to the OpenAI client.
     """
-    if settings.openai_proxy:
-        os.environ["HTTP_PROXY"] = settings.openai_proxy
-        os.environ["HTTPS_PROXY"] = settings.openai_proxy
 
     if not settings.openai_api_key:
         message = "OPENAI_API_KEY is not set"
         logging.error("[OpenAI] %s", message)
         raise RuntimeError(message)
 
-    client = OpenAI(api_key=settings.openai_api_key)
+    http_client: httpx.Client | None = None
+    if settings.openai_proxy:
+        http_client = httpx.Client(proxies=settings.openai_proxy)
+
+    client = OpenAI(api_key=settings.openai_api_key, http_client=http_client)
     if settings.openai_assistant_id:
         logging.info("[OpenAI] Using assistant: %s", settings.openai_assistant_id)
     return client


### PR DESCRIPTION
## Summary
- avoid mutating process-wide environment when setting OpenAI proxy
- configure OpenAI client with a dedicated httpx session

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: 7 failed, 244 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e298892c832aa8524698be403e1c