### PR TITLE
refactor: cast context user data

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -80,10 +80,11 @@ async def photo_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
 async def sugar_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Prompt user for current sugar level."""
-    user_data = context.user_data
-    if user_data is None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
         return END
-    assert user_data is not None
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -112,10 +113,11 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     chat_data = getattr(context, "chat_data", None)
     if chat_data is not None and not chat_data.get("sugar_active"):
         return END
-    user_data = context.user_data
-    if user_data is None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
         return END
-    assert user_data is not None
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -160,10 +162,11 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Entry point for dose calculation conversation."""
-    user_data = context.user_data
-    if user_data is None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
         return END
-    assert user_data is not None
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -180,10 +183,11 @@ async def dose_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_method_choice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle method selection for dose calculation."""
-    user_data = context.user_data
-    if user_data is None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
         return END
-    assert user_data is not None
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -212,10 +216,11 @@ async def dose_method_choice(update: Update, context: ContextTypes.DEFAULT_TYPE)
 
 async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Capture XE amount from user."""
-    user_data = context.user_data
-    if user_data is None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
         return END
-    assert user_data is not None
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -248,10 +253,11 @@ async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Capture carbohydrates in grams."""
-    user_data = context.user_data
-    if user_data is None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
         return END
-    assert user_data is not None
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -286,10 +292,11 @@ async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Finalize dose calculation after receiving sugar level."""
-    user_data = context.user_data
-    if user_data is None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
         return END
-    assert user_data is not None
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -370,10 +377,11 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Cancel dose calculation conversation."""
-    user_data = context.user_data
-    if user_data is None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
         return END
-    assert user_data is not None
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -403,10 +411,11 @@ def _cancel_then(
 
 async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle freeform text commands for adding diary entries."""
-    user_data = context.user_data
-    if user_data is None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
         return
-    assert user_data is not None
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return
@@ -914,10 +923,11 @@ async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 
 async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo: bool = False) -> int:
     """Process food photos and trigger nutrition analysis."""
-    user_data = context.user_data
-    if user_data is None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
         return END
-    assert user_data is not None
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         query = update.callback_query
@@ -1175,10 +1185,11 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
 
 async def doc_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle images sent as documents."""
-    user_data = context.user_data
-    if user_data is None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
         return END
-    assert user_data is not None
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, cast
 
 from telegram import (
     InlineKeyboardButton,
@@ -122,10 +122,10 @@ async def onboarding_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         return ConversationHandler.END
     user_data_raw = context.user_data
     if user_data_raw is None:
-        user_data: dict[str, Any] = {}
-        context.user_data = user_data
-    else:
-        user_data = user_data_raw
+        context.user_data = {}
+        user_data_raw = context.user_data
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     try:
         icr = float(message.text.replace(",", "."))
     except ValueError:
@@ -149,10 +149,10 @@ async def onboarding_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         return ConversationHandler.END
     user_data_raw = context.user_data
     if user_data_raw is None:
-        user_data: dict[str, Any] = {}
-        context.user_data = user_data
-    else:
-        user_data = user_data_raw
+        context.user_data = {}
+        user_data_raw = context.user_data
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     try:
         cf = float(message.text.replace(",", "."))
     except ValueError:
@@ -175,10 +175,10 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     user = update.effective_user
     user_data_raw = context.user_data
     if user_data_raw is None:
-        user_data: dict[str, Any] = {}
-        context.user_data = user_data
-    else:
-        user_data = user_data_raw
+        context.user_data = {}
+        user_data_raw = context.user_data
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     if message is None or message.text is None or user is None:
         return ConversationHandler.END
     try:
@@ -461,10 +461,10 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     message = update.message
     user_data_raw = context.user_data
     if user_data_raw is None:
-        user_data: dict[str, Any] = {}
-        context.user_data = user_data
-    else:
-        user_data = user_data_raw
+        context.user_data = {}
+        user_data_raw = context.user_data
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     if message is None:
         return ConversationHandler.END
 

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
 from telegram.ext import (
     CommandHandler,
@@ -591,7 +591,12 @@ async def profile_edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
 
 async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle ICR input."""
-    user_data = context.user_data or {}
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        context.user_data = {}
+        user_data_raw = context.user_data
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     context.user_data = user_data
     message = update.message
     if message is None or message.text is None:
@@ -618,7 +623,12 @@ async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
 async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle CF input."""
-    user_data = context.user_data or {}
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        context.user_data = {}
+        user_data_raw = context.user_data
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     context.user_data = user_data
     message = update.message
     if message is None or message.text is None:
@@ -649,7 +659,12 @@ async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle target BG input."""
-    user_data = context.user_data or {}
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        context.user_data = {}
+        user_data_raw = context.user_data
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     context.user_data = user_data
     message = update.message
     if message is None or message.text is None:
@@ -684,7 +699,12 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle low threshold input."""
-    user_data = context.user_data or {}
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        context.user_data = {}
+        user_data_raw = context.user_data
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     context.user_data = user_data
     message = update.message
     if message is None or message.text is None:
@@ -717,7 +737,12 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     return PROFILE_HIGH
 async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle high threshold input and save profile."""
-    user_data = context.user_data or {}
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        context.user_data = {}
+        user_data_raw = context.user_data
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     context.user_data = user_data
     message = update.message
     if message is None or message.text is None:

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -190,10 +190,10 @@ async def report_period_callback(
     elif period == "custom":
         user_data_raw = context.user_data
         if user_data_raw is None:
-            user_data: dict[str, Any] = {}
-            context.user_data = user_data
-        else:
-            user_data = user_data_raw
+            context.user_data = {}
+            user_data_raw = context.user_data
+        assert user_data_raw is not None
+        user_data = cast(dict[str, Any], user_data_raw)
         user_data["awaiting_report_date"] = True
         await query.edit_message_text(
             "Введите дату начала отчёта в формате YYYY-MM-DD\n"
@@ -275,10 +275,10 @@ async def send_report(
     gpt_text: str | None = default_gpt_text
     user_data_raw = context.user_data
     if user_data_raw is None:
-        user_data: dict[str, Any] = {}
-        context.user_data = user_data
-    else:
-        user_data = user_data_raw
+        context.user_data = {}
+        user_data_raw = context.user_data
+    assert user_data_raw is not None
+    user_data = cast(dict[str, Any], user_data_raw)
     thread_id = cast(str | None, user_data.get("thread_id"))
     if thread_id is None:
         with SessionLocal() as session:

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ForceReply
 from telegram.ext import ContextTypes
+from typing import Any, cast
 
 from services.api.app.diabetes.services.db import Entry, SessionLocal
 from services.api.app.diabetes.utils.ui import menu_keyboard
@@ -25,10 +26,11 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         return
 
     if data == "confirm_entry":
-        user_data = context.user_data
-        if user_data is None:
+        user_data_raw = context.user_data
+        if user_data_raw is None:
             return
-        assert user_data is not None
+        assert user_data_raw is not None
+        user_data = cast(dict[str, Any], user_data_raw)
         entry_data = user_data.pop("pending_entry", None)
         if not entry_data:
             await query.edit_message_text("❗ Нет данных для сохранения.")
@@ -55,10 +57,11 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             reminder_handlers.schedule_after_meal(user.id, job_queue)
         return
     elif data == "edit_entry":
-        user_data = context.user_data
-        if user_data is None:
+        user_data_raw = context.user_data
+        if user_data_raw is None:
             return
-        assert user_data is not None
+        assert user_data_raw is not None
+        user_data = cast(dict[str, Any], user_data_raw)
         entry_data = user_data.get("pending_entry")
         if not entry_data:
             await query.edit_message_text("❗ Нет данных для редактирования.")
@@ -72,10 +75,11 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         )
         return
     elif data == "cancel_entry":
-        user_data = context.user_data
-        if user_data is None:
+        user_data_raw = context.user_data
+        if user_data_raw is None:
             return
-        assert user_data is not None
+        assert user_data_raw is not None
+        user_data = cast(dict[str, Any], user_data_raw)
         user_data.pop("pending_entry", None)
         await query.edit_message_text("❌ Запись отменена.")
         message = query.message
@@ -114,10 +118,11 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 await query.edit_message_text("❌ Запись удалена.")
                 return
             if action == "edit":
-                user_data = context.user_data
-                if user_data is None:
+                user_data_raw = context.user_data
+                if user_data_raw is None:
                     return
-                assert user_data is not None
+                assert user_data_raw is not None
+                user_data = cast(dict[str, Any], user_data_raw)
                 message = query.message
                 if message is None:
                     return
@@ -157,10 +162,11 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             logger.warning("Invalid edit_field data: %s", data)
             await query.edit_message_text("Некорректные данные для редактирования.")
             return
-        user_data = context.user_data
-        if user_data is None:
+        user_data_raw = context.user_data
+        if user_data_raw is None:
             return
-        assert user_data is not None
+        assert user_data_raw is not None
+        user_data = cast(dict[str, Any], user_data_raw)
         user_data["edit_id"] = edit_entry_id
         user_data["edit_field"] = field
         user_data["edit_query"] = query

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -79,7 +79,11 @@ async def test_report_request_and_custom_flow(
     called = {}
 
     async def dummy_send_report(
-        update, context, date_from, period_label, query=None
+        update: Update,
+        context: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        date_from: dt.datetime,
+        period_label: str,
+        query: DummyQuery | None = None,
     ) -> None:
         called["called"] = True
         expected = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
@@ -115,7 +119,11 @@ async def test_report_period_callback_week(
     called: dict[str, dt.datetime | str] = {}
 
     async def dummy_send_report(
-        update, context, date_from, period_label, query=None
+        update: Update,
+        context: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        date_from: dt.datetime,
+        period_label: str,
+        query: DummyQuery | None = None,
     ) -> None:
         called["date_from"] = date_from
         called["period_label"] = period_label


### PR DESCRIPTION
## Summary
- assert context.user_data is present and cast to dict[str, Any]
- add annotations for dummy_send_report helper in tests

## Testing
- `mypy services/api/app/diabetes/handlers/router.py services/api/app/diabetes/handlers/dose_handlers.py services/api/app/diabetes/handlers/onboarding_handlers.py services/api/app/diabetes/handlers/profile/conversation.py services/api/app/diabetes/handlers/reporting_handlers.py tests/test_handlers_report_request.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0eb36f874832a9d2208e51c7016d1