### PR TITLE
[tests] Add stub for date2num and typed PDF wrapper

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 explicit_package_bases = True
+mypy_path = stubs
 
 [mypy-telegram.*]
 ignore_missing_imports = True

--- a/stubs/matplotlib/__init__.pyi
+++ b/stubs/matplotlib/__init__.pyi
@@ -1,0 +1,1 @@
+# Stub package for matplotlib

--- a/stubs/matplotlib/dates.pyi
+++ b/stubs/matplotlib/dates.pyi
@@ -1,0 +1,3 @@
+from datetime import datetime
+
+def date2num(date: datetime) -> float: ...

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -26,7 +26,7 @@ def date2num(date: datetime.datetime) -> float:
 
 def read_pdf(stream: BinaryIO) -> _PdfReader:
     """Typed wrapper around :class:`pypdf.PdfReader`."""
-    return _PdfReader(stream)
+    return cast(Callable[[BinaryIO], _PdfReader], _PdfReader)(stream)
 
 
 class DummyEntry:


### PR DESCRIPTION
## Summary
- avoid untyped PdfReader call in reporting tests
- add local stub for `matplotlib.dates.date2num`
- configure mypy to load local stubs

## Testing
- `ruff check tests/test_reporting.py stubs/matplotlib/dates.pyi`
- `pytest tests/test_reporting.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f18e10e8832abefe40bc1b91b177