### PR TITLE
[utils] manage httpx client lifecycle

### DIFF
--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -9,6 +9,7 @@ from services.api.app.diabetes.utils import openai_utils
 
 
 def test_get_openai_client_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(openai_utils, "_http_client", None)
     monkeypatch.setattr(settings, "openai_api_key", "")
     with pytest.raises(RuntimeError):
         openai_utils.get_openai_client()
@@ -16,13 +17,10 @@ def test_get_openai_client_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> 
 
 def test_get_openai_client_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_http_client = Mock()
-    http_client_cm = Mock(
-        __enter__=Mock(return_value=fake_http_client),
-        __exit__=Mock(return_value=None),
-    )
-    http_client_mock = Mock(return_value=http_client_cm)
+    http_client_mock = Mock(return_value=fake_http_client)
     openai_mock = Mock()
 
+    monkeypatch.setattr(openai_utils, "_http_client", None)
     monkeypatch.setattr(settings, "openai_api_key", "key")
     monkeypatch.setattr(settings, "openai_proxy", "http://proxy")
     monkeypatch.setattr(httpx, "Client", http_client_mock)
@@ -31,19 +29,23 @@ def test_get_openai_client_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     client = openai_utils.get_openai_client()
 
     http_client_mock.assert_called_once_with(proxies="http://proxy")
-    http_client_cm.__enter__.assert_called_once()
-    http_client_cm.__exit__.assert_called_once()
+    fake_http_client.close.assert_not_called()
     openai_mock.assert_called_once_with(api_key="key", http_client=fake_http_client)
     assert client is openai_mock.return_value
+
+    openai_utils.dispose_http_client()
+    fake_http_client.close.assert_called_once()
 
 
 def test_get_openai_client_logs_assistant(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     openai_mock = Mock()
+    monkeypatch.setattr(openai_utils, "_http_client", None)
     monkeypatch.setattr(openai_utils, "OpenAI", openai_mock)
     monkeypatch.setattr(settings, "openai_api_key", "key")
     monkeypatch.setattr(settings, "openai_assistant_id", "assistant")
+    monkeypatch.setattr(settings, "openai_proxy", None)
 
     with caplog.at_level(logging.INFO):
         openai_utils.get_openai_client()
@@ -51,12 +53,13 @@ def test_get_openai_client_logs_assistant(
     assert any("Using assistant: assistant" in r.message for r in caplog.records)
 
 
-
 def test_get_openai_client_without_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     openai_mock = Mock()
+    http_client_mock = Mock()
+
+    monkeypatch.setattr(openai_utils, "_http_client", None)
     monkeypatch.setattr(openai_utils, "OpenAI", openai_mock)
     monkeypatch.setattr(settings, "openai_api_key", "key")
-    http_client_mock = Mock()
     monkeypatch.setattr(settings, "openai_proxy", None)
     monkeypatch.setattr(httpx, "Client", http_client_mock)
 


### PR DESCRIPTION
## Summary
- keep OpenAI httpx client open until explicit disposal
- cover OpenAI client lifecycle with unit tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a312b9e054832a935ae0a92c7a4f00