### PR TITLE
[tests] assert pending entry presence

### DIFF
--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -100,5 +100,6 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
     # Final reply should include dish name from Vision response
     assert any("Борщ" in reply for reply in msg_photo.replies)
     entry = context.user_data.get("pending_entry")
+    assert entry is not None
     assert entry["carbs_g"] == 30
     assert entry["xe"] == 2


### PR DESCRIPTION
## Summary
- ensure vision prompt test checks that pending entry exists before subscripting

## Testing
- `ruff check tests/test_handlers_vision_prompt.py`
- `pytest tests/test_handlers_vision_prompt.py -q`
- `mypy -v tests/test_handlers_vision_prompt.py` *(fails: Library stubs not installed for "reportlab.pdfbase.pdfmetrics" )*

------
https://chatgpt.com/codex/tasks/task_e_68a0eb368420832aae7de6d3b59b36fe