### PR TITLE
[webapp] import Telegram theme with relative path

### DIFF
--- a/services/webapp/public/telegram-init.js
+++ b/services/webapp/public/telegram-init.js
@@ -1,5 +1,8 @@
 (async function () {
-    const mod = await import("/assets/telegram-theme.js");
+    const themeModules = import.meta?.glob?.("./assets/telegram-theme*.js");
+    const mod = themeModules
+        ? await themeModules[Object.keys(themeModules)[0]]()
+        : await import(new URL("./assets/telegram-theme.js", import.meta.url).href);
     const applyTheme = mod.applyTheme ?? mod.default ?? mod.a;
     const app = window.Telegram?.WebApp;
     if (!app) {


### PR DESCRIPTION
## Summary
- load Telegram theme from relative assets path using optional glob for hashed filenames

## Testing
- `npm run build`
- `node test-theme.mjs`
- `pytest -q` *(fails: AttributeError and coverage under 85%)*
- `mypy --strict .` *(fails: Unsupported right operand type for in ("dict[str, Any] | None"))*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a207adce4c832aa39240362084e81f