### PR TITLE
[webapp] Validate history items

### DIFF
--- a/services/webapp/ui/src/api/history.api.test.ts
+++ b/services/webapp/ui/src/api/history.api.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const mockTgFetch = vi.hoisted(() => vi.fn());
+
+vi.mock('../lib/tgFetch', () => ({ tgFetch: mockTgFetch }));
+
+import { getHistory } from './history';
+
+afterEach(() => {
+  mockTgFetch.mockReset();
+});
+
+describe('getHistory', () => {
+  it('returns parsed history on valid response', async () => {
+    const history = [
+      { id: '1', date: '2024-01-01', time: '12:00', type: 'meal' },
+    ];
+    mockTgFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(history)),
+    );
+    await expect(getHistory()).resolves.toEqual(history);
+  });
+
+  it('throws on invalid history item', async () => {
+    mockTgFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([{ id: '1', time: '12:00', type: 'meal' }]),
+      ),
+    );
+    await expect(getHistory()).rejects.toThrow(
+      'Некорректная запись истории',
+    );
+  });
+});

--- a/services/webapp/ui/src/api/history.ts
+++ b/services/webapp/ui/src/api/history.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 
@@ -13,14 +14,32 @@ export interface HistoryRecord {
   type: 'measurement' | 'meal' | 'insulin';
 }
 
+const historyRecordSchema = z.object({
+  id: z.string(),
+  date: z.string(),
+  time: z.string(),
+  sugar: z.number().optional(),
+  carbs: z.number().optional(),
+  breadUnits: z.number().optional(),
+  insulin: z.number().optional(),
+  notes: z.string().optional(),
+  type: z.enum(['measurement', 'meal', 'insulin']),
+});
+
 export async function getHistory(): Promise<HistoryRecord[]> {
   try {
     const res = await tgFetch(`${API_BASE}/history`);
     const data = await res.json();
     if (!Array.isArray(data)) {
-      throw new Error('Некорректный ответ');
+      throw new Error('Некорректный ответ API');
     }
-    return data as HistoryRecord[];
+    const parsed = z.array(historyRecordSchema).safeParse(data);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      const path = issue.path.join('.') || 'элемент';
+      throw new Error(`Некорректная запись истории: ${path} ${issue.message}`);
+    }
+    return parsed.data as HistoryRecord[];
   } catch (error) {
     console.error('Failed to fetch history:', error);
     if (error instanceof Error) {


### PR DESCRIPTION
## Summary
- validate each history item using Zod
- add tests for valid and invalid history API responses

## Testing
- `npx vitest run src/api/*.test.ts`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a3080dab50832abb7b8c4d003d7d0d