### PR TITLE
webapp: add ARIA links for modal

### DIFF
--- a/services/webapp/ui/src/components/Modal.test.tsx
+++ b/services/webapp/ui/src/components/Modal.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Modal from './Modal'
+
+describe('Modal', () => {
+  it('sets ARIA attributes for title and content', () => {
+    render(
+      <Modal open onClose={() => {}} title="Test title">
+        <p>Test content</p>
+      </Modal>
+    )
+    const dialog = screen.getByRole('dialog')
+    const heading = screen.getByRole('heading', { name: 'Test title' })
+    const description = screen.getByText('Test content').parentElement as HTMLElement
+    expect(dialog.getAttribute('aria-labelledby')).toBe(heading.id)
+    expect(dialog.getAttribute('aria-describedby')).toBe(description.id)
+  })
+})

--- a/services/webapp/ui/src/components/Modal.tsx
+++ b/services/webapp/ui/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from 'react';
+import { useEffect, useRef, useId, type ReactNode } from 'react';
 import { Button } from '@/components/ui/button';
 
 interface ModalProps {
@@ -12,6 +12,8 @@ interface ModalProps {
 const Modal = ({ open, onClose, title, footer, children }: ModalProps) => {
   const overlayRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  const descriptionId = useId();
 
   useEffect(() => {
     if (!open) return;
@@ -67,11 +69,17 @@ const Modal = ({ open, onClose, title, footer, children }: ModalProps) => {
       onMouseDown={handleOverlayClick}
       role="dialog"
       aria-modal="true"
+      aria-labelledby={title ? titleId : undefined}
+      aria-describedby={descriptionId}
       className="fixed inset-0 z-50 flex items-center justify-center bg-overlay"
     >
       <div ref={modalRef} className="modal-card">
         <div className="flex items-center justify-between p-4 border-b border-border">
-          {title && <h2 className="text-lg font-semibold">{title}</h2>}
+          {title && (
+            <h2 id={titleId} className="text-lg font-semibold">
+              {title}
+            </h2>
+          )}
           <Button
             onClick={onClose}
             variant="ghost"
@@ -81,7 +89,9 @@ const Modal = ({ open, onClose, title, footer, children }: ModalProps) => {
             ×
           </Button>
         </div>
-        <div className="p-4">{children}</div>
+        <div id={descriptionId} className="p-4">
+          {children}
+        </div>
         {footer && <div className="p-4 border-t border-border">{footer}</div>}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- link modal dialog with its title and content using ARIA attributes
- test modal ARIA labeling

## Testing
- `npm run test` (fails: Missing script: "test")
- `npx vitest run --environment jsdom` (fails: cannot resolve 'react-test-renderer')
- `npx vitest run src/components/Modal.test.tsx --environment jsdom`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1b72e1920832ab6d961a78f20a57f