### PR TITLE
[alembic] handle missing dotenv

### DIFF
--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -1,6 +1,7 @@
 # file: services/api/alembic/env.py
 from __future__ import annotations
 
+import logging
 import os
 from logging.config import fileConfig
 from urllib.parse import quote_plus
@@ -8,6 +9,8 @@ from pathlib import Path
 
 from alembic import context
 from sqlalchemy import create_engine, pool  # используем create_engine — без set_main_option
+
+logger = logging.getLogger(__name__)
 
 # Загружаем .env: сначала корень, затем сервисный (сервисный перекрывает)
 try:
@@ -18,8 +21,11 @@ try:
     service_env = _HERE.parents[1] / ".env"  # services/api/.env
     load_dotenv(root_env)
     load_dotenv(service_env, override=True)
-except Exception:
-    pass
+except ImportError:
+    logger.info("python-dotenv is not installed; skipping .env loading")
+except (FileNotFoundError, OSError) as exc:
+    logger.error("Failed to load .env file: %s", exc)
+    raise
 
 config = context.config
 if config.config_file_name:

--- a/tests/test_alembic_env.py
+++ b/tests/test_alembic_env.py
@@ -1,0 +1,50 @@
+# test_alembic_env.py
+
+import builtins
+import contextlib
+import importlib
+import logging
+import sys
+import types
+from types import ModuleType
+from typing import Any, Iterator
+
+import alembic.context
+import pytest
+
+
+def test_env_handles_missing_dotenv(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    original_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals: dict[str, Any] | None = None,
+        locals: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        if name == "dotenv":
+            raise ImportError
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "services.api.alembic.env", raising=False)
+
+    dummy_config = types.SimpleNamespace(config_file_name=None)
+    monkeypatch.setattr(alembic.context, "config", dummy_config, raising=False)
+    monkeypatch.setattr(alembic.context, "is_offline_mode", lambda: True)
+    monkeypatch.setattr(alembic.context, "configure", lambda *a, **kw: None)
+
+    @contextlib.contextmanager
+    def begin_transaction() -> Iterator[None]:
+        yield
+
+    monkeypatch.setattr(alembic.context, "begin_transaction", begin_transaction)
+    monkeypatch.setattr(alembic.context, "run_migrations", lambda: None)
+
+    with caplog.at_level(logging.INFO):
+        importlib.import_module("services.api.alembic.env")
+
+    assert "python-dotenv is not installed" in caplog.text


### PR DESCRIPTION
## Summary
- log .env loading issues and raise on file errors in Alembic env
- add smoke test when python-dotenv is missing

## Testing
- `pytest tests/test_alembic_env.py -q -o addopts=`
- `pytest -q` *(fails: Required test coverage of 85% not reached. Total coverage: 74.12%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a21c54df44832abdbaa676431c79a7