### PR TITLE
tests: fix dose info session cast

### DIFF
--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -85,7 +85,7 @@ async def test_entry_without_dose_has_no_unit(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(sessionmaker[DummySession], sessionmaker(class_=DummySession))
+    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
@@ -140,7 +140,7 @@ async def test_entry_without_sugar_has_placeholder(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(sessionmaker[DummySession], sessionmaker(class_=DummySession))
+    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)


### PR DESCRIPTION
## Summary
- cast `SessionLocal` sessionmaker to `Session`
- import `Session` in dose info tests

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: tests/test_profile_self.py::test_profile_self_valid_header, tests/test_webapp_history.py::test_history_persist_and_update, tests/test_webapp_history.py::test_history_concurrent_writes, tests/test_webapp_timezone.py::test_timezone_persist_and_validate, tests/test_webapp_timezone.py::test_timezone_partial_file, tests/test_webapp_timezone.py::test_timezone_concurrent_writes, tests/test_webapp_timezone.py::test_timezone_async_writes)*

------
https://chatgpt.com/codex/tasks/task_e_68a1615c81e4832aa171fa79e1585b6c