### PR TITLE
[logging] add module loggers

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -16,6 +16,9 @@ except ModuleNotFoundError as exc:  # pragma: no cover - executed at import time
     ) from exc
 
 
+logger = logging.getLogger(__name__)
+
+
 class Settings(BaseSettings):
     """Runtime application configuration.
 

--- a/services/api/app/middleware/auth.py
+++ b/services/api/app/middleware/auth.py
@@ -5,9 +5,9 @@ from fastapi import HTTPException, Request
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
-ALLOWED_ROLES = {"patient", "clinician", "org_admin", "superadmin"}
-
 logger = logging.getLogger(__name__)
+
+ALLOWED_ROLES = {"patient", "clinician", "org_admin", "superadmin"}
 
 
 class AuthMiddleware(BaseHTTPMiddleware):

--- a/services/api/app/services/audit.py
+++ b/services/api/app/services/audit.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 
+logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger("audit")
 
 


### PR DESCRIPTION
## Summary
- declare module loggers in config and audit services
- fix auth middleware logger placement

## Testing
- `pytest -q` *(fails: Coverage failure: total of 74 is less than fail-under=85)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a22422339c832a9755d85c1d2c563a