### PR TITLE
[telegram] Preserve Base.__init__ in compat Application

### DIFF
--- a/services/api/app/telegram_compat.py
+++ b/services/api/app/telegram_compat.py
@@ -10,8 +10,6 @@ Remove this module once ``python-telegram-bot`` is upgraded and includes the
 fix natively.
 """
 
-from dataclasses import dataclass
-
 import telegram.ext as ext
 from telegram.ext import _application, _applicationbuilder
 
@@ -19,11 +17,8 @@ Base = _application.Application
 
 if not hasattr(Base, "__weakref__"):  # pragma: no branch
 
-    @dataclass(slots=True, weakref_slot=True)
     class _CompatApplication(Base):
-        pass
-
-    _CompatApplication.__slots__ = (*Base.__slots__, *_CompatApplication.__slots__)
+        __slots__ = (*Base.__slots__, "__weakref__")
 
     _application.Application = _CompatApplication
     _applicationbuilder.Application = _CompatApplication


### PR DESCRIPTION
## Summary
- Ensure _CompatApplication keeps Base.__init__ by removing dataclass wrapper and manually adding `__weakref__` to `__slots__`.

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1aeeb5f7c832abeb416d3a636a24a