### PR TITLE
[ui] Use ReactNode directly in component props

### DIFF
--- a/services/webapp/ui/src/components/MedicalHeader.tsx
+++ b/services/webapp/ui/src/components/MedicalHeader.tsx
@@ -1,13 +1,14 @@
 import { ArrowLeft } from 'lucide-react';
+import { type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
 import ThemeToggle from '@/components/ThemeToggle';
+import { Button } from '@/components/ui/button';
 
 interface MedicalHeaderProps {
   title: string;
   showBack?: boolean;
   onBack?: () => void;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export const MedicalHeader = ({ title, showBack, onBack, children }: MedicalHeaderProps) => {

--- a/services/webapp/ui/src/components/Modal.tsx
+++ b/services/webapp/ui/src/components/Modal.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 import { Button } from '@/components/ui/button';
 
 interface ModalProps {
   open: boolean;
   onClose: () => void;
   title?: string;
-  footer?: React.ReactNode;
-  children: React.ReactNode;
+  footer?: ReactNode;
+  children: ReactNode;
 }
 
 const Modal = ({ open, onClose, title, footer, children }: ModalProps) => {

--- a/services/webapp/ui/src/components/SegmentedControl.tsx
+++ b/services/webapp/ui/src/components/SegmentedControl.tsx
@@ -1,8 +1,8 @@
-import { useRef } from 'react';
+import { useRef, type ReactNode } from 'react';
 
 export interface SegmentedItem {
   value: string;
-  icon?: React.ReactNode;
+  icon?: ReactNode;
   label?: string;
 }
 

--- a/services/webapp/ui/src/components/Sheet.tsx
+++ b/services/webapp/ui/src/components/Sheet.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 
 interface SheetProps {
   open: boolean;
   onClose: () => void;
   side?: 'top' | 'bottom' | 'left' | 'right';
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 const Sheet = ({ open, onClose, side = 'bottom', children }: SheetProps) => {


### PR DESCRIPTION
## Summary
- import `ReactNode` from `react` in several UI components
- use `ReactNode` type for children/slots instead of `React.ReactNode`

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a1aef84310832ab611098cc05dd8b9