### PR TITLE
[tests] Simplify user_data handling in vision prompt test

### DIFF
--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -99,8 +99,8 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
     assert "название" in captured["content"]
     # Final reply should include dish name from Vision response
     assert any("Борщ" in reply for reply in msg_photo.replies)
-    assert context.user_data is not None
-    user_data: dict[str, Any] = context.user_data
+    user_data = context.user_data
+    assert user_data is not None
     entry = user_data.get("pending_entry")
     assert entry is not None
     assert entry["carbs_g"] == 30


### PR DESCRIPTION
## Summary
- simplify user_data assignment in vision prompt test

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200 in webapp timezone and history tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a1614a4548832aa398325fe092ea70