### PR TITLE
[webapp] Add shared time utilities

### DIFF
--- a/services/webapp/ui/src/lib/time.test.ts
+++ b/services/webapp/ui/src/lib/time.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { parseTimeToMinutes, isValidTime, isValidTimeFormat } from './time'
+
+describe('parseTimeToMinutes', () => {
+  it('parses valid times', () => {
+    expect(parseTimeToMinutes('00:00')).toBe(0)
+    expect(parseTimeToMinutes('1:00')).toBe(60)
+    expect(parseTimeToMinutes('23:59')).toBe(23 * 60 + 59)
+  })
+
+  it('returns NaN for invalid format', () => {
+    expect(Number.isNaN(parseTimeToMinutes('abc'))).toBe(true)
+    expect(Number.isNaN(parseTimeToMinutes('12-34'))).toBe(true)
+    expect(Number.isNaN(parseTimeToMinutes('1234'))).toBe(true)
+  })
+
+  it('returns NaN for out-of-range values', () => {
+    expect(Number.isNaN(parseTimeToMinutes('24:00'))).toBe(true)
+    expect(Number.isNaN(parseTimeToMinutes('23:60'))).toBe(true)
+    expect(Number.isNaN(parseTimeToMinutes('-1:00'))).toBe(true)
+  })
+})
+
+describe('validation helpers', () => {
+  it('validates proper times', () => {
+    expect(isValidTime('00:00')).toBe(true)
+    expect(isValidTime('23:59')).toBe(true)
+  })
+
+  it('detects invalid formats', () => {
+    expect(isValidTimeFormat('abc')).toBe(false)
+    expect(isValidTime('abc')).toBe(false)
+  })
+
+  it('detects out-of-range times', () => {
+    expect(isValidTime('24:00')).toBe(false)
+    expect(isValidTime('23:60')).toBe(false)
+  })
+})

--- a/services/webapp/ui/src/lib/time.ts
+++ b/services/webapp/ui/src/lib/time.ts
@@ -1,0 +1,28 @@
+export const TIME_REGEX = /^(\d{1,2}):(\d{2})$/
+
+/**
+ * Parses HH:MM string to total minutes from midnight.
+ * Returns NaN for invalid format or out-of-range values.
+ */
+export function parseTimeToMinutes(t: string): number {
+  const match = TIME_REGEX.exec(t.trim())
+  if (!match) return NaN
+  const hours = Number(match[1])
+  const minutes = Number(match[2])
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return NaN
+  return hours * 60 + minutes
+}
+
+/**
+ * Checks whether a string matches HH:MM format (no range validation).
+ */
+export function isValidTimeFormat(t: string): boolean {
+  return TIME_REGEX.test(t.trim())
+}
+
+/**
+ * Validates time string to be within 00:00-23:59 range.
+ */
+export function isValidTime(t: string): boolean {
+  return !Number.isNaN(parseTimeToMinutes(t))
+}

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -13,6 +13,7 @@ import {
   type ReminderType,
   type NormalizedReminderType,
 } from '@/lib/reminders'
+import { parseTimeToMinutes } from '@/lib/time'
 import { Reminder as ApiReminder } from '@sdk'
 
 interface Reminder {
@@ -36,15 +37,6 @@ const TYPE_ICON: Record<NormalizedReminderType, string> = {
   insulin: '💉',
   meal: '🍽️',
   medicine: '💊',
-}
-
-function parseTimeToMinutes(t: string): number {
-  const match = /^(\d{1,2}):(\d{2})$/.exec(t)
-  if (!match) return NaN
-  const h = Number(match[1])
-  const m = Number(match[2])
-  if (h > 23 || m > 59) return NaN
-  return h * 60 + m
 }
 
 function SkeletonItem() {

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -11,6 +11,7 @@ import {
   type ReminderType,
   type NormalizedReminderType,
 } from "@/lib/reminders";
+import { isValidTime } from "@/lib/time";
 
 const TYPES: Record<NormalizedReminderType, { label: string; emoji: string }> = {
   sugar: { label: "Сахар", emoji: "🩸" },
@@ -25,18 +26,6 @@ const PRESETS: Record<NormalizedReminderType, number[]> = {
   meal: [180, 240, 360],
   medicine: [240, 480, 720]
 };
-
-function isValidTime(time: string): boolean {
-  const [hours, minutes] = time.split(":").map(Number);
-  return (
-    Number.isInteger(hours) &&
-    Number.isInteger(minutes) &&
-    hours >= 0 &&
-    hours <= 23 &&
-    minutes >= 0 &&
-    minutes <= 59
-  );
-}
 
 interface Reminder {
   id: number;


### PR DESCRIPTION
## Summary
- add reusable time parsing helpers
- refactor reminder components to use shared helpers
- test time parsing edge cases

## Testing
- `npm --workspace services/webapp/ui run lint`
- `cd services/webapp/ui && npx vitest run --environment jsdom`


------
https://chatgpt.com/codex/tasks/task_e_68a172382b54832a9c555938165cfb7b