### PR TITLE
[telegram] patch Application __slots__ for Python 3.13

### DIFF
--- a/docs/telegram-compat.md
+++ b/docs/telegram-compat.md
@@ -1,0 +1,12 @@
+# Telegram compatibility workaround
+
+Python 3.13 requires classes with `__slots__` that support weak references to
+explicitly include `"__weakref__"`. Older versions of
+[`python-telegram-bot`](https://python-telegram-bot.org/) miss this slot on the
+internal `telegram.ext._application.Application` class, causing
+`ApplicationBuilder().build()` to fail.
+
+The project temporarily patches `Application.__slots__` in
+`services/api/app/telegram_compat.py`. This file can be removed once the
+`python-telegram-bot` dependency is upgraded to a version that already includes
+this fix.

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import services.api.app.telegram_compat  # noqa: F401
+
 from telegram.ext import (
     Application,
     CallbackQueryHandler,

--- a/services/api/app/telegram_compat.py
+++ b/services/api/app/telegram_compat.py
@@ -1,0 +1,16 @@
+"""Temporary Telegram compatibility helpers.
+
+This module patches :class:`telegram.ext._application.Application` to work on
+Python 3.13. The current version of ``python-telegram-bot`` lacks the
+``"__weakref__"`` slot which becomes mandatory in Python 3.13 for classes using
+``__slots__``. Importing this module adds the missing slot so that
+``ApplicationBuilder().build()`` succeeds.
+
+Remove this module once ``python-telegram-bot`` is upgraded and includes the
+fix natively.
+"""
+
+from telegram.ext._application import Application
+
+if "__weakref__" not in getattr(Application, "__slots__", ()):
+    Application.__slots__ = (*Application.__slots__, "__weakref__")  # type: ignore[attr-defined]

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -7,6 +7,8 @@ import logging
 import sys
 from typing import Any
 
+import services.api.app.telegram_compat  # noqa: F401
+
 from telegram import BotCommand
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
 from sqlalchemy.exc import SQLAlchemyError

--- a/tests/test_telegram_compat.py
+++ b/tests/test_telegram_compat.py
@@ -1,0 +1,7 @@
+import services.api.app.telegram_compat  # noqa: F401
+from telegram.ext import ApplicationBuilder
+
+
+def test_application_builder_build() -> None:
+    app = ApplicationBuilder().token("TESTTOKEN").build()
+    assert app is not None


### PR DESCRIPTION
## Summary
- import compatibility shim to ensure python-telegram-bot works on Python 3.13
- add telegram_compat module and regression test
- document temporary workaround

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a17f94a38c832a936597ad866a0dbb