### PR TITLE
[tests] annotate dummy helpers

### DIFF
--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime as dt
 import os
 from types import SimpleNamespace
@@ -76,7 +78,7 @@ async def test_report_request_and_custom_flow(
     assert query.edited
     assert any("YYYY-MM-DD" in text for text in query.edited)
 
-    called = {}
+    called: dict[str, bool] = {}
 
     async def dummy_send_report(
         update: Update,


### PR DESCRIPTION
## Summary
- add `from __future__ import annotations` to report request tests
- type `called` dictionary used by dummy helper

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f1915004832a840d05f6d5bf79cd