### PR TITLE
[services] Patch Telegram Application with subclass

### DIFF
--- a/docs/telegram-compat.md
+++ b/docs/telegram-compat.md
@@ -6,11 +6,12 @@ explicitly include `"__weakref__"`. Older versions of
 internal `telegram.ext._application.Application` class, causing
 `ApplicationBuilder().build()` to fail.
 
-The project temporarily replaces `Application` with a small subclass in
-`services/api/app/telegram_compat.py` that includes the missing
-`"__weakref__"` slot and rebinds `telegram.ext._application.Application` to
-this subclass. Importing the top-level package (`services.api.app`) applies the
-patch automatically, so individual modules or users do not need to import
-`telegram_compat` manually. This file can be removed once the
-`python-telegram-bot` dependency is upgraded to a version that already includes
-this fix.
+The project temporarily replaces `Application` with a subclass in
+`services/api/app/telegram_compat.py`. This subclass extends
+`telegram.ext._application.Application` and declares
+`__slots__ = (*Base.__slots__, "__weakref__")`, then rebinds
+`telegram.ext._application.Application` to itself. Importing the top-level
+package (`services.api.app`) applies the patch automatically, so individual
+modules or users do not need to import `telegram_compat` manually. This file can
+be removed once the `python-telegram-bot` dependency is upgraded to a version
+that already includes this fix.

--- a/services/api/app/telegram_compat.py
+++ b/services/api/app/telegram_compat.py
@@ -12,11 +12,11 @@ fix natively.
 
 from telegram.ext import _application
 
-BaseApplication = _application.Application
+Base = _application.Application
 
-if not hasattr(BaseApplication, "__weakref__"):
+if not hasattr(Base, "__weakref__"):  # pragma: no branch
 
-    class _CompatApplication(BaseApplication):
-        __slots__ = (*getattr(BaseApplication, "__slots__", ()), "__weakref__")
+    class _CompatApplication(Base):
+        __slots__ = (*Base.__slots__, "__weakref__")
 
     _application.Application = _CompatApplication


### PR DESCRIPTION
## Summary
- patch telegram.ext._application.Application with subclass exposing '__weakref__' slot
- document the subclass-based Telegram compatibility workaround

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68a199ea3054832a8e7fb5ec965acaa4