### PR TITLE
tests: decouple dummy message from telegram

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -9,3 +9,6 @@ ignore_missing_imports = True
 
 [mypy-diabetes_sdk.*]
 ignore_missing_imports = True
+
+[mypy-reportlab.*]
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- replace Message subclass with simple dataclass in doc handler tests
- guard context.user_data lookups and ignore reportlab imports in mypy config

## Testing
- `mypy tests/test_handlers_doc.py`
- `mypy services/api/app/diabetes/handlers/dose_handlers.py`
- `ruff check services/api/app tests/test_handlers_doc.py`
- `pytest tests/test_handlers_doc.py`
- `pytest` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a0eb3cbfb0832a86d0d17c61d896b5