### PR TITLE
[webapp] Define TelegramHook type for context

### DIFF
--- a/services/webapp/ui/src/contexts/telegram-context.ts
+++ b/services/webapp/ui/src/contexts/telegram-context.ts
@@ -1,7 +1,9 @@
 import { createContext, useContext } from "react"
-import type { useTelegram } from "@/hooks/useTelegram"
+import { useTelegram } from "@/hooks/useTelegram"
 
-const TelegramContext = createContext<ReturnType<typeof useTelegram> | null>(null)
+type TelegramHook = ReturnType<typeof useTelegram>
+
+const TelegramContext = createContext<TelegramHook | null>(null)
 
 const useTelegramContext = () => {
   const context = useContext(TelegramContext)


### PR DESCRIPTION
## Summary
- replace type-only import with runtime import in Telegram context
- introduce `TelegramHook` alias and use it for typed context creation

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a2c48d2504832aaab484f5944a65cd