### PR TITLE
tests: cast date2num for precise typing

### DIFF
--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -4,7 +4,7 @@ import datetime
 import io
 import os
 from types import SimpleNamespace
-from typing import Any, BinaryIO
+from typing import Any, BinaryIO, Callable, cast
 
 import matplotlib.pyplot as plt
 from matplotlib.dates import date2num as _date2num
@@ -21,7 +21,7 @@ from services.api.app.diabetes.services.reporting import make_sugar_plot, genera
 
 def date2num(date: datetime.datetime) -> float:
     """Typed wrapper around :func:`matplotlib.dates.date2num`."""
-    return float(_date2num(date))
+    return float(cast(Callable[[datetime.datetime], float], _date2num)(date))
 
 
 def read_pdf(stream: BinaryIO) -> _PdfReader:


### PR DESCRIPTION
## Summary
- ensure typed `date2num` wrapper casts `matplotlib` function for mypy

## Testing
- `ruff check tests/test_reporting.py`
- `mypy --strict tests/test_reporting.py`
- `pytest tests/test_reporting.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0eb357ca4832a8b23077128bc9650