### PR TITLE
[tests] Assert context user data before casting

### DIFF
--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -97,8 +97,8 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1)),
     )
     await router.callback_router(update_cb2, context)
-    user_data = context.user_data
-    assert user_data is not None
+    assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     assert user_data["edit_field"] == "dose"
 
     reply_msg = DummyMessage(text="5")

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -59,7 +59,7 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     kwargs = query.message.kwargs[0]
     assert kwargs.get("reply_markup") == common_handlers.menu_keyboard
     assert context.user_data is not None
-    user_data: dict[str, Any] = context.user_data
+    user_data = cast(dict[str, Any], context.user_data)
     assert "pending_entry" not in user_data
 
 
@@ -127,5 +127,5 @@ async def test_callback_router_ignores_reminder_action() -> None:
 
     assert query.edited == []
     assert context.user_data is not None
-    user_data: dict[str, Any] = context.user_data
+    user_data = cast(dict[str, Any], context.user_data)
     assert "pending_entry" in user_data

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -70,8 +70,8 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
 
     assert result == 200
     assert called.flag
-    user_data = context.user_data
-    assert user_data is not None
+    assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     assert user_data["__file_path"] == "photos/1_uid.png"
     assert update.message.photo == ()
 
@@ -289,6 +289,6 @@ async def test_photo_then_freeform_calculates_dose(
     assert "Углеводы: 10.0 г" in reply
     assert "Сахар: 5.0 ммоль/л" in reply
     assert "Ваша доза: 1.0 Ед" in reply
-    user_data = context.user_data
-    assert user_data is not None
+    assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     assert "dose" in user_data["pending_entry"]

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -45,8 +45,8 @@ async def test_freeform_handler_edits_pending_entry_keeps_state() -> None:
 
     await handlers.freeform_handler(update, context)
 
-    user_data = context.user_data
-    assert user_data is not None
+    assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     pending = user_data.get("pending_entry")
     assert pending is not None
     assert pending["dose"] == 3.5
@@ -98,8 +98,8 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
 
     await handlers.freeform_handler(update, context)
 
-    user_data = context.user_data
-    assert user_data is not None
+    assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     pending = user_data.get("pending_entry")
     assert pending is not None
     assert pending["sugar_before"] == 5.6
@@ -132,8 +132,8 @@ async def test_freeform_handler_sugar_only_flow() -> None:
 
     await handlers.freeform_handler(update, context)
 
-    user_data = context.user_data
-    assert user_data is not None
+    assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     pending = user_data.get("pending_entry")
     assert pending is not None
     assert pending["sugar_before"] == 4.2

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -188,8 +188,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await router.callback_router(update_cb, context)
     assert context.user_data is not None
-    user_data = context.user_data
-    assert user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     assert user_data["edit_entry"] == {
         "id": entry_id,
         "chat_id": 42,
@@ -209,8 +208,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data is not None
-    user_data = context.user_data
-    assert user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     assert user_data["edit_id"] == entry_id
     assert user_data["edit_field"] == "xe"
     assert user_data["edit_query"] is field_query
@@ -234,8 +232,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert field_query.answer_texts[-1] == "Изменено"
     assert context.user_data is not None
-    user_data = context.user_data
-    assert user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     assert not any(
         k in user_data for k in ("edit_id", "edit_field", "edit_entry", "edit_query")
     )

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -95,8 +95,8 @@ async def test_photo_flow_saves_entry(
     setattr(type(context), "user_data", PropertyMock(return_value=user_data))
     setattr(type(context), "job_queue", PropertyMock(return_value=None))
 
-    user_data = context.user_data
-    assert user_data is not None
+    assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
 
     async def fake_get_file(file_id: str) -> Any:
         class File:

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -204,7 +204,7 @@ async def test_profile_view_preserves_user_data(monkeypatch: pytest.MonkeyPatch)
     await handlers.profile_view(update, context)
 
     assert context.user_data is not None
-    user_data = context.user_data
+    user_data = cast(dict[str, Any], context.user_data)
     assert user_data["thread_id"] == "tid"
     assert user_data["foo"] == "bar"
 

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -55,8 +55,8 @@ async def test_report_request_and_custom_flow(
     )
 
     await reporting_handlers.report_request(update, context)
-    user_data = context.user_data
-    assert user_data is not None
+    assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     assert "awaiting_report_date" not in user_data
     assert any("Выберите период" in t for t in message.replies)
     assert message.kwargs
@@ -72,8 +72,8 @@ async def test_report_request_and_custom_flow(
 
     await reporting_handlers.report_period_callback(update_cb, context)
 
-    user_data = context.user_data
-    assert user_data is not None
+    assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     assert user_data.get("awaiting_report_date") is True
     assert query.edited
     assert any("YYYY-MM-DD" in text for text in query.edited)
@@ -104,8 +104,8 @@ async def test_report_request_and_custom_flow(
 
     called_flag = called.get("called")
     assert called_flag is not None
-    user_data = context.user_data
-    assert user_data is not None
+    assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     assert "awaiting_report_date" not in user_data
 
 

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -99,8 +99,8 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
     assert "название" in captured["content"]
     # Final reply should include dish name from Vision response
     assert any("Борщ" in reply for reply in msg_photo.replies)
-    user_data = context.user_data
-    assert user_data is not None
+    assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     entry = user_data.get("pending_entry")
     assert entry is not None
     assert entry["carbs_g"] == 30

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -370,8 +370,8 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
     assert query.answers
     answer = query.answers[0]
     assert answer == "Готово ✅"
-    user_data = context.user_data
-    assert isinstance(user_data, dict)
+    assert context.user_data is not None
+    user_data = cast(dict[str, Any], context.user_data)
     assert "pending_entry" in user_data
 
 


### PR DESCRIPTION
## Summary
- Assert `context.user_data` is not `None` in tests before accessing
- Cast `context.user_data` to `dict[str, Any]` for clarity

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68a16a6c5560832aa2a4a93b6aedbea4