### PR TITLE
[compat] Rebind Application class

### DIFF
--- a/services/api/app/telegram_compat.py
+++ b/services/api/app/telegram_compat.py
@@ -10,7 +10,8 @@ Remove this module once ``python-telegram-bot`` is upgraded and includes the
 fix natively.
 """
 
-from telegram.ext import _application
+import telegram.ext as ext
+from telegram.ext import _application, _applicationbuilder
 
 Base = _application.Application
 
@@ -20,3 +21,5 @@ if not hasattr(Base, "__weakref__"):  # pragma: no branch
         __slots__ = (*Base.__slots__, "__weakref__")
 
     _application.Application = _CompatApplication
+    _applicationbuilder.Application = _CompatApplication
+    ext.Application = _CompatApplication


### PR DESCRIPTION
## Summary
- rebind patched `_CompatApplication` across telegram modules to ensure `ApplicationBuilder().build()` works under Python 3.13

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a19e2c8120832a8536f63555002085