### PR TITLE
[handlers] Save parsed entry before confirmation

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -444,7 +444,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     else:
         event_dt = datetime.datetime.now(datetime.timezone.utc)
     user_data.pop("pending_entry", None)
-    entry_data = {
+    user_data["pending_entry"] = {
         "telegram_id": user_id,
         "event_time": event_dt,
         "xe": fields.get("xe"),
@@ -453,12 +453,12 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         "sugar_before": fields.get("sugar_before"),
         "photo_path": None,
     }
-    user_data["pending_entry"] = entry_data
+    pending_entry = user_data["pending_entry"]
 
-    xe_val: float | None = entry_data.get("xe")
-    carbs_val: float | None = entry_data.get("carbs_g")
-    dose_val: float | None = entry_data.get("dose")
-    sugar_val: float | None = entry_data.get("sugar_before")
+    xe_val: float | None = pending_entry.get("xe")
+    carbs_val: float | None = pending_entry.get("carbs_g")
+    dose_val: float | None = pending_entry.get("dose")
+    sugar_val: float | None = pending_entry.get("sugar_before")
     date_str = event_dt.strftime("%d.%m %H:%M")
     xe_part = f"{xe_val} ХЕ" if xe_val is not None else ""
     carb_part = f"{carbs_val:.0f} г углеводов" if carbs_val is not None else ""


### PR DESCRIPTION
## Summary
- ensure GPT parse results populate `user_data['pending_entry']` with relevant fields before confirmation prompt

## Testing
- `pytest tests/handlers/test_gpt_handlers.py::test_parse_command_valid_time -q --cov-fail-under=0`
- `mypy --strict services/api/app/diabetes/handlers/gpt_handlers.py tests/handlers/test_gpt_handlers.py`
- `ruff check services/api/app/diabetes/handlers/gpt_handlers.py tests/handlers/test_gpt_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2c27abf6c832a98dcf28795580c15