### PR TITLE
[tests] use local user_data variable

### DIFF
--- a/tests/test_photo_handlers.py
+++ b/tests/test_photo_handlers.py
@@ -80,5 +80,6 @@ async def test_photo_handler_get_file_telegram_error(
     assert result == photo_handlers.ConversationHandler.END
     assert message.texts == ["⚠️ Не удалось сохранить фото. Попробуйте ещё раз."]
     assert context.user_data is not None
-    assert photo_handlers.WAITING_GPT_FLAG not in context.user_data
+    user_data = context.user_data
+    assert photo_handlers.WAITING_GPT_FLAG not in user_data
     assert "[PHOTO] Failed to save photo" in caplog.text


### PR DESCRIPTION
## Summary
- refine photo handler test to use local `user_data` variable before checking for GPT flag

## Testing
- `pytest -q tests/test_photo_handlers.py` *(fails: Required test coverage of 85% not reached, 17.80%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a213913488832a9976a4bd8144d101