### PR TITLE
[ui] Replace empty interfaces with type aliases

### DIFF
--- a/services/webapp/ui/src/components/ui/command.tsx
+++ b/services/webapp/ui/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/services/webapp/ui/src/components/ui/textarea.tsx
+++ b/services/webapp/ui/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {


### PR DESCRIPTION
## Summary
- replace TextareaProps interface with React attribute type alias
- update CommandDialogProps to type alias to satisfy ESLint

## Testing
- `npm --workspace services/webapp/ui test` (fails: Missing script "test")
- `npm --workspace services/webapp/ui run lint` (fails: @typescript-eslint/no-require-imports in tailwind.config.ts, no no-empty-object-type errors)
- `npm --workspace services/webapp/ui exec -- eslint src/components/ui/textarea.tsx -f json`


------
https://chatgpt.com/codex/tasks/task_e_68a161b14584832aa0501c757f118b37