### PR TITLE
[tests] fix status comparison type

### DIFF
--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from types import SimpleNamespace, TracebackType
-from http import HTTPStatus
 from typing import Any, cast
 
 import pytest
@@ -33,7 +32,7 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
 
     async def fake_photo_handler(update, context) -> int:
         called.flag = True
-        return HTTPStatus.OK.value
+        return 200
 
     class DummyFile:
         async def download_to_drive(self, path) -> None:
@@ -64,7 +63,7 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
 
     result = await handlers.doc_handler(update, context)
 
-    assert result == HTTPStatus.OK.value
+    assert result == 200
     assert called.flag
     assert context.user_data["__file_path"] == "photos/1_uid.png"
     assert update.message.photo == ()


### PR DESCRIPTION
## Summary
- compare document handler results to integer status codes to avoid type mismatches

## Testing
- `ruff check tests/test_handlers_doc.py`
- `pytest tests/test_handlers_doc.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0def4ccf4832abee88a9ccb6c6af5