### PR TITLE
[handlers] Split dose calc handlers into modules

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -24,7 +24,7 @@ class UserData(TypedDict, total=False):
     chat_id: int
 
 
-from .dose_calc import _cancel_then
+from .dose_calc import _cancel_then  # noqa: E402
 
 __all__ = ["_cancel_then", "UserData"]
 

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -1,0 +1,375 @@
+import datetime
+import logging
+import re
+from typing import cast
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes
+from sqlalchemy.orm import Session
+
+from services.api.app.diabetes.services.db import SessionLocal, Entry, Profile, run_db
+from services.api.app.diabetes.services.repository import commit
+from services.api.app.diabetes.utils.functions import (
+    PatientProfile,
+    calc_bolus,
+    smart_input,
+)
+from services.api.app.diabetes.gpt_command_parser import parse_command
+from services.api.app.diabetes.utils.ui import confirm_keyboard, menu_keyboard
+
+from .alert_handlers import check_alert
+from .dose_validation import _sanitize
+from .reporting_handlers import render_entry, send_report
+from . import UserData
+
+logger = logging.getLogger(__name__)
+
+
+async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle freeform text commands for adding diary entries."""
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        return
+    user_data = cast(UserData, user_data_raw)
+    message = update.message
+    if message is None:
+        return
+    text = message.text
+    if text is None:
+        return
+    user = update.effective_user
+    if user is None:
+        return
+    raw_text = text.strip()
+    user_id = user.id
+    logger.info("FREEFORM raw='%s'  user=%s", _sanitize(raw_text), user_id)
+
+    if user_data.get("awaiting_report_date"):
+        text = raw_text.lower()
+        if "назад" in text or text == "/cancel":
+            user_data.pop("awaiting_report_date", None)
+            await message.reply_text(
+                "📋 Выберите действие:", reply_markup=menu_keyboard
+            )
+            return
+        try:
+            date_from = datetime.datetime.strptime(raw_text, "%Y-%m-%d").replace(
+                tzinfo=datetime.timezone.utc
+            )
+        except ValueError:
+            await message.reply_text(
+                "❗ Некорректная дата. Используйте формат YYYY-MM-DD."
+            )
+            return
+        await send_report(update, context, date_from, "указанный период")
+        user_data.pop("awaiting_report_date", None)
+        return
+
+    pending_entry = user_data.get("pending_entry")
+    pending_fields = user_data.get("pending_fields")
+    edit_id = user_data.get("edit_id")
+    if pending_entry is not None and edit_id is None and pending_fields:
+        field = pending_fields[0]
+        text = raw_text.replace(",", ".")
+        try:
+            value = float(text)
+        except ValueError:
+            if field == "sugar":
+                await message.reply_text("Введите сахар числом в ммоль/л.")
+            elif field == "xe":
+                await message.reply_text("Введите число ХЕ.")
+            else:
+                await message.reply_text("Введите дозу инсулина числом.")
+            return
+        if value < 0:
+            if field == "sugar":
+                await message.reply_text("Сахар не может быть отрицательным.")
+            elif field == "xe":
+                await message.reply_text("Количество ХЕ не может быть отрицательным.")
+            else:
+                await message.reply_text("Доза инсулина не может быть отрицательной.")
+            return
+        if field == "sugar":
+            pending_entry["sugar_before"] = value
+        elif field == "xe":
+            pending_entry["xe"] = value
+            pending_entry["carbs_g"] = value * 12
+        else:
+            pending_entry["dose"] = value
+        pending_fields.pop(0)
+        if pending_fields:
+            next_field = pending_fields[0]
+            if next_field == "sugar":
+                await message.reply_text("Введите уровень сахара (ммоль/л).")
+            elif next_field == "xe":
+                await message.reply_text("Введите количество ХЕ.")
+            else:
+                await message.reply_text("Введите дозу инсулина (ед.).")
+            return
+
+        def db_save_entry(session: Session) -> bool:
+            entry = Entry(**pending_entry)
+            session.add(entry)
+            return bool(commit(session))
+
+        try:
+            ok = await run_db(db_save_entry, sessionmaker=SessionLocal)
+        except AttributeError:
+            with SessionLocal() as session:
+                ok = db_save_entry(session)
+        if not ok:
+            await message.reply_text("⚠️ Не удалось сохранить запись.")
+            return
+        sugar = pending_entry.get("sugar_before")
+        if sugar is not None:
+            await check_alert(update, context, sugar)
+        user_data.pop("pending_entry", None)
+        user_data.pop("pending_fields", None)
+        xe = pending_entry.get("xe")
+        dose = pending_entry.get("dose")
+        xe_info = f", ХЕ {xe}" if xe is not None else ""
+        dose_info = f", доза {dose} Ед." if dose is not None else ", доза —"
+        sugar_info = f"сахар {sugar} ммоль/л" if sugar is not None else "сахар —"
+        await message.reply_text(
+            f"✅ Запись сохранена: {sugar_info}{xe_info}{dose_info}",
+            reply_markup=menu_keyboard,
+        )
+        return
+    if pending_entry is not None and edit_id is None:
+        entry = pending_entry
+        text = raw_text.lower()
+        if (
+            re.fullmatch(r"-?\d+(?:[.,]\d+)?", text)
+            and entry.get("sugar_before") is None
+        ):
+            try:
+                sugar = float(text.replace(",", "."))
+            except ValueError:
+                await message.reply_text("Некорректное числовое значение.")
+                return
+            if sugar < 0:
+                await message.reply_text("Сахар не может быть отрицательным.")
+                return
+            entry["sugar_before"] = sugar
+            if entry.get("carbs_g") is not None or entry.get("xe") is not None:
+                xe_val = entry.get("xe")
+                carbs_g = entry.get("carbs_g")
+                if carbs_g is None and xe_val is not None:
+                    carbs_g = xe_val * 12
+                    entry["carbs_g"] = carbs_g
+                user_id = user.id
+                try:
+                    profile = await run_db(
+                        lambda s: s.get(Profile, user_id), sessionmaker=SessionLocal
+                    )
+                except AttributeError:
+                    with SessionLocal() as session:
+                        profile = session.get(Profile, user_id)
+                if (
+                    profile is not None
+                    and profile.icr is not None
+                    and profile.cf is not None
+                    and profile.target_bg is not None
+                ):
+                    patient = PatientProfile(
+                        icr=profile.icr, cf=profile.cf, target_bg=profile.target_bg
+                    )
+                    dose = calc_bolus(carbs_g, sugar, patient)
+                    entry["dose"] = dose
+                    await message.reply_text(
+                        f"💉 Расчёт дозы: {dose} Ед.", reply_markup=confirm_keyboard()
+                    )
+                    return
+            await message.reply_text(
+                "Введите количество углеводов или ХЕ.", reply_markup=menu_keyboard
+            )
+            return
+        await message.reply_text(
+            "Не понял, воспользуйтесь /help или кнопками меню"
+        )
+        return
+    if edit_id is not None:
+        text = raw_text.replace(",", ".")
+        try:
+            value = float(text)
+        except ValueError:
+            await message.reply_text("Введите значение числом.")
+            return
+        if value < 0:
+            await message.reply_text("Значение не может быть отрицательным.")
+            return
+        field = user_data.get("edit_field")
+        if field == "sugar":
+            user_data.setdefault("edit_entry", {})["sugar_before"] = value
+        elif field == "xe":
+            user_data.setdefault("edit_entry", {})["xe"] = value
+            user_data.setdefault("edit_entry", {})["carbs_g"] = value * 12
+        else:
+            user_data.setdefault("edit_entry", {})["dose"] = value
+        edit_info = user_data.get("edit_entry", {})
+        markup = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(
+                        "✏️ Изменить", callback_data=f"edit:{user_data['edit_id']}"
+                    ),
+                    InlineKeyboardButton(
+                        "🗑 Удалить", callback_data=f"del:{user_data['edit_id']}"
+                    ),
+                ]
+            ]
+        )
+        render_text = render_entry(edit_info)
+        await message.reply_text(render_text, reply_markup=markup, parse_mode="HTML")
+        user_data.pop("edit_id", None)
+        user_data.pop("edit_field", None)
+        user_data.pop("edit_entry", None)
+        return
+
+    try:
+        quick = smart_input(raw_text)
+    except ValueError as exc:
+        msg = str(exc)
+        if "mismatched unit for sugar" in msg:
+            await message.reply_text("❗ Сахар указывается в ммоль/л, не в XE.")
+        elif "mismatched unit for dose" in msg:
+            await message.reply_text("❗ Доза указывается в ед., не в ммоль.")
+        elif "mismatched unit for xe" in msg:
+            await message.reply_text("❗ ХЕ указываются числом, без ммоль/л и ед.")
+        else:
+            await message.reply_text(
+                "Не удалось распознать значения, используйте сахар=5 xe=1 dose=2"
+            )
+        return
+    if any(v is not None for v in quick.values()):
+        sugar = quick["sugar"]
+        xe = quick["xe"]
+        dose = quick["dose"]
+        if any(v is not None and v < 0 for v in (sugar, xe, dose)):
+            await message.reply_text("Значения не могут быть отрицательными.")
+            return
+        entry_data = {
+            "telegram_id": user_id,
+            "event_time": datetime.datetime.now(datetime.timezone.utc),
+            "sugar_before": sugar,
+            "xe": xe,
+            "dose": dose,
+            "carbs_g": xe * 12 if xe is not None else None,
+        }
+        missing = [f for f in ("sugar", "xe", "dose") if quick[f] is None]
+        if not missing:
+            def db_save_quick(session: Session) -> bool:
+                entry = Entry(**entry_data)
+                session.add(entry)
+                return bool(commit(session))
+            try:
+                ok = await run_db(db_save_quick, sessionmaker=SessionLocal)
+            except AttributeError:
+                with SessionLocal() as session:
+                    ok = db_save_quick(session)
+            if not ok:
+                await message.reply_text("⚠️ Не удалось сохранить запись.")
+                return
+            if sugar is not None:
+                await check_alert(update, context, sugar)
+            await message.reply_text(
+                f"✅ Запись сохранена: сахар {sugar} ммоль/л, ХЕ {xe}, доза {dose} Ед.",
+                reply_markup=menu_keyboard,
+            )
+            return
+        user_data["pending_entry"] = entry_data
+        user_data["pending_fields"] = missing
+        next_field = missing[0]
+        if next_field == "sugar":
+            await message.reply_text("Введите уровень сахара (ммоль/л).")
+        elif next_field == "xe":
+            await message.reply_text("Введите количество ХЕ.")
+        else:
+            await message.reply_text("Введите дозу инсулина (ед.).")
+        return
+
+    parsed = await parse_command(raw_text)
+    logger.info("FREEFORM parsed=%s", parsed)
+    if not parsed or parsed.get("action") != "add_entry":
+        await message.reply_text("Не понял, воспользуйтесь /help или кнопками меню")
+        return
+
+    fields = parsed.get("fields")
+    if not isinstance(fields, dict):
+        await message.reply_text("Не удалось распознать данные, попробуйте ещё раз.")
+        return
+    if any(
+        v is not None and v < 0
+        for v in (
+            fields.get("xe"),
+            fields.get("carbs_g"),
+            fields.get("dose"),
+            fields.get("sugar_before"),
+        )
+    ):
+        await message.reply_text("Значения не могут быть отрицательными.")
+        return
+    entry_date_obj = parsed.get("entry_date")
+    time_obj = parsed.get("time")
+
+    if isinstance(entry_date_obj, str):
+        try:
+            event_dt = datetime.datetime.fromisoformat(entry_date_obj)
+            if event_dt.tzinfo is None:
+                event_dt = event_dt.replace(tzinfo=datetime.timezone.utc)
+            else:
+                event_dt = event_dt.astimezone(datetime.timezone.utc)
+        except ValueError:
+            event_dt = datetime.datetime.now(datetime.timezone.utc)
+    elif isinstance(time_obj, str):
+        try:
+            hh, mm = map(int, time_obj.split(":"))
+            today = datetime.datetime.now(datetime.timezone.utc).date()
+            event_dt = datetime.datetime.combine(
+                today, datetime.time(hh, mm), tzinfo=datetime.timezone.utc
+            )
+        except (ValueError, TypeError):
+            await message.reply_text(
+                "⏰ Неверный формат времени. Использую текущее время."
+            )
+            event_dt = datetime.datetime.now(datetime.timezone.utc)
+    else:
+        event_dt = datetime.datetime.now(datetime.timezone.utc)
+    user_data.pop("pending_entry", None)
+    user_data["pending_entry"] = {
+        "telegram_id": user_id,
+        "event_time": event_dt,
+        "xe": fields.get("xe"),
+        "carbs_g": fields.get("carbs_g"),
+        "dose": fields.get("dose"),
+        "sugar_before": fields.get("sugar_before"),
+        "photo_path": None,
+    }
+
+    xe_val: float | None = fields.get("xe")
+    carbs_val: float | None = fields.get("carbs_g")
+    dose_val: float | None = fields.get("dose")
+    sugar_val: float | None = fields.get("sugar_before")
+    date_str = event_dt.strftime("%d.%m %H:%M")
+    xe_part = f"{xe_val} ХЕ" if xe_val is not None else ""
+    carb_part = f"{carbs_val:.0f} г углеводов" if carbs_val is not None else ""
+    dose_part = f"Инсулин: {dose_val} ед" if dose_val is not None else ""
+    sugar_part = f"Сахар: {sugar_val} ммоль/л" if sugar_val is not None else ""
+    lines = "  \n- ".join(filter(None, [xe_part or carb_part, dose_part, sugar_part]))
+
+    reply = (
+        f"💉 Расчёт завершён:\n\n{date_str}  \n- {lines}\n\nСохранить это в дневник?"
+    )
+    await message.reply_text(text=reply, reply_markup=confirm_keyboard())
+    return
+
+
+async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Placeholder GPT chat handler."""
+    message = update.message
+    if message is None:
+        return
+    await message.reply_text("🗨️ Чат с GPT временно недоступен.")
+
+
+__all__ = ["SessionLocal", "freeform_handler", "chat_with_gpt"]

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -46,6 +46,9 @@ def register_handlers(
         alert_handlers,
         sos_handlers,
         security_handlers,
+        photo_handlers,
+        sugar_handlers,
+        gpt_handlers,
     )
 
     app.add_handler(onboarding_conv)
@@ -56,11 +59,11 @@ def register_handlers(
     # inputs for profile aren't captured by sugar logging
     app.add_handler(profile.profile_conv)
     app.add_handler(profile.profile_webapp_handler)
-    app.add_handler(dose_calc.sugar_conv)
+    app.add_handler(sugar_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("cancel", dose_calc.dose_cancel))
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("help", help_command))
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("gpt", dose_calc.chat_with_gpt))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("gpt", gpt_handlers.chat_with_gpt))
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("reminders", reminder_handlers.reminders_list))
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("addreminder", reminder_handlers.add_reminder))
     app.add_handler(reminder_handlers.reminder_action_handler)
@@ -79,7 +82,7 @@ def register_handlers(
         MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📊 История$"), reporting_handlers.history_view)
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📷 Фото еды$"), dose_calc.photo_prompt)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📷 Фото еды$"), photo_handlers.photo_prompt)
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^🕹 Быстрый ввод$"), smart_input_help)
@@ -99,12 +102,12 @@ def register_handlers(
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.TEXT & ~filters.COMMAND, dose_calc.freeform_handler
+            filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler
         )
     )
-    app.add_handler(MessageHandler[ContextTypes.DEFAULT_TYPE](filters.PHOTO, dose_calc.photo_handler))
+    app.add_handler(MessageHandler[ContextTypes.DEFAULT_TYPE](filters.PHOTO, photo_handlers.photo_handler))
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Document.IMAGE, dose_calc.doc_handler)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Document.IMAGE, photo_handlers.doc_handler)
     )
     app.add_handler(
         CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](

--- a/tests/test_gpt_handlers.py
+++ b/tests/test_gpt_handlers.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+import services.api.app.diabetes.handlers.gpt_handlers as gpt_handlers
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.texts.append(text)
+
+
+@pytest.mark.asyncio
+async def test_chat_with_gpt_replies() -> None:
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]], SimpleNamespace())
+    await gpt_handlers.chat_with_gpt(update, context)
+    assert message.texts == ["🗨️ Чат с GPT временно недоступен."]

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -10,6 +10,8 @@ import pytest
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
+import services.api.app.diabetes.handlers.sugar_handlers as sugar_handlers
 from services.api.app.diabetes.handlers import dose_calc
 from services.api.app.diabetes.utils.ui import sugar_keyboard
 
@@ -28,7 +30,7 @@ class DummyMessage:
 async def test_prompt_photo_sends_message() -> None:
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message))
-    await dose_calc.prompt_photo(
+    await photo_handlers.prompt_photo(
         update,
         cast(
             CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -48,7 +50,7 @@ async def test_prompt_sugar_sends_message() -> None:
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
-    await dose_calc.prompt_sugar(update, context)
+    await sugar_handlers.prompt_sugar(update, context)
     assert any("сахар" in t.lower() for t in message.texts)
     assert message.kwargs and message.kwargs[0].get("reply_markup") is sugar_keyboard
 

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 from telegram import Update
 from telegram.ext import CallbackContext
 
-import services.api.app.diabetes.handlers.dose_calc as dose_calc
+import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
 
 
 class DummyMessage:
@@ -84,9 +84,9 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
             )
         )
 
-    monkeypatch.setattr(dose_calc, "send_message", fake_send_message)
-    monkeypatch.setattr(dose_calc, "_get_client", lambda: DummyClient())
-    monkeypatch.setattr(dose_calc, "menu_keyboard", None)
+    monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
+    monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
+    monkeypatch.setattr(photo_handlers, "menu_keyboard", None)
 
     msg_photo = DummyMessage(photo=[DummyPhoto()])
     update = cast(
@@ -94,7 +94,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: pytest.MonkeyPatch, 
         SimpleNamespace(message=msg_photo, effective_user=SimpleNamespace(id=1)),
     )
 
-    await dose_calc.photo_handler(update, context)
+    await photo_handlers.photo_handler(update, context)
 
     assert "название" in captured["content"]
     # Final reply should include dish name from Vision response

--- a/tests/test_photo_handlers.py
+++ b/tests/test_photo_handlers.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
+
+
+class DummyMessage:
+    def __init__(self, photo: tuple[Any, ...] | None = None) -> None:
+        self.photo: tuple[Any, ...] = () if photo is None else photo
+        self.texts: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.texts.append(text)
+
+
+@pytest.mark.asyncio
+async def test_photo_prompt_sends_message() -> None:
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]], SimpleNamespace())
+    await photo_handlers.photo_prompt(update, context)
+    assert any("фото" in t.lower() for t in message.texts)
+
+
+@pytest.mark.asyncio
+async def test_photo_handler_waiting_flag_returns_end() -> None:
+    message = DummyMessage(photo=(SimpleNamespace(file_id="f", file_unique_id="u"),))
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={photo_handlers.WAITING_GPT_FLAG: True}),
+    )
+    result = await photo_handlers.photo_handler(update, context)
+    assert result == photo_handlers.ConversationHandler.END
+    assert message.texts and "подождите" in message.texts[0].lower()

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -9,7 +9,8 @@ from telegram.ext import CallbackContext
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from services.api.app.diabetes.handlers import dose_calc, profile as profile_handlers
+import services.api.app.diabetes.handlers.sugar_handlers as sugar_handlers
+from services.api.app.diabetes.handlers import profile as profile_handlers
 from services.api.app.diabetes.services.db import Base, Entry, User
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -33,7 +34,7 @@ async def test_profile_input_not_logged_as_sugar(monkeypatch: pytest.MonkeyPatch
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
     monkeypatch.setattr(profile_handlers, "SessionLocal", TestSession)
-    monkeypatch.setattr(dose_calc, "SessionLocal", TestSession)
+    monkeypatch.setattr(sugar_handlers, "SessionLocal", TestSession)
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -54,7 +55,7 @@ async def test_profile_input_not_logged_as_sugar(monkeypatch: pytest.MonkeyPatch
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, chat_data=shared_chat_data),
     )
-    await dose_calc.sugar_start(sugar_update, sugar_context)
+    await sugar_handlers.sugar_start(sugar_update, sugar_context)
 
     # Start profile conversation which should cancel sugar conversation
     prof_msg = DummyMessage("/profile")

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -25,6 +25,9 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch: pytest.Monkey
         dose_calc,
         profile as profile_handlers,
         reporting_handlers,
+        photo_handlers,
+        sugar_handlers,
+        gpt_handlers,
     )
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
@@ -33,19 +36,19 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch: pytest.Monkey
     handlers = app.handlers[0]
     callbacks = [getattr(h, "callback", None) for h in handlers]
 
-    assert dose_calc.freeform_handler in callbacks
-    assert dose_calc.photo_handler in callbacks
-    assert dose_calc.doc_handler in callbacks
-    assert dose_calc.prompt_photo in callbacks
+    assert gpt_handlers.freeform_handler in callbacks
+    assert photo_handlers.photo_handler in callbacks
+    assert photo_handlers.doc_handler in callbacks
+    assert photo_handlers.prompt_photo in callbacks
     assert dose_calc.dose_cancel in callbacks
-    assert dose_calc.prompt_sugar not in callbacks
+    assert sugar_handlers.prompt_sugar not in callbacks
     assert callback_router in callbacks
     assert reporting_handlers.report_period_callback in callbacks
     assert profile_handlers.profile_view in callbacks
     assert profile_handlers.profile_back in callbacks
     assert reporting_handlers.report_request in callbacks
     assert reporting_handlers.history_view in callbacks
-    assert dose_calc.chat_with_gpt in callbacks
+    assert gpt_handlers.chat_with_gpt in callbacks
     assert security_handlers.hypo_alert_faq in callbacks
     # Reminder handlers should be registered
     assert any(
@@ -80,7 +83,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch: pytest.Monkey
 
     conv_handlers = [h for h in handlers if isinstance(h, ConversationHandler)]
     assert dose_calc.dose_conv in conv_handlers
-    assert dose_calc.sugar_conv in conv_handlers
+    assert sugar_handlers.sugar_conv in conv_handlers
     assert profile_handlers.profile_conv in conv_handlers
     assert onb_conv[0] in conv_handlers
     conv_cmds = [
@@ -91,7 +94,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch: pytest.Monkey
     assert conv_cmds and "dose" in conv_cmds[0].commands
     sugar_conv_cmds = [
         ep
-        for ep in dose_calc.sugar_conv.entry_points
+        for ep in sugar_handlers.sugar_conv.entry_points
         if isinstance(ep, CommandHandler)
     ]
     assert sugar_conv_cmds and "sugar" in sugar_conv_cmds[0].commands
@@ -114,21 +117,21 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch: pytest.Monkey
     text_handlers = [
         h
         for h in handlers
-        if isinstance(h, MessageHandler) and h.callback is dose_calc.freeform_handler
+        if isinstance(h, MessageHandler) and h.callback is gpt_handlers.freeform_handler
     ]
     assert text_handlers
 
-    photo_handlers = [
+    photo_handler_msgs = [
         h
         for h in handlers
-        if isinstance(h, MessageHandler) and h.callback is dose_calc.photo_handler
+        if isinstance(h, MessageHandler) and h.callback is photo_handlers.photo_handler
     ]
-    assert photo_handlers
+    assert photo_handler_msgs
 
     doc_handlers = [
         h
         for h in handlers
-        if isinstance(h, MessageHandler) and h.callback is dose_calc.doc_handler
+        if isinstance(h, MessageHandler) and h.callback is photo_handlers.doc_handler
     ]
     assert doc_handlers
 
@@ -136,14 +139,14 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch: pytest.Monkey
     photo_prompt_handlers = [
         h
         for h in handlers
-        if isinstance(h, MessageHandler) and h.callback is dose_calc.photo_prompt
+        if isinstance(h, MessageHandler) and h.callback is photo_handlers.photo_prompt
     ]
     assert photo_prompt_handlers
 
     sugar_cmd = [
         h
         for h in handlers
-        if isinstance(h, CommandHandler) and h.callback is dose_calc.sugar_start
+        if isinstance(h, CommandHandler) and h.callback is sugar_handlers.sugar_start
     ]
     assert not sugar_cmd
 
@@ -178,7 +181,7 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch: pytest.Monkey
     gpt_cmd = [
         h
         for h in handlers
-        if isinstance(h, CommandHandler) and h.callback is dose_calc.chat_with_gpt
+        if isinstance(h, CommandHandler) and h.callback is gpt_handlers.chat_with_gpt
     ]
     assert gpt_cmd and "gpt" in gpt_cmd[0].commands
 

--- a/tests/test_sugar_handlers.py
+++ b/tests/test_sugar_handlers.py
@@ -8,7 +8,7 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-import services.api.app.diabetes.handlers.dose_calc as dose_calc
+import services.api.app.diabetes.handlers.sugar_handlers as sugar_handlers
 from services.api.app.diabetes.services.db import Base, Entry
 
 
@@ -24,18 +24,6 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_photo_prompt_sends_message() -> None:
-    message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message))
-    context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(),
-    )
-    await dose_calc.photo_prompt(update, context)
-    assert any("фото" in r.lower() for r in message.replies)
-
-
-@pytest.mark.asyncio
 async def test_sugar_start_initializes_pending_entry() -> None:
     message = DummyMessage()
     update = cast(
@@ -45,8 +33,8 @@ async def test_sugar_start_initializes_pending_entry() -> None:
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, chat_data={}),
     )
-    state = await dose_calc.sugar_start(update, context)
-    assert state == dose_calc.SUGAR_VAL
+    state = await sugar_handlers.sugar_start(update, context)
+    assert state == sugar_handlers.SUGAR_VAL
     assert context.user_data is not None
     assert context.user_data["pending_entry"]["telegram_id"] == 1
     assert context.chat_data is not None
@@ -63,12 +51,12 @@ async def test_sugar_val_non_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, chat_data={}),
     )
-    await dose_calc.sugar_start(start_update, context)
+    await sugar_handlers.sugar_start(start_update, context)
 
     def fail_session() -> Any:
         raise AssertionError("DB should not be used")
 
-    monkeypatch.setattr(dose_calc, "SessionLocal", fail_session)
+    monkeypatch.setattr(sugar_handlers, "SessionLocal", fail_session)
 
     called = False
 
@@ -76,12 +64,12 @@ async def test_sugar_val_non_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
         nonlocal called
         called = True
 
-    monkeypatch.setattr(dose_calc, "check_alert", fake_check_alert)
+    monkeypatch.setattr(sugar_handlers, "check_alert", fake_check_alert)
 
     message = DummyMessage("abc")
     update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
-    result = await dose_calc.sugar_val(update, context)
-    assert result == dose_calc.SUGAR_VAL
+    result = await sugar_handlers.sugar_val(update, context)
+    assert result == sugar_handlers.SUGAR_VAL
     assert message.replies[-1] == "Введите сахар числом в ммоль/л."
     assert not called
 
@@ -96,12 +84,12 @@ async def test_sugar_val_negative(monkeypatch: pytest.MonkeyPatch) -> None:
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, chat_data={}),
     )
-    await dose_calc.sugar_start(start_update, context)
+    await sugar_handlers.sugar_start(start_update, context)
 
     def fail_session() -> Any:
         raise AssertionError("DB should not be used")
 
-    monkeypatch.setattr(dose_calc, "SessionLocal", fail_session)
+    monkeypatch.setattr(sugar_handlers, "SessionLocal", fail_session)
 
     called = False
 
@@ -109,12 +97,12 @@ async def test_sugar_val_negative(monkeypatch: pytest.MonkeyPatch) -> None:
         nonlocal called
         called = True
 
-    monkeypatch.setattr(dose_calc, "check_alert", fake_check_alert)
+    monkeypatch.setattr(sugar_handlers, "check_alert", fake_check_alert)
 
     message = DummyMessage("-1")
     update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
-    result = await dose_calc.sugar_val(update, context)
-    assert result == dose_calc.SUGAR_VAL
+    result = await sugar_handlers.sugar_val(update, context)
+    assert result == sugar_handlers.SUGAR_VAL
     assert message.replies[-1] == "Сахар не может быть отрицательным."
     assert not called
 
@@ -129,7 +117,7 @@ async def test_sugar_val_valid_saves_and_alerts(monkeypatch: pytest.MonkeyPatch)
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, chat_data={}),
     )
-    await dose_calc.sugar_start(start_update, context)
+    await sugar_handlers.sugar_start(start_update, context)
 
     engine = create_engine(
         "sqlite:///:memory:",
@@ -138,19 +126,19 @@ async def test_sugar_val_valid_saves_and_alerts(monkeypatch: pytest.MonkeyPatch)
     )
     Base.metadata.create_all(engine)
     session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(dose_calc, "SessionLocal", session_factory)
+    monkeypatch.setattr(sugar_handlers, "SessionLocal", session_factory)
 
     captured: dict[str, float] = {}
 
     async def fake_check_alert(update: Update, ctx: Any, sugar: float) -> None:
         captured["value"] = sugar
 
-    monkeypatch.setattr(dose_calc, "check_alert", fake_check_alert)
+    monkeypatch.setattr(sugar_handlers, "check_alert", fake_check_alert)
 
     message = DummyMessage("5.5")
     update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
-    result = await dose_calc.sugar_val(update, context)
-    assert result == dose_calc.END
+    result = await sugar_handlers.sugar_val(update, context)
+    assert result == sugar_handlers.END
     assert captured["value"] == 5.5
     assert any("сохран" in r.lower() for r in message.replies)
 
@@ -160,3 +148,16 @@ async def test_sugar_val_valid_saves_and_alerts(monkeypatch: pytest.MonkeyPatch)
         entry = entries[0]
         assert entry.sugar_before == 5.5
         assert entry.telegram_id == 1
+
+
+@pytest.mark.asyncio
+async def test_sugar_val_inactive_chat_returns_end() -> None:
+    message = DummyMessage("5")
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}, chat_data={}),
+    )
+    result = await sugar_handlers.sugar_val(update, context)
+    assert result == sugar_handlers.END
+    assert not message.replies


### PR DESCRIPTION
## Summary
- modularize dose calculation by extracting sugar, photo, and GPT flows into dedicated handler modules
- wire new handlers into registration and add targeted tests

## Testing
- `ruff check services/api/app/diabetes/handlers/dose_calc.py services/api/app/diabetes/handlers/sugar_handlers.py services/api/app/diabetes/handlers/photo_handlers.py services/api/app/diabetes/handlers/gpt_handlers.py services/api/app/diabetes/handlers/registration.py tests/test_sugar_handlers.py tests/test_photo_handlers.py tests/test_gpt_handlers.py tests/test_handlers_doc.py tests/test_handlers_photo_sugar_save.py tests/test_handlers_vision_prompt.py tests/test_handlers_prompts.py tests/test_profile_ignores_sugar_conv.py tests/test_register_handlers.py`
- `mypy --strict services/api/app/diabetes/handlers/dose_calc.py services/api/app/diabetes/handlers/sugar_handlers.py services/api/app/diabetes/handlers/photo_handlers.py services/api/app/diabetes/handlers/gpt_handlers.py services/api/app/diabetes/handlers/registration.py tests/test_sugar_handlers.py tests/test_photo_handlers.py tests/test_gpt_handlers.py tests/test_handlers_doc.py tests/test_handlers_photo_sugar_save.py tests/test_handlers_vision_prompt.py tests/test_handlers_prompts.py tests/test_profile_ignores_sugar_conv.py tests/test_register_handlers.py`
- `pytest tests/test_photo_handlers.py tests/test_sugar_handlers.py tests/test_gpt_handlers.py tests/test_handlers_doc.py tests/test_handlers_photo_sugar_save.py tests/test_handlers_vision_prompt.py tests/test_handlers_prompts.py tests/test_profile_ignores_sugar_conv.py tests/test_register_handlers.py -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68a1eb489104832a810c1632dbab2b4c