### PR TITLE
[parser] handle missing JSON in _extract_first_json

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -62,7 +62,7 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
     while True:
         start = text.find("{", search_start)
         if start == -1:
-            return None
+            break
 
         # If the object is preceded by ``[``, treat it as part of an array and
         # skip it so that we don't parse array responses like ``[{...}]``.

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -312,6 +312,20 @@ def test_extract_first_json_malformed_input() -> None:
     assert gpt_command_parser._extract_first_json(text) is None
 
 
+def test_extract_first_json_simple_object() -> None:
+    text = '{"action":"add_entry","fields":{}}'
+    assert gpt_command_parser._extract_first_json(text) == {
+        "action": "add_entry",
+        "fields": {},
+    }
+
+
+def test_extract_first_json_no_object() -> None:
+    assert (
+        gpt_command_parser._extract_first_json("just some text without json") is None
+    )
+
+
 @pytest.mark.asyncio
 async def test_parse_command_with_multiple_jsons(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- break loop instead of returning to ensure `_extract_first_json` correctly falls through when no JSON object is found
- add unit tests for `_extract_first_json` covering presence and absence of JSON objects

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a2e3480f64832a8e5aae639adb27d5