### PR TITLE
[tests] use sessionmaker for dummy sessions

### DIFF
--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -4,11 +4,12 @@ import datetime
 import os
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
+from sqlalchemy.orm import sessionmaker
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -64,6 +65,9 @@ async def test_entry_without_dose_has_no_unit(
     )
 
     class DummySession:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
         def __enter__(self) -> "DummySession":
             return self
 
@@ -81,7 +85,7 @@ async def test_entry_without_dose_has_no_unit(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
+    session_factory = cast(sessionmaker[DummySession], sessionmaker(class_=DummySession))
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
@@ -116,6 +120,9 @@ async def test_entry_without_sugar_has_placeholder(
     )
 
     class DummySession:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
         def __enter__(self) -> "DummySession":
             return self
 
@@ -133,7 +140,7 @@ async def test_entry_without_sugar_has_placeholder(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
+    session_factory = cast(sessionmaker[DummySession], sessionmaker(class_=DummySession))
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 from types import SimpleNamespace, TracebackType
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 
 import pytest
 from telegram import Message, Update
 from telegram.ext import CallbackContext
+from sqlalchemy.orm import sessionmaker
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
@@ -256,6 +257,9 @@ async def test_photo_then_freeform_calculates_dose(
     await handlers.photo_handler(update_photo, context)
 
     class DummySession:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
         def __enter__(self) -> "DummySession":
             return self
 
@@ -270,7 +274,7 @@ async def test_photo_then_freeform_calculates_dose(
         def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
+    session_factory = cast(sessionmaker[DummySession], sessionmaker(class_=DummySession))
     handlers.SessionLocal = session_factory
 
     sugar_msg = DummyMessage(text="5")

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -1,11 +1,12 @@
 import datetime
 from types import SimpleNamespace, TracebackType
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
+from sqlalchemy.orm import sessionmaker
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
@@ -66,6 +67,9 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         "photo_path": "photos/img.jpg",
     }
     class DummySession:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
         def __enter__(self) -> "DummySession":
             return self
 
@@ -80,7 +84,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
+    session_factory = cast(sessionmaker[DummySession], sessionmaker(class_=DummySession))
     handlers.SessionLocal = session_factory
     message = DummyMessage("5,6")
     update = cast(


### PR DESCRIPTION
## Summary
- replace test session factory casts with SQLAlchemy `sessionmaker`
- drop redundant casts when assigning to `SessionLocal`

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: unauthorized 401 in profile and webapp tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f1954e28832a982b4f2a9fd457b4