### PR TITLE
[webapp] use model types from sdk

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,6 @@
-import { DefaultApi, Reminder, instanceOfReminder } from '@sdk';
+import { DefaultApi } from '@sdk';
 import { Configuration } from '@sdk/runtime';
+import { instanceOfReminder, type Reminder } from '@sdk/models';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -13,7 +13,7 @@ import {
   type NormalizedReminderType,
 } from '@/lib/reminders'
 import { parseTimeToMinutes } from '@/lib/time'
-import { Reminder as ApiReminder } from '@sdk'
+import type { Reminder as ApiReminder } from '@sdk/models'
 import type { Reminder } from '@/types/reminder'
 
 const TYPE_LABEL: Record<NormalizedReminderType, string> = {


### PR DESCRIPTION
## Summary
- switch Reminder import to `@sdk/models` in Reminders page
- adjust reminders API to import model helpers from `@sdk/models`

## Testing
- `npm run build`
- `pytest -q` *(fails: AttributeError and coverage 73% < 85%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1fb282ed0832a8ecc5d77d4b382bf