### PR TITLE
[handlers] Export back_keyboard and type-safe user data access

### DIFF
--- a/services/api/app/diabetes/handlers/profile/__init__.py
+++ b/services/api/app/diabetes/handlers/profile/__init__.py
@@ -2,6 +2,7 @@
 
 from . import conversation as _conversation
 from .api import get_api, save_profile, set_timezone, fetch_profile, post_profile
+from services.api.app.diabetes.utils.ui import back_keyboard
 from .conversation import (
     profile_command,
     profile_view,
@@ -14,7 +15,6 @@ from .conversation import (
     profile_icr,
     profile_webapp_save,
     profile_webapp_handler,
-    back_keyboard,
     PROFILE_ICR,
     PROFILE_CF,
     PROFILE_TARGET,
@@ -61,6 +61,7 @@ _conversation.set_timezone = set_timezone
 _conversation.fetch_profile = fetch_profile
 _conversation.post_profile = post_profile
 _conversation.parse_profile_args = parse_profile_args
+_conversation.back_keyboard = back_keyboard
 
 # Ensure constants are visible when importing this package
 _conversation.__all__ = [

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -98,7 +98,8 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data is not None
-    assert context.user_data["edit_field"] == "dose"
+    user_data = cast(dict[str, Any], context.user_data)
+    assert user_data["edit_field"] == "dose"
 
     reply_msg = DummyMessage(text="5")
     update_msg = cast(

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -188,7 +188,8 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await router.callback_router(update_cb, context)
     assert context.user_data is not None
-    assert context.user_data["edit_entry"] == {
+    user_data = cast(dict[str, Any], context.user_data)
+    assert user_data["edit_entry"] == {
         "id": entry_id,
         "chat_id": 42,
         "message_id": 24,
@@ -207,9 +208,10 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data is not None
-    assert context.user_data["edit_id"] == entry_id
-    assert context.user_data["edit_field"] == "xe"
-    assert context.user_data["edit_query"] is field_query
+    user_data = cast(dict[str, Any], context.user_data)
+    assert user_data["edit_id"] == entry_id
+    assert user_data["edit_field"] == "xe"
+    assert user_data["edit_query"] is field_query
     assert any("Введите" in t for t in entry_message.replies)
 
     reply_msg = DummyMessage(text="3")
@@ -230,8 +232,9 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert field_query.answer_texts[-1] == "Изменено"
     assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     assert not any(
-        k in context.user_data for k in ("edit_id", "edit_field", "edit_entry", "edit_query")
+        k in user_data for k in ("edit_id", "edit_field", "edit_entry", "edit_query")
     )
     edited_text, chat_id, message_id, kwargs = context.bot.edited[0]
     assert chat_id == 42 and message_id == 24

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -204,8 +204,9 @@ async def test_profile_view_preserves_user_data(monkeypatch: pytest.MonkeyPatch)
     await handlers.profile_view(update, context)
 
     assert context.user_data is not None
-    assert context.user_data["thread_id"] == "tid"
-    assert context.user_data["foo"] == "bar"
+    user_data = cast(dict[str, Any], context.user_data)
+    assert user_data["thread_id"] == "tid"
+    assert user_data["foo"] == "bar"
 
 
 


### PR DESCRIPTION
## Summary
- export `back_keyboard` directly from profile handlers package
- ensure tests safely access `context.user_data`

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f192a40c832ab0814cd710893e1c