### PR TITLE
[tests] Assert context user_data before indexing

### DIFF
--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -87,6 +87,7 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, bot=DummyBot()),
     )
+    assert context.user_data is not None
 
     await router.callback_router(update_cb, context)
 
@@ -96,6 +97,7 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1)),
     )
     await router.callback_router(update_cb2, context)
+    assert context.user_data is not None
     assert context.user_data["edit_field"] == "dose"
 
     reply_msg = DummyMessage(text="5")

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -184,8 +184,10 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, bot=DummyBot()),
     )
+    assert context.user_data is not None
 
     await router.callback_router(update_cb, context)
+    assert context.user_data is not None
     assert context.user_data["edit_entry"] == {
         "id": entry_id,
         "chat_id": 42,
@@ -204,6 +206,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1)),
     )
     await router.callback_router(update_cb2, context)
+    assert context.user_data is not None
     assert context.user_data["edit_id"] == entry_id
     assert context.user_data["edit_field"] == "xe"
     assert context.user_data["edit_query"] is field_query
@@ -226,6 +229,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         assert entry_db.sugar_before == 5
 
     assert field_query.answer_texts[-1] == "Изменено"
+    assert context.user_data is not None
     assert not any(
         k in context.user_data for k in ("edit_id", "edit_field", "edit_entry", "edit_query")
     )


### PR DESCRIPTION
## Summary
- assert `context.user_data is not None` before accessing fields in edit record tests

## Testing
- `ruff check services/api/app tests`
- `mypy tests/test_edit_record.py tests/test_handlers_history_edit.py`
- `pytest tests` *(fails: 7 tests: unauthorized responses)*

------
https://chatgpt.com/codex/tasks/task_e_68a0eb4a3bd4832a953e99163738a868