### PR TITLE
[telegram] Auto-apply compatibility patch

### DIFF
--- a/docs/telegram-compat.md
+++ b/docs/telegram-compat.md
@@ -7,6 +7,8 @@ internal `telegram.ext._application.Application` class, causing
 `ApplicationBuilder().build()` to fail.
 
 The project temporarily patches `Application.__slots__` in
-`services/api/app/telegram_compat.py`. This file can be removed once the
-`python-telegram-bot` dependency is upgraded to a version that already includes
-this fix.
+`services/api/app/telegram_compat.py`. Importing the top-level package
+(`services.api.app`) automatically applies this patch, so individual modules or
+users do not need to import `telegram_compat` manually. This file can be removed
+once the `python-telegram-bot` dependency is upgraded to a version that already
+includes this fix.

--- a/services/api/app/__init__.py
+++ b/services/api/app/__init__.py
@@ -1,0 +1,12 @@
+"""App package initialization."""
+
+# Import compatibility patches for python-telegram-bot before any
+# ApplicationBuilder instances are created.  The module modifies the
+# ``Application`` class in-place so simply importing it is sufficient.
+#
+# This makes the patch run automatically whenever ``services.api.app`` or any
+# of its subpackages are imported, removing the need for manual imports in
+# tests or application code.
+from . import telegram_compat  # noqa: F401
+
+__all__ = []

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import services.api.app.telegram_compat  # noqa: F401
-
 from telegram.ext import (
     Application,
     CallbackQueryHandler,

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -7,8 +7,6 @@ import logging
 import sys
 from typing import Any
 
-import services.api.app.telegram_compat  # noqa: F401
-
 from telegram import BotCommand
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
 from sqlalchemy.exc import SQLAlchemyError

--- a/tests/test_telegram_compat.py
+++ b/tests/test_telegram_compat.py
@@ -1,4 +1,4 @@
-import services.api.app.telegram_compat  # noqa: F401
+import services.api.app  # noqa: F401  # ensures compatibility patch is applied
 from telegram.ext import ApplicationBuilder
 
 


### PR DESCRIPTION
## Summary
- automatically apply python-telegram-bot Application compatibility patch on package import
- drop manual telegram_compat imports from handlers, bot entry, and tests
- document automatic patching for telegram compatibility

## Testing
- `ruff check services/api/app tests -v`
- `pytest tests/test_telegram_compat.py -q`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1852192f0832a999d6ba03db121f3