### PR TITLE
[tests] Annotate fake_run_db

### DIFF
--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -169,7 +169,7 @@ async def test_photo_flow_saves_entry(monkeypatch: pytest.MonkeyPatch, tmp_path:
     gpt_handlers.SessionLocal = session_factory
 
     async def fake_run_db(
-        func: Callable[[Session], T],
+        func: Callable[..., T],
         *args: Any,
         sessionmaker: Callable[[], Session],
         **kwargs: Any,


### PR DESCRIPTION
## Summary
- refine fake_run_db to accept any callable signature and return type

## Testing
- `mypy --strict tests/test_handlers_photo_sugar_save.py`
- `pytest tests/test_handlers_photo_sugar_save.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a1f867c198832a929d50f90539b86d