### PR TITLE
[handlers] remove duplicate None check in router

### DIFF
--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -19,8 +19,6 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     query = update.callback_query
     if query is None:
         return
-    if query is None:
-        return
     await query.answer()
     data = query.data or ""
 


### PR DESCRIPTION
## Summary
- remove redundant None check in callback_router to rely on explicit condition

## Testing
- `pytest -q` (fails: KeyError in gpt_handlers tests)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a2b8af609c832a93549b8331591d63