### PR TITLE
[webapp] Fetch reminder once

### DIFF
--- a/services/webapp/ui/src/reminders/CreateReminder.test.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.test.tsx
@@ -1,0 +1,34 @@
+import { render, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ state: undefined }),
+  useParams: () => ({ id: "1" }),
+}));
+
+vi.mock("@/contexts/telegram-context", () => ({
+  useTelegramContext: () => ({ user: { id: 123 }, sendData: vi.fn() }),
+}));
+
+vi.mock("@/api/reminders", () => ({
+  getReminder: vi.fn().mockResolvedValue({
+    id: 1,
+    type: "sugar",
+    time: "08:00",
+    title: "Test",
+    intervalHours: 1,
+  }),
+  createReminder: vi.fn(),
+  updateReminder: vi.fn(),
+}));
+
+import CreateReminder from "./CreateReminder";
+import { getReminder } from "@/api/reminders";
+
+describe("CreateReminder", () => {
+  it("requests reminder only once", async () => {
+    render(<CreateReminder />);
+    await waitFor(() => expect(getReminder).toHaveBeenCalledTimes(1));
+  });
+});

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import { createReminder, updateReminder, getReminder } from "@/api/reminders";
 import { Reminder as ApiReminder } from "@sdk";
 import { useTelegramContext } from "@/contexts/telegram-context";
-import { useToast } from "@/hooks/use-toast";
+import { toast } from "@/hooks/use-toast";
 import {
   normalizeReminderType,
   type ReminderType,
@@ -51,7 +51,6 @@ export default function CreateReminder() {
   const location = useLocation();
   const params = useParams();
   const { user, sendData } = useTelegramContext();
-  const { toast } = useToast();
   const [editing, setEditing] = useState<Reminder | undefined>(
     (location.state as Reminder | undefined) ?? undefined,
   );
@@ -68,45 +67,44 @@ export default function CreateReminder() {
   const [typeOpen, setTypeOpen] = useState(false);
 
   useEffect(() => {
-    if (!editing && params.id && user?.id) {
-      const id = Number(params.id);
-      if (Number.isNaN(id)) {
-        const message = "Некорректный ID напоминания";
-        setError(message);
-        toast({ title: "Ошибка", description: message, variant: "destructive" });
-        return;
-      }
-      (async () => {
-        try {
-          const data = await getReminder(user.id, id);
-          if (data) {
-            const nt = normalizeReminderType(data.type as ReminderType);
-            const loaded: Reminder = {
-              id: data.id ?? id,
-              type: nt,
-              title: data.title ?? TYPES[nt].label,
-              time: data.time || "",
-              interval: data.intervalHours != null ? data.intervalHours * 60 : undefined,
-            };
-            setEditing(loaded);
-            setType(loaded.type);
-            setTitle(loaded.title);
-            setTime(loaded.time);
-            setIntervalMinutes(loaded.interval ?? 60);
-          } else {
-            const message = "Не удалось загрузить напоминание";
-            setError(message);
-            toast({ title: "Ошибка", description: message, variant: "destructive" });
-          }
-        } catch (err) {
-          const message =
-            err instanceof Error ? err.message : "Не удалось загрузить напоминание";
+    if (!params.id || !user?.id) return;
+    const id = Number(params.id);
+    if (Number.isNaN(id)) {
+      const message = "Некорректный ID напоминания";
+      setError(message);
+      toast({ title: "Ошибка", description: message, variant: "destructive" });
+      return;
+    }
+    (async () => {
+      try {
+        const data = await getReminder(user.id, id);
+        if (data) {
+          const nt = normalizeReminderType(data.type as ReminderType);
+          const loaded: Reminder = {
+            id: data.id ?? id,
+            type: nt,
+            title: data.title ?? TYPES[nt].label,
+            time: data.time || "",
+            interval: data.intervalHours != null ? data.intervalHours * 60 : undefined,
+          };
+          setEditing(loaded);
+          setType(loaded.type);
+          setTitle(loaded.title);
+          setTime(loaded.time);
+          setIntervalMinutes(loaded.interval ?? 60);
+        } else {
+          const message = "Не удалось загрузить напоминание";
           setError(message);
           toast({ title: "Ошибка", description: message, variant: "destructive" });
         }
-      })();
-    }
-  }, [editing, params.id, user?.id, toast]);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Не удалось загрузить напоминание";
+        setError(message);
+        toast({ title: "Ошибка", description: message, variant: "destructive" });
+      }
+    })();
+  }, [params.id, user?.id]);
 
   const validName = title.trim().length >= 2;
   const validTime = isValidTime(time);


### PR DESCRIPTION
## Summary
- avoid repeated reminder fetch by removing toast and editing from effect deps
- import toast directly and rely only on params.id and user id
- add test to ensure reminder fetch runs once

## Testing
- `npm --workspace services/webapp/ui run lint`
- `npx vitest run --config services/webapp/ui/vite.config.ts --environment jsdom services/webapp/ui/src/reminders/CreateReminder.test.tsx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a172325a88832a8f67eabfd86f8b0b