### PR TITLE
[ui] add error boundary around routes

### DIFF
--- a/services/webapp/ui/src/App.tsx
+++ b/services/webapp/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { Routes, Route } from "react-router-dom";
 import { ThemeProvider } from "next-themes";
 import { Suspense, lazy } from "react";
 import { useTelegramContext } from "@/contexts/telegram-context";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const Home = lazy(() => import("./pages/Home"));
 const Profile = lazy(() => import("./pages/Profile"));
@@ -48,19 +49,21 @@ const AppContent = () => {
 
   return (
     <Suspense fallback={<div>Загрузка...</div>}>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/profile" element={<Profile />} />
-        <Route path="/reminders" element={<Reminders />} />
-        <Route path="/reminders/new" element={<CreateReminder />} />
-        <Route path="/reminders/:id/edit" element={<CreateReminder />} />
-        <Route path="/history" element={<History />} />
-        <Route path="/history/new-measurement" element={<NewMeasurement />} />
-        <Route path="/history/new-meal" element={<NewMeal />} />
-        <Route path="/analytics" element={<Analytics />} />
-        <Route path="/subscription" element={<Subscription />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+      <ErrorBoundary>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/profile" element={<Profile />} />
+          <Route path="/reminders" element={<Reminders />} />
+          <Route path="/reminders/new" element={<CreateReminder />} />
+          <Route path="/reminders/:id/edit" element={<CreateReminder />} />
+          <Route path="/history" element={<History />} />
+          <Route path="/history/new-measurement" element={<NewMeasurement />} />
+          <Route path="/history/new-meal" element={<NewMeal />} />
+          <Route path="/analytics" element={<Analytics />} />
+          <Route path="/subscription" element={<Subscription />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </ErrorBoundary>
     </Suspense>
   );
 };

--- a/services/webapp/ui/src/components/ErrorBoundary.tsx
+++ b/services/webapp/ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught an error", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen bg-background flex items-center justify-center">
+          <div className="text-center space-y-2">
+            <p className="text-lg font-medium">Что-то пошло не так</p>
+            <button
+              className="underline"
+              onClick={() => window.location.reload()}
+            >
+              Обновить страницу
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/services/webapp/ui/src/components/index.ts
+++ b/services/webapp/ui/src/components/index.ts
@@ -3,3 +3,4 @@ export { SegmentedControl } from './SegmentedControl';
 export { default as MedicalButton } from './MedicalButton';
 export { default as ThemeToggle } from './ThemeToggle';
 export { default as Sheet } from './Sheet';
+export { default as ErrorBoundary } from './ErrorBoundary';


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary component
- guard application routes with ErrorBoundary to present fallback when pages crash

## Testing
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui run typecheck`
- `npm --workspace services/webapp/ui exec -- vitest run -c ../../../vitest.config.ts` *(fails: Failed to resolve import "@/api/reminders")*

------
https://chatgpt.com/codex/tasks/task_e_68a18d458654832aa137524f897361d6