### PR TITLE
[handlers] Guard user_data and refine test type hints

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -81,9 +81,8 @@ async def photo_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 async def sugar_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Prompt user for current sugar level."""
     user_data = context.user_data
-    if user_data is None:
+    if not isinstance(user_data, dict):
         return END
-    assert user_data is not None
     message = update.message
     if message is None:
         return END
@@ -213,9 +212,8 @@ async def dose_method_choice(update: Update, context: ContextTypes.DEFAULT_TYPE)
 async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Capture XE amount from user."""
     user_data = context.user_data
-    if user_data is None:
+    if not isinstance(user_data, dict):
         return END
-    assert user_data is not None
     message = update.message
     if message is None:
         return END
@@ -249,9 +247,8 @@ async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Capture carbohydrates in grams."""
     user_data = context.user_data
-    if user_data is None:
+    if not isinstance(user_data, dict):
         return END
-    assert user_data is not None
     message = update.message
     if message is None:
         return END
@@ -287,9 +284,8 @@ async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Finalize dose calculation after receiving sugar level."""
     user_data = context.user_data
-    if user_data is None:
+    if not isinstance(user_data, dict):
         return END
-    assert user_data is not None
     message = update.message
     if message is None:
         return END
@@ -404,9 +400,8 @@ def _cancel_then(
 async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle freeform text commands for adding diary entries."""
     user_data = context.user_data
-    if user_data is None:
+    if not isinstance(user_data, dict):
         return
-    assert user_data is not None
     message = update.message
     if message is None:
         return
@@ -915,9 +910,8 @@ async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo: bool = False) -> int:
     """Process food photos and trigger nutrition analysis."""
     user_data = context.user_data
-    if user_data is None:
+    if not isinstance(user_data, dict):
         return END
-    assert user_data is not None
     message = update.message
     if message is None:
         query = update.callback_query

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -4,12 +4,11 @@ import datetime
 import os
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
-from sqlalchemy.orm import sessionmaker
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -82,7 +81,7 @@ async def test_entry_without_dose_has_no_unit(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(sessionmaker, lambda: DummySession())
+    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
@@ -134,7 +133,7 @@ async def test_entry_without_sugar_has_placeholder(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(sessionmaker, lambda: DummySession())
+    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 from types import SimpleNamespace, TracebackType
-from typing import Any, cast
+from typing import Any, Callable, cast
 
-from sqlalchemy.orm import sessionmaker
 
 import pytest
 from telegram import Message, Update
@@ -267,7 +266,7 @@ async def test_photo_then_freeform_calculates_dose(
         def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(sessionmaker, lambda: DummySession())
+    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
     handlers.SessionLocal = session_factory
 
     sugar_msg = DummyMessage(text="5")

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -1,8 +1,7 @@
 import datetime
 from types import SimpleNamespace, TracebackType
-from typing import Any, cast
+from typing import Any, Callable, cast
 
-from sqlalchemy.orm import sessionmaker
 
 import pytest
 from telegram import Update
@@ -81,7 +80,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(sessionmaker, lambda: DummySession())
+    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
     handlers.SessionLocal = session_factory
     message = DummyMessage("5,6")
     update = cast(

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 from types import SimpleNamespace, TracebackType
-from typing import Any, cast
+from typing import Any, Callable, cast
 
-from sqlalchemy.orm import sessionmaker
 from unittest.mock import Mock, PropertyMock
 
 import pytest
@@ -44,8 +43,8 @@ class DummyPhoto:
 
 
 class DummySession:
-    def __init__(self):
-        self.added = []
+    def __init__(self) -> None:
+        self.added: list[Any] = []
 
     def __enter__(self) -> "DummySession":
         return self
@@ -162,8 +161,10 @@ async def test_photo_flow_saves_entry(
         Update,
         SimpleNamespace(message=msg_sugar, effective_user=SimpleNamespace(id=1)),
     )
-    session_factory = cast(sessionmaker, lambda: session)
-    dose_handlers.SessionLocal = session_factory
+    def session_factory() -> DummySession:
+        return session
+
+    dose_handlers.SessionLocal = cast(Callable[[], DummySession], session_factory)
     await dose_handlers.freeform_handler(update_sugar, context)
     assert context.user_data["pending_entry"]["sugar_before"] == 5.5
 

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -172,7 +172,7 @@ def test_schedule_with_next_interval(monkeypatch: pytest.MonkeyPatch) -> None:
 
     class DummyDatetime(datetime):
         @classmethod
-        def now(cls):  # type: ignore[override]
+        def now(cls) -> datetime:
             return now
 
     monkeypatch.setattr(handlers, "datetime", DummyDatetime)


### PR DESCRIPTION
## Summary
- check that `context.user_data` is a dict before assigning `pending_entry`
- use Callable dummy session factories in tests and annotate helper stubs
- add return annotations to test utilities

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200)*
- `mypy --config-file mypy.ini services/api/app`


------
https://chatgpt.com/codex/tasks/task_e_68a0eb42b93c832ab368a1667d8f1152