### PR TITLE
[handlers] expose dose calc helper functions

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -345,6 +345,10 @@ __all__ = [
     "_cancel_then",
     "dose_conv",
     "prompt_dose",
+    "commit",
+    "parse_command",
+    "smart_input",
+    "send_report",
     # re-exported handlers
     "photo_prompt",
     "photo_handler",

--- a/tests/test_dose_calc_reexports.py
+++ b/tests/test_dose_calc_reexports.py
@@ -1,0 +1,40 @@
+import pytest
+from types import SimpleNamespace
+from typing import Any, cast
+
+from telegram import Update
+from telegram.ext import CallbackContext
+
+import services.api.app.diabetes.handlers.dose_calc as dose_calc
+
+
+@pytest.mark.asyncio
+async def test_reexported_names_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    commit_marker = object()
+    parse_marker = object()
+    smart_marker = object()
+    send_report_marker = object()
+
+    async def dummy_freeform_handler(update: Any, context: Any) -> None:
+        handlers = dose_calc._gpt_handlers  # type: ignore[attr-defined]
+        assert handlers.commit is commit_marker
+        assert handlers.parse_command is parse_marker
+        assert handlers.smart_input is smart_marker
+        assert handlers.send_report is send_report_marker
+
+    monkeypatch.setattr(dose_calc, "commit", commit_marker)
+    monkeypatch.setattr(dose_calc, "parse_command", parse_marker)
+    monkeypatch.setattr(dose_calc, "smart_input", smart_marker)
+    monkeypatch.setattr(dose_calc, "send_report", send_report_marker)
+    gpt_handlers = dose_calc._gpt_handlers  # type: ignore[attr-defined]
+    monkeypatch.setattr(gpt_handlers, "freeform_handler", dummy_freeform_handler)
+
+    assert "commit" in dose_calc.__all__
+    assert "parse_command" in dose_calc.__all__
+    assert "smart_input" in dose_calc.__all__
+    assert "send_report" in dose_calc.__all__
+
+    await dose_calc.freeform_handler(
+        cast(Update, SimpleNamespace()),
+        cast(CallbackContext[Any, Any, Any, Any], SimpleNamespace()),
+    )


### PR DESCRIPTION
## Summary
- re-export `commit`, `parse_command`, `smart_input`, and `send_report` from `dose_calc` and include them in `__all__`
- add regression test ensuring these helpers can be patched through `dose_calc`

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a21cea75c0832ab13b4ce6d8571962