### PR TITLE
tests: ensure context user data not none

### DIFF
--- a/tests/test_photo_handlers.py
+++ b/tests/test_photo_handlers.py
@@ -79,5 +79,6 @@ async def test_photo_handler_get_file_telegram_error(
 
     assert result == photo_handlers.ConversationHandler.END
     assert message.texts == ["⚠️ Не удалось сохранить фото. Попробуйте ещё раз."]
+    assert context.user_data is not None
     assert photo_handlers.WAITING_GPT_FLAG not in context.user_data
     assert "[PHOTO] Failed to save photo" in caplog.text


### PR DESCRIPTION
## Summary
- test that context.user_data exists before accessing WAITING_GPT_FLAG in photo handler Telegram error test

## Testing
- `pytest -q --cov` (fails: AttributeError: module 'services.api.app.diabetes.handlers.dose_calc' has no attribute 'commit')
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a20f542684832a8673d13334f2c7b4