### PR TITLE
[tests] Simplify DummySession sessionmaker usage

### DIFF
--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -64,7 +64,7 @@ async def test_entry_without_dose_has_no_unit(
         Update, DummyUpdate(message=message, effective_user=DummyUser(id=1))
     )
 
-    class DummySession:
+    class DummySession(Session):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             pass
 
@@ -85,7 +85,7 @@ async def test_entry_without_dose_has_no_unit(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
+    session_factory = sessionmaker(class_=DummySession)
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
@@ -119,7 +119,7 @@ async def test_entry_without_sugar_has_placeholder(
         Update, DummyUpdate(message=message, effective_user=DummyUser(id=1))
     )
 
-    class DummySession:
+    class DummySession(Session):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             pass
 
@@ -140,7 +140,7 @@ async def test_entry_without_sugar_has_placeholder(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
+    session_factory = sessionmaker(class_=DummySession)
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 import pytest
 from telegram import Message, Update
 from telegram.ext import CallbackContext
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers
 
@@ -256,7 +256,7 @@ async def test_photo_then_freeform_calculates_dose(
 
     await handlers.photo_handler(update_photo, context)
 
-    class DummySession:
+    class DummySession(Session):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             pass
 
@@ -274,7 +274,7 @@ async def test_photo_then_freeform_calculates_dose(
         def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(sessionmaker[DummySession], sessionmaker(class_=DummySession))
+    session_factory = sessionmaker(class_=DummySession)
     handlers.SessionLocal = session_factory
 
     sugar_msg = DummyMessage(text="5")

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -66,7 +66,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         "sugar_before": None,
         "photo_path": "photos/img.jpg",
     }
-    class DummySession:
+    class DummySession(Session):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             pass
 
@@ -84,7 +84,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         def get(self, model: Any, user_id: int) -> SimpleNamespace:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
+    session_factory = sessionmaker(class_=DummySession)
     handlers.SessionLocal = session_factory
     message = DummyMessage("5,6")
     update = cast(

--- a/tests/test_run_db.py
+++ b/tests/test_run_db.py
@@ -35,7 +35,7 @@ async def test_run_db_sqlite_in_memory(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_run_db_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
     dummy_engine = SimpleNamespace(url=SimpleNamespace(drivername="postgresql", database="db"))
 
-    class DummySession:
+    class DummySession(SASession):
         def get_bind(self) -> SimpleNamespace:
             return dummy_engine
 


### PR DESCRIPTION
## Summary
- ensure DummySession subclasses `sqlalchemy.orm.Session`
- build session factories with `sessionmaker(class_=DummySession)`
- assign `SessionLocal` directly without casts

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a16a62af5c832ab28369eba6f4730b