### PR TITLE
[webapp] Replace div tiles with links for accessibility

### DIFF
--- a/services/webapp/ui/src/index.css
+++ b/services/webapp/ui/src/index.css
@@ -19,7 +19,8 @@ Design tokens and base styles live in styles/theme.css
   .medical-tile {
     @apply medical-card hover:bg-card/80 active:scale-95 cursor-pointer
            flex flex-col items-center justify-center min-h-[120px] text-center
-           transition-all duration-200 touch-manipulation;
+           transition-all duration-200 touch-manipulation
+           focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-medical-blue;
   }
 
   .medical-list-item {

--- a/services/webapp/ui/src/pages/Home.tsx
+++ b/services/webapp/ui/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import type { LucideIcon } from 'lucide-react';
 import { Clock, User, BookOpen, Star } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import MedicalButton from '@/components/MedicalButton';
@@ -83,10 +83,6 @@ const Home = (): JSX.Element => {
 
   const dayStats = stats ?? fallbackDayStats;
 
-  const handleTileClick = (route: string): void => {
-    navigate(route);
-  };
-
   return (
     <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
       <MedicalHeader title="СахарФото" />
@@ -108,11 +104,11 @@ const Home = (): JSX.Element => {
             const Icon = item.icon;
             const { bg, text } = COLOR_MAP[item.color];
             return (
-              <div
+              <Link
                 key={item.id}
+                to={item.route}
                 className="medical-tile"
                 style={{ animationDelay: `${index * 100}ms` }}
-                onClick={() => handleTileClick(item.route)}
               >
                 <div
                   className={`w-12 h-12 rounded-xl flex items-center justify-center mb-3 ${bg}`}
@@ -121,7 +117,7 @@ const Home = (): JSX.Element => {
                 </div>
                 <h3 className="font-semibold text-foreground mb-1">{item.title}</h3>
                 <p className="text-sm text-muted-foreground">{item.description}</p>
-              </div>
+              </Link>
             );
           })}
         </div>


### PR DESCRIPTION
## Summary
- replace medical tile divs on Home page with react-router Links
- add focus styles so tiles are keyboard navigable

## Testing
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui run typecheck`
- `pytest -q --cov` *(fails: KeyboardInterrupt; no tests ran)*
- `mypy --strict .` *(terminated early: Interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a2c80b6d10832a91553ebb5732eec3