### PR TITLE
[tests] defer db module import for coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,6 @@ import warnings
 
 import pytest
 
-from services.api.app.diabetes.services.db import dispose_engine
-
-
 warnings.filterwarnings(
     "ignore", category=ResourceWarning, module=r"anyio\.streams\.memory"
 )
@@ -14,6 +11,8 @@ warnings.filterwarnings(
 @pytest.fixture(autouse=True, scope="session")
 def _dispose_engine_after_tests() -> Iterator[None]:
     """Dispose the global database engine after the test session."""
+    from services.api.app.diabetes.services.db import dispose_engine
+
     yield
     dispose_engine()
 
@@ -21,5 +20,7 @@ def _dispose_engine_after_tests() -> Iterator[None]:
 @pytest.fixture(autouse=True, scope="module")
 def _dispose_engine_per_module() -> Iterator[None]:
     """Dispose the global database engine after each test module."""
+    from services.api.app.diabetes.services.db import dispose_engine
+
     yield
     dispose_engine()


### PR DESCRIPTION
## Summary
- defer `services.api.app.diabetes.services.db` import in tests to after coverage startup

## Testing
- `pytest -q tests/test_run_db.py` *(fails: Coverage failure: total of 3 is less than fail-under=85)*
- `mypy --strict tests/conftest.py` *(interrupted: took too long)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1c6a93c00832a96480047be930de1