### PR TITLE
[ui] Add @sdk path alias

### DIFF
--- a/services/webapp/ui/tsconfig.app.json
+++ b/services/webapp/ui/tsconfig.app.json
@@ -24,6 +24,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
+      "@sdk": ["../../../libs/ts-sdk"],
       "@sdk/*": ["../../../libs/ts-sdk/*"]
     }
   },


### PR DESCRIPTION
## Summary
- allow importing the TypeScript SDK via `@sdk`

## Testing
- `npm --workspace services/webapp/ui run typecheck`
- `pytest tests/`
- `ruff check services/api/app tests`


------
https://chatgpt.com/codex/tasks/task_e_68a18d416ff8832aaacd1e6f34361f90