### PR TITLE
[webapp] load telegram theme module in init script

### DIFF
--- a/services/webapp/public/assets/telegram-theme.js
+++ b/services/webapp/public/assets/telegram-theme.js
@@ -1,0 +1,40 @@
+export const supportsColorMethods = (app) => {
+  const [major = 0, minor = 0] = (app?.version || "0.0")
+    .split(".")
+    .map((n) => parseInt(n, 10));
+  if (app?.platform === "tdesktop") {
+    return major > 4 || (major === 4 && minor >= 8);
+  }
+  return major > 6 || (major === 6 && minor >= 1);
+};
+
+export function applyTheme(src, ignoreScheme = false) {
+  const root = document.documentElement;
+  const p = src?.themeParams ?? {};
+  const map = {
+    "--tg-theme-bg-color": p.bg_color,
+    "--tg-theme-text-color": p.text_color,
+    "--tg-theme-hint-color": p.hint_color,
+    "--tg-theme-link-color": p.link_color,
+    "--tg-theme-button-color": p.button_color,
+    "--tg-theme-button-text-color": p.button_text_color,
+    "--tg-theme-secondary-bg-color": p.secondary_bg_color,
+  };
+  if (ignoreScheme) {
+    Object.keys(map).forEach((k) => root.style.removeProperty(k));
+    root.classList.remove("dark");
+    root.style.colorScheme = "light";
+    if (src && supportsColorMethods(src)) {
+      if (src.setBackgroundColor) src.setBackgroundColor("#ffffff");
+      if (src.setHeaderColor) src.setHeaderColor("#ffffff");
+    }
+    return "light";
+  }
+  Object.entries(map).forEach(([k, v]) => v && root.style.setProperty(k, v));
+  root.style.colorScheme = "";
+  const scheme = src?.colorScheme ?? "light";
+  root.classList.toggle("dark", scheme === "dark");
+  return scheme;
+}
+
+export default applyTheme;

--- a/services/webapp/public/telegram-init.js
+++ b/services/webapp/public/telegram-init.js
@@ -1,9 +1,5 @@
 (async function () {
-    const themeModules = import.meta?.glob?.("./assets/telegram-theme*.js");
-    const mod = themeModules
-        ? await themeModules[Object.keys(themeModules)[0]]()
-        : await import(new URL("./assets/telegram-theme.js", import.meta.url).href);
-    const applyTheme = mod.applyTheme ?? mod.default ?? mod.a;
+    const { applyTheme } = await import("./assets/telegram-theme.js");
     const app = window.Telegram?.WebApp;
     if (!app) {
         return;

--- a/services/webapp/public/timezone.html
+++ b/services/webapp/public/timezone.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
     <title>Часовой пояс</title>
-    <script src="/telegram-init.js"></script>
+    <script type="module" src="/telegram-init.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/services/webapp/ui/index.html
+++ b/services/webapp/ui/index.html
@@ -33,7 +33,7 @@
 
     <!-- Telegram SDK + инициализация темы (не бандлим, грузим отдельным скриптом) -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <script src="/telegram-init.js"></script>
+    <script type="module" src="/telegram-init.js"></script>
 
     <!-- Open Graph / Twitter -->
     <meta property="og:title" content="СахарФото — ассистент для диабетиков" />

--- a/services/webapp/ui/public/assets/telegram-theme.js
+++ b/services/webapp/ui/public/assets/telegram-theme.js
@@ -1,0 +1,40 @@
+export const supportsColorMethods = (app) => {
+  const [major = 0, minor = 0] = (app?.version || "0.0")
+    .split(".")
+    .map((n) => parseInt(n, 10));
+  if (app?.platform === "tdesktop") {
+    return major > 4 || (major === 4 && minor >= 8);
+  }
+  return major > 6 || (major === 6 && minor >= 1);
+};
+
+export function applyTheme(src, ignoreScheme = false) {
+  const root = document.documentElement;
+  const p = src?.themeParams ?? {};
+  const map = {
+    "--tg-theme-bg-color": p.bg_color,
+    "--tg-theme-text-color": p.text_color,
+    "--tg-theme-hint-color": p.hint_color,
+    "--tg-theme-link-color": p.link_color,
+    "--tg-theme-button-color": p.button_color,
+    "--tg-theme-button-text-color": p.button_text_color,
+    "--tg-theme-secondary-bg-color": p.secondary_bg_color,
+  };
+  if (ignoreScheme) {
+    Object.keys(map).forEach((k) => root.style.removeProperty(k));
+    root.classList.remove("dark");
+    root.style.colorScheme = "light";
+    if (src && supportsColorMethods(src)) {
+      if (src.setBackgroundColor) src.setBackgroundColor("#ffffff");
+      if (src.setHeaderColor) src.setHeaderColor("#ffffff");
+    }
+    return "light";
+  }
+  Object.entries(map).forEach(([k, v]) => v && root.style.setProperty(k, v));
+  root.style.colorScheme = "";
+  const scheme = src?.colorScheme ?? "light";
+  root.classList.toggle("dark", scheme === "dark");
+  return scheme;
+}
+
+export default applyTheme;

--- a/services/webapp/ui/public/telegram-init.js
+++ b/services/webapp/ui/public/telegram-init.js
@@ -1,5 +1,5 @@
 (async function () {
-    const { applyTheme } = await import("/src/lib/telegram-theme.ts");
+    const { applyTheme } = await import("./assets/telegram-theme.js");
     const app = window.Telegram?.WebApp;
     if (!app) {
         return;


### PR DESCRIPTION
## Summary
- refactor telegram-init script to import bundled theme directly
- load telegram-init as ES module in UI and timezone pages
- bundle static telegram theme asset

## Testing
- `npm -C services/webapp/ui run build`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a2f4daa0b0832a802b0b8ab814accc