### PR TITLE
[ui] Guard state updates in reminder effect

### DIFF
--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -50,6 +50,7 @@ export default function CreateReminder() {
   const [typeOpen, setTypeOpen] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     if (!params.id || !user?.id) return;
     const id = Number(params.id);
     if (Number.isNaN(id)) {
@@ -61,6 +62,7 @@ export default function CreateReminder() {
     (async () => {
       try {
         const data = await getReminder(user.id, id);
+        if (cancelled) return;
         if (data) {
           const nt = normalizeReminderType(data.type);
           const loaded: Reminder = {
@@ -87,6 +89,9 @@ export default function CreateReminder() {
         toast({ title: "Ошибка", description: message, variant: "destructive" });
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [params.id, user?.id, toast]);
 
   const validName = title.trim().length >= 2;


### PR DESCRIPTION
## Summary
- prevent state updates after unmount in reminder creation effect

## Testing
- `pytest -q` *(fails: Required test coverage of 85% not reached)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1c396dd34832abf4e0f32b2f2b8cb