### PR TITLE
[ui] Refactor reminders imports

### DIFF
--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -4,6 +4,9 @@ const mockRemindersGet = vi.hoisted(() => vi.fn());
 
 vi.mock('@sdk', () => ({
   DefaultApi: vi.fn(() => ({ remindersGet: mockRemindersGet })),
+}));
+
+vi.mock('@sdk/models', () => ({
   instanceOfReminder: vi.fn(),
 }));
 

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,4 +1,6 @@
-import { DefaultApi, Reminder, instanceOfReminder } from '@sdk';
+import { DefaultApi } from '@sdk';
+import type { Reminder } from '@sdk/models';
+import { instanceOfReminder } from '@sdk/models';
 import { Configuration } from '@sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';


### PR DESCRIPTION
## Summary
- Import `DefaultApi` and `Reminder` from updated SDK packages
- Adjust reminders API test to mock `@sdk` and `@sdk/models` separately

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: Failed to resolve import "@sdk" etc.)*
- `pytest -q --cov` *(fails: 9 failed, 317 passed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1fb21732c832ab113c7a0a8ff76ae