### PR TITLE
[ui] Handle missing reminder gracefully

### DIFF
--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ResponseError } from '@sdk/runtime';
 
 const mockRemindersGet = vi.hoisted(() => vi.fn());
 
@@ -9,9 +10,20 @@ vi.mock('@sdk', () => ({
 
 import { getReminder } from './reminders';
 
+afterEach(() => {
+  mockRemindersGet.mockReset();
+});
+
 describe('getReminder', () => {
   it('throws on invalid API response', async () => {
     mockRemindersGet.mockResolvedValueOnce([]);
     await expect(getReminder(1, 1)).rejects.toThrow('Некорректный ответ API');
+  });
+
+  it('returns null on 404 response', async () => {
+    mockRemindersGet.mockRejectedValueOnce(
+      new ResponseError(new Response(null, { status: 404 })),
+    );
+    await expect(getReminder(1, 1)).resolves.toBeNull();
   });
 });

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,5 @@
 import { DefaultApi, instanceOfReminder, type Reminder } from '@sdk';
-import { Configuration } from '@sdk/runtime';
+import { Configuration, ResponseError } from '@sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 
@@ -33,7 +33,7 @@ export async function getReminders(telegramId: number): Promise<Reminder[]> {
 export async function getReminder(
   telegramId: number,
   id: number,
-): Promise<Reminder> {
+): Promise<Reminder | null> {
   try {
     const data = await api.remindersGet({ telegramId, id });
 
@@ -45,6 +45,9 @@ export async function getReminder(
     return data;
   } catch (error) {
     console.error('Failed to fetch reminder:', error);
+    if (error instanceof ResponseError && error.response.status === 404) {
+      return null;
+    }
     if (error instanceof Error) {
       throw error;
     }


### PR DESCRIPTION
## Summary
- return null when reminder lookup responds 404
- test for missing reminder branch

## Testing
- `npm --workspace services/webapp/ui exec vitest run src/api/reminders.api.test.ts`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a2fe558704832a9c19cdd61af39e00