### PR TITLE
[db] add engine dispose helper and tests

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -14,7 +14,7 @@ from sqlalchemy import (
     Boolean,
     func,
 )
-from sqlalchemy.engine import URL
+from sqlalchemy.engine import URL, Engine
 from sqlalchemy.exc import UnboundExecutionError
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -84,6 +84,27 @@ async def run_db(
             return wrapper()
 
     return await asyncio.to_thread(wrapper)
+
+
+def dispose_engine(target: Engine | None = None) -> None:
+    """Dispose of a SQLAlchemy engine.
+
+    Parameters
+    ----------
+    target:
+        The engine to dispose. If ``None`` the module's global engine is used
+        and reset.
+    """
+
+    global engine
+    with engine_lock:
+        eng = target or engine
+        if eng is None:
+            return
+        eng.dispose()
+        if target is None and eng is engine:
+            engine = None
+            SessionLocal.configure(bind=None)
 
 
 # ───────────────────────── модели ────────────────────────────

--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -2,13 +2,29 @@ import json
 from types import SimpleNamespace
 from typing import Any, Callable, cast
 
+import warnings
+from contextlib import contextmanager
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from services.api.app.diabetes.services.db import Base, User, Reminder, Entry
 import services.api.app.diabetes.handlers.reminder_handlers as handlers
 from services.api.app.diabetes.services.repository import commit
+from services.api.app.diabetes.services.db import Base, User, Reminder, Entry, dispose_engine
+
+
+@contextmanager
+def no_warnings() -> Any:
+    try:
+        with pytest.warns(None):
+            yield
+            return
+    except TypeError:
+        pass
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        yield
 
 
 class DummyMessage:
@@ -45,7 +61,7 @@ class DummyJobQueue:
         return []
 
 
-def _setup_db() -> sessionmaker[Any]:
+def _setup_db() -> tuple[sessionmaker[Any], Any]:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -55,33 +71,40 @@ def _setup_db() -> sessionmaker[Any]:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar", time="08:00", is_enabled=True))
         session.commit()
-    return TestSession
+    return TestSession, engine
 
 
 @pytest.mark.asyncio
 async def test_bad_input_does_not_create_entry() -> None:
-    TestSession = _setup_db()
+    TestSession, engine = _setup_db()
     msg = DummyMessage(json.dumps({"id": 1, "type": "sugar", "value": "bad"}))
     update = cast(
         Any, SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1))
     )
     context = cast(Any, SimpleNamespace(job_queue=DummyJobQueue()))
-    await handlers.reminder_webapp_save(update, context)
+    with no_warnings():
+        await handlers.reminder_webapp_save(update, context)
     assert msg.replies and "Неверный формат" in msg.replies[0]
     with TestSession() as session:
         assert session.query(Entry).count() == 0
+    with no_warnings():
+        dispose_engine(engine)
 
 
 @pytest.mark.asyncio
 async def test_good_input_updates_and_ends() -> None:
-    TestSession = _setup_db()
+    TestSession, engine = _setup_db()
     msg = DummyMessage(json.dumps({"id": 1, "type": "sugar", "value": "09:30"}))
     update = cast(
         Any, SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1))
     )
     context = cast(Any, SimpleNamespace(job_queue=DummyJobQueue()))
-    await handlers.reminder_webapp_save(update, context)
+    with no_warnings():
+        await handlers.reminder_webapp_save(update, context)
     with TestSession() as session:
         rem = session.get(Reminder, 1)
         assert rem.time == "09:30"
         assert session.query(Entry).count() == 0
+    with no_warnings():
+        dispose_engine(engine)
+


### PR DESCRIPTION
## Summary
- add `dispose_engine()` utility for cleaning up SQLAlchemy engines
- use helper in profile and reminder handler tests
- guard engine disposal paths against warnings

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68a17f96aff8832aa31554a717701c12