### PR TITLE
tests: reuse user_data variable

### DIFF
--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -58,8 +58,9 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     assert query.message.kwargs
     kwargs = query.message.kwargs[0]
     assert kwargs.get("reply_markup") == common_handlers.menu_keyboard
-    assert context.user_data is not None
-    assert "pending_entry" not in context.user_data
+    user_data = context.user_data
+    assert user_data is not None
+    assert "pending_entry" not in user_data
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- reuse user_data variable in cancel entry test

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` *(fails: tests/test_profile_self.py::test_profile_self_valid_header - assert 401 == 200, tests/test_webapp_history.py::test_history_persist_and_update - assert 401 == 200, tests/test_webapp_history.py::test_history_concurrent_writes - assert 401 == 200, tests/test_webapp_timezone.py::test_timezone_persist_and_validate - assert 401 == 200, tests/test_webapp_timezone.py::test_timezone_partial_file - assert 401 == 500, tests/test_webapp_timezone.py::test_timezone_concurrent_writes - assert 401 == 200, tests/test_webapp_timezone.py::test_timezone_async_writes - assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f1a36d94832a8bb22a9f611e568b