### PR TITLE
[handlers] Split freeform handler into reusable helpers

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -34,6 +34,429 @@ class EditMessageMeta(TypedDict):
     message_id: int
 
 
+async def handle_pending_entry(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    user_data: UserData,
+    raw_text: str,
+    user_id: int,
+) -> bool:
+    """Process step-by-step diary entry input."""
+    message = update.message
+    if message is None:
+        return False
+
+    pending_entry = user_data.get("pending_entry")
+    pending_fields = user_data.get("pending_fields")
+    edit_id = user_data.get("edit_id")
+    if pending_entry is None or edit_id is not None:
+        return False
+    if pending_fields:
+        field = pending_fields[0]
+        text = raw_text.replace(",", ".")
+        try:
+            value = float(text)
+        except ValueError:
+            if field == "sugar":
+                await message.reply_text("Введите сахар числом в ммоль/л.")
+            elif field == "xe":
+                await message.reply_text("Введите число ХЕ.")
+            else:
+                await message.reply_text("Введите дозу инсулина числом.")
+            return True
+        if value < 0:
+            if field == "sugar":
+                await message.reply_text("Сахар не может быть отрицательным.")
+            elif field == "xe":
+                await message.reply_text(
+                    "Количество ХЕ не может быть отрицательным.",
+                )
+            else:
+                await message.reply_text(
+                    "Доза инсулина не может быть отрицательной.",
+                )
+            return True
+        if field == "sugar":
+            pending_entry["sugar_before"] = value
+        elif field == "xe":
+            pending_entry["xe"] = value
+            pending_entry["carbs_g"] = value * 12
+        else:
+            pending_entry["dose"] = value
+        pending_fields.pop(0)
+        if pending_fields:
+            next_field = pending_fields[0]
+            if next_field == "sugar":
+                await message.reply_text("Введите уровень сахара (ммоль/л).")
+            elif next_field == "xe":
+                await message.reply_text("Введите количество ХЕ.")
+            else:
+                await message.reply_text("Введите дозу инсулина (ед.).")
+            return True
+
+        def db_save_entry(session: Session) -> bool:
+            entry = Entry(**pending_entry)
+            session.add(entry)
+            return bool(commit(session))
+
+        try:
+            ok = await run_db(db_save_entry, sessionmaker=SessionLocal)
+        except AttributeError:
+            with SessionLocal() as session:
+                ok = db_save_entry(session)
+        if not ok:
+            await message.reply_text("⚠️ Не удалось сохранить запись.")
+            return True
+        sugar = pending_entry.get("sugar_before")
+        if sugar is not None:
+            await check_alert(update, context, sugar)
+        user_data.pop("pending_entry", None)
+        user_data.pop("pending_fields", None)
+        xe = pending_entry.get("xe")
+        dose = pending_entry.get("dose")
+        xe_info = f", ХЕ {xe}" if xe is not None else ""
+        dose_info = f", доза {dose} Ед." if dose is not None else ", доза —"
+        sugar_info = (
+            f"сахар {sugar} ммоль/л" if sugar is not None else "сахар —"
+        )
+        await message.reply_text(
+            f"✅ Запись сохранена: {sugar_info}{xe_info}{dose_info}",
+            reply_markup=menu_keyboard,
+        )
+        return True
+
+    entry = pending_entry
+    text = raw_text.lower()
+    if re.fullmatch(r"-?\d+(?:[.,]\d+)?", text) and entry.get("sugar_before") is None:
+        try:
+            sugar = float(text.replace(",", "."))
+        except ValueError:
+            await message.reply_text("Некорректное числовое значение.")
+            return True
+        if sugar < 0:
+            await message.reply_text("Сахар не может быть отрицательным.")
+            return True
+        entry["sugar_before"] = sugar
+        if entry.get("carbs_g") is not None or entry.get("xe") is not None:
+            xe_val = entry.get("xe")
+            carbs_g = entry.get("carbs_g")
+            if carbs_g is None and xe_val is not None:
+                carbs_g = xe_val * 12
+                entry["carbs_g"] = carbs_g
+            try:
+                profile = await run_db(
+                    lambda s: s.get(Profile, user_id), sessionmaker=SessionLocal
+                )
+            except AttributeError:
+                with SessionLocal() as session:
+                    profile = session.get(Profile, user_id)
+            if (
+                profile is not None
+                and profile.icr is not None
+                and profile.cf is not None
+                and profile.target_bg is not None
+            ):
+                patient = PatientProfile(
+                    icr=profile.icr, cf=profile.cf, target_bg=profile.target_bg
+                )
+                dose = calc_bolus(carbs_g, sugar, patient)
+                entry["dose"] = dose
+                await message.reply_text(
+                    f"💉\u202fРасчёт дозы: {dose}\u202fЕд.\n"
+                    f"Сахар: {sugar}\u202fммоль/л",
+                    reply_markup=confirm_keyboard(),
+                )
+                return True
+        await message.reply_text(
+            "Введите количество углеводов или ХЕ.",
+            reply_markup=menu_keyboard,
+        )
+        return True
+    return False
+
+
+async def handle_edit_mode(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    user_data: UserData,
+    raw_text: str,
+) -> bool:
+    """Handle editing of existing diary entries."""
+    message = update.message
+    if message is None:
+        return False
+    edit_id = user_data.get("edit_id")
+    if edit_id is None:
+        return False
+    text = raw_text.replace(",", ".")
+    try:
+        value = float(text)
+    except ValueError:
+        await message.reply_text("Введите значение числом.")
+        return True
+    if value < 0:
+        await message.reply_text("Значение не может быть отрицательным.")
+        return True
+    field = cast(str | None, user_data.get("edit_field"))
+
+    def db_edit(session: Session) -> Entry | None:
+        entry = session.get(Entry, edit_id)
+        if entry is None:
+            return None
+        if field == "sugar":
+            entry.sugar_before = value
+        elif field == "xe":
+            entry.xe = value
+        else:
+            entry.dose = value
+        if not commit(session):
+            return None
+        session.refresh(entry)
+        return entry
+
+    try:
+        entry = await run_db(db_edit, sessionmaker=SessionLocal)
+    except AttributeError:
+        with SessionLocal() as session:
+            entry = db_edit(session)
+    if entry is None:
+        await message.reply_text("⚠️ Не удалось сохранить запись.")
+        return True
+    edit_info_raw = user_data.get("edit_entry")
+    if not isinstance(edit_info_raw, dict):
+        return True
+    edit_info = cast(EditMessageMeta, edit_info_raw)
+    chat_id = edit_info["chat_id"]
+    message_id = edit_info["message_id"]
+    markup = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    "✏️ Изменить", callback_data=f"edit:{entry.id}"
+                ),
+                InlineKeyboardButton("🗑 Удалить", callback_data=f"del:{entry.id}"),
+            ]
+        ]
+    )
+    render_text = render_entry(entry)
+    await context.bot.edit_message_text(
+        render_text,
+        chat_id=chat_id,
+        message_id=message_id,
+        reply_markup=markup,
+        parse_mode="HTML",
+    )
+    edit_query = cast(CallbackQuery | None, user_data.get("edit_query"))
+    if edit_query is not None:
+        await edit_query.answer("Изменено")
+    for key in ("edit_id", "edit_field", "edit_entry", "edit_query"):
+        user_data.pop(key, None)
+    return True
+
+
+async def handle_smart_input(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    user_data: UserData,
+    raw_text: str,
+    user_id: int,
+) -> bool:
+    """Process quick smart-input strings."""
+    message = update.message
+    if message is None:
+        return False
+    try:
+        quick = smart_input(raw_text)
+    except ValueError as exc:
+        msg = str(exc)
+        if "mismatched unit for sugar" in msg:
+            await message.reply_text("❗ Сахар указывается в ммоль/л, не в XE.")
+        elif "mismatched unit for dose" in msg:
+            await message.reply_text(
+                "❗ Доза указывается в ед., не в ммоль.",
+            )
+        elif "mismatched unit for xe" in msg:
+            await message.reply_text(
+                "❗ ХЕ указываются числом, без ммоль/л и ед.",
+            )
+        else:
+            await message.reply_text(
+                "Не удалось распознать значения, используйте сахар=5 xe=1 dose=2",
+            )
+        return True
+
+    carbs_match = re.search(
+        r"(?:carbs|углеводов)\s*=\s*(-?\d+(?:[.,]\d+)?)", raw_text, re.I,
+    )
+    pending_entry = user_data.get("pending_entry")
+    edit_id = user_data.get("edit_id")
+    if (
+        pending_entry is not None
+        and edit_id is None
+        and (any(v is not None for v in quick.values()) or carbs_match)
+    ):
+        if quick["sugar"] is not None:
+            pending_entry["sugar_before"] = quick["sugar"]
+        if quick["xe"] is not None:
+            pending_entry["xe"] = quick["xe"]
+            pending_entry["carbs_g"] = quick["xe"] * 12
+        elif carbs_match:
+            pending_entry["carbs_g"] = float(
+                carbs_match.group(1).replace(",", "."),
+            )
+        if quick["dose"] is not None:
+            pending_entry["dose"] = quick["dose"]
+        await message.reply_text("Данные обновлены.")
+        return True
+    if any(v is not None for v in quick.values()):
+        sugar = quick["sugar"]
+        xe = quick["xe"]
+        dose = quick["dose"]
+        if any(v is not None and v < 0 for v in (sugar, xe, dose)):
+            await message.reply_text("Значения не могут быть отрицательными.")
+            return True
+        entry_data = {
+            "telegram_id": user_id,
+            "event_time": datetime.datetime.now(datetime.timezone.utc),
+            "sugar_before": sugar,
+            "xe": xe,
+            "dose": dose,
+            "carbs_g": xe * 12 if xe is not None else None,
+        }
+        missing = [f for f in ("sugar", "xe", "dose") if quick[f] is None]
+        if not missing:
+
+            def db_save_quick(session: Session) -> bool:
+                entry = Entry(**entry_data)
+                session.add(entry)
+                return bool(commit(session))
+
+            try:
+                ok = await run_db(db_save_quick, sessionmaker=SessionLocal)
+            except AttributeError:
+                with SessionLocal() as session:
+                    ok = db_save_quick(session)
+            if not ok:
+                await message.reply_text("⚠️ Не удалось сохранить запись.")
+                return True
+            if sugar is not None:
+                await check_alert(update, context, sugar)
+            await message.reply_text(
+                f"✅ Запись сохранена: сахар {sugar} ммоль/л, ХЕ {xe}, доза {dose} Ед.",
+                reply_markup=menu_keyboard,
+            )
+            return True
+        user_data["pending_entry"] = entry_data
+        user_data["pending_fields"] = missing
+        next_field = missing[0]
+        if next_field == "sugar":
+            await message.reply_text("Введите уровень сахара (ммоль/л).")
+        elif next_field == "xe":
+            await message.reply_text("Введите количество ХЕ.")
+        else:
+            await message.reply_text("Введите дозу инсулина (ед.).")
+        return True
+    return False
+
+
+async def handle_parsed_command(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    user_data: UserData,
+    raw_text: str,
+    user_id: int,
+) -> bool:
+    """Parse complex commands and prepare pending entries."""
+    message = update.message
+    if message is None:
+        return False
+    parsed = await parse_command(raw_text)
+    logger.info("FREEFORM parsed=%s", parsed)
+    if not parsed or parsed.get("action") != "add_entry":
+        await message.reply_text(
+            "Не понял, воспользуйтесь /help или кнопками меню",
+        )
+        return True
+    fields = parsed.get("fields")
+    if not isinstance(fields, dict):
+        await message.reply_text(
+            "Не удалось распознать данные, попробуйте ещё раз.",
+        )
+        return True
+    if any(
+        v is not None and v < 0
+        for v in (
+            fields.get("xe"),
+            fields.get("carbs_g"),
+            fields.get("dose"),
+            fields.get("sugar_before"),
+        )
+    ):
+        await message.reply_text("Значения не могут быть отрицательными.")
+        return True
+    entry_date_obj = parsed.get("entry_date")
+    time_obj = parsed.get("time")
+
+    if isinstance(entry_date_obj, str):
+        try:
+            event_dt = datetime.datetime.fromisoformat(entry_date_obj)
+            if event_dt.tzinfo is None:
+                event_dt = event_dt.replace(tzinfo=datetime.timezone.utc)
+            else:
+                event_dt = event_dt.astimezone(datetime.timezone.utc)
+        except ValueError:
+            event_dt = datetime.datetime.now(datetime.timezone.utc)
+    elif isinstance(time_obj, str):
+        try:
+            hh, mm = map(int, time_obj.split(":"))
+            today = datetime.datetime.now(datetime.timezone.utc).date()
+            event_dt = datetime.datetime.combine(
+                today,
+                datetime.time(hh, mm),
+                tzinfo=datetime.timezone.utc,
+            )
+        except (ValueError, TypeError):
+            await message.reply_text(
+                "⏰ Неверный формат времени. Использую текущее время.",
+            )
+            event_dt = datetime.datetime.now(datetime.timezone.utc)
+    else:
+        event_dt = datetime.datetime.now(datetime.timezone.utc)
+    user_data.pop("pending_entry", None)
+    user_data["pending_entry"] = {
+        "telegram_id": user_id,
+        "event_time": event_dt,
+        "xe": fields.get("xe"),
+        "carbs_g": fields.get("carbs_g"),
+        "dose": fields.get("dose"),
+        "sugar_before": fields.get("sugar_before"),
+        "photo_path": None,
+    }
+
+    xe_val: float | None = fields.get("xe")
+    carbs_val: float | None = fields.get("carbs_g")
+    dose_val: float | None = fields.get("dose")
+    sugar_val: float | None = fields.get("sugar_before")
+    date_str = event_dt.strftime("%d.%m %H:%M")
+    xe_part = f"{xe_val} ХЕ" if xe_val is not None else ""
+    carb_part = (
+        f"{carbs_val:.0f} г углеводов" if carbs_val is not None else ""
+    )
+    dose_part = f"Инсулин: {dose_val} ед" if dose_val is not None else ""
+    sugar_part = (
+        f"Сахар: {sugar_val} ммоль/л" if sugar_val is not None else ""
+    )
+    lines = "  \n- ".join(
+        filter(None, [xe_part or carb_part, dose_part, sugar_part]),
+    )
+
+    reply = (
+        f"💉 Расчёт завершён:\n\n{date_str}  \n- {lines}\n\nСохранить это в дневник?"
+    )
+    await message.reply_text(text=reply, reply_markup=confirm_keyboard())
+    return True
+
+
 async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle freeform text commands for adding diary entries."""
     user_data_raw = context.user_data
@@ -74,351 +497,13 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         user_data.pop("awaiting_report_date", None)
         return
 
-    pending_entry = user_data.get("pending_entry")
-    pending_fields = user_data.get("pending_fields")
-    edit_id = user_data.get("edit_id")
-    if pending_entry is not None and edit_id is None and pending_fields:
-        field = pending_fields[0]
-        text = raw_text.replace(",", ".")
-        try:
-            value = float(text)
-        except ValueError:
-            if field == "sugar":
-                await message.reply_text("Введите сахар числом в ммоль/л.")
-            elif field == "xe":
-                await message.reply_text("Введите число ХЕ.")
-            else:
-                await message.reply_text("Введите дозу инсулина числом.")
-            return
-        if value < 0:
-            if field == "sugar":
-                await message.reply_text("Сахар не может быть отрицательным.")
-            elif field == "xe":
-                await message.reply_text("Количество ХЕ не может быть отрицательным.")
-            else:
-                await message.reply_text("Доза инсулина не может быть отрицательной.")
-            return
-        if field == "sugar":
-            pending_entry["sugar_before"] = value
-        elif field == "xe":
-            pending_entry["xe"] = value
-            pending_entry["carbs_g"] = value * 12
-        else:
-            pending_entry["dose"] = value
-        pending_fields.pop(0)
-        if pending_fields:
-            next_field = pending_fields[0]
-            if next_field == "sugar":
-                await message.reply_text("Введите уровень сахара (ммоль/л).")
-            elif next_field == "xe":
-                await message.reply_text("Введите количество ХЕ.")
-            else:
-                await message.reply_text("Введите дозу инсулина (ед.).")
-            return
-
-        def db_save_entry(session: Session) -> bool:
-            entry = Entry(**pending_entry)
-            session.add(entry)
-            return bool(commit(session))
-
-        try:
-            ok = await run_db(db_save_entry, sessionmaker=SessionLocal)
-        except AttributeError:
-            with SessionLocal() as session:
-                ok = db_save_entry(session)
-        if not ok:
-            await message.reply_text("⚠️ Не удалось сохранить запись.")
-            return
-        sugar = pending_entry.get("sugar_before")
-        if sugar is not None:
-            await check_alert(update, context, sugar)
-        user_data.pop("pending_entry", None)
-        user_data.pop("pending_fields", None)
-        xe = pending_entry.get("xe")
-        dose = pending_entry.get("dose")
-        xe_info = f", ХЕ {xe}" if xe is not None else ""
-        dose_info = f", доза {dose} Ед." if dose is not None else ", доза —"
-        sugar_info = f"сахар {sugar} ммоль/л" if sugar is not None else "сахар —"
-        await message.reply_text(
-            f"✅ Запись сохранена: {sugar_info}{xe_info}{dose_info}",
-            reply_markup=menu_keyboard,
-        )
+    if await handle_pending_entry(update, context, user_data, raw_text, user_id):
         return
-    if pending_entry is not None and edit_id is None:
-        entry = pending_entry
-        text = raw_text.lower()
-        if (
-            re.fullmatch(r"-?\d+(?:[.,]\d+)?", text)
-            and entry.get("sugar_before") is None
-        ):
-            try:
-                sugar = float(text.replace(",", "."))
-            except ValueError:
-                await message.reply_text("Некорректное числовое значение.")
-                return
-            if sugar < 0:
-                await message.reply_text("Сахар не может быть отрицательным.")
-                return
-            entry["sugar_before"] = sugar
-            if entry.get("carbs_g") is not None or entry.get("xe") is not None:
-                xe_val = entry.get("xe")
-                carbs_g = entry.get("carbs_g")
-                if carbs_g is None and xe_val is not None:
-                    carbs_g = xe_val * 12
-                    entry["carbs_g"] = carbs_g
-                user_id = user.id
-                try:
-                    profile = await run_db(
-                        lambda s: s.get(Profile, user_id), sessionmaker=SessionLocal
-                    )
-                except AttributeError:
-                    with SessionLocal() as session:
-                        profile = session.get(Profile, user_id)
-                if (
-                    profile is not None
-                    and profile.icr is not None
-                    and profile.cf is not None
-                    and profile.target_bg is not None
-                ):
-                    patient = PatientProfile(
-                        icr=profile.icr, cf=profile.cf, target_bg=profile.target_bg
-                    )
-                    dose = calc_bolus(carbs_g, sugar, patient)
-                    entry["dose"] = dose
-                    await message.reply_text(
-                        f"💉\u202fРасчёт дозы: {dose}\u202fЕд.\nСахар: {sugar}\u202fммоль/л",
-                        reply_markup=confirm_keyboard(),
-                    )
-                    return
-            await message.reply_text(
-                "Введите количество углеводов или ХЕ.", reply_markup=menu_keyboard
-            )
-            return
-        # fall through to smart input parsing for non-numeric messages
-    if edit_id is not None:
-        text = raw_text.replace(",", ".")
-        try:
-            value = float(text)
-        except ValueError:
-            await message.reply_text("Введите значение числом.")
-            return
-        if value < 0:
-            await message.reply_text("Значение не может быть отрицательным.")
-            return
-        field = cast(str | None, user_data.get("edit_field"))
-
-        def db_edit(session: Session) -> Entry | None:
-            entry = session.get(Entry, edit_id)
-            if entry is None:
-                return None
-            if field == "sugar":
-                entry.sugar_before = value
-            elif field == "xe":
-                entry.xe = value
-            else:
-                entry.dose = value
-            if not commit(session):
-                return None
-            session.refresh(entry)
-            return entry
-
-        try:
-            entry = await run_db(db_edit, sessionmaker=SessionLocal)
-        except AttributeError:
-            with SessionLocal() as session:
-                entry = db_edit(session)
-        if entry is None:
-            await message.reply_text("⚠️ Не удалось сохранить запись.")
-            return
-        edit_info_raw = user_data.get("edit_entry")
-        if not isinstance(edit_info_raw, dict):
-            return
-        edit_info = cast(EditMessageMeta, edit_info_raw)
-        chat_id = edit_info["chat_id"]
-        message_id = edit_info["message_id"]
-        markup = InlineKeyboardMarkup(
-            [
-                [
-                    InlineKeyboardButton(
-                        "✏️ Изменить", callback_data=f"edit:{entry.id}"
-                    ),
-                    InlineKeyboardButton("🗑 Удалить", callback_data=f"del:{entry.id}"),
-                ]
-            ]
-        )
-        render_text = render_entry(entry)
-        await context.bot.edit_message_text(
-            render_text,
-            chat_id=chat_id,
-            message_id=message_id,
-            reply_markup=markup,
-            parse_mode="HTML",
-        )
-        edit_query = cast(CallbackQuery | None, user_data.get("edit_query"))
-        if edit_query is not None:
-            await edit_query.answer("Изменено")
-        for key in ("edit_id", "edit_field", "edit_entry", "edit_query"):
-            user_data.pop(key, None)
+    if await handle_edit_mode(update, context, user_data, raw_text):
         return
-
-    try:
-        quick = smart_input(raw_text)
-    except ValueError as exc:
-        msg = str(exc)
-        if "mismatched unit for sugar" in msg:
-            await message.reply_text("❗ Сахар указывается в ммоль/л, не в XE.")
-        elif "mismatched unit for dose" in msg:
-            await message.reply_text("❗ Доза указывается в ед., не в ммоль.")
-        elif "mismatched unit for xe" in msg:
-            await message.reply_text("❗ ХЕ указываются числом, без ммоль/л и ед.")
-        else:
-            await message.reply_text(
-                "Не удалось распознать значения, используйте сахар=5 xe=1 dose=2",
-            )
+    if await handle_smart_input(update, context, user_data, raw_text, user_id):
         return
-
-    carbs_match = re.search(
-        r"(?:carbs|углеводов)\s*=\s*(-?\d+(?:[.,]\d+)?)", raw_text, re.I
-    )
-    if (
-        pending_entry is not None
-        and edit_id is None
-        and (any(v is not None for v in quick.values()) or carbs_match)
-    ):
-        if quick["sugar"] is not None:
-            pending_entry["sugar_before"] = quick["sugar"]
-        if quick["xe"] is not None:
-            pending_entry["xe"] = quick["xe"]
-            pending_entry["carbs_g"] = quick["xe"] * 12
-        elif carbs_match:
-            pending_entry["carbs_g"] = float(carbs_match.group(1).replace(",", "."))
-        if quick["dose"] is not None:
-            pending_entry["dose"] = quick["dose"]
-        await message.reply_text("Данные обновлены.")
-        return
-    if any(v is not None for v in quick.values()):
-        sugar = quick["sugar"]
-        xe = quick["xe"]
-        dose = quick["dose"]
-        if any(v is not None and v < 0 for v in (sugar, xe, dose)):
-            await message.reply_text("Значения не могут быть отрицательными.")
-            return
-        entry_data = {
-            "telegram_id": user_id,
-            "event_time": datetime.datetime.now(datetime.timezone.utc),
-            "sugar_before": sugar,
-            "xe": xe,
-            "dose": dose,
-            "carbs_g": xe * 12 if xe is not None else None,
-        }
-        missing = [f for f in ("sugar", "xe", "dose") if quick[f] is None]
-        if not missing:
-
-            def db_save_quick(session: Session) -> bool:
-                entry = Entry(**entry_data)
-                session.add(entry)
-                return bool(commit(session))
-
-            try:
-                ok = await run_db(db_save_quick, sessionmaker=SessionLocal)
-            except AttributeError:
-                with SessionLocal() as session:
-                    ok = db_save_quick(session)
-            if not ok:
-                await message.reply_text("⚠️ Не удалось сохранить запись.")
-                return
-            if sugar is not None:
-                await check_alert(update, context, sugar)
-            await message.reply_text(
-                f"✅ Запись сохранена: сахар {sugar} ммоль/л, ХЕ {xe}, доза {dose} Ед.",
-                reply_markup=menu_keyboard,
-            )
-            return
-        user_data["pending_entry"] = entry_data
-        user_data["pending_fields"] = missing
-        next_field = missing[0]
-        if next_field == "sugar":
-            await message.reply_text("Введите уровень сахара (ммоль/л).")
-        elif next_field == "xe":
-            await message.reply_text("Введите количество ХЕ.")
-        else:
-            await message.reply_text("Введите дозу инсулина (ед.).")
-        return
-
-    parsed = await parse_command(raw_text)
-    logger.info("FREEFORM parsed=%s", parsed)
-    if not parsed or parsed.get("action") != "add_entry":
-        await message.reply_text("Не понял, воспользуйтесь /help или кнопками меню")
-        return
-
-    fields = parsed.get("fields")
-    if not isinstance(fields, dict):
-        await message.reply_text("Не удалось распознать данные, попробуйте ещё раз.")
-        return
-    if any(
-        v is not None and v < 0
-        for v in (
-            fields.get("xe"),
-            fields.get("carbs_g"),
-            fields.get("dose"),
-            fields.get("sugar_before"),
-        )
-    ):
-        await message.reply_text("Значения не могут быть отрицательными.")
-        return
-    entry_date_obj = parsed.get("entry_date")
-    time_obj = parsed.get("time")
-
-    if isinstance(entry_date_obj, str):
-        try:
-            event_dt = datetime.datetime.fromisoformat(entry_date_obj)
-            if event_dt.tzinfo is None:
-                event_dt = event_dt.replace(tzinfo=datetime.timezone.utc)
-            else:
-                event_dt = event_dt.astimezone(datetime.timezone.utc)
-        except ValueError:
-            event_dt = datetime.datetime.now(datetime.timezone.utc)
-    elif isinstance(time_obj, str):
-        try:
-            hh, mm = map(int, time_obj.split(":"))
-            today = datetime.datetime.now(datetime.timezone.utc).date()
-            event_dt = datetime.datetime.combine(
-                today, datetime.time(hh, mm), tzinfo=datetime.timezone.utc
-            )
-        except (ValueError, TypeError):
-            await message.reply_text(
-                "⏰ Неверный формат времени. Использую текущее время."
-            )
-            event_dt = datetime.datetime.now(datetime.timezone.utc)
-    else:
-        event_dt = datetime.datetime.now(datetime.timezone.utc)
-    user_data.pop("pending_entry", None)
-    user_data["pending_entry"] = {
-        "telegram_id": user_id,
-        "event_time": event_dt,
-        "xe": fields.get("xe"),
-        "carbs_g": fields.get("carbs_g"),
-        "dose": fields.get("dose"),
-        "sugar_before": fields.get("sugar_before"),
-        "photo_path": None,
-    }
-
-    xe_val: float | None = fields.get("xe")
-    carbs_val: float | None = fields.get("carbs_g")
-    dose_val: float | None = fields.get("dose")
-    sugar_val: float | None = fields.get("sugar_before")
-    date_str = event_dt.strftime("%d.%m %H:%M")
-    xe_part = f"{xe_val} ХЕ" if xe_val is not None else ""
-    carb_part = f"{carbs_val:.0f} г углеводов" if carbs_val is not None else ""
-    dose_part = f"Инсулин: {dose_val} ед" if dose_val is not None else ""
-    sugar_part = f"Сахар: {sugar_val} ммоль/л" if sugar_val is not None else ""
-    lines = "  \n- ".join(filter(None, [xe_part or carb_part, dose_part, sugar_part]))
-
-    reply = (
-        f"💉 Расчёт завершён:\n\n{date_str}  \n- {lines}\n\nСохранить это в дневник?"
-    )
-    await message.reply_text(text=reply, reply_markup=confirm_keyboard())
-    return
+    await handle_parsed_command(update, context, user_data, raw_text, user_id)
 
 
 async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -429,4 +514,12 @@ async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     await message.reply_text("🗨️ Чат с GPT временно недоступен.")
 
 
-__all__ = ["SessionLocal", "freeform_handler", "chat_with_gpt"]
+__all__ = [
+    "SessionLocal",
+    "freeform_handler",
+    "chat_with_gpt",
+    "handle_pending_entry",
+    "handle_edit_mode",
+    "handle_smart_input",
+    "handle_parsed_command",
+]

--- a/tests/handlers/test_gpt_handlers.py
+++ b/tests/handlers/test_gpt_handlers.py
@@ -176,10 +176,9 @@ async def test_smart_input_missing_fields(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(gpt_handlers, "smart_input", fake_smart_input)
     message = DummyMessage("sugar=5")
     update = make_update(message)
-    user_data: dict[str, Any] = {}
-    context = make_context(user_data)
+    context = make_context({})
     await gpt_handlers.freeform_handler(update, context)
-    assert user_data["pending_fields"] == ["xe", "dose"]
+    assert cast(dict[str, Any], context.user_data)["pending_fields"] == ["xe", "dose"]
     assert "количество ХЕ" in message.replies[0][0]
 
 
@@ -260,9 +259,8 @@ async def test_parse_command_valid_time(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(gpt_handlers, "parse_command", fake_parse)
     message = DummyMessage("entry")
     update = make_update(message)
-    user_data: dict[str, Any] = {}
-    context = make_context(user_data)
+    context = make_context({})
     await gpt_handlers.freeform_handler(update, context)
-    assert user_data["pending_entry"]["xe"] == 1
+    assert cast(dict[str, Any], context.user_data)["pending_entry"]["xe"] == 1
     assert "Расчёт завершён" in message.replies[0][0]
 

--- a/tests/test_gpt_handler_helpers.py
+++ b/tests/test_gpt_handler_helpers.py
@@ -1,0 +1,109 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+import services.api.app.diabetes.handlers.gpt_handlers as gpt_handlers
+from services.api.app.diabetes.handlers import UserData
+
+
+class DummyMessage:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.replies.append(text)
+
+
+def make_update(message: DummyMessage) -> Update:
+    return cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
+
+
+def make_context(user_data: dict[str, Any]) -> CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]:
+    return cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data=user_data, bot=SimpleNamespace()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_pending_entry_invalid() -> None:
+    message = DummyMessage("abc")
+    update = make_update(message)
+    user_data = {"pending_entry": {}, "pending_fields": ["xe"]}
+    context = make_context(user_data)
+    handled = await gpt_handlers.handle_pending_entry(
+        update,
+        context,
+        cast(UserData, user_data),
+        "abc",
+        1,
+    )
+    assert handled is True
+    assert message.replies == ["Введите число ХЕ."]
+
+
+@pytest.mark.asyncio
+async def test_handle_edit_mode_negative() -> None:
+    message = DummyMessage("-1")
+    update = make_update(message)
+    user_data = {"edit_id": 1, "edit_field": "xe"}
+    context = make_context(user_data)
+    handled = await gpt_handlers.handle_edit_mode(
+        update,
+        context,
+        cast(UserData, user_data),
+        "-1",
+    )
+    assert handled is True
+    assert message.replies == ["Значение не может быть отрицательным."]
+
+
+@pytest.mark.asyncio
+async def test_handle_smart_input_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    message = DummyMessage("bad")
+    update = make_update(message)
+    user_data: dict[str, Any] = {}
+    context = make_context(user_data)
+
+    def fake_smart_input(text: str) -> dict[str, float | None]:
+        raise ValueError("mismatched unit for xe")
+
+    monkeypatch.setattr(gpt_handlers, "smart_input", fake_smart_input)
+    handled = await gpt_handlers.handle_smart_input(
+        update,
+        context,
+        cast(UserData, user_data),
+        "bad",
+        1,
+    )
+    assert handled is True
+    assert message.replies[0].startswith("❗ ХЕ")
+
+
+@pytest.mark.asyncio
+async def test_handle_parsed_command_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    message = DummyMessage("cmd")
+    update = make_update(message)
+    user_data: dict[str, Any] = {}
+    context = make_context(user_data)
+
+    async def fake_parse(text: str) -> dict[str, str]:
+        return {"action": "noop"}
+
+    monkeypatch.setattr(gpt_handlers, "parse_command", fake_parse)
+    handled = await gpt_handlers.handle_parsed_command(
+        update,
+        context,
+        cast(UserData, user_data),
+        "cmd",
+        1,
+    )
+    assert handled is True
+    assert message.replies == ["Не понял, воспользуйтесь /help или кнопками меню"]


### PR DESCRIPTION
## Summary
- refactor freeform_handler by extracting helper functions for pending entries, edit mode, smart input and parsed commands
- expose new helpers and simplify freeform_handler
- add unit tests for the helper functions

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a23c0afb88832ab6c28d15a4e2663c