### PR TITLE
[utils] add tests for OpenAI client creation

### DIFF
--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,0 +1,45 @@
+import logging
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from services.api.app.config import settings
+from services.api.app.diabetes.utils import openai_utils
+
+
+def test_get_openai_client_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "")
+    with pytest.raises(RuntimeError):
+        openai_utils.get_openai_client()
+
+
+def test_get_openai_client_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_http_client = object()
+    http_client_mock = Mock(return_value=fake_http_client)
+    openai_mock = Mock()
+
+    monkeypatch.setattr(settings, "openai_api_key", "key")
+    monkeypatch.setattr(settings, "openai_proxy", "http://proxy")
+    monkeypatch.setattr(httpx, "Client", http_client_mock)
+    monkeypatch.setattr(openai_utils, "OpenAI", openai_mock)
+
+    client = openai_utils.get_openai_client()
+
+    http_client_mock.assert_called_once_with(proxies="http://proxy")
+    openai_mock.assert_called_once_with(api_key="key", http_client=fake_http_client)
+    assert client is openai_mock.return_value
+
+
+def test_get_openai_client_logs_assistant(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    openai_mock = Mock()
+    monkeypatch.setattr(openai_utils, "OpenAI", openai_mock)
+    monkeypatch.setattr(settings, "openai_api_key", "key")
+    monkeypatch.setattr(settings, "openai_assistant_id", "assistant")
+
+    with caplog.at_level(logging.INFO):
+        openai_utils.get_openai_client()
+
+    assert any("Using assistant: assistant" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- add tests for OpenAI client creation

## Testing
- `pytest -q tests/test_openai_utils.py` (fails: Coverage failure: total of 4 is less than fail-under=85)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1bc5eab5c832abc414da0b68a24d4