### PR TITLE
[ui] Support external abort signal in tgFetch

### DIFF
--- a/services/webapp/ui/src/api/tgFetch.api.test.ts
+++ b/services/webapp/ui/src/api/tgFetch.api.test.ts
@@ -62,4 +62,19 @@ describe('tgFetch', () => {
     vi.advanceTimersByTime(10_000);
     await expect(promise).rejects.toThrow(REQUEST_TIMEOUT_MESSAGE);
   });
+
+  it('supports external abort signal', async () => {
+    (global.fetch as Mock).mockImplementation((_, options: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        options.signal?.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError')),
+        );
+      }),
+    );
+
+    const abortController = new AbortController();
+    const promise = tgFetch('/api/profile', { signal: abortController.signal });
+    abortController.abort();
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
 });


### PR DESCRIPTION
## Summary
- handle external abort signals alongside internal timeout in tgFetch
- test request cancellation via external signal

## Testing
- `npx vitest run services/webapp/ui/src/api/tgFetch.api.test.ts services/webapp/ui/src/lib/tgFetch.test.ts`
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui run typecheck`
- `npx vitest run` *(fails: Failed to resolve import "react-test-renderer")*

------
https://chatgpt.com/codex/tasks/task_e_68a1efba9cb4832a8a04e528ebd5babd