### PR TITLE
[webapp] Add default case to toast reducer

### DIFF
--- a/services/webapp/ui/src/hooks/use-toast.ts
+++ b/services/webapp/ui/src/hooks/use-toast.ts
@@ -124,6 +124,8 @@ export const reducer = (state: State, action: Action): State => {
         ...state,
         toasts: state.toasts.filter((t) => t.id !== action.toastId),
       }
+    default:
+      return state
   }
 }
 


### PR DESCRIPTION
## Summary
- handle unknown toast reducer actions by returning previous state

## Testing
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui run typecheck`
- `npx vitest run` *(fails: Failed to resolve import "@/api/reminders" ...)*
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a18531453c832a88caface6651b14f