### PR TITLE
tests: refine session factory typing

### DIFF
--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -4,12 +4,11 @@ import datetime
 import os
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
-from sqlalchemy.orm import sessionmaker
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -82,7 +81,7 @@ async def test_entry_without_dose_has_no_unit(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(sessionmaker, lambda: DummySession())
+    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
@@ -134,7 +133,7 @@ async def test_entry_without_sugar_has_placeholder(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(sessionmaker, lambda: DummySession())
+    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -1,8 +1,7 @@
 import datetime
 from types import SimpleNamespace, TracebackType
-from typing import Any, cast
+from typing import Any, Callable, cast
 
-from sqlalchemy.orm import sessionmaker
 
 import pytest
 from telegram import Update
@@ -81,7 +80,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(sessionmaker, lambda: DummySession())
+    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
     handlers.SessionLocal = session_factory
     message = DummyMessage("5,6")
     update = cast(


### PR DESCRIPTION
## Summary
- use `Callable[[], DummySession]` when stubbing `SessionLocal` in tests
- assert or cache `context.user_data` before subscripting to satisfy type checker

## Testing
- `ruff check tests/test_handlers_freeform_pending.py tests/test_dose_info_unit.py tests/test_handlers_doc.py tests/test_handlers_photo_sugar_save.py`
- `pytest tests/test_handlers_freeform_pending.py tests/test_dose_info_unit.py tests/test_handlers_doc.py tests/test_handlers_photo_sugar_save.py`
- `mypy tests/test_handlers_freeform_pending.py` *(fails: Library stubs not installed for "reportlab.pdfbase.pdfmetrics")*

------
https://chatgpt.com/codex/tasks/task_e_68a0eb3e1748832a912e8d89510cbdb2