### PR TITLE
[handlers] Store pending entry and test confirm

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -393,7 +393,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     else:
         event_dt = datetime.datetime.now(datetime.timezone.utc)
     user_data.pop("pending_entry", None)
-    user_data["pending_entry"] = {
+    entry = {
         "telegram_id": user_id,
         "event_time": event_dt,
         "xe": fields.get("xe"),
@@ -402,6 +402,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         "sugar_before": fields.get("sugar_before"),
         "photo_path": None,
     }
+    user_data["pending_entry"] = entry
 
     xe_val: float | None = fields.get("xe")
     carbs_val: float | None = fields.get("carbs_g")


### PR DESCRIPTION
## Summary
- ensure GPT handler saves pending entry before confirmation
- verify confirm keyboard and entry data in GPT handler tests

## Testing
- `make ci` *(fails: No rule to make target 'ci')*
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a23c092b74832a8fd69a3dabba5769