### PR TITLE
tests: fix mypy strict errors

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -16,3 +16,9 @@ ignore_errors = True
 
 [mypy-libs.*]
 ignore_errors = True
+
+[mypy-playwright.*]
+ignore_missing_imports = True
+
+[mypy-reportlab.*]
+ignore_missing_imports = True

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -98,7 +98,7 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["edit_field"] == "dose"
 
     reply_msg = DummyMessage(text="5")

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -59,7 +59,7 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     kwargs = query.message.kwargs[0]
     assert kwargs.get("reply_markup") == common_handlers.menu_keyboard
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert "pending_entry" not in user_data
 
 
@@ -127,5 +127,5 @@ async def test_callback_router_ignores_reminder_action() -> None:
 
     assert query.edited == []
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert "pending_entry" in user_data

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -68,7 +68,7 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
     assert result == 200
     assert called.flag
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["__file_path"] == "photos/1_uid.png"
     assert update.message is not None
     msg = update.message
@@ -270,10 +270,10 @@ async def test_photo_then_freeform_calculates_dose(
         ) -> None:
             pass
 
-        def get(self, entity: Any, ident: Any, **kwargs: Any) -> Any:
+        def get(self, *args: Any, **kwargs: Any) -> Any:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
+    session_factory = cast(Any, sessionmaker(class_=DummySession))
     handlers.SessionLocal = session_factory
 
     sugar_msg = DummyMessage(text="5")
@@ -289,5 +289,5 @@ async def test_photo_then_freeform_calculates_dose(
     assert "Сахар: 5.0 ммоль/л" in reply
     assert "Ваша доза: 1.0 Ед" in reply
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert "dose" in user_data["pending_entry"]

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -46,7 +46,7 @@ async def test_freeform_handler_edits_pending_entry_keeps_state() -> None:
     await handlers.freeform_handler(update, context)
 
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     pending = user_data.get("pending_entry")
     assert pending is not None
     assert pending["dose"] == 3.5
@@ -81,10 +81,10 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         ) -> None:
             pass
 
-        def get(self, entity: Any, ident: Any, **kwargs: Any) -> Any:
+        def get(self, *args: Any, **kwargs: Any) -> Any:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
+    session_factory = cast(Any, sessionmaker(class_=DummySession))
     handlers.SessionLocal = session_factory
     message = DummyMessage("5,6")
     update = cast(
@@ -99,7 +99,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
     await handlers.freeform_handler(update, context)
 
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     pending = user_data.get("pending_entry")
     assert pending is not None
     assert pending["sugar_before"] == 5.6
@@ -133,7 +133,7 @@ async def test_freeform_handler_sugar_only_flow() -> None:
     await handlers.freeform_handler(update, context)
 
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     pending = user_data.get("pending_entry")
     assert pending is not None
     assert pending["sugar_before"] == 4.2

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -188,7 +188,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await router.callback_router(update_cb, context)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["edit_entry"] == {
         "id": entry_id,
         "chat_id": 42,
@@ -208,7 +208,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await router.callback_router(update_cb2, context)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["edit_id"] == entry_id
     assert user_data["edit_field"] == "xe"
     assert user_data["edit_query"] is field_query
@@ -232,7 +232,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert field_query.answer_texts[-1] == "Изменено"
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert not any(
         k in user_data for k in ("edit_id", "edit_field", "edit_entry", "edit_query")
     )

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -68,7 +68,7 @@ class DummySession(Session):
     def commit(self) -> None:
         pass
 
-    def get(self, entity: Any, ident: Any, **kwargs: Any) -> Any:
+    def get(self, *args: Any, **kwargs: Any) -> Any:
         return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
 
@@ -97,7 +97,7 @@ async def test_photo_flow_saves_entry(
     setattr(cast(Any, type(context)), "job_queue", PropertyMock(return_value=None))
 
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
 
     async def fake_get_file(file_id: str) -> Any:
         class File:
@@ -149,7 +149,7 @@ async def test_photo_flow_saves_entry(
     monkeypatch.setattr(dose_handlers, "extract_nutrition_info", lambda text: (30.0, 2.0))
     user_data["thread_id"] = "tid"
 
-    msg_photo = DummyMessage(photo=(DummyPhoto(),))
+    msg_photo = DummyMessage(photo=cast(tuple[PhotoSize, ...], (DummyPhoto(),)))
     update_photo = cast(
         Update,
         SimpleNamespace(message=msg_photo, effective_user=SimpleNamespace(id=1)),
@@ -166,7 +166,7 @@ async def test_photo_flow_saves_entry(
         Update,
         SimpleNamespace(message=msg_sugar, effective_user=SimpleNamespace(id=1)),
     )
-    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
+    session_factory = cast(Any, sessionmaker(class_=DummySession))
     dose_handlers.SessionLocal = session_factory
     await dose_handlers.freeform_handler(update_sugar, context)
     assert user_data["pending_entry"]["sugar_before"] == 5.5

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -204,7 +204,7 @@ async def test_profile_view_preserves_user_data(monkeypatch: pytest.MonkeyPatch)
     await handlers.profile_view(update, context)
 
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data["thread_id"] == "tid"
     assert user_data["foo"] == "bar"
 

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -56,7 +56,7 @@ async def test_report_request_and_custom_flow(
 
     await reporting_handlers.report_request(update, context)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert "awaiting_report_date" not in user_data
     assert any("Выберите период" in t for t in message.replies)
     assert message.kwargs
@@ -73,7 +73,7 @@ async def test_report_request_and_custom_flow(
     await reporting_handlers.report_period_callback(update_cb, context)
 
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert user_data.get("awaiting_report_date") is True
     assert query.edited
     assert any("YYYY-MM-DD" in text for text in query.edited)
@@ -105,7 +105,7 @@ async def test_report_request_and_custom_flow(
     called_flag = called.get("called")
     assert called_flag is not None
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert "awaiting_report_date" not in user_data
 
 

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -100,7 +100,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
     # Final reply should include dish name from Vision response
     assert any("Борщ" in reply for reply in msg_photo.replies)
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     entry = user_data.get("pending_entry")
     assert entry is not None
     assert entry["carbs_g"] == 30

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -371,7 +371,7 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
     answer = query.answers[0]
     assert answer == "Готово ✅"
     assert context.user_data is not None
-    user_data = cast(dict[str, Any], context.user_data)
+    user_data = context.user_data
     assert "pending_entry" in user_data
 
 

--- a/tests/test_run_db.py
+++ b/tests/test_run_db.py
@@ -36,16 +36,7 @@ async def test_run_db_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
     dummy_engine = SimpleNamespace(url=SimpleNamespace(drivername="postgresql", database="db"))
 
     class DummySession(SASession):
-        def get_bind(
-            self,
-            mapper: Any | None = None,
-            *,
-            clause: Any | None = None,
-            bind: Any | None = None,
-            _sa_skip_events: bool | None = None,
-            _sa_skip_for_implicit_returning: bool = False,
-            **kw: Any,
-        ) -> Any:
+        def get_bind(self, *args: Any, **kwargs: Any) -> Any:
             return dummy_engine
 
         def __enter__(self) -> "DummySession":

--- a/tests/test_webapp_history.py
+++ b/tests/test_webapp_history.py
@@ -5,7 +5,7 @@ import json
 import time
 import urllib.parse
 
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 import pytest
 from fastapi.testclient import TestClient
@@ -114,7 +114,7 @@ async def test_history_concurrent_writes(monkeypatch: pytest.MonkeyPatch) -> Non
 
     async def post_record(rec: dict[str, Any]) -> None:
         async with AsyncClient(
-            transport=ASGITransport(app=server.app), base_url="http://test"
+            transport=ASGITransport(app=cast(Any, server.app)), base_url="http://test"
         ) as ac:
             resp = await ac.post("/api/history", json=rec, headers=headers)
             assert resp.status_code == 200

--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -6,7 +6,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 import urllib.parse
 
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 import pytest
 from fastapi.testclient import TestClient
@@ -136,7 +136,7 @@ async def test_timezone_async_writes(
 
     async def write_tz(tz: str) -> None:
         async with AsyncClient(
-            transport=ASGITransport(app=server.app), base_url="http://test"
+            transport=ASGITransport(app=cast(Any, server.app)), base_url="http://test"
         ) as ac:
             resp = await ac.put("/timezone", json={"tz": tz}, headers=headers)
             assert resp.status_code == 200
@@ -150,7 +150,7 @@ async def test_timezone_async_writes(
         tz_value = tz_row.tz
 
     async with AsyncClient(
-        transport=ASGITransport(app=server.app), base_url="http://test"
+        transport=ASGITransport(app=cast(Any, server.app)), base_url="http://test"
     ) as ac:
         resp = await ac.get("/timezone", headers=headers)
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- relax dummy SQLAlchemy session overrides and drop redundant casts
- ignore missing stubs for external libs in mypy
- cast FastAPI apps for ASGI transport in web app tests

## Testing
- `pre-commit run --files mypy.ini tests/test_edit_record.py tests/test_handlers_cancel_entry.py tests/test_handlers_doc.py tests/test_handlers_freeform_pending.py tests/test_handlers_history_edit.py tests/test_handlers_photo_sugar_save.py tests/test_handlers_profile.py tests/test_handlers_report_request.py tests/test_handlers_vision_prompt.py tests/test_reminders.py tests/test_run_db.py tests/test_webapp_timezone.py tests/test_webapp_history.py`
- `mypy --strict .`
- `pytest tests/test_edit_record.py tests/test_handlers_cancel_entry.py tests/test_handlers_doc.py tests/test_handlers_freeform_pending.py tests/test_handlers_history_edit.py tests/test_handlers_photo_sugar_save.py tests/test_handlers_profile.py tests/test_handlers_report_request.py tests/test_handlers_vision_prompt.py tests/test_reminders.py tests/test_run_db.py tests/test_webapp_history.py tests/test_webapp_timezone.py`

------
https://chatgpt.com/codex/tasks/task_e_68a175aee368832aa0269afd45fab720