### PR TITLE
[tests] ensure user_data not None in edit_record test

### DIFF
--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -97,8 +97,8 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1)),
     )
     await router.callback_router(update_cb2, context)
-    assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
+    assert user_data is not None
     assert user_data["edit_field"] == "dose"
 
     reply_msg = DummyMessage(text="5")


### PR DESCRIPTION
## Summary
- clarify user_data typing in edit_record test

## Testing
- `ruff check tests/test_edit_record.py`
- `pytest tests/test_edit_record.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a16168890c832a94364f6b3462d14c