### PR TITLE
[webapp] Use nullish coalescing for API_BASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,14 @@ sudo apt install python3.12 python3.12-venv
 - обязательные значения: `TELEGRAM_TOKEN` (токен бота), `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
 - дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `VITE_API_BASE`, `UVICORN_WORKERS`
 - при необходимости настройте прокси для OpenAI через переменные окружения
-Переменная `VITE_API_BASE` задаёт базовый URL API для WebApp и используется SDK‑клиентом:
+Переменная `VITE_API_BASE` задаёт базовый URL API для WebApp и используется SDK‑клиентом.
+Если переменная не задана, используется путь `/api`.
+Чтобы отправлять запросы на тот же домен без префикса, укажите пустое значение:
+
 ```env
-VITE_API_BASE=http://localhost:8000
+VITE_API_BASE=
+# или задайте полный URL
+# VITE_API_BASE=http://localhost:8000
 ```
 
 Telegram‑клиенты не могут обращаться к `localhost`, поэтому `WEBAPP_URL` должен быть публичным **HTTPS**‑адресом. Для локальной разработки используйте туннель (например, [ngrok](https://ngrok.com/)).

--- a/services/webapp/ui/src/api/base.api.test.ts
+++ b/services/webapp/ui/src/api/base.api.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+describe('API_BASE', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('is empty string when VITE_API_BASE is empty', async () => {
+    vi.stubEnv('VITE_API_BASE', '');
+    vi.resetModules();
+    const { API_BASE } = await import('./base');
+    expect(API_BASE).toBe('');
+  });
+
+  it('defaults to /api when VITE_API_BASE is undefined', async () => {
+    const { API_BASE } = await import('./base');
+    expect(API_BASE).toBe('/api');
+  });
+});
+

--- a/services/webapp/ui/src/api/base.ts
+++ b/services/webapp/ui/src/api/base.ts
@@ -1,1 +1,1 @@
-export const API_BASE = import.meta.env.VITE_API_BASE || '/api';
+export const API_BASE = import.meta.env.VITE_API_BASE ?? '/api';


### PR DESCRIPTION
## Summary
- allow empty `VITE_API_BASE` by using nullish coalescing
- document usage of blank `VITE_API_BASE`
- test `API_BASE` behavior for empty env var

## Testing
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui exec vitest run` *(fails: document is not defined in CreateReminder.test.tsx, ChartStyle tests)*
- `npm --workspace services/webapp/ui exec vitest run src/api`

------
https://chatgpt.com/codex/tasks/task_e_68a1852d20a4832a82bc2eb103a760f5