### PR TITLE
[ui] Add ids and label associations in History filters

### DIFF
--- a/services/webapp/ui/src/pages/History.tsx
+++ b/services/webapp/ui/src/pages/History.tsx
@@ -137,22 +137,30 @@ const History = () => {
           
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-foreground mb-2">
+              <label
+                htmlFor="history-date"
+                className="block text-sm font-medium text-foreground mb-2"
+              >
                 Дата
               </label>
               <input
+                id="history-date"
                 type="date"
                 value={selectedDate}
                 onChange={(e) => setSelectedDate(e.target.value)}
                 className="medical-input"
               />
             </div>
-            
+
             <div>
-              <label className="block text-sm font-medium text-foreground mb-2">
+              <label
+                htmlFor="history-type"
+                className="block text-sm font-medium text-foreground mb-2"
+              >
                 Тип записи
               </label>
               <select
+                id="history-type"
                 value={selectedType}
                 onChange={(e) => setSelectedType(e.target.value)}
                 className="medical-input"


### PR DESCRIPTION
## Summary
- link History filter labels to inputs using htmlFor
- add unique ids to date and type select fields

## Testing
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui run typecheck`
- `pre-commit run --files services/webapp/ui/src/pages/History.tsx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1894af854832a8758d984408cede7