### PR TITLE
[tests] Ensure sqlite connections are closed in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 from collections.abc import Iterator
+import sqlite3
+from typing import Any, Callable
 import warnings
 
 import pytest
@@ -6,6 +8,27 @@ import pytest
 warnings.filterwarnings(
     "ignore", category=ResourceWarning, module=r"anyio\.streams\.memory"
 )
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _close_sqlite_connections() -> Iterator[None]:
+    """Ensure that all sqlite3 connections are closed after the test session."""
+
+    connections: list[sqlite3.Connection] = []
+    original_connect: Callable[..., sqlite3.Connection] = sqlite3.connect
+
+    def tracking_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+        conn = original_connect(*args, **kwargs)
+        connections.append(conn)
+        return conn
+
+    sqlite3.connect = tracking_connect  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        sqlite3.connect = original_connect  # type: ignore[assignment]
+        for conn in connections:
+            conn.close()
 
 
 @pytest.fixture(autouse=True, scope="session")


### PR DESCRIPTION
## Summary
- track sqlite3 connections opened during tests and close them at session end
- prevent ResourceWarning noise in test suite

## Testing
- `pytest -q` (fails: Coverage failure: total of 69 is less than fail-under=85)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1c9363c00832ab453e6201cf6ddd9