### PR TITLE
[config] validate tokens via os.getenv

### DIFF
--- a/config.py
+++ b/config.py
@@ -46,8 +46,6 @@ def validate_tokens(required: Iterable[str] | None = None) -> None:
     """
 
     required_vars = list(required or [])
-    missing = [var for var in required_vars if not globals().get(var)]
+    missing = [var for var in required_vars if not os.getenv(var)]
     if missing:
-        raise RuntimeError(
-            "Missing required environment variables: " + ", ".join(missing)
-        )
+        raise RuntimeError("Missing required environment variables: " + ", ".join(missing))

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -1,0 +1,36 @@
+"""Tests for the top-level :mod:`config` module."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+
+import pytest
+
+
+def _reload(module: str) -> ModuleType:
+    if module in sys.modules:
+        del sys.modules[module]
+    return importlib.import_module(module)
+
+
+def test_validate_tokens_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Expect ``RuntimeError`` when a required variable is absent."""
+
+    monkeypatch.delenv("UNDECLARED_TOKEN", raising=False)
+    config = _reload("config")
+
+    with pytest.raises(RuntimeError):
+        config.validate_tokens(["UNDECLARED_TOKEN"])
+
+
+def test_validate_tokens_env_not_declared(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Variables set in the environment but not exposed are still validated."""
+
+    monkeypatch.setenv("UNDECLARED_TOKEN", "secret")
+    config = _reload("config")
+
+    assert not hasattr(config, "UNDECLARED_TOKEN")
+
+    config.validate_tokens(["UNDECLARED_TOKEN"])


### PR DESCRIPTION
## Summary
- ensure validate_tokens reads from the environment with `os.getenv`
- test validation when env var exists but module lacks attribute

## Testing
- `pytest -q` *(fails: commit attribute missing, coverage < 85%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a216eaf244832ab3d64f9ffcb40d72