### PR TITLE
[profile] Define profile_icr for MyPy

### DIFF
--- a/services/api/app/diabetes/handlers/profile/__init__.py
+++ b/services/api/app/diabetes/handlers/profile/__init__.py
@@ -1,5 +1,7 @@
 """Expose profile conversation handlers and helpers."""
 
+from typing import Any
+
 from . import conversation as _conversation
 from .api import get_api, save_profile, set_timezone, fetch_profile, post_profile
 from .conversation import (
@@ -95,4 +97,9 @@ _conversation.__all__ = [
 import sys as _sys
 
 _sys.modules[__name__] = _conversation
+profile_icr = _conversation.profile_icr
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_conversation, name)
 


### PR DESCRIPTION
## Summary
- Expose `profile_icr` as a module-level attribute
- Delegate dynamic attribute lookups to the conversation module for typing

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200 in several test cases)*
- `mypy services/api/app/diabetes/handlers/profile` *(fails: Library stubs not installed for reportlab.*)


------
https://chatgpt.com/codex/tasks/task_e_68a0f18e2618832ab9b34a607676dedb