### PR TITLE
[webapp] Validate reminder API responses

### DIFF
--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const mockRemindersGet = vi.hoisted(() => vi.fn());
+
+vi.mock('@sdk', () => ({
+  DefaultApi: vi.fn(() => ({ remindersGet: mockRemindersGet })),
+  instanceOfReminder: vi.fn(),
+}));
+
+import { getReminder } from './reminders';
+
+describe('getReminder', () => {
+  it('throws on invalid API response', async () => {
+    mockRemindersGet.mockResolvedValueOnce([]);
+    await expect(getReminder(1, 1)).rejects.toThrow('Некорректный ответ API');
+  });
+});

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,4 +1,4 @@
-import { DefaultApi, Reminder } from '@sdk';
+import { DefaultApi, Reminder, instanceOfReminder } from '@sdk';
 import { Configuration } from '@sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
@@ -33,13 +33,16 @@ export async function getReminders(telegramId: number): Promise<Reminder[]> {
 export async function getReminder(
   telegramId: number,
   id: number,
-): Promise<Reminder | null> {
+): Promise<Reminder> {
   try {
     const data = await api.remindersGet({ telegramId, id });
-    if (Array.isArray(data)) {
-      return data[0] ?? null;
+
+    if (!data || Array.isArray(data) || !instanceOfReminder(data)) {
+      console.error('Unexpected reminder API response:', data);
+      throw new Error('Некорректный ответ API');
     }
-    return data ?? null;
+
+    return data;
   } catch (error) {
     console.error('Failed to fetch reminder:', error);
     if (error instanceof Error) {


### PR DESCRIPTION
## Summary
- validate API response shape before returning a reminder
- test error handling on malformed reminder API data

## Testing
- `npm --workspace services/webapp/ui exec vitest run src/api/reminders.api.test.ts`
- `pytest -q` *(fails: AttributeError and coverage 72% < 85%)*
- `mypy --strict .` *(fails: unused ignore comments)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1f7a56948832a8cc262b04ecdd0be