### PR TITLE
[tests] remove unused type ignore comments

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,15 +29,12 @@ _original_create_engine: Callable[..., sqlalchemy.engine.Engine] = (
     sqlalchemy.create_engine
 )
 
-
 def _tracking_create_engine(*args: Any, **kwargs: Any) -> sqlalchemy.engine.Engine:
     engine = _original_create_engine(*args, **kwargs)
     _engines.append(engine)
     return engine
 
-
 setattr(sqlalchemy, "create_engine", _tracking_create_engine)
-
 
 @pytest.fixture(autouse=True, scope="session")
 def _close_sqlite_connections() -> Iterator[None]:


### PR DESCRIPTION
## Summary
- clean up `tests/conftest.py` after dropping obsolete `type: ignore` directives

## Testing
- `pytest -q --cov` *(fails: No module named 'telegram')*
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named "attrs" and others)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a1fd2d3cc0832aadb2c1674a63f28e