### PR TITLE
[webapp] Ensure history fields render zero values

### DIFF
--- a/services/webapp/ui/src/pages/History.tsx
+++ b/services/webapp/ui/src/pages/History.tsx
@@ -230,7 +230,7 @@ const History = () => {
                   </div>
 
                   <div className="grid grid-cols-4 gap-4 text-sm mb-2">
-                    {record.sugar && (
+                    {record.sugar !== undefined && (
                       <div>
                         <div className={`font-semibold ${getSugarColor(record.sugar)}`}>
                           {record.sugar}
@@ -238,22 +238,22 @@ const History = () => {
                         <div className="text-xs text-muted-foreground">ммоль/л</div>
                       </div>
                     )}
-                    
-                    {record.carbs && (
+
+                    {record.carbs !== undefined && (
                       <div>
                         <div className="font-semibold text-foreground">{record.carbs}</div>
                         <div className="text-xs text-muted-foreground">г углев.</div>
                       </div>
                     )}
-                    
-                    {record.breadUnits && (
+
+                    {record.breadUnits !== undefined && (
                       <div>
                         <div className="font-semibold text-foreground">{record.breadUnits}</div>
                         <div className="text-xs text-muted-foreground">ХЕ</div>
                       </div>
                     )}
-                    
-                    {record.insulin && (
+
+                    {record.insulin !== undefined && (
                       <div>
                         <div className="font-semibold text-medical-blue">{record.insulin}</div>
                         <div className="text-xs text-muted-foreground">ед.</div>


### PR DESCRIPTION
## Summary
- ensure meal history shows sugar, carbs, bread units, and insulin when their values are 0 by checking for `undefined` instead of truthiness

## Testing
- `ruff check services/api/app tests`
- `pytest tests/`
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a1894b5414832a81637022bc6e5c86