### PR TITLE
[handlers] Preserve quick-input pending state

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -363,6 +363,8 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             "carbs_g": xe * 12 if xe is not None else None,
         }
         missing = [f for f in ("sugar", "xe", "dose") if quick[f] is None]
+        user_data["pending_entry"] = entry_data
+        user_data["pending_fields"] = missing
         if not missing:
 
             def db_save_quick(session: Session) -> bool:
@@ -380,13 +382,13 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 return
             if sugar is not None:
                 await check_alert(update, context, sugar)
+            user_data.pop("pending_entry", None)
+            user_data.pop("pending_fields", None)
             await message.reply_text(
                 f"✅ Запись сохранена: сахар {sugar} ммоль/л, ХЕ {xe}, доза {dose} Ед.",
                 reply_markup=menu_keyboard,
             )
             return
-        user_data["pending_entry"] = entry_data
-        user_data["pending_fields"] = missing
         next_field = missing[0]
         if next_field == "sugar":
             await message.reply_text("Введите уровень сахара (ммоль/л).")


### PR DESCRIPTION
## Summary
- store quick input entry and missing fields before returning
- clean up pending state after a successful save

## Testing
- `pytest -q tests/handlers/test_gpt_handlers.py::test_smart_input_missing_fields -o addopts=''`
- `pytest -q tests/handlers/test_gpt_handlers.py::test_smart_input_missing_fields --cov=services/api/app/diabetes/handlers/gpt_handlers.py --cov-fail-under=85` *(fails: Coverage failure: total of 24 is less than fail-under=85)*
- `mypy --strict services/api/app/diabetes/handlers/gpt_handlers.py tests/handlers/test_gpt_handlers.py`
- `ruff check services/api/app/diabetes/handlers/gpt_handlers.py tests/handlers/test_gpt_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2c279bba4832a880276c73089881f