### PR TITLE
[tests] subclass DummySession from Session

### DIFF
--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -64,7 +64,7 @@ async def test_entry_without_dose_has_no_unit(
         Update, DummyUpdate(message=message, effective_user=DummyUser(id=1))
     )
 
-    class DummySession:
+    class DummySession(Session):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             pass
 
@@ -85,7 +85,7 @@ async def test_entry_without_dose_has_no_unit(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
+    session_factory = sessionmaker(class_=DummySession)
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
@@ -119,7 +119,7 @@ async def test_entry_without_sugar_has_placeholder(
         Update, DummyUpdate(message=message, effective_user=DummyUser(id=1))
     )
 
-    class DummySession:
+    class DummySession(Session):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             pass
 
@@ -140,7 +140,7 @@ async def test_entry_without_sugar_has_placeholder(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
+    session_factory = sessionmaker(class_=DummySession)
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)


### PR DESCRIPTION
## Summary
- ensure DummySession inherits from sqlalchemy Session in dose info tests
- drop unnecessary casts for sessionmaker

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a16a6477c8832ab6f0a3c480ca86e6