### PR TITLE
[tests] Guard user_data access and tighten DummySession cast

### DIFF
--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from types import SimpleNamespace, TracebackType
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 from sqlalchemy.orm import sessionmaker
 
@@ -105,6 +105,7 @@ async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert result == handlers.ConversationHandler.END
     assert not called.flag
+    assert context.user_data is not None
     assert "__file_path" not in context.user_data
 
 
@@ -123,6 +124,7 @@ async def test_photo_handler_handles_typeerror() -> None:
 
     assert message.texts == ["❗ Файл не распознан как изображение."]
     assert result == handlers.ConversationHandler.END
+    assert context.user_data is not None
     assert handlers.WAITING_GPT_FLAG not in context.user_data
 
 
@@ -267,7 +269,7 @@ async def test_photo_then_freeform_calculates_dose(
         def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(sessionmaker, lambda: DummySession())
+    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
     handlers.SessionLocal = session_factory
 
     sugar_msg = DummyMessage(text="5")

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -99,6 +99,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
     assert "название" in captured["content"]
     # Final reply should include dish name from Vision response
     assert any("Борщ" in reply for reply in msg_photo.replies)
+    assert context.user_data is not None
     entry = context.user_data.get("pending_entry")
     assert entry["carbs_g"] == 30
     assert entry["xe"] == 2


### PR DESCRIPTION
## Summary
- ensure `context.user_data` is not `None` before membership or `.get` checks in tests
- cast DummySession factory to `Callable[[], DummySession]`

## Testing
- `pytest tests/test_handlers_doc.py tests/test_handlers_vision_prompt.py`
- `mypy tests/test_handlers_doc.py tests/test_handlers_vision_prompt.py` *(fails: process produced excessive logging and did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_68a0eb3b3c14832ab51439f3ea9b5342