### PR TITLE
[tests] type fake_run_db helper

### DIFF
--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -269,10 +269,12 @@ async def test_photo_then_freeform_calculates_dose(monkeypatch: pytest.MonkeyPat
 
     async def fake_run_db(
         func: Callable[[Session], T],
+        *args: Any,
         sessionmaker: Callable[[], Session],
+        **kwargs: Any,
     ) -> T:
         with cast(Any, sessionmaker()) as s:
-            return func(cast(Session, s))
+            return func(cast(Session, s), *args, **kwargs)
 
     monkeypatch.setattr(gpt_handlers, "run_db", fake_run_db)
 


### PR DESCRIPTION
## Summary
- add parameter and return type annotations to fake_run_db in tests/test_handlers_doc.py

## Testing
- `pytest tests/test_handlers_doc.py -q` *(fails: coverage 20.50% < 85%)*
- `pytest -q --maxfail=1` *(fails: 1 failed, 32 passed)*
- `mypy --strict tests/test_handlers_doc.py`
- `ruff check tests/test_handlers_doc.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1f864d7c8832aa68da286a37ab160