### PR TITLE
[handlers] handle TelegramError when saving photos

### DIFF
--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -79,7 +79,7 @@ async def photo_handler(
         try:
             file = await context.bot.get_file(photo.file_id)
             await file.download_to_drive(file_path)
-        except OSError as exc:
+        except (TelegramError, OSError) as exc:
             logging.exception("[PHOTO] Failed to save photo: %s", exc)
             await message.reply_text("⚠️ Не удалось сохранить фото. Попробуйте ещё раз.")
             user_data.pop(WAITING_GPT_FLAG, None)
@@ -276,7 +276,6 @@ async def photo_handler(
         return END
     finally:
         user_data.pop(WAITING_GPT_FLAG, None)
-
 
 
 async def doc_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:


### PR DESCRIPTION
## Summary
- handle TelegramError during photo download and clean GPT waiting flag
- test photo handler TelegramError failure scenario

## Testing
- `pytest -q` *(fails: coverage failure and 9 failing tests)*
- `mypy --strict services/api/app/diabetes/handlers/photo_handlers.py tests/test_photo_handlers.py` *(interrupted)*
- `ruff check . -v | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68a1fbccb08c832ab57cf6ad51de7d6a