### PR TITLE
[tests] Enforce coverage for diabetes package

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,8 @@
 [pytest]
 asyncio_mode = auto
+addopts =
+    --cov=services.api.app.diabetes
+    --cov-report=term-missing
+    --cov-fail-under=85
 markers =
     asyncio: mark a coroutine test


### PR DESCRIPTION
## Summary
- enforce coverage on services.api.app.diabetes via pytest addopts

## Testing
- `pytest -q` *(fails: Required test coverage of 85% not reached. Total coverage: 67.47%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1b6ba8800832a8ecedd4acb12e85c