### PR TITLE
[sdk] Export Reminder type guard

### DIFF
--- a/libs/ts-sdk/apis/index.ts
+++ b/libs/ts-sdk/apis/index.ts
@@ -2,3 +2,4 @@
 /* eslint-disable */
 export * from './DefaultApi';
 export * from '../models';
+export { instanceOfReminder } from '../models/Reminder';

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,6 +1,5 @@
-import { DefaultApi } from '@sdk';
+import { DefaultApi, instanceOfReminder, type Reminder } from '@sdk';
 import { Configuration } from '@sdk/runtime';
-import { instanceOfReminder, type Reminder } from '@sdk/models';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 


### PR DESCRIPTION
## Summary
- export `instanceOfReminder` from SDK entrypoint
- use the SDK export in webapp reminders API client

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a20903b664832a873952151c83459f