### PR TITLE
handlers: prompt next missing field for quick input

### DIFF
--- a/tests/handlers/test_gpt_handlers.py
+++ b/tests/handlers/test_gpt_handlers.py
@@ -170,15 +170,16 @@ async def test_smart_input_negative(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 async def test_smart_input_missing_fields(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_smart_input(text: str) -> dict[str, float | None]:
+    def fake_smart_input_first(text: str) -> dict[str, float | None]:
         return {"sugar": 5.0, "xe": None, "dose": None}
 
-    monkeypatch.setattr(gpt_handlers, "smart_input", fake_smart_input)
+    monkeypatch.setattr(gpt_handlers, "smart_input", fake_smart_input_first)
     message = DummyMessage("sugar=5")
     update = make_update(message)
-    user_data: dict[str, Any] = {}
+    user_data: dict[str, Any] = {"state": 0}
     context = make_context(user_data)
     await gpt_handlers.freeform_handler(update, context)
+    assert user_data["pending_entry"]["sugar_before"] == 5.0
     assert user_data["pending_fields"] == ["xe", "dose"]
     assert "количество ХЕ" in message.replies[0][0]
 
@@ -260,7 +261,7 @@ async def test_parse_command_valid_time(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(gpt_handlers, "parse_command", fake_parse)
     message = DummyMessage("entry")
     update = make_update(message)
-    user_data: dict[str, Any] = {}
+    user_data: dict[str, Any] = {"state": 0}
     context = make_context(user_data)
     await gpt_handlers.freeform_handler(update, context)
     assert user_data["pending_entry"]["xe"] == 1

--- a/tests/test_gpt_handlers.py
+++ b/tests/test_gpt_handlers.py
@@ -294,7 +294,8 @@ async def test_freeform_handler_quick_update_pending_entry(
     monkeypatch.setattr(gpt_handlers, "smart_input", fake_smart_input)
     await gpt_handlers.freeform_handler(update, context)
     assert user_data["pending_entry"]["sugar_before"] == 5.0
-    assert message.texts == ["Данные обновлены."]
+    assert user_data["pending_fields"] == ["xe", "dose"]
+    assert message.texts == ["Введите количество ХЕ."]
 
 
 @pytest.mark.asyncio
@@ -319,7 +320,8 @@ async def test_freeform_handler_quick_update_pending_entry_xe(
     await gpt_handlers.freeform_handler(update, context)
     assert user_data["pending_entry"]["xe"] == 2.0
     assert user_data["pending_entry"]["carbs_g"] == 24.0
-    assert message.texts == ["Данные обновлены."]
+    assert user_data["pending_fields"] == ["sugar", "dose"]
+    assert message.texts == ["Введите уровень сахара (ммоль/л)."]
 
 
 @pytest.mark.asyncio

--- a/tests/test_pending_dose_carbs.py
+++ b/tests/test_pending_dose_carbs.py
@@ -41,4 +41,6 @@ async def test_freeform_pending_updates_dose_and_carbs() -> None:
 
     assert entry["dose"] == 3.5
     assert entry["carbs_g"] == 30.0
-    assert message.replies and "обновлены" in message.replies[0].lower()
+    user_data = cast(dict[str, Any], context.user_data)
+    assert user_data.get("pending_fields") == ["sugar", "xe"]
+    assert message.replies == ["Введите уровень сахара (ммоль/л)."]


### PR DESCRIPTION
## Summary
- ensure partial quick inputs store pending state before prompting
- guide users toward the next missing field when continuing entries
- add regression tests for smart input missing fields and pending entry updates

## Testing
- `pytest -q --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a23c063614832ab6f78d87f91f681d