### PR TITLE
[api] Load Telegram token dynamically

### DIFF
--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -2,6 +2,7 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import time
 from typing import Any
 from urllib.parse import parse_qsl
@@ -64,7 +65,7 @@ def require_tg_user(
     if not init_data:
         raise HTTPException(status_code=401, detail="missing init data")
 
-    token: str | None = settings.telegram_token
+    token: str | None = os.getenv("TELEGRAM_TOKEN") or settings.telegram_token
     if not token:
         logger.error("telegram token not configured")
         raise HTTPException(status_code=500, detail="server misconfigured")

--- a/tests/test_profile_self.py
+++ b/tests/test_profile_self.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import json
+import time
 import urllib.parse
 
 import pytest
@@ -15,7 +16,7 @@ client = TestClient(app)
 
 def build_init_data(user_id: int = 1) -> str:
     user = json.dumps({"id": user_id, "first_name": "A"}, separators=(",", ":"))
-    params = {"auth_date": "123", "query_id": "abc", "user": user}
+    params = {"auth_date": str(int(time.time())), "query_id": "abc", "user": user}
     data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
     secret = hmac.new(b"WebAppData", TOKEN.encode(), hashlib.sha256).digest()
     params["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()

--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import hmac
 import json
+import time
 from concurrent.futures import ThreadPoolExecutor
 import urllib.parse
 
@@ -16,7 +17,6 @@ from sqlalchemy.pool import StaticPool
 
 import services.api.app.main as server
 from services.api.app.diabetes.services import db
-from services.api.app.config import settings
 
 
 TOKEN = "test-token"
@@ -24,7 +24,7 @@ TOKEN = "test-token"
 
 def build_init_data(user_id: int = 1) -> str:
     user = json.dumps({"id": user_id, "first_name": "A"}, separators=(",", ":"))
-    params = {"auth_date": "123", "query_id": "abc", "user": user}
+    params = {"auth_date": str(int(time.time())), "query_id": "abc", "user": user}
     data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
     secret = hmac.new(b"WebAppData", TOKEN.encode(), hashlib.sha256).digest()
     params["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
@@ -33,7 +33,7 @@ def build_init_data(user_id: int = 1) -> str:
 
 @pytest.fixture
 def auth_headers(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
-    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    monkeypatch.setenv("TELEGRAM_TOKEN", TOKEN)
     return {"X-Telegram-Init-Data": build_init_data()}
 
 


### PR DESCRIPTION
## Summary
- ensure Telegram auth reads TELEGRAM_TOKEN from the environment at request time
- update webapp tests to authenticate using dynamic headers

## Testing
- `pytest tests/test_webapp_timezone.py tests/test_webapp_history.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a161ba2e8c832aa58772a5ff9e2a80