### PR TITLE
[tests] Cast context.user_data after assert

### DIFF
--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -88,6 +88,7 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(user_data={}, bot=DummyBot()),
     )
     assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
 
     await router.callback_router(update_cb, context)
 
@@ -98,7 +99,8 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data is not None
-    assert context.user_data["edit_field"] == "dose"
+    user_data = cast(dict[str, Any], context.user_data)
+    assert user_data["edit_field"] == "dose"
 
     reply_msg = DummyMessage(text="5")
     update_msg = cast(

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -59,7 +59,8 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     kwargs = query.message.kwargs[0]
     assert kwargs.get("reply_markup") == common_handlers.menu_keyboard
     assert context.user_data is not None
-    assert "pending_entry" not in context.user_data
+    user_data = cast(dict[str, Any], context.user_data)
+    assert "pending_entry" not in user_data
 
 
 @pytest.mark.asyncio
@@ -126,4 +127,5 @@ async def test_callback_router_ignores_reminder_action() -> None:
 
     assert query.edited == []
     assert context.user_data is not None
-    assert "pending_entry" in context.user_data
+    user_data = cast(dict[str, Any], context.user_data)
+    assert "pending_entry" in user_data

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -107,7 +107,8 @@ async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> 
     assert result == handlers.ConversationHandler.END
     assert not called.flag
     assert context.user_data is not None
-    assert "__file_path" not in context.user_data
+    user_data = cast(dict[str, Any], context.user_data)
+    assert "__file_path" not in user_data
 
 
 @pytest.mark.asyncio
@@ -126,7 +127,8 @@ async def test_photo_handler_handles_typeerror() -> None:
     assert message.texts == ["❗ Файл не распознан как изображение."]
     assert result == handlers.ConversationHandler.END
     assert context.user_data is not None
-    assert handlers.WAITING_GPT_FLAG not in context.user_data
+    user_data = cast(dict[str, Any], context.user_data)
+    assert handlers.WAITING_GPT_FLAG not in user_data
 
 
 @pytest.mark.asyncio

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -185,10 +185,12 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(user_data={}, bot=DummyBot()),
     )
     assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
 
     await router.callback_router(update_cb, context)
     assert context.user_data is not None
-    assert context.user_data["edit_entry"] == {
+    user_data = cast(dict[str, Any], context.user_data)
+    assert user_data["edit_entry"] == {
         "id": entry_id,
         "chat_id": 42,
         "message_id": 24,
@@ -207,9 +209,10 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data is not None
-    assert context.user_data["edit_id"] == entry_id
-    assert context.user_data["edit_field"] == "xe"
-    assert context.user_data["edit_query"] is field_query
+    user_data = cast(dict[str, Any], context.user_data)
+    assert user_data["edit_id"] == entry_id
+    assert user_data["edit_field"] == "xe"
+    assert user_data["edit_query"] is field_query
     assert any("Введите" in t for t in entry_message.replies)
 
     reply_msg = DummyMessage(text="3")
@@ -230,8 +233,9 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert field_query.answer_texts[-1] == "Изменено"
     assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     assert not any(
-        k in context.user_data for k in ("edit_id", "edit_field", "edit_entry", "edit_query")
+        k in user_data for k in ("edit_id", "edit_field", "edit_entry", "edit_query")
     )
     edited_text, chat_id, message_id, kwargs = context.bot.edited[0]
     assert chat_id == 42 and message_id == 24

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -204,8 +204,9 @@ async def test_profile_view_preserves_user_data(monkeypatch: pytest.MonkeyPatch)
     await handlers.profile_view(update, context)
 
     assert context.user_data is not None
-    assert context.user_data["thread_id"] == "tid"
-    assert context.user_data["foo"] == "bar"
+    user_data = cast(dict[str, Any], context.user_data)
+    assert user_data["thread_id"] == "tid"
+    assert user_data["foo"] == "bar"
 
 
 

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -100,7 +100,8 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
     # Final reply should include dish name from Vision response
     assert any("Борщ" in reply for reply in msg_photo.replies)
     assert context.user_data is not None
-    entry = context.user_data.get("pending_entry")
+    user_data = cast(dict[str, Any], context.user_data)
+    entry = user_data.get("pending_entry")
     assert entry is not None
     assert entry["carbs_g"] == 30
     assert entry["xe"] == 2


### PR DESCRIPTION
## Summary
- Cast `context.user_data` to typed dict after verifying non-None
- Reference the local `user_data` variable for keys like `edit_entry`, `edit_id`, and file flags

## Testing
- `ruff check services/api/app tests`
- `pytest` *(fails: 7 tests due to 401 Unauthorized)*
- `pytest tests/test_edit_record.py tests/test_handlers_cancel_entry.py tests/test_handlers_history_edit.py tests/test_handlers_doc.py tests/test_handlers_profile.py tests/test_handlers_vision_prompt.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0f1a1bbd8832aba260e31273e2fc1