### PR TITLE
[webapp] Parse API error details in tgFetch

### DIFF
--- a/services/webapp/ui/src/lib/tgFetch.test.ts
+++ b/services/webapp/ui/src/lib/tgFetch.test.ts
@@ -59,6 +59,26 @@ describe('tgFetch', () => {
     await expect(tgFetch('/api/profile/self')).rejects.toThrow('Internal Error');
   });
 
+  it('uses detail from JSON error response', async () => {
+    (global.fetch as Mock).mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'Bad request' }), {
+        status: 400,
+      }),
+    );
+    await expect(tgFetch('/api/profile/self')).rejects.toThrow('Bad request');
+  });
+
+  it('uses message from JSON error response', async () => {
+    (global.fetch as Mock).mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Unauthorized' }), {
+        status: 401,
+      }),
+    );
+    await expect(tgFetch('/api/profile/self')).rejects.toThrow(
+      'Unauthorized',
+    );
+  });
+
   it('aborts request after timeout', async () => {
     vi.useFakeTimers();
     (global.fetch as Mock).mockImplementation((_, options: RequestInit) =>


### PR DESCRIPTION
## Summary
- Attempt to parse JSON error payload in tgFetch and surface `detail` or `message`
- Add tests for JSON error handling
- Specify return type for tgFetch

## Testing
- `npm --workspace services/webapp/ui exec vitest run src/lib/tgFetch.test.ts`
- `pytest -q tests/test_utils.py` (fails: Coverage failure: total of 6 is less than fail-under=85)
- `mypy --strict services/api/app/diabetes/utils/helpers.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1c82e49a0832a82279deff80b9a3f