### PR TITLE
[webapp] enforce TypeScript strict mode and CI type checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,9 @@ jobs:
         run: |
           npm ci
           npm run build
+      - name: Type-check webapp UI
+        working-directory: services/webapp/ui
+        run: npm run typecheck
       - name: Install Playwright browsers
         run: playwright install --with-deps
       - name: Run lint

--- a/services/webapp/ui/package.json
+++ b/services/webapp/ui/package.json
@@ -10,7 +10,8 @@
     "build:dev": "npm run prebuild && vite build --mode development",
     "watch": "vite build --watch",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -10,11 +10,11 @@
       "@/*": ["./src/*"],
       "@sdk/*": ["../../../libs/ts-sdk/*"]
     },
-    "noImplicitAny": false,
-    "noUnusedParameters": false,
+    "noImplicitAny": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true,
     "allowJs": true,
-    "noUnusedLocals": false,
-    "strictNullChecks": false
+    "noUnusedLocals": true,
+    "strictNullChecks": true
   }
 }


### PR DESCRIPTION
## Summary
- enable TypeScript strict options in webapp UI
- add typecheck npm script and CI step running `tsc --noEmit`

## Testing
- `npm run typecheck`
- `npm run build`
- `npm run lint`
- `ruff check .`
- `mypy --strict .` *(fails: Library stubs not installed for "reportlab")*
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68a17236b000832ab10c17134ca670b2