### PR TITLE
[hooks] Simplify tgFetch error handling

### DIFF
--- a/services/webapp/ui/src/hooks/useTelegram.ts
+++ b/services/webapp/ui/src/hooks/useTelegram.ts
@@ -123,13 +123,11 @@ export const useTelegram = (
               const resp = await tgFetch("/api/profile/self", {
                 credentials: "include",
               });
-              if (resp.ok) {
-                const data = await resp.json().catch(() => null);
-                if (data?.id) {
-                  if (cancelled) return;
-                  setUser(data);
-                  return;
-                }
+              const data = await resp.json().catch(() => null);
+              if (data?.id) {
+                if (cancelled) return;
+                setUser(data);
+                return;
               }
             } catch (err) {
               console.warn("[TG] profile fetch failed", err);


### PR DESCRIPTION
## Summary
- simplify Telegram profile fallback by removing redundant response.ok check
- rely on tgFetch to throw on failures

## Testing
- `npx vitest run tests/useTelegram.test.ts`
- `npx vitest run` *(fails: Failed to resolve import "@sdk" ...)*
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a2f4ef24e0832a83d4f7ebb99014d7