### PR TITLE
[tests] use non-optional user_data in pending_entry lookups

### DIFF
--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -59,7 +59,8 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     kwargs = query.message.kwargs[0]
     assert kwargs.get("reply_markup") == common_handlers.menu_keyboard
     assert context.user_data is not None
-    assert "pending_entry" not in context.user_data
+    user_data: dict[str, Any] = context.user_data
+    assert "pending_entry" not in user_data
 
 
 @pytest.mark.asyncio
@@ -126,4 +127,5 @@ async def test_callback_router_ignores_reminder_action() -> None:
 
     assert query.edited == []
     assert context.user_data is not None
-    assert "pending_entry" in context.user_data
+    user_data: dict[str, Any] = context.user_data
+    assert "pending_entry" in user_data

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -100,7 +100,8 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
     # Final reply should include dish name from Vision response
     assert any("Борщ" in reply for reply in msg_photo.replies)
     assert context.user_data is not None
-    entry = context.user_data.get("pending_entry")
+    user_data: dict[str, Any] = context.user_data
+    entry = user_data.get("pending_entry")
     assert entry is not None
     assert entry["carbs_g"] == 30
     assert entry["xe"] == 2


### PR DESCRIPTION
## Summary
- Assign `context.user_data` to a typed `user_data` variable after null checks
- Use typed `user_data` in tests when accessing `pending_entry`

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f1903db4832a9f5ecd6f3ca10bd4