### PR TITLE
[tests] Assert non-null user_data without cast

### DIFF
--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -188,7 +188,8 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await router.callback_router(update_cb, context)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
+    assert user_data is not None
     assert user_data["edit_entry"] == {
         "id": entry_id,
         "chat_id": 42,
@@ -208,7 +209,8 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
+    assert user_data is not None
     assert user_data["edit_id"] == entry_id
     assert user_data["edit_field"] == "xe"
     assert user_data["edit_query"] is field_query
@@ -232,7 +234,8 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert field_query.answer_texts[-1] == "Изменено"
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
+    assert user_data is not None
     assert not any(
         k in user_data for k in ("edit_id", "edit_field", "edit_entry", "edit_query")
     )


### PR DESCRIPTION
## Summary
- Avoid `cast()` in history edit test by assigning `user_data` directly and asserting it is not `None`

## Testing
- `ruff check services/api/app tests`
- `pytest tests` (fails: assert 401 == 200)

------
https://chatgpt.com/codex/tasks/task_e_68a16165ebd0832aa9e77174b5e25d0c