### PR TITLE
[ui] Handle non-2xx responses in tgFetch

### DIFF
--- a/services/webapp/ui/src/api/history.ts
+++ b/services/webapp/ui/src/api/history.ts
@@ -16,9 +16,6 @@ export interface HistoryRecord {
 export async function getHistory(): Promise<HistoryRecord[]> {
   try {
     const res = await tgFetch(`${API_BASE}/history`);
-    if (!res.ok) {
-      throw new Error('Не удалось загрузить историю');
-    }
     const data = await res.json();
     if (!Array.isArray(data)) {
       throw new Error('Некорректный ответ');
@@ -41,7 +38,7 @@ export async function updateRecord(record: HistoryRecord) {
       body: JSON.stringify(record),
     });
     const data = await res.json().catch(() => ({}));
-    if (!res.ok || data.status !== 'ok') {
+    if (data.status !== 'ok') {
       throw new Error(data.detail || 'Не удалось обновить запись');
     }
     return data;
@@ -58,7 +55,7 @@ export async function deleteRecord(id: string) {
   try {
     const res = await tgFetch(`${API_BASE}/history/${encodeURIComponent(id)}`, { method: 'DELETE' });
     const data = await res.json().catch(() => ({}));
-    if (!res.ok || data.status !== 'ok') {
+    if (data.status !== 'ok') {
       throw new Error(data.detail || 'Не удалось удалить запись');
     }
     return data;

--- a/services/webapp/ui/src/api/stats.ts
+++ b/services/webapp/ui/src/api/stats.ts
@@ -29,10 +29,6 @@ export const fallbackDayStats: DayStats = {
 export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint[]> {
   try {
     const res = await tgFetch(`${API_BASE}/analytics?telegramId=${telegramId}`);
-    if (!res.ok) {
-      console.error('Analytics API request failed:', res.status);
-      return fallbackAnalytics;
-    }
     const data = await res.json();
     if (!Array.isArray(data)) {
       console.error('Unexpected analytics API response:', data);
@@ -48,10 +44,6 @@ export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint
 export async function fetchDayStats(telegramId: number): Promise<DayStats> {
   try {
     const res = await tgFetch(`${API_BASE}/stats?telegramId=${telegramId}`);
-    if (!res.ok) {
-      console.error('Stats API request failed:', res.status);
-      return fallbackDayStats;
-    }
     const data = await res.json();
 
     if (!data || typeof data !== 'object' || Array.isArray(data)) {

--- a/services/webapp/ui/src/api/tgFetch.api.test.ts
+++ b/services/webapp/ui/src/api/tgFetch.api.test.ts
@@ -41,6 +41,13 @@ describe('tgFetch', () => {
     await expect(tgFetch('/api/profile')).rejects.toThrow('Проблема с сетью');
   });
 
+  it('throws on non-2xx responses', async () => {
+    (global.fetch as Mock).mockResolvedValue(
+      new Response(null, { status: 400, statusText: 'Bad Request' }),
+    );
+    await expect(tgFetch('/api/profile')).rejects.toThrow('Bad Request');
+  });
+
   it('aborts request after timeout', async () => {
     vi.useFakeTimers();
     (global.fetch as Mock).mockImplementation((_, options: RequestInit) =>

--- a/services/webapp/ui/src/lib/tgFetch.test.ts
+++ b/services/webapp/ui/src/lib/tgFetch.test.ts
@@ -52,6 +52,13 @@ describe('tgFetch', () => {
     await expect(tgFetch('/api/profile/self')).rejects.toThrow('Проблема с сетью');
   });
 
+  it('throws on non-2xx responses', async () => {
+    (global.fetch as Mock).mockResolvedValue(
+      new Response(null, { status: 500, statusText: 'Internal Error' }),
+    );
+    await expect(tgFetch('/api/profile/self')).rejects.toThrow('Internal Error');
+  });
+
   it('aborts request after timeout', async () => {
     vi.useFakeTimers();
     (global.fetch as Mock).mockImplementation((_, options: RequestInit) =>

--- a/services/webapp/ui/src/lib/tgFetch.ts
+++ b/services/webapp/ui/src/lib/tgFetch.ts
@@ -22,12 +22,16 @@ export async function tgFetch(
   const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT);
 
   try {
-    return await fetch(input, {
+    const response = await fetch(input, {
       ...init,
       headers,
       credentials: init.credentials ?? "include",
       signal: controller.signal,
     });
+    if (!response.ok) {
+      throw new Error(response.statusText || `HTTP error ${response.status}`);
+    }
+    return response;
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
       throw new Error("Превышено время ожидания запроса");


### PR DESCRIPTION
## Summary
- throw when tgFetch receives a non-OK response, including status text
- simplify history and stats API helpers by removing explicit response.ok checks
- add tests to ensure tgFetch rejects on non-2xx responses

## Testing
- `npx vitest run`
- `npx vitest run src/lib/tgFetch.test.ts src/api/tgFetch.api.test.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a17234cdb4832a8f1ceb7602e602e1