### PR TITLE
[tests] refactor user_data check

### DIFF
--- a/tests/test_photo_handlers.py
+++ b/tests/test_photo_handlers.py
@@ -79,6 +79,7 @@ async def test_photo_handler_get_file_telegram_error(
 
     assert result == photo_handlers.ConversationHandler.END
     assert message.texts == ["⚠️ Не удалось сохранить фото. Попробуйте ещё раз."]
-    assert context.user_data is not None
-    assert photo_handlers.WAITING_GPT_FLAG not in context.user_data
+    user_data = context.user_data
+    assert user_data is not None
+    assert photo_handlers.WAITING_GPT_FLAG not in user_data
     assert "[PHOTO] Failed to save photo" in caplog.text


### PR DESCRIPTION
## Summary
- refactor photo handler test to assert user data flag via local variable

## Testing
- `pytest -q tests/test_photo_handlers.py` *(fails: Coverage failure: total of 18 is less than fail-under=85)*
- `mypy --strict tests/test_photo_handlers.py`
- `ruff check tests/test_photo_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2151efae8832abbb746dee3486972