### PR TITLE
[webapp] unify timeout error message

### DIFF
--- a/services/webapp/ui/src/api/tgFetch.api.test.ts
+++ b/services/webapp/ui/src/api/tgFetch.api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import { tgFetch } from '../lib/tgFetch';
+import { tgFetch, REQUEST_TIMEOUT_MESSAGE } from '../lib/tgFetch';
 
 interface TelegramWebApp {
   initData?: string;
@@ -60,6 +60,6 @@ describe('tgFetch', () => {
 
     const promise = tgFetch('/api/profile');
     vi.advanceTimersByTime(10_000);
-    await expect(promise).rejects.toThrow('Превышено время ожидания');
+    await expect(promise).rejects.toThrow(REQUEST_TIMEOUT_MESSAGE);
   });
 });

--- a/services/webapp/ui/src/lib/tgFetch.test.ts
+++ b/services/webapp/ui/src/lib/tgFetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import { tgFetch } from './tgFetch';
+import { tgFetch, REQUEST_TIMEOUT_MESSAGE } from './tgFetch';
 
 interface TelegramWebApp {
   initData?: string;
@@ -71,7 +71,7 @@ describe('tgFetch', () => {
 
     const promise = tgFetch('/api/profile/self');
     vi.advanceTimersByTime(10_000);
-    await expect(promise).rejects.toThrow('Превышено время ожидания');
+    await expect(promise).rejects.toThrow(REQUEST_TIMEOUT_MESSAGE);
     vi.useRealTimers();
   });
 });

--- a/services/webapp/ui/src/lib/tgFetch.ts
+++ b/services/webapp/ui/src/lib/tgFetch.ts
@@ -1,3 +1,4 @@
+export const REQUEST_TIMEOUT_MESSAGE = "Превышено время ожидания запроса";
 const REQUEST_TIMEOUT = 10_000; // 10 seconds
 
 interface TelegramWebApp {
@@ -34,7 +35,7 @@ export async function tgFetch(
     return response;
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
-      throw new Error("Превышено время ожидания запроса");
+      throw new Error(REQUEST_TIMEOUT_MESSAGE);
     }
     if (error instanceof TypeError || error instanceof DOMException) {
       throw new Error("Проблема с сетью. Проверьте подключение");


### PR DESCRIPTION
## Summary
- export constant REQUEST_TIMEOUT_MESSAGE and use for abort handling in tgFetch
- align tgFetch API and library tests with unified timeout message

## Testing
- `npm run test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: Cannot find package 'react-test-renderer'; document is not defined)*
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1b4af6898832ab9b4573522b84c86