### PR TITLE
[webapp] build telegram theme asset

### DIFF
--- a/services/webapp/public/telegram-init.js
+++ b/services/webapp/public/telegram-init.js
@@ -1,5 +1,6 @@
 (async function () {
-    const { applyTheme } = await import("/ui/src/lib/telegram-theme.ts");
+    const mod = await import("/assets/telegram-theme.js");
+    const applyTheme = mod.applyTheme ?? mod.default ?? mod.a;
     const app = window.Telegram?.WebApp;
     if (!app) {
         return;

--- a/services/webapp/ui/src/lib/telegram-theme.ts
+++ b/services/webapp/ui/src/lib/telegram-theme.ts
@@ -60,3 +60,5 @@ export function applyTheme(
   root.classList.toggle("dark", scheme === "dark");
   return scheme;
 }
+
+export default applyTheme;

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -23,8 +23,19 @@ export default defineConfig(async ({ mode }) => {
     server: { host: '::', port },
     build: {
       outDir: 'dist', // Явно задаём dist (по умолчанию и так dist)
+      minify: false,
       rollupOptions: {
+        treeshake: false,
+        input: {
+          main: path.resolve(__dirname, 'index.html'),
+          'telegram-theme': path.resolve(__dirname, './src/lib/telegram-theme.ts'),
+        },
         output: {
+          entryFileNames: (chunk) =>
+            chunk.name === 'telegram-theme'
+              ? 'assets/telegram-theme.js'
+              : 'assets/[name]-[hash].js',
+          exports: 'named',
           manualChunks: {
             vendor: [
               'react',


### PR DESCRIPTION
## Summary
- load Telegram theme from built asset instead of TypeScript source
- configure Vite to emit `telegram-theme.js` and disable minification/treeshake
- expose `applyTheme` as default export for safer runtime import

## Testing
- `npm --workspace services/webapp/ui run build --ignore-scripts`
- `node <<'NODE'
import('./services/webapp/ui/dist/assets/telegram-theme.js').then(m => {
  const fn = m.applyTheme ?? m.default ?? m.a;
  const { JSDOM } = require('jsdom');
  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
  global.document = dom.window.document;
  const scheme = fn({ colorScheme: 'dark' });
  console.log('scheme', scheme, 'class', document.documentElement.className);
});
NODE`
- `pytest -q && mypy --strict . && ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68a199f86020832a95935f918cf81701