### PR TITLE
[webapp] enable prod minify

### DIFF
--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -11,6 +11,26 @@ export default defineConfig(async ({ mode }) => {
   }
   const base   = mode === 'development' ? '/' : '/ui/'  // dev → '/', prod → '/ui/'
   const port   = 5173                                   // или оставьте 8080 и укажите его в .lovable.yml
+  const rollupOptions = {
+    ...(mode === 'development' ? { treeshake: false } : {}),
+    input: {
+      main: path.resolve(__dirname, 'index.html'),
+      'telegram-theme': path.resolve(
+        __dirname,
+        './src/lib/telegram-theme.ts',
+      ),
+    },
+    output: {
+      entryFileNames: (chunk) =>
+        chunk.name === 'telegram-theme'
+          ? 'assets/telegram-theme.js'
+          : 'assets/[name]-[hash].js',
+      exports: 'named',
+      manualChunks: {
+        vendor: ['react', 'react-dom', 'react-router-dom'],
+      },
+    },
+  }
   return {
     base,
     plugins,
@@ -23,28 +43,8 @@ export default defineConfig(async ({ mode }) => {
     server: { host: '::', port },
     build: {
       outDir: 'dist', // Явно задаём dist (по умолчанию и так dist)
-      minify: false,
-      rollupOptions: {
-        treeshake: false,
-        input: {
-          main: path.resolve(__dirname, 'index.html'),
-          'telegram-theme': path.resolve(__dirname, './src/lib/telegram-theme.ts'),
-        },
-        output: {
-          entryFileNames: (chunk) =>
-            chunk.name === 'telegram-theme'
-              ? 'assets/telegram-theme.js'
-              : 'assets/[name]-[hash].js',
-          exports: 'named',
-          manualChunks: {
-            vendor: [
-              'react',
-              'react-dom',
-              'react-router-dom'
-            ]
-          }
-        }
-      }
+      minify: mode === 'development' ? false : 'esbuild',
+      rollupOptions,
     },
   }
 })


### PR DESCRIPTION
## Summary
- enable Vite minify with esbuild for production
- keep existing build settings in development

## Testing
- `pytest -q --cov` *(fails: no tests run)*
- `mypy --strict services/api/app` *(fails: interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a2cd6f11c4832a8a434ceebe07278f