### PR TITLE
[handlers] Export back_keyboard in profile conversation

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -902,6 +902,7 @@ __all__ = [
     "profile_conv",
     "profile_webapp_save",
     "profile_webapp_handler",
+    "back_keyboard",
     "PROFILE_ICR",
     "PROFILE_CF",
     "PROFILE_TARGET",


### PR DESCRIPTION
## Summary
- export `back_keyboard` in profile conversation handlers

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` *(fails: 7 failed, 244 passed; Unauthorized responses)*

------
https://chatgpt.com/codex/tasks/task_e_68a161475210832aa5f5b36f9f92b776