### PR TITLE
[handlers] Preserve pending fields prompt

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -334,15 +334,18 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 reply_markup=menu_keyboard,
             )
             return
+        # Save the partially filled entry and prompt for the next field
+        # before returning early.  This ensures that the conversation
+        # state is preserved even if some values are still missing.
         user_data["pending_entry"] = entry_data
         user_data["pending_fields"] = missing
         next_field = missing[0]
-        if next_field == "sugar":
-            await message.reply_text("Введите уровень сахара (ммоль/л).")
-        elif next_field == "xe":
-            await message.reply_text("Введите количество ХЕ.")
-        else:
-            await message.reply_text("Введите дозу инсулина (ед.).")
+        prompts = {
+            "sugar": "Введите уровень сахара (ммоль/л).",
+            "xe": "Введите количество ХЕ.",
+            "dose": "Введите дозу инсулина (ед.).",
+        }
+        await message.reply_text(prompts[next_field])
         return
 
     parsed = await parse_command(raw_text)

--- a/tests/handlers/test_gpt_handlers.py
+++ b/tests/handlers/test_gpt_handlers.py
@@ -112,7 +112,7 @@ async def test_pending_entry_next_field(monkeypatch: pytest.MonkeyPatch) -> None
     await gpt_handlers.freeform_handler(update, context)
     assert entry["xe"] == 1
     assert user_data["pending_fields"] == ["dose"]
-    assert "дозу инсулина" in message.replies[0][0]
+    assert message.replies[0][0] == "Введите дозу инсулина (ед.)."
 
 
 @pytest.mark.asyncio
@@ -176,11 +176,12 @@ async def test_smart_input_missing_fields(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(gpt_handlers, "smart_input", fake_smart_input)
     message = DummyMessage("sugar=5")
     update = make_update(message)
-    user_data: dict[str, Any] = {}
-    context = make_context(user_data)
+    context = make_context({})
     await gpt_handlers.freeform_handler(update, context)
-    assert user_data["pending_fields"] == ["xe", "dose"]
-    assert "количество ХЕ" in message.replies[0][0]
+    data = cast(dict[str, Any], context.user_data)
+    assert data["pending_fields"] == ["xe", "dose"]
+    assert data["pending_entry"]["sugar_before"] == 5.0
+    assert message.replies[0][0] == "Введите количество ХЕ."
 
 
 @pytest.mark.asyncio
@@ -260,9 +261,9 @@ async def test_parse_command_valid_time(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(gpt_handlers, "parse_command", fake_parse)
     message = DummyMessage("entry")
     update = make_update(message)
-    user_data: dict[str, Any] = {}
-    context = make_context(user_data)
+    context = make_context({})
     await gpt_handlers.freeform_handler(update, context)
-    assert user_data["pending_entry"]["xe"] == 1
+    data = cast(dict[str, Any], context.user_data)
+    assert data["pending_entry"]["xe"] == 1
     assert "Расчёт завершён" in message.replies[0][0]
 


### PR DESCRIPTION
## Summary
- keep partially parsed entries by storing `pending_entry` and `pending_fields`
- ensure the next missing value is prompted explicitly
- add regression tests for smart_input pending-field flow

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a23ca3c87c832ab7c1709210bb1380