### PR TITLE
[webapp] Add VITE env var typings

### DIFF
--- a/services/webapp/ui/src/vite-env.d.ts
+++ b/services/webapp/ui/src/vite-env.d.ts
@@ -2,13 +2,15 @@
 
 // файл: services/webapp/ui/src/vite-env.d.ts
 declare global {
-    interface ImportMetaEnv {
-      readonly VITE_TELEGRAM_BOT: string;
-    }
-    interface ImportMeta {
-      readonly env: ImportMetaEnv;
-    }
+  interface ImportMetaEnv {
+    readonly VITE_TELEGRAM_BOT: string;
+    readonly VITE_API_BASE?: string;
+    readonly VITE_FORCE_LIGHT?: string;
   }
-  
-  export { };
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
+}
+
+export {}
   


### PR DESCRIPTION
## Summary
- add VITE_API_BASE and VITE_FORCE_LIGHT to ImportMetaEnv
- keep global augmentation with export {}

## Testing
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui run typecheck`
- `pytest tests`
- `ruff check services/api/app tests`


------
https://chatgpt.com/codex/tasks/task_e_68a17ebdc464832aa38c477f0546e23d