### PR TITLE
[tests] Simplify user_data assignment

### DIFF
--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -204,7 +204,7 @@ async def test_profile_view_preserves_user_data(monkeypatch: pytest.MonkeyPatch)
     await handlers.profile_view(update, context)
 
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["thread_id"] == "tid"
     assert user_data["foo"] == "bar"
 


### PR DESCRIPTION
## Summary
- remove unnecessary cast when assigning `user_data` in profile view preservation test

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_handlers_profile.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1614f03d4832a86476e5058f6363d