### PR TITLE
[tests] fix mypy warns

### DIFF
--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 
 import pytest
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Iterator, cast
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from unittest.mock import MagicMock
@@ -16,9 +16,10 @@ from services.api.app.diabetes.services.db import Base, User, Profile, dispose_e
 
 
 @contextmanager
-def no_warnings() -> Any:
+def no_warnings() -> Iterator[None]:
     try:
-        with pytest.warns(None):
+        warns = cast(Any, pytest.warns)
+        with warns(None):
             yield
             return
     except TypeError:

--- a/tests/test_profile_no_sdk.py
+++ b/tests/test_profile_no_sdk.py
@@ -38,7 +38,7 @@ def _patch_import(monkeypatch: pytest.MonkeyPatch) -> None:
         locals: Any = None,
         fromlist: Any = (),
         level: int = 0,
-    ):
+    ) -> Any:
         if name.startswith("diabetes_sdk"):
             raise ImportError("diabetes_sdk not available")
         return real_import(name, globals, locals, fromlist, level)

--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -1,6 +1,6 @@
 import json
 from types import SimpleNamespace
-from typing import Any, Callable, cast
+from typing import Any, Callable, Iterator, cast
 
 import warnings
 from contextlib import contextmanager
@@ -15,9 +15,10 @@ from services.api.app.diabetes.services.db import Base, User, Reminder, Entry, d
 
 
 @contextmanager
-def no_warnings() -> Any:
+def no_warnings() -> Iterator[None]:
     try:
-        with pytest.warns(None):
+        warns = cast(Any, pytest.warns)
+        with warns(None):
             yield
             return
     except TypeError:


### PR DESCRIPTION
## Summary
- suppress type errors for pytest.warns(None) by casting to Any in tests
- annotate helper import shim with return type to satisfy mypy

## Testing
- `ruff check tests/test_reminder_edit_block_leak.py tests/test_handlers_profile.py tests/test_profile_no_sdk.py`
- `mypy --strict tests/test_reminder_edit_block_leak.py tests/test_handlers_profile.py tests/test_profile_no_sdk.py`
- `pytest tests/test_reminder_edit_block_leak.py tests/test_handlers_profile.py tests/test_profile_no_sdk.py`
- `mypy --strict .`


------
https://chatgpt.com/codex/tasks/task_e_68a1892640a0832a8bad387a34b0b20f