### PR TITLE
[gpt] Ensure pending entry stored

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -393,7 +393,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     else:
         event_dt = datetime.datetime.now(datetime.timezone.utc)
     user_data.pop("pending_entry", None)
-    user_data["pending_entry"] = {
+    entry_data = {
         "telegram_id": user_id,
         "event_time": event_dt,
         "xe": fields.get("xe"),
@@ -402,11 +402,12 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         "sugar_before": fields.get("sugar_before"),
         "photo_path": None,
     }
+    user_data["pending_entry"] = entry_data
 
-    xe_val: float | None = fields.get("xe")
-    carbs_val: float | None = fields.get("carbs_g")
-    dose_val: float | None = fields.get("dose")
-    sugar_val: float | None = fields.get("sugar_before")
+    xe_val: float | None = entry_data.get("xe")
+    carbs_val: float | None = entry_data.get("carbs_g")
+    dose_val: float | None = entry_data.get("dose")
+    sugar_val: float | None = entry_data.get("sugar_before")
     date_str = event_dt.strftime("%d.%m %H:%M")
     xe_part = f"{xe_val} ХЕ" if xe_val is not None else ""
     carb_part = f"{carbs_val:.0f} г углеводов" if carbs_val is not None else ""


### PR DESCRIPTION
## Summary
- Store parsed entry details in `user_data['pending_entry']` before confirmation
- Verify pending entry and confirmation text in GPT handler tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a23ca49448832a911b523f051e2dbc