### PR TITLE
[deps] add sqlalchemy stubs and fix mypy

### DIFF
--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -34,6 +34,8 @@ six==1.17.0
 sniffio==1.3.1
 SQLAlchemy==2.0.42
 tqdm==4.67.1
+# Typing stubs
+sqlalchemy-stubs==0.4
 typing-inspection==0.4.0
 typing_extensions==4.13.2
 fastapi==0.115.0

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -85,7 +85,7 @@ async def test_entry_without_dose_has_no_unit(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
+    session_factory: sessionmaker = sessionmaker(class_=DummySession)
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
@@ -140,7 +140,7 @@ async def test_entry_without_sugar_has_placeholder(
     async def noop(*args: Any, **kwargs: Any) -> None:
         pass
 
-    session_factory = cast(sessionmaker[Session], sessionmaker(class_=DummySession))
+    session_factory: sessionmaker = sessionmaker(class_=DummySession)
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)

--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -55,7 +55,7 @@ class DummyJobQueue:
         return []
 
 
-def _setup_db() -> tuple[sessionmaker[Any], Any]:
+def _setup_db() -> tuple[sessionmaker, Any]:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -9,7 +9,7 @@ import pytest
 from .context_stub import AlertContext, ContextStub
 
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import sessionmaker
 from telegram import Bot, Update
 from telegram.ext import ApplicationBuilder, ContextTypes, MessageHandler, filters
 
@@ -33,7 +33,7 @@ class DummyMessage:
 
 
 @pytest.fixture
-def test_session(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+def test_session(monkeypatch: pytest.MonkeyPatch) -> sessionmaker:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -46,7 +46,7 @@ def test_session(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("contact", ["@alice", "123456"])
-async def test_soscontact_stores_contact(test_session: sessionmaker[Session], contact: Any) -> None:
+async def test_soscontact_stores_contact(test_session: sessionmaker, contact: Any) -> None:
     with test_session() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(Profile(telegram_id=1))
@@ -71,7 +71,7 @@ async def test_soscontact_stores_contact(test_session: sessionmaker[Session], co
 
 
 @pytest.mark.asyncio
-async def test_alert_notifies_user_and_contact(test_session: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_alert_notifies_user_and_contact(test_session: sessionmaker, monkeypatch: pytest.MonkeyPatch) -> None:
     with test_session() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(Profile(telegram_id=1, low_threshold=4, high_threshold=8))
@@ -112,7 +112,7 @@ async def test_alert_notifies_user_and_contact(test_session: sessionmaker[Sessio
 
 
 @pytest.mark.asyncio
-async def test_alert_skips_phone_contact(test_session: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_alert_skips_phone_contact(test_session: sessionmaker, monkeypatch: pytest.MonkeyPatch) -> None:
     with test_session() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(

--- a/tests/test_webapp_history.py
+++ b/tests/test_webapp_history.py
@@ -28,7 +28,7 @@ def build_init_data(user_id: int = 1) -> str:
     return urllib.parse.urlencode(params)
 
 
-def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker:
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
     )

--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -35,7 +35,7 @@ def auth_headers(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
     return {"X-Telegram-Init-Data": build_init_data()}
 
 
-def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker:
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
     )

--- a/tests/test_webapp_user.py
+++ b/tests/test_webapp_user.py
@@ -16,7 +16,7 @@ from services.api.app.config import settings
 from services.api.app.diabetes.services import db
 
 
-def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker:
     engine = create_engine(
         "sqlite:///:memory:",
         connect_args={"check_same_thread": False},


### PR DESCRIPTION
## Summary
- add SQLAlchemy stub package and update tests
- remove unsupported generic `sessionmaker` annotations

## Testing
- `pytest -q --cov`
- `mypy --strict services/api/app libs/py-sdk tests`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1d362f334832ab61f801ebbe99ea4