### PR TITLE
[tests] Use catch_warnings in reminder edit leak test

### DIFF
--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -16,13 +16,6 @@ from services.api.app.diabetes.services.db import Base, User, Reminder, Entry, d
 
 @contextmanager
 def no_warnings() -> Iterator[None]:
-    try:
-        warns = cast(Any, pytest.warns)
-        with warns(None):
-            yield
-            return
-    except TypeError:
-        pass
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         yield


### PR DESCRIPTION
## Summary
- simplify `no_warnings` helper to rely on `warnings.catch_warnings` with `warnings.simplefilter("error")`

## Testing
- `ruff check tests/test_reminder_edit_block_leak.py`
- `mypy --strict tests/test_reminder_edit_block_leak.py`
- `pytest tests/test_reminder_edit_block_leak.py`

------
https://chatgpt.com/codex/tasks/task_e_68a190aad08c832a89a09cc85cf1db6f