### PR TITLE
tests: assert user_data before access

### DIFF
--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -186,6 +186,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     await router.callback_router(update_cb, context)
+    assert context.user_data is not None
     assert context.user_data["edit_entry"] == {
         "id": entry_id,
         "chat_id": 42,
@@ -204,6 +205,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1)),
     )
     await router.callback_router(update_cb2, context)
+    assert context.user_data is not None
     assert context.user_data["edit_id"] == entry_id
     assert context.user_data["edit_field"] == "xe"
     assert context.user_data["edit_query"] is field_query
@@ -226,6 +228,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         assert entry_db.sugar_before == 5
 
     assert field_query.answer_texts[-1] == "Изменено"
+    assert context.user_data is not None
     assert not any(
         k in context.user_data for k in ("edit_id", "edit_field", "edit_entry", "edit_query")
     )


### PR DESCRIPTION
## Summary
- ensure callback data comprehension yields `list[str]`
- assert `context.user_data` is set before indexing in history edit tests

## Testing
- `ruff check tests/test_handlers_history_edit.py`
- `mypy tests/test_handlers_history_edit.py --ignore-missing-imports`
- `pytest tests/test_handlers_history_edit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0eb44650c832a8887809d6725c4b8