### PR TITLE
[webapp] Split profile type import

### DIFF
--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,4 +1,5 @@
-import { DefaultApi, Profile } from '@sdk';
+import { DefaultApi } from '@sdk';
+import type { Profile } from '@sdk/models';
 import { Configuration, ResponseError } from '@sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';


### PR DESCRIPTION
## Summary
- split Profile type import to avoid runtime dependency

## Testing
- `pre-commit run --files services/webapp/ui/src/api/profile.ts`
- `npm ci` (services/webapp/ui)
- `npm run build` *(fails: "instanceOfReminder" is not exported)*
- `npx vitest run` *(fails: missing peer deps and jsdom errors)*
- `npx vitest run tests/useTelegram.test.ts`
- `pytest -q` *(fails: coverage <85% and failing tests)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1fb2d9e84832a9d59bc5ee636d60e