### PR TITLE
tests: import app after coverage start

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,2 +1,12 @@
-# sitecustomize.py
-import services.api.app  # noqa: F401  # applies telegram compatibility patch on interpreter start
+"""Customize Python startup behavior for the project.
+
+The project imports ``services.api.app`` at interpreter start to apply a
+Telegram compatibility patch.  Importing the package too early prevents test
+coverage from measuring the module, so skip the import when running tests.
+The tests themselves import ``services.api.app`` once coverage has started.
+"""
+
+import os
+
+if "PYTEST_CURRENT_TEST" not in os.environ:
+    import services.api.app  # noqa: F401  # applies Telegram compatibility patch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,12 @@ warnings.filterwarnings(
 
 
 @pytest.fixture(autouse=True, scope="session")
+def _apply_telegram_patch() -> None:
+    """Import the app package after coverage starts to apply Telegram patch."""
+    import services.api.app  # noqa: F401
+
+
+@pytest.fixture(autouse=True, scope="session")
 def _dispose_engine_after_tests() -> Iterator[None]:
     """Dispose the global database engine after the test session."""
     from services.api.app.diabetes.services.db import dispose_engine


### PR DESCRIPTION
## Summary
- avoid pre-importing `services.api.app` during tests so coverage can monitor it
- load telegram compatibility patch in a session fixture after coverage is active

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q` *(fails: Coverage failure: total of 69 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c9371558832aab36d0d197174aa6