### PR TITLE
logging: use module logger instances

### DIFF
--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -80,7 +80,7 @@ async def photo_handler(
             file = await context.bot.get_file(photo.file_id)
             await file.download_to_drive(file_path)
         except (TelegramError, OSError) as exc:
-            logging.exception("[PHOTO] Failed to save photo: %s", exc)
+            logger.exception("[PHOTO] Failed to save photo: %s", exc)
             await message.reply_text("⚠️ Не удалось сохранить фото. Попробуйте ещё раз.")
             user_data.pop(WAITING_GPT_FLAG, None)
             return END
@@ -175,7 +175,7 @@ async def photo_handler(
             return END
 
         if run.status != "completed":
-            logging.error("[VISION][RUN_FAILED] run.status=%s", run.status)
+            logger.error("[VISION][RUN_FAILED] run.status=%s", run.status)
             if status_message and hasattr(status_message, "edit_text"):
                 try:
                     await status_message.edit_text("⚠️ Vision не смог обработать фото.")
@@ -256,23 +256,23 @@ async def photo_handler(
         return PHOTO_SUGAR
 
     except OSError as exc:
-        logging.exception("[PHOTO] File processing error: %s", exc)
+        logger.exception("[PHOTO] File processing error: %s", exc)
         await message.reply_text(
             "⚠️ Ошибка при обработке файла изображения. Попробуйте ещё раз."
         )
         return END
     except OpenAIError as exc:
-        logging.exception("[PHOTO] Vision API error: %s", exc)
+        logger.exception("[PHOTO] Vision API error: %s", exc)
         await message.reply_text(
             "⚠️ Vision не смог обработать фото. Попробуйте ещё раз."
         )
         return END
     except ValueError as exc:
-        logging.exception("[PHOTO] Parsing error: %s", exc)
+        logger.exception("[PHOTO] Parsing error: %s", exc)
         await message.reply_text("⚠️ Не удалось распознать фото. Попробуйте ещё раз.")
         return END
     except TelegramError as exc:
-        logging.exception("[PHOTO] Telegram error: %s", exc)
+        logger.exception("[PHOTO] Telegram error: %s", exc)
         return END
     finally:
         user_data.pop(WAITING_GPT_FLAG, None)

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -35,6 +35,8 @@ from services.api.app.diabetes.services.reporting import make_sugar_plot, genera
 from services.api.app.diabetes.utils.ui import menu_keyboard
 from . import UserData
 
+logger = logging.getLogger(__name__)
+
 LOW_SUGAR_THRESHOLD = 3.0
 HIGH_SUGAR_THRESHOLD = 13.0
 
@@ -338,15 +340,15 @@ async def send_report(
                         default_gpt_text,
                     )
             else:
-                logging.error("[GPT][RUN_FAILED] status=%s", run.status)
+                logger.error("[GPT][RUN_FAILED] status=%s", run.status)
         except OpenAIError:
-            logging.exception("[GPT] Failed to get recommendations")
+            logger.exception("[GPT] Failed to get recommendations")
         except OSError as exc:
-            logging.exception(
+            logger.exception(
                 "[GPT] OS error while getting recommendations: %s", exc
             )
     else:
-        logging.warning("[GPT] thread_id missing for user %s", user_id)
+        logger.warning("[GPT] thread_id missing for user %s", user_id)
     report_msg = "<b>Отчёт сформирован</b>\n\n" + "\n".join(summary_lines + day_lines)
 
     plot_buf = make_sugar_plot(entries, period_label)

--- a/services/api/app/diabetes/services/reporting.py
+++ b/services/api/app/diabetes/services/reporting.py
@@ -18,6 +18,8 @@ from reportlab.pdfgen import canvas
 
 from services.api.app.config import settings
 
+logger = logging.getLogger(__name__)
+
 date2num_typed: Callable[[datetime], float] = date2num
 
 # Регистрация шрифтов для поддержки кириллицы и жирного начертания
@@ -42,7 +44,7 @@ def _register_font(name: str, filename: str) -> str | None:
             msg = f"[PDF] Cannot register font {name} at {path}: {e}"
         else:
             msg = f"[PDF] Invalid font {name} at {path}: {e}"
-        logging.warning(msg)
+        logger.warning(msg)
         if _font_dir != DEFAULT_FONT_DIR:
             fallback = os.path.join(DEFAULT_FONT_DIR, filename)
             try:
@@ -59,7 +61,7 @@ def _register_font(name: str, filename: str) -> str | None:
                     msg2 = (
                         f"[PDF] Invalid default font {name} at {fallback}: {e2}"
                     )
-                logging.warning(msg2)
+                logger.warning(msg2)
                 return msg2
         return msg
 
@@ -113,7 +115,7 @@ def make_sugar_plot(entries: Iterable[SugarEntry], period_label: str) -> io.Byte
     sugars_plot: list[float] = [cast(float, e.sugar_before) for e in entries_sorted]
 
     if not sugars_plot:
-        logging.info("No sugar data available for %s", period_label)
+        logger.info("No sugar data available for %s", period_label)
         buf = io.BytesIO()
         plt.figure(figsize=(7, 3))
         plt.text(
@@ -191,7 +193,7 @@ def generate_pdf_report(
     """
     font_errors = register_fonts()
     if font_errors:
-        logging.warning("[PDF] Font registration issues: %s", "; ".join(font_errors))
+        logger.warning("[PDF] Font registration issues: %s", "; ".join(font_errors))
 
     buffer = io.BytesIO()
     c = canvas.Canvas(buffer, pagesize=A4)
@@ -264,9 +266,9 @@ def generate_pdf_report(
             )
             y -= 65 * mm
         except OSError as e:
-            logging.warning("[PDF] Cannot read plot image: %s", e)
+            logger.warning("[PDF] Cannot read plot image: %s", e)
         except ValueError as e:
-            logging.exception("[PDF] Invalid plot image: %s", e)
+            logger.exception("[PDF] Invalid plot image: %s", e)
 
     # Анализ и рекомендации
     y -= 8 * mm

--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -5,6 +5,8 @@ from openai import OpenAI
 
 from services.api.app.config import settings
 
+logger = logging.getLogger(__name__)
+
 
 def get_openai_client() -> OpenAI:
     """Return a configured OpenAI client.
@@ -16,7 +18,7 @@ def get_openai_client() -> OpenAI:
 
     if not settings.openai_api_key:
         message = "OPENAI_API_KEY is not set"
-        logging.error("[OpenAI] %s", message)
+        logger.error("[OpenAI] %s", message)
         raise RuntimeError(message)
 
     http_client: httpx.Client | None = None
@@ -25,5 +27,5 @@ def get_openai_client() -> OpenAI:
 
     client = OpenAI(api_key=settings.openai_api_key, http_client=http_client)
     if settings.openai_assistant_id:
-        logging.info("[OpenAI] Using assistant: %s", settings.openai_assistant_id)
+        logger.info("[OpenAI] Using assistant: %s", settings.openai_assistant_id)
     return client

--- a/services/worker/main.py
+++ b/services/worker/main.py
@@ -3,11 +3,13 @@
 import logging
 import sys
 
+logger = logging.getLogger(__name__)
+
 try:
     from diabetes_sdk import Configuration
     from diabetes_sdk.api import default_api
 except ImportError:
-    logging.error(
+    logger.error(
         "diabetes_sdk is required to run the worker. "
         "Install it with 'pip install diabetes_sdk'."
     )
@@ -17,7 +19,7 @@ except ImportError:
 def run() -> None:
     """Entry point for the worker service."""
     api = default_api.DefaultApi(configuration=Configuration())
-    logging.info("Worker started. API client ready: %s", api)
+    logger.info("Worker started. API client ready: %s", api)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- create module-level loggers and replace direct logging calls

## Testing
- `pytest -q` *(fails: coverage failure: total of 74 is less than fail-under=85)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a221b98cc4832aa1879880f6b86104