### PR TITLE
[tests] Guard update message in doc handler test

### DIFF
--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -73,6 +73,7 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
     user_data = context.user_data
     assert user_data is not None
     assert user_data["__file_path"] == "photos/1_uid.png"
+    assert update.message is not None
     assert update.message.photo == ()
 
 


### PR DESCRIPTION
## Summary
- Ensure `update.message` is not `None` before asserting `photo`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a16a612014832ab501294ec418753d