### PR TITLE
[profile] handle ImportError in get_api

### DIFF
--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -93,9 +93,14 @@ def get_api() -> tuple[object, type[Exception], type]:
         from diabetes_sdk.configuration import Configuration
         from diabetes_sdk.exceptions import ApiException
         from diabetes_sdk.models.profile import Profile as ProfileModel
-    except Exception:  # pragma: no cover - import failure is tested separately
+    except ImportError:  # pragma: no cover - import failure is tested separately
         logger.warning(
             "diabetes_sdk is not installed. Falling back to local profile API.",
+        )
+        return LocalProfileAPI(), Exception, LocalProfile
+    except RuntimeError:  # pragma: no cover - initialization issues
+        logger.warning(
+            "diabetes_sdk could not be initialized. Falling back to local profile API.",
         )
         return LocalProfileAPI(), Exception, LocalProfile
     api = DefaultApi(ApiClient(Configuration(host=settings.api_url)))
@@ -144,6 +149,7 @@ def fetch_profile(
         return api.profiles_get(telegram_id=user_id)
     except ApiException:
         return None
+
 
 def post_profile(
     api: "DefaultApi",


### PR DESCRIPTION
## Summary
- handle ImportError and RuntimeError in profile API helper
- extend tests to cover ImportError and runtime error cases

## Testing
- `pytest -q --cov`
- `mypy --strict services/api/app/diabetes/handlers/profile/api.py tests/test_profile_no_sdk.py`
- `ruff check services/api/app/diabetes/handlers/profile/api.py tests/test_profile_no_sdk.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2112b0910832a8c94e52a69383caf