### PR TITLE
[handlers] Simplify user_data typing and session factory

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -80,11 +80,9 @@ async def photo_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
 async def sugar_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Prompt user for current sugar level."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         return END
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -113,11 +111,9 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     chat_data = getattr(context, "chat_data", None)
     if chat_data is not None and not chat_data.get("sugar_active"):
         return END
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         return END
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -162,11 +158,9 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Entry point for dose calculation conversation."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         return END
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -183,11 +177,9 @@ async def dose_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_method_choice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle method selection for dose calculation."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         return END
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -216,11 +208,9 @@ async def dose_method_choice(update: Update, context: ContextTypes.DEFAULT_TYPE)
 
 async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Capture XE amount from user."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         return END
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -253,11 +243,9 @@ async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Capture carbohydrates in grams."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         return END
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -292,11 +280,9 @@ async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Finalize dose calculation after receiving sugar level."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         return END
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -377,11 +363,9 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Cancel dose calculation conversation."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         return END
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END
@@ -411,11 +395,9 @@ def _cancel_then(
 
 async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle freeform text commands for adding diary entries."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         return
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return
@@ -923,11 +905,9 @@ async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 
 async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo: bool = False) -> int:
     """Process food photos and trigger nutrition analysis."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         return END
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         query = update.callback_query
@@ -1185,11 +1165,9 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE, demo
 
 async def doc_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle images sent as documents."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         return END
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
     message = update.message
     if message is None:
         return END

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from collections.abc import Awaitable, Callable
-from typing import Any, cast
 
 from telegram import (
     InlineKeyboardButton,
@@ -120,12 +119,10 @@ async def onboarding_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     message = update.message
     if message is None or message.text is None:
         return ConversationHandler.END
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
     try:
         icr = float(message.text.replace(",", "."))
     except ValueError:
@@ -147,12 +144,10 @@ async def onboarding_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     message = update.message
     if message is None or message.text is None:
         return ConversationHandler.END
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
     try:
         cf = float(message.text.replace(",", "."))
     except ValueError:
@@ -173,12 +168,10 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     """Handle target BG input and proceed to demo."""
     message = update.message
     user = update.effective_user
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
     if message is None or message.text is None or user is None:
         return ConversationHandler.END
     try:
@@ -459,12 +452,10 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     from . import _cancel_then
     from .dose_handlers import photo_prompt
     message = update.message
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
     if message is None:
         return ConversationHandler.END
 

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
 from telegram.ext import (
     CommandHandler,
@@ -591,12 +591,10 @@ async def profile_edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
 
 async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle ICR input."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
     context.user_data = user_data
     message = update.message
     if message is None or message.text is None:
@@ -623,12 +621,10 @@ async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
 async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle CF input."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
     context.user_data = user_data
     message = update.message
     if message is None or message.text is None:
@@ -659,12 +655,10 @@ async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle target BG input."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
     context.user_data = user_data
     message = update.message
     if message is None or message.text is None:
@@ -699,12 +693,10 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle low threshold input."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
     context.user_data = user_data
     message = update.message
     if message is None or message.text is None:
@@ -737,12 +729,10 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     return PROFILE_HIGH
 async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle high threshold input and save profile."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
     context.user_data = user_data
     message = update.message
     if message is None or message.text is None:

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -10,7 +10,7 @@ import os as os
 import html
 import logging
 
-from typing import Any, Protocol, cast
+from typing import Protocol, cast
 
 from openai import OpenAIError
 from openai.types.beta.threads import TextContentBlock
@@ -188,12 +188,10 @@ async def report_period_callback(
         )
         await send_report(update, context, date_from, "последний месяц", query=query)
     elif period == "custom":
-        user_data_raw = context.user_data
-        if user_data_raw is None:
+        user_data = context.user_data
+        if user_data is None:
             context.user_data = {}
-            user_data_raw = context.user_data
-        assert user_data_raw is not None
-        user_data = cast(dict[str, Any], user_data_raw)
+            user_data = context.user_data
         user_data["awaiting_report_date"] = True
         await query.edit_message_text(
             "Введите дату начала отчёта в формате YYYY-MM-DD\n"
@@ -273,12 +271,10 @@ async def send_report(
 
     default_gpt_text = "Не удалось получить рекомендации."
     gpt_text: str | None = default_gpt_text
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    user_data = context.user_data
+    if user_data is None:
         context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
     thread_id = cast(str | None, user_data.get("thread_id"))
     if thread_id is None:
         with SessionLocal() as session:

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ForceReply
 from telegram.ext import ContextTypes
-from typing import Any, cast
 
 from services.api.app.diabetes.services.db import Entry, SessionLocal
 from services.api.app.diabetes.utils.ui import menu_keyboard
@@ -26,11 +25,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         return
 
     if data == "confirm_entry":
-        user_data_raw = context.user_data
-        if user_data_raw is None:
-            return
-        assert user_data_raw is not None
-        user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
         entry_data = user_data.pop("pending_entry", None)
         if not entry_data:
             await query.edit_message_text("❗ Нет данных для сохранения.")
@@ -57,11 +52,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             reminder_handlers.schedule_after_meal(user.id, job_queue)
         return
     elif data == "edit_entry":
-        user_data_raw = context.user_data
-        if user_data_raw is None:
-            return
-        assert user_data_raw is not None
-        user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
         entry_data = user_data.get("pending_entry")
         if not entry_data:
             await query.edit_message_text("❗ Нет данных для редактирования.")
@@ -75,11 +66,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         )
         return
     elif data == "cancel_entry":
-        user_data_raw = context.user_data
-        if user_data_raw is None:
-            return
-        assert user_data_raw is not None
-        user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
         user_data.pop("pending_entry", None)
         await query.edit_message_text("❌ Запись отменена.")
         message = query.message
@@ -118,11 +105,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 await query.edit_message_text("❌ Запись удалена.")
                 return
             if action == "edit":
-                user_data_raw = context.user_data
-                if user_data_raw is None:
-                    return
-                assert user_data_raw is not None
-                user_data = cast(dict[str, Any], user_data_raw)
+                user_data = context.user_data
                 message = query.message
                 if message is None:
                     return
@@ -162,11 +145,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             logger.warning("Invalid edit_field data: %s", data)
             await query.edit_message_text("Некорректные данные для редактирования.")
             return
-        user_data_raw = context.user_data
-        if user_data_raw is None:
-            return
-        assert user_data_raw is not None
-        user_data = cast(dict[str, Any], user_data_raw)
+        user_data = context.user_data
         user_data["edit_id"] = edit_entry_id
         user_data["edit_field"] = field
         user_data["edit_query"] = query

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -98,7 +98,7 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["edit_field"] == "dose"
 
     reply_msg = DummyMessage(text="5")

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 import pytest
 from telegram import Message, Update
 from telegram.ext import CallbackContext
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
@@ -274,7 +274,7 @@ async def test_photo_then_freeform_calculates_dose(
         def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(sessionmaker[DummySession], sessionmaker(class_=DummySession))
+    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
     handlers.SessionLocal = session_factory
 
     sugar_msg = DummyMessage(text="5")

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -188,7 +188,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await router.callback_router(update_cb, context)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["edit_entry"] == {
         "id": entry_id,
         "chat_id": 42,
@@ -208,7 +208,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["edit_id"] == entry_id
     assert user_data["edit_field"] == "xe"
     assert user_data["edit_query"] is field_query
@@ -232,7 +232,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert field_query.answer_texts[-1] == "Изменено"
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert not any(
         k in user_data for k in ("edit_id", "edit_field", "edit_entry", "edit_query")
     )

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -204,7 +204,7 @@ async def test_profile_view_preserves_user_data(monkeypatch: pytest.MonkeyPatch)
     await handlers.profile_view(update, context)
 
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["thread_id"] == "tid"
     assert user_data["foo"] == "bar"
 


### PR DESCRIPTION
## Summary
- avoid unnecessary `cast(dict[str, Any], ...)` when accessing `context.user_data`
- type `sessionmaker` factory as `Session` in tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: test_profile_self_valid_header, test_history_persist_and_update, test_history_concurrent_writes, test_timezone_persist_and_validate, test_timezone_partial_file, test_timezone_concurrent_writes, test_timezone_async_writes)*

------
https://chatgpt.com/codex/tasks/task_e_68a1615a8a00832a905ad031f65304ee