### PR TITLE
[tests] assert bot exists in alert tests

### DIFF
--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -191,6 +191,7 @@ async def test_three_alerts_notify(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(effective_user=SimpleNamespace(id=1, first_name="Ivan")),
     )
     context = cast(AlertContext, ContextStub(bot=DummyBot()))
+    assert context.bot is not None
     bot = cast(DummyBot, context.bot)
 
     async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
@@ -257,6 +258,7 @@ async def test_alert_message_without_coords(monkeypatch: pytest.MonkeyPatch) -> 
         SimpleNamespace(effective_user=SimpleNamespace(id=1, first_name="Ivan")),
     )
     context = cast(AlertContext, ContextStub(bot=DummyBot()))
+    assert context.bot is not None
     bot = cast(DummyBot, context.bot)
 
     async def fake_get_coords_and_link() -> tuple[str | None, str | None]:


### PR DESCRIPTION
## Summary
- Ensure alert test stubs always provide a bot instance
- Use a typed `bot` variable for `.sent` checks in alert tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: 7, unauthorized responses)*
- `pytest tests/test_alerts.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0f199ac7c832a8a26c38570698af3