### PR TITLE
[ui] handle missing Telegram user

### DIFF
--- a/services/webapp/ui/src/App.tsx
+++ b/services/webapp/ui/src/App.tsx
@@ -37,12 +37,28 @@ const AppContent = () => {
   }
 
   if (error) {
+    if (error.code === "no-user") {
+      return (
+        <div className="min-h-screen bg-background flex items-center justify-center">
+          <div className="text-center space-y-2">
+            <p className="text-lg font-medium">
+              Не удалось определить пользователя Telegram
+            </p>
+            <p className="text-muted-foreground">
+              Попробуйте открыть приложение из Telegram.
+            </p>
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
         <div className="text-center space-y-2">
           <p className="text-lg font-medium">Что-то пошло не так</p>
           <p className="text-muted-foreground">Попробуйте обновить приложение.</p>
-          <p className="text-sm text-muted-foreground">{error}</p>
+          <p className="text-sm text-muted-foreground">
+            {error.message ?? error.code}
+          </p>
         </div>
       </div>
     );

--- a/services/webapp/ui/src/hooks/useTelegram.ts
+++ b/services/webapp/ui/src/hooks/useTelegram.ts
@@ -50,6 +50,11 @@ interface TelegramWindow extends Window {
   Telegram?: { WebApp?: TelegramWebApp };
 }
 
+interface TelegramError {
+  code: string;
+  message?: string;
+}
+
 export const useTelegram = (
   forceLight: boolean = import.meta.env.VITE_FORCE_LIGHT === "true",
 ) => {
@@ -59,7 +64,7 @@ export const useTelegram = (
   );
   const [isReady, setReady] = useState<boolean>(false);
   const [user, setUser] = useState<TelegramUser | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<TelegramError | null>(null);
   const [colorScheme, setScheme] = useState<Scheme>("light");
   const mainClickRef = useRef<(() => void) | null>(null);
   const backClickRef = useRef<(() => void) | null>(null);
@@ -136,7 +141,7 @@ export const useTelegram = (
             }
           }
           if (cancelled) return;
-          setError("no-user");
+          setError({ code: "no-user" });
         };
         void tryFallback();
       }
@@ -151,7 +156,10 @@ export const useTelegram = (
       };
     } catch (e) {
       console.error("[TG] init error:", e);
-      setError(e instanceof Error ? e.message : String(e));
+      setError({
+        code: "unknown",
+        message: e instanceof Error ? e.message : String(e),
+      });
       setReady(true);
     }
   }, [tg, applyTheme, forceLight]);


### PR DESCRIPTION
## Summary
- use structured error objects in Telegram hook
- show a friendly message when the Telegram user cannot be determined

## Testing
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui run typecheck`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `npx vitest run --environment jsdom` *(fails: window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f4e9a718832aab232a89d71dcbb9