### PR TITLE
[ui] handle window absence in mobile hook

### DIFF
--- a/services/webapp/ui/src/hooks/use-mobile.test.tsx
+++ b/services/webapp/ui/src/hooks/use-mobile.test.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { describe, expect, it } from "vitest";
+import { useIsMobile } from "./use-mobile";
+
+describe("useIsMobile", () => {
+  it("returns false when window is undefined", () => {
+    let result = true;
+    const TestComponent = () => {
+      result = useIsMobile();
+      return null;
+    };
+    act(() => {
+      TestRenderer.create(<TestComponent />);
+    });
+    expect(result).toBe(false);
+  }, { environment: "node" });
+});

--- a/services/webapp/ui/src/hooks/use-mobile.tsx
+++ b/services/webapp/ui/src/hooks/use-mobile.tsx
@@ -3,9 +3,13 @@ import * as React from "react"
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = React.useState<boolean>(false)
 
   React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = (event: MediaQueryListEvent) => {
       setIsMobile(event.matches)
@@ -26,5 +30,5 @@ export function useIsMobile() {
     }
   }, [])
 
-  return !!isMobile
+  return isMobile
 }


### PR DESCRIPTION
## Summary
- safeguard `useIsMobile` hook for missing `window`
- test `useIsMobile` without `window` using react-test-renderer

## Testing
- `npm run test` *(fails: Missing script "test")*
- `npx vitest run --root services/webapp/ui src/hooks/use-mobile.test.tsx`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1b0b35eec832ab39c39b1ec0c04dd