### PR TITLE
[handlers] Include sugar in dose calculation message

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -177,7 +177,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     dose = calc_bolus(carbs_g, sugar, patient)
                     entry["dose"] = dose
                     await message.reply_text(
-                        f"💉 Расчёт дозы: {dose} Ед.\nСахар: {sugar} ммоль/л",
+                        f"💉\u202fРасчёт дозы: {dose}\u202fЕд.\nСахар: {sugar}\u202fммоль/л",
                         reply_markup=confirm_keyboard(),
                     )
                     return

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -287,8 +287,7 @@ async def test_photo_then_freeform_calculates_dose(monkeypatch: pytest.MonkeyPat
     await gpt_handlers.freeform_handler(update_sugar, context)
 
     reply = sugar_msg.texts[0]
-    assert "Расчёт дозы" in reply
-    assert "Расчёт дозы: 1.0 Ед" in reply
+    assert reply == "💉\u202fРасчёт дозы: 1.0\u202fЕд.\nСахар: 5.0\u202fммоль/л"
     assert context.user_data is not None
     user_data = context.user_data
     assert "dose" in user_data["pending_entry"]

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -106,7 +106,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
     assert "pending_entry" in user_data
     assert message.replies
     text = message.replies[0]
-    assert "5.6 ммоль/л" in text
+    assert "5.6\u202fммоль/л" in text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ensure GPT freeform handler replies with sugar value alongside dose using narrow no‑break spaces
- adjust handler tests for new message format

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a21cef0500832aa19130f4386ea1f0