### PR TITLE
tests: simplify user_data assignment

### DIFF
--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -98,7 +98,7 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["edit_field"] == "dose"
 
     reply_msg = DummyMessage(text="5")

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -59,7 +59,7 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     kwargs = query.message.kwargs[0]
     assert kwargs.get("reply_markup") == common_handlers.menu_keyboard
     assert context.user_data is not None
-    user_data: dict[str, Any] = context.user_data
+    user_data = context.user_data
     assert "pending_entry" not in user_data
 
 
@@ -127,5 +127,5 @@ async def test_callback_router_ignores_reminder_action() -> None:
 
     assert query.edited == []
     assert context.user_data is not None
-    user_data: dict[str, Any] = context.user_data
+    user_data = context.user_data
     assert "pending_entry" in user_data

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -188,7 +188,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await router.callback_router(update_cb, context)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["edit_entry"] == {
         "id": entry_id,
         "chat_id": 42,
@@ -208,7 +208,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["edit_id"] == entry_id
     assert user_data["edit_field"] == "xe"
     assert user_data["edit_query"] is field_query
@@ -232,7 +232,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert field_query.answer_texts[-1] == "Изменено"
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert not any(
         k in user_data for k in ("edit_id", "edit_field", "edit_entry", "edit_query")
     )

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -204,7 +204,7 @@ async def test_profile_view_preserves_user_data(monkeypatch: pytest.MonkeyPatch)
     await handlers.profile_view(update, context)
 
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["thread_id"] == "tid"
     assert user_data["foo"] == "bar"
 

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -100,7 +100,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
     # Final reply should include dish name from Vision response
     assert any("Борщ" in reply for reply in msg_photo.replies)
     assert context.user_data is not None
-    user_data: dict[str, Any] = context.user_data
+    user_data = context.user_data
     entry = user_data.get("pending_entry")
     assert entry is not None
     assert entry["carbs_g"] == 30


### PR DESCRIPTION
## Summary
- avoid casting when assigning user_data
- ensure context.user_data is asserted non-null before assignment

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a161669038832a970cc9821b23e938