### PR TITLE
tests: remove override ignore in DummyDatetime now

### DIFF
--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -177,7 +177,7 @@ def test_schedule_with_next_interval(monkeypatch: pytest.MonkeyPatch) -> None:
 
     class DummyDatetime(datetime):
         @classmethod
-        def now(cls, tz: tzinfo | None = None) -> "DummyDatetime":  # type: ignore[override]
+        def now(cls, tz: tzinfo | None = None) -> "DummyDatetime":
             result = now
             if tz is not None:
                 result = result.replace(tzinfo=tz)


### PR DESCRIPTION
## Summary
- remove unneeded type ignore on DummyDatetime.now

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68a16a667544832a8841369f09c50042