### PR TITLE
[ts-sdk] Re-export models from APIs index

### DIFF
--- a/libs/ts-sdk/apis/index.ts
+++ b/libs/ts-sdk/apis/index.ts
@@ -1,3 +1,4 @@
 /* tslint:disable */
 /* eslint-disable */
 export * from './DefaultApi';
+export * from '../models';


### PR DESCRIPTION
## Summary
- re-export models from the SDK API entry

## Testing
- `npm run build`
- `pytest -q --cov` *(fails: module 'services.api.app.diabetes.handlers.dose_calc' has no attribute 'commit')*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a200b69b50832ab0eb11ff627cbfc8