### PR TITLE
[tests] Simplify no_warnings fixture

### DIFF
--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -17,13 +17,6 @@ from services.api.app.diabetes.services.db import Base, User, Profile, dispose_e
 
 @contextmanager
 def no_warnings() -> Iterator[None]:
-    try:
-        warns = cast(Any, pytest.warns)
-        with warns(None):
-            yield
-            return
-    except TypeError:
-        pass
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         yield


### PR DESCRIPTION
## Summary
- simplify `no_warnings` fixture to use `warnings.catch_warnings` and `warnings.simplefilter("error")`

## Testing
- `ruff check tests/test_handlers_profile.py`
- `mypy --strict tests/test_handlers_profile.py`


------
https://chatgpt.com/codex/tasks/task_e_68a190ab5ae4832a8b2a4195d1ef44f4