### PR TITLE
[diabetes] Improve dose parsing with trailing tokens

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -265,19 +265,25 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             await message.reply_text("❗ ХЕ указываются числом, без ммоль/л и ед.")
         else:
             await message.reply_text(
-                "Не удалось распознать значения, используйте сахар=5 xe=1 dose=2"
+                "Не удалось распознать значения, используйте сахар=5 xe=1 dose=2",
             )
         return
-    if pending_entry is not None and edit_id is None and any(v is not None for v in quick.values()):
+
+    carbs_match = re.search(
+        r"(?:carbs|углеводов)\s*=\s*(-?\d+(?:[.,]\d+)?)", raw_text, re.I
+    )
+    if pending_entry is not None and edit_id is None and (
+        any(v is not None for v in quick.values()) or carbs_match
+    ):
         if quick["sugar"] is not None:
             pending_entry["sugar_before"] = quick["sugar"]
         if quick["xe"] is not None:
             pending_entry["xe"] = quick["xe"]
             pending_entry["carbs_g"] = quick["xe"] * 12
-        else:
-            m = re.search(r"(?:carbs|углеводов)\s*=\s*(-?\d+(?:[.,]\d+)?)", raw_text, re.I)
-            if m:
-                pending_entry["carbs_g"] = float(m.group(1).replace(",", "."))
+        elif carbs_match:
+            pending_entry["carbs_g"] = float(
+                carbs_match.group(1).replace(",", ".")
+            )
         if quick["dose"] is not None:
             pending_entry["dose"] = quick["dose"]
         await message.reply_text("Данные обновлены.")

--- a/services/api/app/diabetes/utils/functions.py
+++ b/services/api/app/diabetes/utils/functions.py
@@ -70,8 +70,11 @@ SUGAR_VALUE_RE = re.compile(
 SUGAR_UNIT_RE = re.compile(rf"\b({NUMBER_RE})\s*(ммоль/?л|mmol/?l)\b")
 XE_VALUE_RE = re.compile(rf"\b{XE_LABEL_RE.pattern}\s*[:=]?\s*({NUMBER_RE})\b")
 XE_UNIT_RE = re.compile(rf"\b({NUMBER_RE})\s*(?:xe|хе)\b")
+# ``dose`` may be followed immediately by another token (e.g. ``"carbs=30"``).
+# ``\b`` would fail in such cases, so we use a lookahead that ensures the
+# number is terminated by a non-numeric character or end of string.
 DOSE_VALUE_RE = re.compile(
-    rf"\b{DOSE_WORD_RE.pattern}\s*[:=]?\s*({NUMBER_RE})\b"
+    rf"\b{DOSE_WORD_RE.pattern}\s*[:=]?\s*({NUMBER_RE})(?=$|\s|[^0-9a-zA-Z.,])"
 )
 DOSE_UNIT_RE = re.compile(rf"\b({NUMBER_RE})\s*(?:ед\.?|units?|u)\b")
 ONLY_NUMBER_RE = re.compile(rf"\s*({NUMBER_RE})\s*")

--- a/tests/test_pending_dose_carbs.py
+++ b/tests/test_pending_dose_carbs.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+from typing import Any, cast
+import datetime
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+import services.api.app.diabetes.handlers.gpt_handlers as gpt_handlers
+
+class DummyMessage:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_freeform_pending_updates_dose_and_carbs() -> None:
+    entry = {
+        "telegram_id": 1,
+        "event_time": datetime.datetime.now(datetime.timezone.utc),
+        "carbs_g": None,
+        "xe": None,
+        "dose": None,
+        "sugar_before": None,
+        "photo_path": None,
+    }
+    message = DummyMessage("dose=3.5 carbs=30")
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={"pending_entry": entry}),
+    )
+
+    await gpt_handlers.freeform_handler(update, context)
+
+    assert entry["dose"] == 3.5
+    assert entry["carbs_g"] == 30.0
+    assert message.replies and "обновлены" in message.replies[0].lower()


### PR DESCRIPTION
## Summary
- handle dose tokens followed by additional fields in smart_input
- update pending-entry logic to apply parsed dose and carbs
- add regression test for `dose=3.5 carbs=30`

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a21cf1ec34832a991a944718c52be0