### PR TITLE
tests: subclass dummy session from sqlalchemy

### DIFF
--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -66,7 +66,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         "sugar_before": None,
         "photo_path": "photos/img.jpg",
     }
-    class DummySession:
+    class DummySession(Session):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             pass
 
@@ -84,7 +84,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
+    session_factory = sessionmaker(class_=DummySession)
     handlers.SessionLocal = session_factory
     message = DummyMessage("5,6")
     update = cast(


### PR DESCRIPTION
## Summary
- simplify DummySession in freeform pending entry tests by subclassing SQLAlchemy Session and relying on inferred sessionmaker type

## Testing
- `ruff check tests/test_handlers_freeform_pending.py`
- `pytest tests/test_handlers_freeform_pending.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a16a5d649c832a96b8a8a16f57e725