### PR TITLE
[tests] Add metadata tables test

### DIFF
--- a/tests/test_models_metadata.py
+++ b/tests/test_models_metadata.py
@@ -1,0 +1,6 @@
+from services.api.app.diabetes.models import metadata
+
+
+def test_models_metadata_contains_expected_tables() -> None:
+    assert "users" in metadata.tables
+    assert "profiles" in metadata.tables


### PR DESCRIPTION
## Summary
- add regression test ensuring the exported metadata exposes `users` and `profiles` tables

## Testing
- `pytest -q` *(fails: Required test coverage of 85% not reached)*
- `pytest -q --no-cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1bc6a9250832ab9fecbaaadb81de8