### PR TITLE
[webapp] handle telegram init errors

### DIFF
--- a/services/webapp/ui/src/App.tsx
+++ b/services/webapp/ui/src/App.tsx
@@ -22,7 +22,7 @@ const NotFound = lazy(() => import("./pages/NotFound"));
 const queryClient = new QueryClient();
 
 const AppContent = () => {
-  const { isReady } = useTelegramContext();
+  const { isReady, error } = useTelegramContext();
 
   if (!isReady) {
     return (
@@ -30,6 +30,17 @@ const AppContent = () => {
         <div className="animate-pulse text-center">
           <div className="w-16 h-16 rounded-full bg-primary/20 mx-auto mb-4"></div>
           <p className="text-muted-foreground">Загрузка СахарФото...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-center space-y-2">
+          <p className="text-lg font-medium">Что-то пошло не так</p>
+          <p className="text-muted-foreground">Попробуйте обновить приложение.</p>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- show fallback message when Telegram context initialization fails

## Testing
- `npm run lint`
- `npx vitest run ../../../tests/useTelegram.test.ts --root ../../../`
- `pytest tests/test_webapp_user.py`


------
https://chatgpt.com/codex/tasks/task_e_68a17ebde390832ab6bc78abac9ef4a8