### PR TITLE
[ui] surface Telegram init errors

### DIFF
--- a/services/webapp/ui/src/App.tsx
+++ b/services/webapp/ui/src/App.tsx
@@ -42,6 +42,7 @@ const AppContent = () => {
         <div className="text-center space-y-2">
           <p className="text-lg font-medium">Что-то пошло не так</p>
           <p className="text-muted-foreground">Попробуйте обновить приложение.</p>
+          <p className="text-sm text-muted-foreground">{error}</p>
         </div>
       </div>
     );

--- a/services/webapp/ui/src/hooks/useTelegram.ts
+++ b/services/webapp/ui/src/hooks/useTelegram.ts
@@ -151,6 +151,7 @@ export const useTelegram = (
       };
     } catch (e) {
       console.error("[TG] init error:", e);
+      setError(e instanceof Error ? e.message : String(e));
       setReady(true);
     }
   }, [tg, applyTheme, forceLight]);

--- a/tests/useTelegram.test.ts
+++ b/tests/useTelegram.test.ts
@@ -37,3 +37,31 @@ describe('useTelegram hook fallback', () => {
     expect(result.current.user).toBeNull();
   });
 });
+
+describe('useTelegram hook init error', () => {
+  beforeEach(() => {
+    (window as any).Telegram = {
+      WebApp: {
+        initData: '',
+        initDataUnsafe: {},
+        ready: vi.fn(() => {
+          throw new Error('init failed');
+        }),
+        expand: vi.fn(),
+      },
+    };
+  });
+
+  afterEach(() => {
+    delete (window as any).Telegram;
+    vi.restoreAllMocks();
+  });
+
+  it('sets error when initialization fails', async () => {
+    const { result } = renderHook(() => useTelegram(false));
+    await waitFor(() => {
+      expect(result.current.error).toBe('init failed');
+    });
+    expect(result.current.isReady).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- handle Telegram initialization failures by surfacing error messages
- display initialization errors in app content
- test failed initialization to ensure error state is set

## Testing
- `npx vitest run tests/useTelegram.test.ts`
- `npx vitest run` *(fails: Failed to resolve import)*
- `pytest -q` *(fails: unrecognized arguments --cov)*
- `mypy --strict .` *(fails: Unused "type: ignore" comment)*
- `ruff check .`
- `npm --workspace services/webapp/ui run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1f1521b18832ab8c21c7ff895015b