### PR TITLE
[webapp] Extract Reminder type

### DIFF
--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -14,15 +14,7 @@ import {
 } from '@/lib/reminders'
 import { parseTimeToMinutes } from '@/lib/time'
 import { Reminder as ApiReminder } from '@sdk'
-
-interface Reminder {
-  id: number
-  type: NormalizedReminderType
-  title: string
-  time: string   // "HH:MM"
-  active: boolean
-  interval?: number // stored in minutes
-}
+import type { Reminder } from '@/types/reminder'
 
 const TYPE_LABEL: Record<NormalizedReminderType, string> = {
   sugar: 'Измерение сахара',

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -11,6 +11,7 @@ import {
   type NormalizedReminderType,
 } from "@/lib/reminders";
 import { isValidTime } from "@/lib/time";
+import type { Reminder } from "@/types/reminder";
 
 const TYPES: Record<NormalizedReminderType, { label: string; emoji: string }> = {
   sugar: { label: "Сахар", emoji: "🩸" },
@@ -26,13 +27,6 @@ const PRESETS: Record<NormalizedReminderType, number[]> = {
   medicine: [240, 480, 720]
 };
 
-interface Reminder {
-  id: number;
-  type: NormalizedReminderType;
-  title: string;
-  time: string;
-  interval?: number;
-}
 
 export default function CreateReminder() {
   const navigate = useNavigate();

--- a/services/webapp/ui/src/types/reminder.ts
+++ b/services/webapp/ui/src/types/reminder.ts
@@ -1,0 +1,11 @@
+import { type NormalizedReminderType } from "@/lib/reminders";
+
+export interface Reminder {
+  id: number;
+  type: NormalizedReminderType;
+  title: string;
+  time: string; // "HH:MM"
+  active?: boolean;
+  interval?: number; // stored in minutes
+}
+


### PR DESCRIPTION
## Summary
- centralize Reminder interface in a shared types file
- reuse Reminder type in Reminders and CreateReminder pages

## Testing
- `npm --workspace services/webapp/ui test` *(fails: Missing script: "test")*
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui run typecheck`
- `pytest -q`
- `mypy --strict .` *(fails: process interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1a5955854832ab4995eb965f6ebc4