### PR TITLE
[ci] Target diabetes package for coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+source = services/api/app/diabetes
+
+[report]
+fail_under = 85

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run tests
         run: |
           set -o pipefail
-          pytest --cov=diabetes --cov-report=term-missing --cov-report=xml --cov-fail-under=85 | tee coverage.txt
+          pytest --cov=services.api.app.diabetes --cov-report=term-missing --cov-report=xml --cov-fail-under=85 | tee coverage.txt
           cat coverage.txt >> $GITHUB_STEP_SUMMARY
       - name: Run e2e reminder flow
         run: python tests/e2e_reminder_flow.py

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -18,7 +18,7 @@ from services.api.app.diabetes.services.db import Base, User, Profile, dispose_e
 @contextmanager
 def no_warnings() -> Any:
     try:
-        with pytest.warns(None):
+        with pytest.warns(None):  # type: ignore[call-overload]
             yield
             return
     except TypeError:

--- a/tests/test_profile_no_sdk.py
+++ b/tests/test_profile_no_sdk.py
@@ -32,7 +32,13 @@ async def test_profile_command_and_view_without_sdk(monkeypatch: pytest.MonkeyPa
 
     real_import = builtins.__import__
 
-    def fake_import(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0):
+    def fake_import(
+        name: str,
+        globals: Any = None,
+        locals: Any = None,
+        fromlist: Any = (),
+        level: int = 0,
+    ) -> Any:
         if name.startswith("diabetes_sdk"):
             raise ImportError("diabetes_sdk not available")
         return real_import(name, globals, locals, fromlist, level)

--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -17,7 +17,7 @@ from services.api.app.diabetes.services.db import Base, User, Reminder, Entry, d
 @contextmanager
 def no_warnings() -> Any:
     try:
-        with pytest.warns(None):
+        with pytest.warns(None):  # type: ignore[call-overload]
             yield
             return
     except TypeError:


### PR DESCRIPTION
## Summary
- add coverage configuration for services/api/app/diabetes
- point CI tests to run coverage on services.api.app.diabetes
- tidy tests for mypy warnings

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=85` *(fails: Required test coverage of 85% not reached. Total coverage: 66.97%)*

------
https://chatgpt.com/codex/tasks/task_e_68a18523c6bc832ab517547bb26f327f