### PR TITLE
[tests] dispose engine after each module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,10 @@ def _dispose_engine_after_tests() -> Iterator[None]:
     """Dispose the global database engine after the test session."""
     yield
     dispose_engine()
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _dispose_engine_per_module() -> Iterator[None]:
+    """Dispose the global database engine after each test module."""
+    yield
+    dispose_engine()


### PR DESCRIPTION
## Summary
- dispose global database engine after each test module to release connections

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1bc689fd0832a8295ae9e46acd3b5