### PR TITLE
handlers: fall back to SessionLocal on runtime errors

### DIFF
--- a/tests/handlers/test_gpt_handlers.py
+++ b/tests/handlers/test_gpt_handlers.py
@@ -35,7 +35,7 @@ def make_context(
 ) -> CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]:
     return cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data=user_data or {}),
+        SimpleNamespace(user_data={} if user_data is None else user_data),
     )
 
 
@@ -265,4 +265,3 @@ async def test_parse_command_valid_time(monkeypatch: pytest.MonkeyPatch) -> None
     await gpt_handlers.freeform_handler(update, context)
     assert user_data["pending_entry"]["xe"] == 1
     assert "Расчёт завершён" in message.replies[0][0]
-

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -62,9 +62,7 @@ async def test_entry_without_dose_has_no_unit(
         ),
     )
     message = DummyMessage("5.5")
-    update = cast(
-        Update, DummyUpdate(message=message, effective_user=DummyUser(id=1))
-    )
+    update = cast(Update, DummyUpdate(message=message, effective_user=DummyUser(id=1)))
 
     class DummySession(Session):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -93,6 +91,10 @@ async def test_entry_without_dose_has_no_unit(
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
+    async def fake_run_db(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(dose_handlers._gpt_handlers, "run_db", fake_run_db)  # type: ignore[attr-defined]
 
     await dose_calc.freeform_handler(update, context)
 
@@ -118,9 +120,7 @@ async def test_entry_without_sugar_has_placeholder(
         ),
     )
     message = DummyMessage("5")
-    update = cast(
-        Update, DummyUpdate(message=message, effective_user=DummyUser(id=1))
-    )
+    update = cast(Update, DummyUpdate(message=message, effective_user=DummyUser(id=1)))
 
     class DummySession(Session):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -149,6 +149,10 @@ async def test_entry_without_sugar_has_placeholder(
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
+    async def fake_run_db(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(dose_handlers._gpt_handlers, "run_db", fake_run_db)  # type: ignore[attr-defined]
 
     await dose_calc.freeform_handler(update, context)
 


### PR DESCRIPTION
## Summary
- handle `RuntimeError` from `run_db` and fallback to direct `SessionLocal`
- cover runtime `run_db` fallback with new test

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a22d39b488832a9ccacf6e3153f6c2