### PR TITLE
[handlers] Use refreshed Entry for render entry

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import re
-from typing import cast
+from typing import TypedDict, cast
 
 from telegram import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
@@ -23,6 +23,13 @@ from .reporting_handlers import render_entry, send_report
 from . import UserData
 
 logger = logging.getLogger(__name__)
+
+
+class EditMessageMeta(TypedDict):
+    """Metadata about the message being edited."""
+
+    chat_id: int
+    message_id: int
 
 
 async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -221,11 +228,12 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         if entry is None:
             await message.reply_text("⚠️ Не удалось сохранить запись.")
             return
-        edit_info = user_data.get("edit_entry")
-        if not isinstance(edit_info, dict):
+        edit_info_raw = user_data.get("edit_entry")
+        if not isinstance(edit_info_raw, dict):
             return
-        chat_id = cast(int, edit_info.get("chat_id"))
-        message_id = cast(int, edit_info.get("message_id"))
+        edit_info = cast(EditMessageMeta, edit_info_raw)
+        chat_id = edit_info["chat_id"]
+        message_id = edit_info["message_id"]
         markup = InlineKeyboardMarkup(
             [
                 [

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -112,8 +112,10 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
         assert entry_obj is not None
         entry_db: Entry = entry_obj
         assert entry_db.dose == 5.0
+        day_str = entry_db.event_time.strftime("%d.%m %H:%M")
 
     assert field_query.answer_texts[-1] == "Изменено"
     edited_text, chat_id, message_id, kwargs = context.bot.edited[0]
     assert chat_id == 42 and message_id == 24
+    assert f"<b>{day_str}</b>" in edited_text
     assert f"💉 Доза: <b>{entry_db.dose}</b>" in edited_text


### PR DESCRIPTION
## Summary
- Ensure GPT handlers render diary updates using the refreshed `Entry` instance
- Restrict edit metadata to chat and message identifiers
- Test that edited messages display the original entry timestamp

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a21cf4c518832a9433891b4135b094