### PR TITLE
[handlers] Ensure run_db attribute errors surface

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -121,11 +121,11 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             session.add(entry)
             return bool(commit(session))
 
-        try:
-            ok = await run_db(db_save_entry, sessionmaker=SessionLocal)
-        except AttributeError:
+        if not hasattr(run_db, "__call__"):
             with SessionLocal() as session:
                 ok = db_save_entry(session)
+        else:
+            ok = await run_db(db_save_entry, sessionmaker=SessionLocal)
         if not ok:
             await message.reply_text("⚠️ Не удалось сохранить запись.")
             return
@@ -167,13 +167,13 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     carbs_g = xe_val * 12
                     entry["carbs_g"] = carbs_g
                 user_id = user.id
-                try:
+                if not hasattr(run_db, "__call__"):
+                    with SessionLocal() as session:
+                        profile = session.get(Profile, user_id)
+                else:
                     profile = await run_db(
                         lambda s: s.get(Profile, user_id), sessionmaker=SessionLocal
                     )
-                except AttributeError:
-                    with SessionLocal() as session:
-                        profile = session.get(Profile, user_id)
                 if (
                     profile is not None
                     and profile.icr is not None
@@ -222,11 +222,11 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             session.refresh(entry)
             return entry
 
-        try:
-            entry = await run_db(db_edit, sessionmaker=SessionLocal)
-        except AttributeError:
+        if not hasattr(run_db, "__call__"):
             with SessionLocal() as session:
                 entry = db_edit(session)
+        else:
+            entry = await run_db(db_edit, sessionmaker=SessionLocal)
         if entry is None:
             await message.reply_text("⚠️ Не удалось сохранить запись.")
             return
@@ -322,11 +322,11 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             session.add(entry)
             return bool(commit(session))
 
-        try:
-            ok = await run_db(db_save_pending, sessionmaker=SessionLocal)
-        except AttributeError:
+        if not hasattr(run_db, "__call__"):
             with SessionLocal() as session:
                 ok = db_save_pending(session)
+        else:
+            ok = await run_db(db_save_pending, sessionmaker=SessionLocal)
         if not ok:
             await message.reply_text("⚠️ Не удалось сохранить запись.")
             return
@@ -372,11 +372,11 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 session.add(entry)
                 return bool(commit(session))
 
-            try:
-                ok = await run_db(db_save_quick, sessionmaker=SessionLocal)
-            except AttributeError:
+            if not hasattr(run_db, "__call__"):
                 with SessionLocal() as session:
                     ok = db_save_quick(session)
+            else:
+                ok = await run_db(db_save_quick, sessionmaker=SessionLocal)
             if not ok:
                 await message.reply_text("⚠️ Не удалось сохранить запись.")
                 return

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -15,6 +15,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 import services.api.app.diabetes.handlers.dose_calc as dose_calc
+import services.api.app.diabetes.handlers.gpt_handlers as gpt_handlers
 
 dose_handlers = dose_calc
 
@@ -93,6 +94,11 @@ async def test_entry_without_dose_has_no_unit(
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
+    async def fake_run_db(fn: Any, *args: Any, **kwargs: Any) -> Any:
+        with session_factory() as session:
+            return fn(session)
+
+    monkeypatch.setattr(gpt_handlers, "run_db", fake_run_db)
 
     await dose_calc.freeform_handler(update, context)
 
@@ -149,6 +155,11 @@ async def test_entry_without_sugar_has_placeholder(
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
+    async def fake_run_db(fn: Any, *args: Any, **kwargs: Any) -> Any:
+        with session_factory() as session:
+            return fn(session)
+
+    monkeypatch.setattr(gpt_handlers, "run_db", fake_run_db)
 
     await dose_calc.freeform_handler(update, context)
 

--- a/tests/test_gpt_handlers_db_errors.py
+++ b/tests/test_gpt_handlers_db_errors.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.diabetes.handlers import gpt_handlers
+
+
+class DummyMessage:
+    def __init__(self, text: str | None = None) -> None:
+        self.text = text
+        self.texts: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.texts.append(text)
+        self.kwargs.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_freeform_handler_db_error_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    message = DummyMessage("5")
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={"pending_entry": {}, "pending_fields": ["sugar"]}),
+    )
+
+    async def failing_run_db(*args: Any, **kwargs: Any) -> Any:
+        raise AttributeError("db failure")
+
+    monkeypatch.setattr(gpt_handlers, "run_db", failing_run_db)
+
+    with pytest.raises(AttributeError):
+        await gpt_handlers.freeform_handler(update, context)

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -68,7 +68,9 @@ async def test_freeform_handler_edits_pending_entry_keeps_state(
 
 
 @pytest.mark.asyncio
-async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
+async def test_freeform_handler_adds_sugar_to_photo_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     entry = {
         "telegram_id": 1,
         "event_time": datetime.datetime.now(datetime.timezone.utc),
@@ -98,6 +100,12 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
 
     session_factory = cast(Any, sessionmaker(class_=DummySession))
     handlers.SessionLocal = session_factory
+
+    async def fake_run_db(fn: Any, *args: Any, **kwargs: Any) -> Any:
+        with session_factory() as session:
+            return fn(session)
+
+    monkeypatch.setattr(handlers, "run_db", fake_run_db)
     message = DummyMessage("5,6")
     update = cast(
         Update,


### PR DESCRIPTION
## Summary
- avoid swallowing AttributeError by checking run_db callability before invoking
- add regression test verifying database AttributeErrors bubble up

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check tests/test_handlers_freeform_pending.py tests/test_dose_info_unit.py tests/test_gpt_handlers_db_errors.py services/api/app/diabetes/handlers/gpt_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2e34912f0832abe7b009cb6fe47a2