### PR TITLE
[webapp] extract Telegram theme helpers

### DIFF
--- a/services/webapp/public/telegram-init.js
+++ b/services/webapp/public/telegram-init.js
@@ -1,28 +1,10 @@
-(function () {
+(async function () {
+    const { applyTheme } = await import("/ui/src/lib/telegram-theme.ts");
     const app = window.Telegram?.WebApp;
     if (!app) {
         return;
     }
-
-    const supportsColorMethods = () => {
-        const [major = 0, minor = 0] = (app.version || '0.0')
-            .split('.')
-            .map((n) => parseInt(n, 10));
-        if (app.platform === 'tdesktop') {
-            return major > 4 || (major === 4 && minor >= 8);
-        }
-        return major > 6 || (major === 6 && minor >= 1);
-    };
-
-    const applyTheme = () => {
-        if (supportsColorMethods()) {
-            if (app.setBackgroundColor) app.setBackgroundColor('#fff');
-            if (app.setHeaderColor) app.setHeaderColor('#fff');
-        }
-    };
-
     app.expand?.();
-    applyTheme();
-    app.onEvent?.('themeChanged', applyTheme);
+    applyTheme(app, true);
+    app.onEvent?.('themeChanged', () => applyTheme(app, true));
 })();
-

--- a/services/webapp/ui/public/telegram-init.js
+++ b/services/webapp/ui/public/telegram-init.js
@@ -1,28 +1,10 @@
-(function () {
+(async function () {
+    const { applyTheme } = await import("/src/lib/telegram-theme.ts");
     const app = window.Telegram?.WebApp;
     if (!app) {
         return;
     }
-
-    const supportsColorMethods = () => {
-        const [major = 0, minor = 0] = (app.version || '0.0')
-            .split('.')
-            .map((n) => parseInt(n, 10));
-        if (app.platform === 'tdesktop') {
-            return major > 4 || (major === 4 && minor >= 8);
-        }
-        return major > 6 || (major === 6 && minor >= 1);
-    };
-
-    const applyTheme = () => {
-        if (supportsColorMethods()) {
-            if (app.setBackgroundColor) app.setBackgroundColor('#fff');
-            if (app.setHeaderColor) app.setHeaderColor('#fff');
-        }
-    };
-
     app.expand?.();
-    applyTheme();
-    app.onEvent?.('themeChanged', applyTheme);
+    applyTheme(app, true);
+    app.onEvent?.('themeChanged', () => applyTheme(app, true));
 })();
-

--- a/services/webapp/ui/src/lib/telegram-theme.ts
+++ b/services/webapp/ui/src/lib/telegram-theme.ts
@@ -1,0 +1,62 @@
+export type Scheme = "light" | "dark";
+
+export interface ThemeParams {
+  bg_color?: string;
+  text_color?: string;
+  hint_color?: string;
+  link_color?: string;
+  button_color?: string;
+  button_text_color?: string;
+  secondary_bg_color?: string;
+}
+
+export interface TelegramWebApp {
+  version?: string;
+  platform?: string;
+  themeParams?: ThemeParams;
+  colorScheme?: Scheme;
+  setBackgroundColor?: (color: string) => void;
+  setHeaderColor?: (color: string) => void;
+}
+
+export const supportsColorMethods = (app: TelegramWebApp | null): boolean => {
+  const [major = 0, minor = 0] = (app?.version || "0.0")
+    .split(".")
+    .map((n) => parseInt(n, 10));
+  if (app?.platform === "tdesktop") {
+    return major > 4 || (major === 4 && minor >= 8);
+  }
+  return major > 6 || (major === 6 && minor >= 1);
+};
+
+export function applyTheme(
+  src: TelegramWebApp | null,
+  ignoreScheme = false,
+): Scheme {
+  const root = document.documentElement;
+  const p = src?.themeParams ?? {};
+  const map: Record<string, string | undefined> = {
+    "--tg-theme-bg-color": p.bg_color,
+    "--tg-theme-text-color": p.text_color,
+    "--tg-theme-hint-color": p.hint_color,
+    "--tg-theme-link-color": p.link_color,
+    "--tg-theme-button-color": p.button_color,
+    "--tg-theme-button-text-color": p.button_text_color,
+    "--tg-theme-secondary-bg-color": p.secondary_bg_color,
+  };
+  if (ignoreScheme) {
+    Object.keys(map).forEach((k) => root.style.removeProperty(k));
+    root.classList.remove("dark");
+    root.style.colorScheme = "light";
+    if (src && supportsColorMethods(src)) {
+      if (src.setBackgroundColor) src.setBackgroundColor("#ffffff");
+      if (src.setHeaderColor) src.setHeaderColor("#ffffff");
+    }
+    return "light";
+  }
+  Object.entries(map).forEach(([k, v]) => v && root.style.setProperty(k, v));
+  root.style.colorScheme = "";
+  const scheme = src?.colorScheme ?? "light";
+  root.classList.toggle("dark", scheme === "dark");
+  return scheme;
+}


### PR DESCRIPTION
## Summary
- centralize Telegram theming helpers into `telegram-theme` module
- reuse shared theme logic in `useTelegram` hook
- load `telegram-init` scripts from shared theme module

## Testing
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui exec -- vitest run --config ../../../vitest.config.ts` (fails: Failed to resolve import "@/api/reminders"...)
- `pytest tests`
- `ruff check services/api/app tests`


------
https://chatgpt.com/codex/tasks/task_e_68a18d42cb34832aa26e460982b9e00a