### PR TITLE
[ui] normalize reminder type with default

### DIFF
--- a/services/webapp/ui/src/lib/reminders.ts
+++ b/services/webapp/ui/src/lib/reminders.ts
@@ -2,5 +2,17 @@ export type NormalizedReminderType = "sugar" | "insulin" | "meal" | "medicine";
 export type ReminderType = NormalizedReminderType | "meds";
 
 export const normalizeReminderType = (
-  t: ReminderType,
-): NormalizedReminderType => (t === "meds" ? "medicine" : t);
+  t?: string,
+): NormalizedReminderType => {
+  switch (t) {
+    case "sugar":
+    case "insulin":
+    case "meal":
+    case "medicine":
+      return t;
+    case "meds":
+      return "medicine";
+    default:
+      return "medicine";
+  }
+};

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -10,7 +10,6 @@ import { useTelegramContext } from '@/contexts/telegram-context'
 import { cn } from '@/lib/utils'
 import {
   normalizeReminderType,
-  type ReminderType,
   type NormalizedReminderType,
 } from '@/lib/reminders'
 import { parseTimeToMinutes } from '@/lib/time'
@@ -162,7 +161,7 @@ export default function Reminders() {
         const data = await getReminders(user.id)
         if (cancelled) return
         const normalized: Reminder[] = (data || []).map((r: ApiReminder) => {
-          const nt = normalizeReminderType(r.type as ReminderType)
+          const nt = normalizeReminderType(r.type)
           return {
             id: r.id ?? 0,
             type: nt,

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -8,7 +8,6 @@ import { useTelegramContext } from "@/contexts/telegram-context";
 import { useToast } from "@/hooks/use-toast";
 import {
   normalizeReminderType,
-  type ReminderType,
   type NormalizedReminderType,
 } from "@/lib/reminders";
 import { isValidTime } from "@/lib/time";
@@ -69,7 +68,7 @@ export default function CreateReminder() {
       try {
         const data = await getReminder(user.id, id);
         if (data) {
-          const nt = normalizeReminderType(data.type as ReminderType);
+          const nt = normalizeReminderType(data.type);
           const loaded: Reminder = {
             id: data.id ?? id,
             type: nt,


### PR DESCRIPTION
## Summary
- normalize reminder type to default to `medicine` when undefined or unknown
- simplify reminder type usage in Reminders page
- simplify reminder type usage in CreateReminder

## Testing
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui run typecheck`
- `pytest tests/`
- `ruff check services/api/app tests`
- `npm --workspace services/webapp/ui exec vitest run -- --config ../../../vitest.config.ts` *(fails: Failed to resolve import "@/api/reminders")*


------
https://chatgpt.com/codex/tasks/task_e_68a1894dc480832a8f1388eda6e24ee4