### PR TITLE
[tests] assign user_data directly in edit record test

### DIFF
--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -88,6 +88,7 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(user_data={}, bot=DummyBot()),
     )
     assert context.user_data is not None
+    user_data = context.user_data
 
     await router.callback_router(update_cb, context)
 
@@ -97,8 +98,6 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1)),
     )
     await router.callback_router(update_cb2, context)
-    user_data = context.user_data
-    assert user_data is not None
     assert user_data["edit_field"] == "dose"
 
     reply_msg = DummyMessage(text="5")


### PR DESCRIPTION
## Summary
- assign `user_data` variable directly after ensuring `context.user_data` exists

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a16a707718832aa9d2af4e0254a407