### PR TITLE
tests: dispose db engine after suite

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 asyncio_mode = auto
 markers =
     asyncio: mark a coroutine test
+filterwarnings =
+    ignore::ResourceWarning:anyio.streams.memory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+from collections.abc import Iterator
+import warnings
+
+import pytest
+
+from services.api.app.diabetes.services.db import dispose_engine
+
+
+warnings.filterwarnings(
+    "ignore", category=ResourceWarning, module=r"anyio\.streams\.memory"
+)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _dispose_engine_after_tests() -> Iterator[None]:
+    """Dispose the global database engine after the test session."""
+    yield
+    dispose_engine()

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,6 +1,6 @@
-import pytest
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
+import pytest
 
 from services.api.app.middleware.auth import AuthMiddleware
 
@@ -18,25 +18,25 @@ def create_app() -> FastAPI:
 
 def test_valid_user_id_header() -> None:
     app = create_app()
-    client = TestClient(app)
-    response = client.get("/whoami", headers={"X-User-Id": "123"})
-    assert response.status_code == 200
-    assert response.json() == {"user_id": 123}
+    with TestClient(app) as client:
+        response = client.get("/whoami", headers={"X-User-Id": "123"})
+        assert response.status_code == 200
+        assert response.json() == {"user_id": 123}
 
 
 def test_missing_user_id_header() -> None:
     app = create_app()
-    client = TestClient(app)
-    with pytest.raises(HTTPException) as exc_info:
-        client.get("/whoami")
+    with TestClient(app) as client:
+        with pytest.raises(HTTPException) as exc_info:
+            client.get("/whoami")
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "invalid user id"
 
 
 def test_invalid_user_id_header() -> None:
     app = create_app()
-    client = TestClient(app)
-    with pytest.raises(HTTPException) as exc_info:
-        client.get("/whoami", headers={"X-User-Id": "abc"})
+    with TestClient(app) as client:
+        with pytest.raises(HTTPException) as exc_info:
+            client.get("/whoami", headers={"X-User-Id": "abc"})
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "invalid user id"

--- a/tests/test_profile_self.py
+++ b/tests/test_profile_self.py
@@ -11,7 +11,6 @@ from services.api.app.config import settings
 from services.api.app.main import app
 
 TOKEN = "test-token"
-client = TestClient(app)
 
 
 def build_init_data(user_id: int = 1) -> str:
@@ -26,17 +25,24 @@ def build_init_data(user_id: int = 1) -> str:
 def test_profile_self_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     init_data = build_init_data(42)
-    resp = client.get("/api/profile/self", headers={"X-Telegram-Init-Data": init_data})
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/profile/self", headers={"X-Telegram-Init-Data": init_data}
+        )
     assert resp.status_code == 200
     assert resp.json()["id"] == 42
 
 
 def test_profile_self_missing_header() -> None:
-    resp = client.get("/api/profile/self")
+    with TestClient(app) as client:
+        resp = client.get("/api/profile/self")
     assert resp.status_code == 401
 
 
 def test_profile_self_invalid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
-    resp = client.get("/api/profile/self", headers={"X-Telegram-Init-Data": "bad"})
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/profile/self", headers={"X-Telegram-Init-Data": "bad"}
+        )
     assert resp.status_code == 401

--- a/tests/test_webapp_history.py
+++ b/tests/test_webapp_history.py
@@ -4,7 +4,6 @@ import hmac
 import json
 import time
 import urllib.parse
-
 from typing import Any, Callable, cast
 
 import pytest
@@ -45,61 +44,65 @@ def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
 
 def test_history_auth_required(monkeypatch: pytest.MonkeyPatch) -> None:
     setup_db(monkeypatch)
-    client = TestClient(server.app)
-    rec = {"id": "1", "date": "2024-01-01", "time": "12:00", "type": "measurement"}
-    assert client.post("/api/history", json=rec).status_code == 401
-    assert client.get("/api/history").status_code == 401
-    assert client.delete("/api/history/1").status_code == 401
+    with TestClient(server.app) as client:
+        rec = {"id": "1", "date": "2024-01-01", "time": "12:00", "type": "measurement"}
+        assert client.post("/api/history", json=rec).status_code == 401
+        assert client.get("/api/history").status_code == 401
+        assert client.delete("/api/history/1").status_code == 401
 
 
 def test_history_persist_and_update(monkeypatch: pytest.MonkeyPatch) -> None:
     Session = setup_db(monkeypatch)
     monkeypatch.setenv("TELEGRAM_TOKEN", TOKEN)
-    client = TestClient(server.app)
     headers1 = {"X-Telegram-Init-Data": build_init_data(1)}
     headers2 = {"X-Telegram-Init-Data": build_init_data(2)}
+    with TestClient(server.app) as client:
+        rec1 = {
+            "id": "1",
+            "date": "2024-01-01",
+            "time": "12:00",
+            "type": "measurement",
+        }
+        resp = client.post("/api/history", json=rec1, headers=headers1)
+        assert resp.status_code == 200
 
-    rec1 = {"id": "1", "date": "2024-01-01", "time": "12:00", "type": "measurement"}
-    resp = client.post("/api/history", json=rec1, headers=headers1)
-    assert resp.status_code == 200
+        with Session() as session:
+            stored = session.get(db.HistoryRecord, "1")
+            assert stored is not None
+            assert stored.date == "2024-01-01"
+            assert stored.telegram_id == 1
 
-    with Session() as session:
-        stored = session.get(db.HistoryRecord, "1")
-        assert stored is not None
-        assert stored.date == "2024-01-01"
-        assert stored.telegram_id == 1
+        rec1_update = {**rec1, "sugar": 5.5}
+        resp = client.post("/api/history", json=rec1_update, headers=headers1)
+        assert resp.status_code == 200
 
-    rec1_update = {**rec1, "sugar": 5.5}
-    resp = client.post("/api/history", json=rec1_update, headers=headers1)
-    assert resp.status_code == 200
+        with Session() as session:
+            stored = session.get(db.HistoryRecord, "1")
+            assert stored is not None
+            assert stored.sugar == 5.5
 
-    with Session() as session:
-        stored = session.get(db.HistoryRecord, "1")
-        assert stored is not None
-        assert stored.sugar == 5.5
+        rec2 = {"id": "2", "date": "2024-01-02", "time": "13:00", "type": "meal"}
+        resp = client.post("/api/history", json=rec2, headers=headers1)
+        assert resp.status_code == 200
 
-    rec2 = {"id": "2", "date": "2024-01-02", "time": "13:00", "type": "meal"}
-    resp = client.post("/api/history", json=rec2, headers=headers1)
-    assert resp.status_code == 200
+        rec3 = {"id": "3", "date": "2024-01-03", "time": "14:00", "type": "meal"}
+        resp = client.post("/api/history", json=rec3, headers=headers2)
+        assert resp.status_code == 200
 
-    rec3 = {"id": "3", "date": "2024-01-03", "time": "14:00", "type": "meal"}
-    resp = client.post("/api/history", json=rec3, headers=headers2)
-    assert resp.status_code == 200
+        resp = client.get("/api/history", headers=headers1)
+        assert [r["id"] for r in resp.json()] == ["1", "2"]
 
-    resp = client.get("/api/history", headers=headers1)
-    assert [r["id"] for r in resp.json()] == ["1", "2"]
+        resp = client.get("/api/history", headers=headers2)
+        assert [r["id"] for r in resp.json()] == ["3"]
 
-    resp = client.get("/api/history", headers=headers2)
-    assert [r["id"] for r in resp.json()] == ["3"]
+        resp = client.delete("/api/history/1", headers=headers2)
+        assert resp.status_code == 403
 
-    resp = client.delete("/api/history/1", headers=headers2)
-    assert resp.status_code == 403
+        resp = client.delete("/api/history/1", headers=headers1)
+        assert resp.status_code == 200
 
-    resp = client.delete("/api/history/1", headers=headers1)
-    assert resp.status_code == 200
-
-    resp = client.get("/api/history", headers=headers1)
-    assert [r["id"] for r in resp.json()] == ["2"]
+        resp = client.get("/api/history", headers=headers1)
+        assert [r["id"] for r in resp.json()] == ["2"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_webapp_server.py
+++ b/tests/test_webapp_server.py
@@ -1,25 +1,24 @@
-"""Tests for minimal FastAPI webapp."""
-
 from fastapi.testclient import TestClient
 
 import services.api.app.main as server
 
-client = TestClient(server.app)
-
 
 def test_health() -> None:
-    resp = client.get("/health")
-    assert resp.status_code == 200
-    assert resp.json() == {"status": "ok"}
+    with TestClient(server.app) as client:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
 
 
 def test_static_ui_serving() -> None:
-    resp = client.get("/ui")
-    assert resp.status_code == 200
-    assert "<html" in resp.text.lower()
+    with TestClient(server.app) as client:
+        resp = client.get("/ui")
+        assert resp.status_code == 200
+        assert "<html" in resp.text.lower()
 
 
 def test_unknown_ui_route_serves_index() -> None:
-    resp = client.get("/ui/reminders")
-    assert resp.status_code == 200
-    assert "<html" in resp.text.lower()
+    with TestClient(server.app) as client:
+        resp = client.get("/ui/reminders")
+        assert resp.status_code == 200
+        assert "<html" in resp.text.lower()


### PR DESCRIPTION
## Summary
- dispose global DB engine after test session to prevent leakage
- wrap HTTP TestClient usage in context managers for clean closure
- silence noisy ResourceWarnings from anyio

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1b6bf9250832aab80cff364470c26