### PR TITLE
[tests] Fix context user_data and SessionLocal casting

### DIFF
--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -79,7 +79,7 @@ def make_update(**kwargs: Any) -> MagicMock:
 def make_context(**kwargs: Any) -> MagicMock:
     context = MagicMock(spec=CallbackContext)
     for key, value in kwargs.items():
-        setattr(context, key, value)
+        object.__setattr__(context, key, value)
     return context
 
 

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -6,8 +6,9 @@ from typing import Any, Callable, cast
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
+from sqlalchemy.orm import sessionmaker
 
-import services.api.app.diabetes.handlers.dose_handlers as handlers
+import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 
 
 class DummyMessage:
@@ -42,7 +43,7 @@ async def test_freeform_handler_edits_pending_entry_keeps_state() -> None:
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 
-    await handlers.freeform_handler(update, context)
+    await dose_handlers.freeform_handler(update, context)
 
     user_data = context.user_data
     assert user_data is not None
@@ -81,7 +82,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
     session_factory = cast(Callable[[], DummySession], lambda: DummySession())
-    handlers.SessionLocal = session_factory
+    dose_handlers.SessionLocal = cast(sessionmaker, session_factory)
     message = DummyMessage("5,6")
     update = cast(
         Update,
@@ -92,7 +93,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 
-    await handlers.freeform_handler(update, context)
+    await dose_handlers.freeform_handler(update, context)
 
     user_data = context.user_data
     assert user_data is not None
@@ -126,7 +127,7 @@ async def test_freeform_handler_sugar_only_flow() -> None:
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 
-    await handlers.freeform_handler(update, context)
+    await dose_handlers.freeform_handler(update, context)
 
     user_data = context.user_data
     assert user_data is not None

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, PropertyMock
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
+from sqlalchemy.orm import sessionmaker
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 import services.api.app.diabetes.handlers.router as router
@@ -165,7 +166,7 @@ async def test_photo_flow_saves_entry(
         SimpleNamespace(message=msg_sugar, effective_user=SimpleNamespace(id=1)),
     )
     session_factory = cast(Callable[[], DummySession], lambda: session)
-    dose_handlers.SessionLocal = session_factory
+    dose_handlers.SessionLocal = cast(sessionmaker, session_factory)
     await dose_handlers.freeform_handler(update_sugar, context)
     assert user_data["pending_entry"]["sugar_before"] == 5.5
 

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -140,7 +140,7 @@ def make_update(**kwargs: Any) -> MagicMock:
 def make_context(**kwargs: Any) -> MagicMock:
     context = MagicMock(spec=CallbackContext)
     for key, value in kwargs.items():
-        setattr(context, key, value)
+        object.__setattr__(context, key, value)
     return context
 
 


### PR DESCRIPTION
## Summary
- use `object.__setattr__` when building MagicMock contexts to safely inject `user_data`
- cast temporary session factories to `sessionmaker` before assigning to `dose_handlers.SessionLocal`

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f1a15914832abcf4c14bda63f3fb