### PR TITLE
[tests] Mark fake_smart_input helper as no cover

### DIFF
--- a/tests/test_handlers_freeform_units.py
+++ b/tests/test_handlers_freeform_units.py
@@ -71,7 +71,7 @@ async def test_freeform_handler_guidance_on_valueerror(
         SimpleNamespace(user_data={}),
     )
 
-    def fake_smart_input(_: str) -> NoReturn:
+    def fake_smart_input(_: str) -> NoReturn:  # pragma: no cover
         raise ValueError("boom")
 
     monkeypatch.setattr(handlers, "smart_input", fake_smart_input)


### PR DESCRIPTION
## Summary
- exclude `fake_smart_input` helper from coverage

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_handlers_freeform_units.py::test_freeform_handler_guidance_on_valueerror -q`
- `pytest tests/ -q` *(fails: assert 401 == 200)*
- `mypy --hide-error-context tests/test_handlers_freeform_units.py` *(fails: Library stubs not installed for "reportlab.pdfbase.pdfmetrics")*

------
https://chatgpt.com/codex/tasks/task_e_68a0eb3994dc832a99ea006f2c3d97f4