### PR TITLE
[telegram_auth] enforce init data length

### DIFF
--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -29,6 +29,8 @@ def parse_and_verify_init_data(init_data: str, token: str) -> dict[str, Any]:
     token:
         Bot token used to compute the validation hash.
     """
+    if len(init_data) > 1024:
+        raise HTTPException(status_code=413, detail="init data too long")
     try:
         params: dict[str, Any] = dict(parse_qsl(init_data, strict_parsing=True))
     except ValueError as exc:

--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -67,6 +67,14 @@ def test_parse_and_verify_init_data_invalid_user_json() -> None:
     assert exc.value.detail == "invalid user data"
 
 
+def test_parse_and_verify_init_data_too_long() -> None:
+    init_data = "a" * 1025
+    with pytest.raises(HTTPException) as exc:
+        parse_and_verify_init_data(init_data, TOKEN)
+    assert exc.value.status_code == 413
+    assert exc.value.detail == "init data too long"
+
+
 def test_require_tg_user_valid(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     init_data: str = build_init_data()


### PR DESCRIPTION
## Summary
- reject `init_data` strings longer than 1024 characters
- test oversized `init_data` is rejected

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a307f8c7e0832a95b7f57893805509