### PR TITLE
[utils] close httpx client for OpenAI

### DIFF
--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -21,11 +21,15 @@ def get_openai_client() -> OpenAI:
         logger.error("[OpenAI] %s", message)
         raise RuntimeError(message)
 
-    http_client: httpx.Client | None = None
+    client: OpenAI
     if settings.openai_proxy:
-        http_client = httpx.Client(proxies=settings.openai_proxy)
+        with httpx.Client(proxies=settings.openai_proxy) as http_client:
+            client = OpenAI(
+                api_key=settings.openai_api_key, http_client=http_client
+            )
+    else:
+        client = OpenAI(api_key=settings.openai_api_key, http_client=None)
 
-    client = OpenAI(api_key=settings.openai_api_key, http_client=http_client)
     if settings.openai_assistant_id:
         logger.info("[OpenAI] Using assistant: %s", settings.openai_assistant_id)
     return client


### PR DESCRIPTION
## Summary
- wrap proxy httpx client in context manager when configuring OpenAI
- adjust tests for proxied OpenAI client creation

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a30d890524832ab5379599f9860478