### PR TITLE
[webapp] enable strict ts and fix typings

### DIFF
--- a/libs/ts-sdk/models/Reminder.ts
+++ b/libs/ts-sdk/models/Reminder.ts
@@ -38,6 +38,12 @@ export interface Reminder {
      */
     type: string;
     /**
+     *
+     * @type {string}
+     * @memberof Reminder
+     */
+    title?: string;
+    /**
      * 
      * @type {string}
      * @memberof Reminder
@@ -75,10 +81,11 @@ export function ReminderFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         return json;
     }
     return {
-        
+
         'telegramId': json['telegram_id'],
         'id': json['id'] == null ? undefined : json['id'],
         'type': json['type'],
+        'title': json['title'] == null ? undefined : json['title'],
         'time': json['time'] == null ? undefined : json['time'],
         'intervalHours': json['interval_hours'] == null ? undefined : json['interval_hours'],
         'isEnabled': json['is_enabled'] == null ? undefined : json['is_enabled'],
@@ -95,10 +102,11 @@ export function ReminderToJSONTyped(value?: Reminder | null, ignoreDiscriminator
     }
 
     return {
-        
+
         'telegram_id': value['telegramId'],
         'id': value['id'],
         'type': value['type'],
+        'title': value['title'],
         'time': value['time'],
         'interval_hours': value['intervalHours'],
         'is_enabled': value['isEnabled'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -6139,6 +6139,20 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-smooth": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
@@ -6174,6 +6188,21 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
+      "integrity": "sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.3.1",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-transition-group": {
@@ -8080,6 +8109,7 @@
         "jsdom": "^26.1.0",
         "lovable-tagger": "^1.1.9",
         "postcss": "^8.5.6",
+        "react-test-renderer": "^18.3.1",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",

--- a/services/webapp/ui/package.json
+++ b/services/webapp/ui/package.json
@@ -81,6 +81,7 @@
     "jsdom": "^26.1.0",
     "lovable-tagger": "^1.1.9",
     "postcss": "^8.5.6",
+    "react-test-renderer": "^18.3.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -66,7 +66,7 @@ export async function createReminder(reminder: Reminder) {
 
 export async function updateReminder(reminder: Reminder) {
   try {
-    return await api.remindersPatch({ reminder });
+    return await api.remindersPost({ reminder });
   } catch (error) {
     console.error('Failed to update reminder:', error);
     if (error instanceof Error) {
@@ -78,7 +78,8 @@ export async function updateReminder(reminder: Reminder) {
 
 export async function deleteReminder(telegramId: number, id: number) {
   try {
-    return await api.remindersDelete({ telegramId, id });
+    const reminder = await getReminder(telegramId, id);
+    return await updateReminder({ ...reminder, isEnabled: false });
   } catch (error) {
     console.error('Failed to delete reminder:', error);
     if (error instanceof Error) {

--- a/services/webapp/ui/src/hooks/use-mobile.test.tsx
+++ b/services/webapp/ui/src/hooks/use-mobile.test.tsx
@@ -5,6 +5,9 @@ import { useIsMobile } from "./use-mobile";
 
 describe("useIsMobile", () => {
   it("returns false when window is undefined", () => {
+    const savedWindow = (globalThis as any).window;
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete (globalThis as any).window;
     let result = true;
     const TestComponent = () => {
       result = useIsMobile();
@@ -14,5 +17,6 @@ describe("useIsMobile", () => {
       TestRenderer.create(<TestComponent />);
     });
     expect(result).toBe(false);
-  }, { environment: "node" });
+    (globalThis as any).window = savedWindow;
+  });
 });

--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -12,9 +12,10 @@
     },
     "noImplicitAny": true,
     "noUnusedParameters": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "allowJs": true,
     "noUnusedLocals": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "strict": true
   }
 }

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -1,16 +1,16 @@
 // file: services/webapp/ui/vite.config.ts
-import { defineConfig } from 'vite'
+import { defineConfig, type ConfigEnv, type PluginOption } from 'vite'
 import react from '@vitejs/plugin-react-swc'
+import { componentTagger } from 'lovable-tagger'
 import path from 'path'
 
-export default defineConfig(async ({ mode }) => {
-  const plugins = [react()]
+export default defineConfig(({ mode }: ConfigEnv) => {
+  const plugins: PluginOption[] = [...react()]
   if (mode === 'development') {
-    const { componentTagger } = await import('lovable-tagger')
     plugins.push(componentTagger())
   }
-  const base   = mode === 'development' ? '/' : '/ui/'  // dev → '/', prod → '/ui/'
-  const port   = 5173                                   // или оставьте 8080 и укажите его в .lovable.yml
+  const base = mode === 'development' ? '/' : '/ui/'
+  const port = 5173
   return {
     base,
     plugins,
@@ -22,29 +22,28 @@ export default defineConfig(async ({ mode }) => {
     },
     server: { host: '::', port },
     build: {
-      outDir: 'dist', // Явно задаём dist (по умолчанию и так dist)
+      outDir: 'dist',
       minify: false,
       rollupOptions: {
         treeshake: false,
         input: {
           main: path.resolve(__dirname, 'index.html'),
-          'telegram-theme': path.resolve(__dirname, './src/lib/telegram-theme.ts'),
+          'telegram-theme': path.resolve(
+            __dirname,
+            './src/lib/telegram-theme.ts',
+          ),
         },
         output: {
-          entryFileNames: (chunk) =>
+          entryFileNames: (chunk: { name: string }) =>
             chunk.name === 'telegram-theme'
               ? 'assets/telegram-theme.js'
               : 'assets/[name]-[hash].js',
-          exports: 'named',
+          exports: 'named' as const,
           manualChunks: {
-            vendor: [
-              'react',
-              'react-dom',
-              'react-router-dom'
-            ]
-          }
-        }
-      }
+            vendor: ['react', 'react-dom', 'react-router-dom'],
+          },
+        },
+      },
     },
   }
 })


### PR DESCRIPTION
## Summary
- enable TypeScript strict mode for web UI
- align reminders API client and model with backend
- fix vite config and tests for stricter type checking

## Testing
- `npx tsc -b`
- `npx vitest run --environment jsdom`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a2cff774bc832ab0ff0fd6fbb27118