### PR TITLE
[tests] Remove cast from session factory typing

### DIFF
--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -81,8 +81,11 @@ async def test_entry_without_dose_has_no_unit(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
-    monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
+    def session_factory() -> DummySession:
+        return DummySession()
+
+    SessionLocal: Callable[[], DummySession] = session_factory
+    monkeypatch.setattr(dose_handlers, "SessionLocal", SessionLocal)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
@@ -133,8 +136,11 @@ async def test_entry_without_sugar_has_placeholder(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
-    monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
+    def session_factory() -> DummySession:
+        return DummySession()
+
+    SessionLocal: Callable[[], DummySession] = session_factory
+    monkeypatch.setattr(dose_handlers, "SessionLocal", SessionLocal)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -270,8 +270,11 @@ async def test_photo_then_freeform_calculates_dose(
         def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
-    handlers.SessionLocal = session_factory
+    def session_factory() -> DummySession:
+        return DummySession()
+
+    SessionLocal: Callable[[], DummySession] = session_factory
+    handlers.SessionLocal = SessionLocal
 
     sugar_msg = DummyMessage(text="5")
     update_sugar = cast(

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -80,8 +80,11 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(Callable[[], DummySession], lambda: DummySession())
-    handlers.SessionLocal = session_factory
+    def session_factory() -> DummySession:
+        return DummySession()
+
+    SessionLocal: Callable[[], DummySession] = session_factory
+    handlers.SessionLocal = SessionLocal
     message = DummyMessage("5,6")
     update = cast(
         Update,

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -164,12 +164,15 @@ async def test_photo_flow_saves_entry(
         Update,
         SimpleNamespace(message=msg_sugar, effective_user=SimpleNamespace(id=1)),
     )
-    session_factory = cast(Callable[[], DummySession], lambda: session)
-    dose_handlers.SessionLocal = session_factory
+    def session_factory() -> DummySession:
+        return session
+
+    SessionLocal: Callable[[], DummySession] = session_factory
+    dose_handlers.SessionLocal = SessionLocal
     await dose_handlers.freeform_handler(update_sugar, context)
     assert user_data["pending_entry"]["sugar_before"] == 5.5
 
-    monkeypatch.setattr(router, "SessionLocal", session_factory)
+    monkeypatch.setattr(router, "SessionLocal", SessionLocal)
     import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
 
     async def noop(*args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
## Summary
- Remove redundant casts and explicitly annotate session factory in tests
- Type SessionLocal to accept dummy session factories

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: unauthorized responses in webapp tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f196b248832a8845134ac93db281