### PR TITLE
[webapp] add abort support for history fetch

### DIFF
--- a/services/webapp/ui/src/api/history.ts
+++ b/services/webapp/ui/src/api/history.ts
@@ -1,5 +1,5 @@
-import { tgFetch } from '../lib/tgFetch';
-import { API_BASE } from './base';
+import { tgFetch } from "../lib/tgFetch";
+import { API_BASE } from "./base";
 
 export interface HistoryRecord {
   id: string;
@@ -10,61 +10,64 @@ export interface HistoryRecord {
   breadUnits?: number;
   insulin?: number;
   notes?: string;
-  type: 'measurement' | 'meal' | 'insulin';
+  type: "measurement" | "meal" | "insulin";
 }
 
-export async function getHistory(): Promise<HistoryRecord[]> {
+export async function getHistory(
+  signal?: AbortSignal,
+): Promise<HistoryRecord[]> {
   try {
-    const res = await tgFetch(`${API_BASE}/history`);
+    const res = await tgFetch(`${API_BASE}/history`, { signal });
     const data = await res.json();
     if (!Array.isArray(data)) {
-      throw new Error('Некорректный ответ');
+      throw new Error("Некорректный ответ");
     }
     return data as HistoryRecord[];
   } catch (error) {
-    console.error('Failed to fetch history:', error);
+    console.error("Failed to fetch history:", error);
     if (error instanceof Error) {
       throw error;
     }
-    throw new Error('Не удалось загрузить историю');
+    throw new Error("Не удалось загрузить историю");
   }
 }
 
 export async function updateRecord(record: HistoryRecord) {
   try {
     const res = await tgFetch(`${API_BASE}/history`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(record),
     });
     const data = await res.json().catch(() => ({}));
-    if (data.status !== 'ok') {
-      throw new Error(data.detail || 'Не удалось обновить запись');
+    if (data.status !== "ok") {
+      throw new Error(data.detail || "Не удалось обновить запись");
     }
     return data;
   } catch (error) {
-    console.error('Failed to update history record:', error);
+    console.error("Failed to update history record:", error);
     if (error instanceof Error) {
       throw error;
     }
-    throw new Error('Не удалось обновить запись');
+    throw new Error("Не удалось обновить запись");
   }
 }
 
 export async function deleteRecord(id: string) {
   try {
-    const res = await tgFetch(`${API_BASE}/history/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    const res = await tgFetch(`${API_BASE}/history/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    });
     const data = await res.json().catch(() => ({}));
-    if (data.status !== 'ok') {
-      throw new Error(data.detail || 'Не удалось удалить запись');
+    if (data.status !== "ok") {
+      throw new Error(data.detail || "Не удалось удалить запись");
     }
     return data;
   } catch (error) {
-    console.error('Failed to delete history record:', error);
+    console.error("Failed to delete history record:", error);
     if (error instanceof Error) {
       throw error;
     }
-    throw new Error('Не удалось удалить запись');
+    throw new Error("Не удалось удалить запись");
   }
 }
-

--- a/services/webapp/ui/src/pages/History.tsx
+++ b/services/webapp/ui/src/pages/History.tsx
@@ -1,48 +1,53 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Calendar, TrendingUp, Edit2, Trash2, Filter } from 'lucide-react';
-import { MedicalHeader } from '@/components/MedicalHeader';
-import { useToast } from '@/hooks/use-toast';
-import MedicalButton from '@/components/MedicalButton';
-import { getHistory, updateRecord, deleteRecord, HistoryRecord } from '@/api/history';
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Calendar, TrendingUp, Edit2, Trash2, Filter } from "lucide-react";
+import { MedicalHeader } from "@/components/MedicalHeader";
+import { useToast } from "@/hooks/use-toast";
+import MedicalButton from "@/components/MedicalButton";
+import {
+  getHistory,
+  updateRecord,
+  deleteRecord,
+  HistoryRecord,
+} from "@/api/history";
 
 const History = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
 
   const [records, setRecords] = useState<HistoryRecord[]>([]);
-  const [selectedDate, setSelectedDate] = useState('');
-  const [selectedType, setSelectedType] = useState<string>('all');
-  const [editingRecord, setEditingRecord] = useState<HistoryRecord | null>(null);
+  const [selectedDate, setSelectedDate] = useState("");
+  const [selectedType, setSelectedType] = useState<string>("all");
+  const [editingRecord, setEditingRecord] = useState<HistoryRecord | null>(
+    null,
+  );
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
     (async () => {
       try {
-        const data = await getHistory();
-        if (!cancelled) {
-          setRecords(data);
-        }
+        const data = await getHistory(controller.signal);
+        setRecords(data);
       } catch (err) {
-        if (!cancelled) {
+        if (!controller.signal.aborted) {
           const message =
-            err instanceof Error ? err.message : 'Неизвестная ошибка';
+            err instanceof Error ? err.message : "Неизвестная ошибка";
           toast({
-            title: 'Ошибка',
+            title: "Ошибка",
             description: message,
-            variant: 'destructive',
+            variant: "destructive",
           });
         }
       }
     })();
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [toast]);
 
-  const filteredRecords = records.filter(record => {
+  const filteredRecords = records.filter((record) => {
     const dateMatch = !selectedDate || record.date === selectedDate;
-    const typeMatch = selectedType === 'all' || record.type === selectedType;
+    const typeMatch = selectedType === "all" || record.type === selectedType;
     return dateMatch && typeMatch;
   });
 
@@ -54,20 +59,21 @@ const History = () => {
     if (editingRecord) {
       try {
         await updateRecord(editingRecord);
-        setRecords(prev =>
-          prev.map(r => (r.id === editingRecord.id ? editingRecord : r))
+        setRecords((prev) =>
+          prev.map((r) => (r.id === editingRecord.id ? editingRecord : r)),
         );
         setEditingRecord(null);
         toast({
-          title: 'Запись обновлена',
-          description: 'Изменения сохранены',
+          title: "Запись обновлена",
+          description: "Изменения сохранены",
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Неизвестная ошибка';
+        const message =
+          err instanceof Error ? err.message : "Неизвестная ошибка";
         toast({
-          title: 'Ошибка',
+          title: "Ошибка",
           description: message,
-          variant: 'destructive',
+          variant: "destructive",
         });
       }
     }
@@ -75,58 +81,62 @@ const History = () => {
   const handleDeleteRecord = async (id: string) => {
     const prev = [...records];
     // Optimistically remove record from UI
-    setRecords(prevRecords => prevRecords.filter(r => r.id !== id));
+    setRecords((prevRecords) => prevRecords.filter((r) => r.id !== id));
 
     try {
       await deleteRecord(id);
       toast({
-        title: 'Запись удалена',
-        description: 'Запись успешно удалена из истории',
+        title: "Запись удалена",
+        description: "Запись успешно удалена из истории",
       });
     } catch (err) {
       setRecords(prev);
-      const message = err instanceof Error ? err.message : 'Неизвестная ошибка';
+      const message = err instanceof Error ? err.message : "Неизвестная ошибка";
       toast({
-        title: 'Ошибка',
+        title: "Ошибка",
         description: message,
-        variant: 'destructive',
+        variant: "destructive",
       });
     }
   };
 
   const getRecordIcon = (type: string) => {
     switch (type) {
-      case 'measurement': return '🩸';
-      case 'meal': return '🍽️';
-      case 'insulin': return '💉';
-      default: return '📝';
+      case "measurement":
+        return "🩸";
+      case "meal":
+        return "🍽️";
+      case "insulin":
+        return "💉";
+      default:
+        return "📝";
     }
   };
 
   const getRecordColor = (type: string) => {
     switch (type) {
-      case 'measurement': return 'medical-error';
-      case 'meal': return 'medical-success';
-      case 'insulin': return 'medical-blue';
-      default: return 'neutral-500';
+      case "measurement":
+        return "medical-error";
+      case "meal":
+        return "medical-success";
+      case "insulin":
+        return "medical-blue";
+      default:
+        return "neutral-500";
     }
   };
 
   const getSugarColor = (sugar: number) => {
-    if (sugar < 4) return 'text-medical-error';
-    if (sugar > 10) return 'text-medical-warning';
-    if (sugar >= 4 && sugar <= 7) return 'text-medical-success';
-    return 'text-medical-teal';
+    if (sugar < 4) return "text-medical-error";
+    if (sugar > 10) return "text-medical-warning";
+    if (sugar >= 4 && sugar <= 7) return "text-medical-success";
+    return "text-medical-teal";
   };
 
   return (
     <div className="min-h-screen bg-background">
-      <MedicalHeader 
-        title="История" 
-        showBack 
-        onBack={() => navigate('/')}
-      />
-      
+      <MedicalHeader title="История" showBack onBack={() => navigate("/")} />
+
       <main className="container mx-auto px-4 py-6">
         {/* Фильтры */}
         <div className="medical-card mb-6">
@@ -134,7 +144,7 @@ const History = () => {
             <Filter className="w-4 h-4 text-muted-foreground" />
             <span className="font-medium text-foreground">Фильтры</span>
           </div>
-          
+
           <div className="grid grid-cols-2 gap-4">
             <div>
               <label
@@ -201,92 +211,119 @@ const History = () => {
                 style={{ animationDelay: `${index * 50}ms` }}
               >
                 <div className="flex items-start gap-3">
-                  <div className={`w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0 ${
-                    color === 'medical-error' ? 'bg-medical-error/10' :
-                    color === 'medical-success' ? 'bg-medical-success/10' :
-                    color === 'medical-blue' ? 'bg-medical-blue/10' :
-                    'bg-neutral-500/10'
-                  }`}>
-                    <span className="text-lg">{getRecordIcon(record.type)}</span>
+                  <div
+                    className={`w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0 ${
+                      color === "medical-error"
+                        ? "bg-medical-error/10"
+                        : color === "medical-success"
+                          ? "bg-medical-success/10"
+                          : color === "medical-blue"
+                            ? "bg-medical-blue/10"
+                            : "bg-neutral-500/10"
+                    }`}
+                  >
+                    <span className="text-lg">
+                      {getRecordIcon(record.type)}
+                    </span>
                   </div>
 
                   <div className="flex-1 min-w-0">
-                  <div className="flex items-center justify-between mb-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm text-muted-foreground">
-                        {new Date(record.date).toLocaleDateString('ru-RU')}
-                      </span>
-                      <span className="text-sm font-medium">{record.time}</span>
-                    </div>
-                    
-                    <div className="flex items-center gap-2">
-                      <MedicalButton
-                        size="icon"
-                        onClick={() => handleEditRecord(record)}
-                        className="bg-transparent hover:bg-secondary text-muted-foreground border-0 p-1"
-                        aria-label="Редактировать"
-                      >
-                        <Edit2 className="w-3 h-3" />
-                      </MedicalButton>
-                      <MedicalButton
-                        size="icon"
-                        onClick={() => handleDeleteRecord(record.id)}
-                        className="bg-transparent hover:bg-destructive/10 hover:text-destructive text-muted-foreground border-0 p-1"
-                        aria-label="Удалить"
-                      >
-                        <Trash2 className="w-3 h-3" />
-                      </MedicalButton>
-                    </div>
-                  </div>
+                    <div className="flex items-center justify-between mb-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm text-muted-foreground">
+                          {new Date(record.date).toLocaleDateString("ru-RU")}
+                        </span>
+                        <span className="text-sm font-medium">
+                          {record.time}
+                        </span>
+                      </div>
 
-                  <div className="grid grid-cols-4 gap-4 text-sm mb-2">
-                    {record.sugar !== undefined && (
-                      <div>
-                        <div className={`font-semibold ${getSugarColor(record.sugar)}`}>
-                          {record.sugar}
+                      <div className="flex items-center gap-2">
+                        <MedicalButton
+                          size="icon"
+                          onClick={() => handleEditRecord(record)}
+                          className="bg-transparent hover:bg-secondary text-muted-foreground border-0 p-1"
+                          aria-label="Редактировать"
+                        >
+                          <Edit2 className="w-3 h-3" />
+                        </MedicalButton>
+                        <MedicalButton
+                          size="icon"
+                          onClick={() => handleDeleteRecord(record.id)}
+                          className="bg-transparent hover:bg-destructive/10 hover:text-destructive text-muted-foreground border-0 p-1"
+                          aria-label="Удалить"
+                        >
+                          <Trash2 className="w-3 h-3" />
+                        </MedicalButton>
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-4 gap-4 text-sm mb-2">
+                      {record.sugar !== undefined && (
+                        <div>
+                          <div
+                            className={`font-semibold ${getSugarColor(record.sugar)}`}
+                          >
+                            {record.sugar}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            ммоль/л
+                          </div>
                         </div>
-                        <div className="text-xs text-muted-foreground">ммоль/л</div>
-                      </div>
-                    )}
+                      )}
 
-                    {record.carbs !== undefined && (
-                      <div>
-                        <div className="font-semibold text-foreground">{record.carbs}</div>
-                        <div className="text-xs text-muted-foreground">г углев.</div>
-                      </div>
-                    )}
+                      {record.carbs !== undefined && (
+                        <div>
+                          <div className="font-semibold text-foreground">
+                            {record.carbs}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            г углев.
+                          </div>
+                        </div>
+                      )}
 
-                    {record.breadUnits !== undefined && (
-                      <div>
-                        <div className="font-semibold text-foreground">{record.breadUnits}</div>
-                        <div className="text-xs text-muted-foreground">ХЕ</div>
-                      </div>
-                    )}
+                      {record.breadUnits !== undefined && (
+                        <div>
+                          <div className="font-semibold text-foreground">
+                            {record.breadUnits}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            ХЕ
+                          </div>
+                        </div>
+                      )}
 
-                    {record.insulin !== undefined && (
-                      <div>
-                        <div className="font-semibold text-medical-blue">{record.insulin}</div>
-                        <div className="text-xs text-muted-foreground">ед.</div>
-                      </div>
+                      {record.insulin !== undefined && (
+                        <div>
+                          <div className="font-semibold text-medical-blue">
+                            {record.insulin}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            ед.
+                          </div>
+                        </div>
+                      )}
+                    </div>
+
+                    {record.notes && (
+                      <p className="text-sm text-muted-foreground truncate">
+                        {record.notes}
+                      </p>
                     )}
                   </div>
-                  
-                  {record.notes && (
-                    <p className="text-sm text-muted-foreground truncate">
-                      {record.notes}
-                    </p>
-                  )}
                 </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
         </div>
 
         {/* Форма редактирования */}
         {editingRecord && (
           <div className="medical-card animate-scale-in mt-6">
-            <h3 className="font-semibold text-foreground mb-4">Редактирование записи</h3>
+            <h3 className="font-semibold text-foreground mb-4">
+              Редактирование записи
+            </h3>
 
             <div className="space-y-4">
               <div>
@@ -296,9 +333,9 @@ const History = () => {
                 <input
                   type="date"
                   value={editingRecord.date}
-                  onChange={e =>
-                    setEditingRecord(prev =>
-                      prev ? { ...prev, date: e.target.value } : prev
+                  onChange={(e) =>
+                    setEditingRecord((prev) =>
+                      prev ? { ...prev, date: e.target.value } : prev,
                     )
                   }
                   className="medical-input"
@@ -312,9 +349,9 @@ const History = () => {
                 <input
                   type="time"
                   value={editingRecord.time}
-                  onChange={e =>
-                    setEditingRecord(prev =>
-                      prev ? { ...prev, time: e.target.value } : prev
+                  onChange={(e) =>
+                    setEditingRecord((prev) =>
+                      prev ? { ...prev, time: e.target.value } : prev,
                     )
                   }
                   className="medical-input"
@@ -328,15 +365,17 @@ const History = () => {
                 <input
                   type="number"
                   step="0.1"
-                  value={editingRecord.sugar ?? ''}
-                  onChange={e =>
-                    setEditingRecord(prev =>
+                  value={editingRecord.sugar ?? ""}
+                  onChange={(e) =>
+                    setEditingRecord((prev) =>
                       prev
                         ? {
                             ...prev,
-                            sugar: e.target.value ? Number(e.target.value) : undefined,
+                            sugar: e.target.value
+                              ? Number(e.target.value)
+                              : undefined,
                           }
-                        : prev
+                        : prev,
                     )
                   }
                   className="medical-input"
@@ -349,15 +388,17 @@ const History = () => {
                 </label>
                 <input
                   type="number"
-                  value={editingRecord.carbs ?? ''}
-                  onChange={e =>
-                    setEditingRecord(prev =>
+                  value={editingRecord.carbs ?? ""}
+                  onChange={(e) =>
+                    setEditingRecord((prev) =>
                       prev
                         ? {
                             ...prev,
-                            carbs: e.target.value ? Number(e.target.value) : undefined,
+                            carbs: e.target.value
+                              ? Number(e.target.value)
+                              : undefined,
                           }
-                        : prev
+                        : prev,
                     )
                   }
                   className="medical-input"
@@ -370,15 +411,17 @@ const History = () => {
                 </label>
                 <input
                   type="number"
-                  value={editingRecord.breadUnits ?? ''}
-                  onChange={e =>
-                    setEditingRecord(prev =>
+                  value={editingRecord.breadUnits ?? ""}
+                  onChange={(e) =>
+                    setEditingRecord((prev) =>
                       prev
                         ? {
                             ...prev,
-                            breadUnits: e.target.value ? Number(e.target.value) : undefined,
+                            breadUnits: e.target.value
+                              ? Number(e.target.value)
+                              : undefined,
                           }
-                        : prev
+                        : prev,
                     )
                   }
                   className="medical-input"
@@ -391,15 +434,17 @@ const History = () => {
                 </label>
                 <input
                   type="number"
-                  value={editingRecord.insulin ?? ''}
-                  onChange={e =>
-                    setEditingRecord(prev =>
+                  value={editingRecord.insulin ?? ""}
+                  onChange={(e) =>
+                    setEditingRecord((prev) =>
                       prev
                         ? {
                             ...prev,
-                            insulin: e.target.value ? Number(e.target.value) : undefined,
+                            insulin: e.target.value
+                              ? Number(e.target.value)
+                              : undefined,
                           }
-                        : prev
+                        : prev,
                     )
                   }
                   className="medical-input"
@@ -412,10 +457,10 @@ const History = () => {
                 </label>
                 <input
                   type="text"
-                  value={editingRecord.notes ?? ''}
-                  onChange={e =>
-                    setEditingRecord(prev =>
-                      prev ? { ...prev, notes: e.target.value } : prev
+                  value={editingRecord.notes ?? ""}
+                  onChange={(e) =>
+                    setEditingRecord((prev) =>
+                      prev ? { ...prev, notes: e.target.value } : prev,
                     )
                   }
                   className="medical-input"
@@ -462,7 +507,7 @@ const History = () => {
         {/* Кнопка аналитики */}
         <div className="mt-8">
           <MedicalButton
-            onClick={() => navigate('/analytics')}
+            onClick={() => navigate("/analytics")}
             className="w-full flex items-center justify-center gap-2"
             size="lg"
           >


### PR DESCRIPTION
## Summary
- allow passing AbortSignal to history API requests
- use AbortController in History page to cancel in-flight history loading

## Testing
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui run typecheck`
- `mypy --strict services/api/app/diabetes/utils/functions.py`
- `ruff check .`
- `pytest tests/test_webapp_history.py -q` *(fails: Coverage failure: total of 7 is less than fail-under=74)*
- `npm --workspace services/webapp/ui exec vitest run` *(fails: Cannot find package 'react-test-renderer', ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a308098b74832ab100e0f5228a2f9f