### PR TITLE
[tests] refine session factory typing and remove redundant casts

### DIFF
--- a/services/api/app/diabetes/services/reporting.py
+++ b/services/api/app/diabetes/services/reporting.py
@@ -18,7 +18,7 @@ from reportlab.pdfgen import canvas
 
 from services.api.app.config import settings
 
-date2num_typed = cast(Callable[[datetime], float], date2num)
+date2num_typed: Callable[[datetime], float] = date2num
 
 # Регистрация шрифтов для поддержки кириллицы и жирного начертания
 DEFAULT_FONT_DIR = '/usr/share/fonts/truetype/dejavu'

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, PropertyMock
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 import services.api.app.diabetes.handlers.router as router
@@ -168,7 +168,7 @@ async def test_photo_flow_saves_entry(
     class SessionFactory:
         def __new__(cls, *args: Any, **kwargs: Any) -> DummySession:
             return session
-    session_factory = cast(sessionmaker[DummySession], sessionmaker(class_=SessionFactory))
+    session_factory = cast(sessionmaker[Session], sessionmaker(class_=SessionFactory))
     dose_handlers.SessionLocal = session_factory
     await dose_handlers.freeform_handler(update_sugar, context)
     assert user_data["pending_entry"]["sugar_before"] == 5.5

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -4,7 +4,7 @@ import datetime
 import io
 import os
 from types import SimpleNamespace
-from typing import Any, BinaryIO, Callable, cast
+from typing import Any, BinaryIO
 
 import matplotlib.pyplot as plt
 from matplotlib.dates import date2num as _date2num
@@ -21,12 +21,12 @@ from services.api.app.diabetes.services.reporting import make_sugar_plot, genera
 
 def date2num(date: datetime.datetime) -> float:
     """Typed wrapper around :func:`matplotlib.dates.date2num`."""
-    return float(cast(Callable[[datetime.datetime], float], _date2num)(date))
+    return float(_date2num(date))
 
 
 def read_pdf(stream: BinaryIO) -> _PdfReader:
     """Typed wrapper around :class:`pypdf.PdfReader`."""
-    return cast(Callable[[BinaryIO], _PdfReader], _PdfReader)(stream)
+    return _PdfReader(stream)
 
 
 class DummyEntry:


### PR DESCRIPTION
## Summary
- Type the dummy session factory as `sessionmaker[Session]` before assigning to handlers
- Replace unnecessary `Callable` casts with simple wrappers and variables

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a16162de20832a9d7d23600b6181ec