### PR TITLE
[compat] Patch telegram Application via subclass

### DIFF
--- a/docs/telegram-compat.md
+++ b/docs/telegram-compat.md
@@ -6,9 +6,11 @@ explicitly include `"__weakref__"`. Older versions of
 internal `telegram.ext._application.Application` class, causing
 `ApplicationBuilder().build()` to fail.
 
-The project temporarily patches `Application.__slots__` in
-`services/api/app/telegram_compat.py`. Importing the top-level package
-(`services.api.app`) automatically applies this patch, so individual modules or
-users do not need to import `telegram_compat` manually. This file can be removed
-once the `python-telegram-bot` dependency is upgraded to a version that already
-includes this fix.
+The project temporarily replaces `Application` with a small subclass in
+`services/api/app/telegram_compat.py` that includes the missing
+`"__weakref__"` slot and rebinds `telegram.ext._application.Application` to
+this subclass. Importing the top-level package (`services.api.app`) applies the
+patch automatically, so individual modules or users do not need to import
+`telegram_compat` manually. This file can be removed once the
+`python-telegram-bot` dependency is upgraded to a version that already includes
+this fix.

--- a/services/api/app/telegram_compat.py
+++ b/services/api/app/telegram_compat.py
@@ -10,7 +10,13 @@ Remove this module once ``python-telegram-bot`` is upgraded and includes the
 fix natively.
 """
 
-from telegram.ext._application import Application
+from telegram.ext import _application
 
-if "__weakref__" not in getattr(Application, "__slots__", ()):
-    Application.__slots__ = (*Application.__slots__, "__weakref__")  # type: ignore[attr-defined]
+BaseApplication = _application.Application
+
+if not hasattr(BaseApplication, "__weakref__"):
+
+    class _CompatApplication(BaseApplication):
+        __slots__ = (*getattr(BaseApplication, "__slots__", ()), "__weakref__")
+
+    _application.Application = _CompatApplication


### PR DESCRIPTION
## Summary
- patch `telegram.ext._application.Application` by replacing it with a subclass that adds the required `__weakref__` slot
- explain subclass-based patch in docs

## Testing
- `pytest -q`
- `mypy --strict .` *(interrupted, repository-wide check is slow)*
- `mypy --strict services/api/app/telegram_compat.py`
- `ruff check .`
- `python - <<'PY'
import services.api.app
from telegram.ext import ApplicationBuilder
ApplicationBuilder().token('123:ABC').build()
print('ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a197112e78832a846b310f9fe3ebd0