### PR TITLE
[tests] expand coverage for models, openai utils, dose handlers

### DIFF
--- a/tests/test_dose_handlers_basic.py
+++ b/tests/test_dose_handlers_basic.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram import Update
+from telegram.ext import ContextTypes
+from typing import cast
+
+from services.api.app.diabetes.handlers import dose_handlers
+
+
+@dataclass
+class DummyMessage:
+    text: str | None = None
+    reply_text: AsyncMock = field(default_factory=AsyncMock)
+
+
+@dataclass
+class DummyUpdate:
+    message: DummyMessage | None = None
+
+
+@dataclass
+class DummyContext:
+    user_data: dict[str, object]
+
+
+@pytest.mark.asyncio
+async def test_dose_start_clears_user_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    message = DummyMessage()
+    update = cast(Update, DummyUpdate(message=message))
+    context = cast(
+        ContextTypes.DEFAULT_TYPE,
+        DummyContext(user_data={"pending_entry": 1, "edit_id": 2, "dose_method": "xe"}),
+    )
+    monkeypatch.setattr(dose_handlers, "dose_keyboard", "kb")
+
+    result = await dose_handlers.dose_start(update, context)
+
+    assert context.user_data is not None
+    user_data = cast(dict[str, object], context.user_data)
+    assert user_data == {}
+    message.reply_text.assert_awaited_once_with(
+        "💉 Как рассчитать дозу? Выберите метод:", reply_markup="kb"
+    )
+    assert result == dose_handlers.DOSE_METHOD
+
+
+@pytest.mark.asyncio
+async def test_dose_method_choice_xe() -> None:
+    message = DummyMessage(text="Xe")
+    update = cast(Update, DummyUpdate(message=message))
+    context = cast(ContextTypes.DEFAULT_TYPE, DummyContext(user_data={}))
+
+    result = await dose_handlers.dose_method_choice(update, context)
+
+    assert context.user_data is not None
+    user_data = cast(dict[str, object], context.user_data)
+    assert user_data["dose_method"] == "xe"
+    message.reply_text.assert_awaited_once_with("Введите количество ХЕ.")
+    assert result == dose_handlers.DOSE_XE
+

--- a/tests/test_models_metadata.py
+++ b/tests/test_models_metadata.py
@@ -1,6 +1,13 @@
-from services.api.app.diabetes.models import metadata
+from services.api.app.diabetes import models
+from services.api.app.diabetes.services.db import Base
 
 
 def test_models_metadata_contains_expected_tables() -> None:
-    assert "users" in metadata.tables
-    assert "profiles" in metadata.tables
+    assert "users" in models.metadata.tables
+    assert "profiles" in models.metadata.tables
+
+
+def test_models_exports_metadata() -> None:
+    assert models.__all__ == ["metadata"]
+    assert models.metadata is Base.metadata
+

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -43,3 +43,19 @@ def test_get_openai_client_logs_assistant(
         openai_utils.get_openai_client()
 
     assert any("Using assistant: assistant" in r.message for r in caplog.records)
+
+
+def test_get_openai_client_without_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    openai_mock = Mock()
+    client_mock = Mock()
+
+    monkeypatch.setattr(settings, "openai_api_key", "key")
+    monkeypatch.setattr(settings, "openai_proxy", "")
+    monkeypatch.setattr(httpx, "Client", client_mock)
+    monkeypatch.setattr(openai_utils, "OpenAI", openai_mock)
+
+    client = openai_utils.get_openai_client()
+
+    client_mock.assert_not_called()
+    openai_mock.assert_called_once_with(api_key="key", http_client=None)
+    assert client is openai_mock.return_value


### PR DESCRIPTION
## Summary
- extend OpenAI helper tests to cover proxy-free configuration
- verify diabetes models expose metadata
- add dose handler conversation tests for start and method selection

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68a1c9363e34832aa98204bf8d34721c