### PR TITLE
[tests] cover alert handler errors

### DIFF
--- a/tests/test_alert_handlers.py
+++ b/tests/test_alert_handlers.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.error import TelegramError
+from telegram.ext import ContextTypes
+
+from .context_stub import AlertContext, ContextStub
+import services.api.app.diabetes.handlers.alert_handlers as handlers
+
+
+async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
+    """Return empty coordinates for tests."""
+    return None, None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc_cls", "expected"),
+    [
+        (TelegramError, "Failed to send alert message to user 1"),
+        (OSError, "OS error sending alert message to user 1"),
+    ],
+)
+async def test_send_alert_message_invalid_contact(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    exc_cls: type[BaseException],
+    expected: str,
+) -> None:
+    """User send failures and invalid SOS contact are logged."""
+
+    bot = SimpleNamespace(send_message=AsyncMock(side_effect=exc_cls("boom")))
+    context = cast(AlertContext, ContextStub(bot=bot))
+    monkeypatch.setattr(handlers, "get_coords_and_link", fake_get_coords_and_link)
+
+    profile: dict[str, Any] = {
+        "sos_contact": "bad_contact",
+        "sos_alerts_enabled": True,
+    }
+
+    with caplog.at_level(logging.INFO):
+        await handlers._send_alert_message(
+            1,
+            10.0,
+            profile,
+            cast(ContextTypes.DEFAULT_TYPE, context),
+            "Ivan",
+        )
+
+    assert expected in caplog.text
+    assert (
+        "SOS contact 'bad_contact' is not a Telegram username or chat id; skipping"
+        in caplog.text
+    )
+    assert bot.send_message.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc_cls", "expected"),
+    [
+        (
+            TelegramError,
+            "Failed to send alert message to SOS contact '12345'",
+        ),
+        (
+            OSError,
+            "OS error sending alert message to SOS contact '12345'",
+        ),
+    ],
+)
+async def test_send_alert_message_sos_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    exc_cls: type[BaseException],
+    expected: str,
+) -> None:
+    """Failures sending to SOS contact are logged."""
+
+    bot = SimpleNamespace(
+        send_message=AsyncMock(side_effect=[None, exc_cls("boom")])
+    )
+    context = cast(AlertContext, ContextStub(bot=bot))
+    monkeypatch.setattr(handlers, "get_coords_and_link", fake_get_coords_and_link)
+
+    profile: dict[str, Any] = {
+        "sos_contact": "12345",
+        "sos_alerts_enabled": True,
+    }
+
+    with caplog.at_level(logging.ERROR):
+        await handlers._send_alert_message(
+            1,
+            10.0,
+            profile,
+            cast(ContextTypes.DEFAULT_TYPE, context),
+            "Ivan",
+        )
+
+    assert expected in caplog.text
+    assert bot.send_message.await_count == 2


### PR DESCRIPTION
## Summary
- test alert message failure and invalid SOS contact
- test alert message failure for numeric SOS contact

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1eb3ee898832a8cb63541bce1ff48