### PR TITLE
[utils] Trim trailing slash in webapp URLs

### DIFF
--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -26,19 +26,21 @@ __all__ = (
 )
 
 # ─────────────── Reply-клавиатуры (отображаются на экране чата) ───────────────
+_WEBAPP_URL = settings.webapp_url.rstrip("/") if settings.webapp_url else None
+
 # Create WebApp buttons when WebApp is configured, fall back to text buttons otherwise
 profile_button = (
     KeyboardButton(
-        "📄 Мой профиль", web_app=WebAppInfo(f"{settings.webapp_url}/ui/profile")
+        "📄 Мой профиль", web_app=WebAppInfo(f"{_WEBAPP_URL}/ui/profile")
     )
-    if settings.webapp_url
+    if _WEBAPP_URL
     else KeyboardButton("📄 Мой профиль")
 )
 reminders_button = (
     KeyboardButton(
-        "⏰ Напоминания", web_app=WebAppInfo(f"{settings.webapp_url}/ui/reminders")
+        "⏰ Напоминания", web_app=WebAppInfo(f"{_WEBAPP_URL}/ui/reminders")
     )
-    if settings.webapp_url
+    if _WEBAPP_URL
     else KeyboardButton("⏰ Напоминания")
 )
 
@@ -117,10 +119,10 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
         Button instance when ``WEBAPP_URL`` is set and valid, otherwise ``None``.
     """
 
-    if not settings.webapp_url:
+    if not _WEBAPP_URL:
         return None
 
     return InlineKeyboardButton(
         "Определить автоматически",
-        web_app=WebAppInfo(f"{settings.webapp_url}/ui/timezone"),
+        web_app=WebAppInfo(f"{_WEBAPP_URL}/ui/timezone"),
     )

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -1,12 +1,18 @@
-import pytest
-
 import importlib
 from urllib.parse import urlparse
 
+import pytest
 
-def test_menu_keyboard_webapp_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+
+@pytest.mark.parametrize(
+    "base_url",
+    ["https://example.com", "https://example.com/"],
+)
+def test_menu_keyboard_webapp_urls(
+    monkeypatch: pytest.MonkeyPatch, base_url: str
+) -> None:
     """Menu buttons should open webapp paths for profile and reminders."""
-    monkeypatch.setenv("WEBAPP_URL", "https://example.com")
+    monkeypatch.setenv("WEBAPP_URL", base_url)
 
     import services.api.app.config as config
     import services.api.app.diabetes.utils.ui as ui


### PR DESCRIPTION
## Summary
- ensure menu buttons strip trailing slashes from `WEBAPP_URL`
- test menu buttons with and without trailing slash

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a30d9eeac4832aaced0709482ab7af