### PR TITLE
[ui] use ES module import for tailwindcss-animate

### DIFF
--- a/services/webapp/ui/tailwind.config.ts
+++ b/services/webapp/ui/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -127,5 +128,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- refactor tailwind config to use ESM import for tailwindcss-animate

## Testing
- `npm run lint` *(fails: 2 errors, 8 warnings; no `no-require-imports` issues)*
- `npx eslint tailwind.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a161b39430832a8cab0a1d5ecd2ac9