### PR TITLE
[tests] specify handler generics

### DIFF
--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -16,9 +16,16 @@ from services.api.app.diabetes.handlers import dose_handlers
 
 
 def _find_handler(
-    fallbacks: Iterable[BaseHandler[Update, CallbackContext]],
+    fallbacks: Iterable[
+        BaseHandler[
+            Update,
+            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        ]
+    ],
     regex: str,
-) -> MessageHandler[CallbackContext]:
+) -> MessageHandler[
+    CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+]:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)
@@ -48,7 +55,7 @@ async def test_photo_button_cancels_and_prompts_photo() -> None:
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
-        CallbackContext,
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
     )
     await handler.callback(update, context)

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -22,9 +22,16 @@ from services.api.app.diabetes.handlers import (
 
 
 def _find_handler(
-    fallbacks: Iterable[BaseHandler[Update, CallbackContext]],
+    fallbacks: Iterable[
+        BaseHandler[
+            Update,
+            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        ]
+    ],
     regex: str,
-) -> MessageHandler[CallbackContext]:
+) -> MessageHandler[
+    CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+]:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)
@@ -45,13 +52,17 @@ class DummyMessage:
         self.kwargs.append(kwargs)
 
 
-async def _exercise(handler: MessageHandler[CallbackContext]) -> None:
+async def _exercise(
+    handler: MessageHandler[
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+    ]
+) -> None:
     message = DummyMessage("📷 Фото еды")
     update = cast(
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
     context = cast(
-        CallbackContext,
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}, "dose_method": "xe"}),
     )
     await handler.callback(update, context)


### PR DESCRIPTION
## Summary
- refine `_find_handler` to use fully generic `CallbackContext`
- apply same generics to test helpers and casts

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` *(fails: assert 401 == 200, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f19db468832a83c2f1452708ab12