### PR TITLE
[handlers] refactor callback routing

### DIFF
--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import logging
-from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ForceReply
+from telegram import (
+    Update,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    ForceReply,
+    CallbackQuery,
+)
 from telegram.ext import ContextTypes
-from typing import cast
+from typing import Awaitable, Callable, cast
 
 from services.api.app.diabetes.services.db import Entry, SessionLocal
 from services.api.app.diabetes.utils.ui import menu_keyboard
@@ -12,6 +18,179 @@ from services.api.app.diabetes.services.repository import commit
 from . import UserData
 
 logger = logging.getLogger(__name__)
+
+
+Handler = Callable[
+    [Update, ContextTypes.DEFAULT_TYPE, CallbackQuery, str], Awaitable[None]
+]
+
+
+async def handle_confirm_entry(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, query: CallbackQuery, _: str
+) -> None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        return
+    user_data = cast(UserData, user_data_raw)
+    entry_data = user_data.pop("pending_entry", None)
+    if not entry_data:
+        await query.edit_message_text("❗ Нет данных для сохранения.")
+        return
+    with SessionLocal() as session:
+        entry = Entry(**entry_data)
+        session.add(entry)
+        if not commit(session):
+            await query.edit_message_text("⚠️ Не удалось сохранить запись.")
+            return
+    sugar = entry_data.get("sugar_before")
+    if sugar is not None:
+        from .alert_handlers import check_alert
+
+        await check_alert(update, context, sugar)
+    await query.edit_message_text("✅ Запись сохранена в дневник!")
+    from . import reminder_handlers
+
+    job_queue = getattr(context, "job_queue", None)
+    if job_queue:
+        user = update.effective_user
+        if user is None:
+            return
+        reminder_handlers.schedule_after_meal(user.id, job_queue)
+
+
+async def handle_edit_entry(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, query: CallbackQuery, _: str
+) -> None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        return
+    user_data = cast(UserData, user_data_raw)
+    entry_data = user_data.get("pending_entry")
+    if not entry_data:
+        await query.edit_message_text("❗ Нет данных для редактирования.")
+        return
+    user_data["edit_id"] = None
+    await query.edit_message_text(
+        "Отправьте новое сообщение в формате:\n"
+        "`сахар=<ммоль/л>  xe=<ХЕ>  carbs=<г>  dose=<ед>`\n"
+        "Можно указывать не все поля (что прописано — то и поменяется).",
+        parse_mode="Markdown",
+    )
+
+
+async def handle_cancel_entry(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, query: CallbackQuery, _: str
+) -> None:
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        return
+    user_data = cast(UserData, user_data_raw)
+    user_data.pop("pending_entry", None)
+    await query.edit_message_text("❌ Запись отменена.")
+    message = query.message
+    if message is None:
+        return
+    await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
+
+
+async def handle_edit_or_delete(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, query: CallbackQuery, data: str
+) -> None:
+    action, entry_id_str = data.split(":", 1)
+    try:
+        entry_id = int(entry_id_str)
+    except ValueError:
+        logger.warning("Invalid entry_id in callback data: %s", entry_id_str)
+        await query.edit_message_text("Некорректный идентификатор записи.")
+        return
+    with SessionLocal() as session:
+        existing_entry: Entry | None = session.get(Entry, entry_id)
+        if existing_entry is None:
+            await query.edit_message_text("Запись не найдена (уже удалена).")
+            return
+        user = update.effective_user
+        if user is None:
+            return
+        if existing_entry.telegram_id != user.id:
+            await query.edit_message_text(
+                "⚠️ Эта запись принадлежит другому пользователю."
+            )
+            return
+        if action == "del":
+            session.delete(existing_entry)
+            if not commit(session):
+                await query.edit_message_text("⚠️ Не удалось удалить запись.")
+                return
+            await query.edit_message_text("❌ Запись удалена.")
+            return
+    if action != "edit":
+        return
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        return
+    user_data = cast(UserData, user_data_raw)
+    message = query.message
+    if message is None:
+        return
+    user_data["edit_entry"] = {
+        "id": entry_id,
+        "chat_id": message.chat_id,
+        "message_id": message.message_id,
+    }
+    keyboard = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    "сахар", callback_data=f"edit_field:{entry_id}:sugar"
+                )
+            ],
+            [InlineKeyboardButton("xe", callback_data=f"edit_field:{entry_id}:xe")],
+            [
+                InlineKeyboardButton(
+                    "dose", callback_data=f"edit_field:{entry_id}:dose"
+                )
+            ],
+        ]
+    )
+    await query.edit_message_reply_markup(reply_markup=keyboard)
+
+
+async def handle_edit_field(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, query: CallbackQuery, data: str
+) -> None:
+    try:
+        _, entry_id_str, field = data.split(":")
+        edit_entry_id = int(entry_id_str)
+    except ValueError:
+        logger.warning("Invalid edit_field data: %s", data)
+        await query.edit_message_text("Некорректные данные для редактирования.")
+        return
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        return
+    user_data = cast(UserData, user_data_raw)
+    user_data["edit_id"] = edit_entry_id
+    user_data["edit_field"] = field
+    user_data["edit_query"] = query
+    prompt = {
+        "sugar": "Введите уровень сахара (ммоль/л).",
+        "xe": "Введите количество ХЕ.",
+        "dose": "Введите дозу инсулина (ед.).",
+    }.get(field, "Введите значение")
+    message = query.message
+    if message is None:
+        return
+    await message.reply_text(prompt, reply_markup=ForceReply(selective=True))
+
+
+callback_handlers: dict[str, Handler] = {
+    "confirm_entry": handle_confirm_entry,
+    "edit_entry": handle_edit_entry,
+    "cancel_entry": handle_cancel_entry,
+    "edit_field:": handle_edit_field,
+    "edit:": handle_edit_or_delete,
+    "del:": handle_edit_or_delete,
+}
 
 
 async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -25,153 +204,11 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     if data.startswith("rem_"):
         return
 
-    if data == "confirm_entry":
-        user_data_raw = context.user_data
-        if user_data_raw is None:
+    for key, handler in callback_handlers.items():
+        if data == key or data.startswith(key):
+            await handler(update, context, query, data)
             return
-        user_data = cast(UserData, user_data_raw)
-        entry_data = user_data.pop("pending_entry", None)
-        if not entry_data:
-            await query.edit_message_text("❗ Нет данных для сохранения.")
-            return
-        with SessionLocal() as session:
-            entry = Entry(**entry_data)
-            session.add(entry)
-            if not commit(session):
-                await query.edit_message_text("⚠️ Не удалось сохранить запись.")
-                return
-        sugar = entry_data.get("sugar_before")
-        if sugar is not None:
-            from .alert_handlers import check_alert
-            await check_alert(update, context, sugar)
-        await query.edit_message_text("✅ Запись сохранена в дневник!")
-        from . import reminder_handlers
 
-        job_queue = getattr(context, "job_queue", None)
-        if job_queue:
-            user = update.effective_user
-            if user is None:
-                return
-            reminder_handlers.schedule_after_meal(user.id, job_queue)
-        return
-    elif data == "edit_entry":
-        user_data_raw = context.user_data
-        if user_data_raw is None:
-            return
-        user_data = cast(UserData, user_data_raw)
-        entry_data = user_data.get("pending_entry")
-        if not entry_data:
-            await query.edit_message_text("❗ Нет данных для редактирования.")
-            return
-        user_data["edit_id"] = None
-        await query.edit_message_text(
-            "Отправьте новое сообщение в формате:\n"
-            "`сахар=<ммоль/л>  xe=<ХЕ>  carbs=<г>  dose=<ед>`\n"
-            "Можно указывать не все поля (что прописано — то и поменяется).",
-            parse_mode="Markdown",
-        )
-        return
-    elif data == "cancel_entry":
-        user_data_raw = context.user_data
-        if user_data_raw is None:
-            return
-        user_data = cast(UserData, user_data_raw)
-        user_data.pop("pending_entry", None)
-        await query.edit_message_text("❌ Запись отменена.")
-        message = query.message
-        if message is None:
-            return
-        await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
-        return
-    elif data.startswith("edit:") or data.startswith("del:"):
-        action, entry_id_str = data.split(":", 1)
-        try:
-            entry_id = int(entry_id_str)
-        except ValueError:
-            logger.warning("Invalid entry_id in callback data: %s", entry_id_str)
-            await query.edit_message_text("Некорректный идентификатор записи.")
-            return
-        with SessionLocal() as session:
-            existing_entry: Entry | None = session.get(Entry, entry_id)
-            if existing_entry is None:
-                await query.edit_message_text("Запись не найдена (уже удалена).")
-                return
-            user = update.effective_user
-            if user is None:
-                return
-            if existing_entry.telegram_id != user.id:
-                await query.edit_message_text(
-                    "⚠️ Эта запись принадлежит другому пользователю."
-                )
-                return
-            if action == "del":
-                session.delete(existing_entry)
-                if not commit(session):
-                    await query.edit_message_text("⚠️ Не удалось удалить запись.")
-                    return
-                await query.edit_message_text("❌ Запись удалена.")
-                return
-            if action == "edit":
-                user_data_raw = context.user_data
-                if user_data_raw is None:
-                    return
-                user_data = cast(UserData, user_data_raw)
-                message = query.message
-                if message is None:
-                    return
-                user_data["edit_entry"] = {
-                    "id": existing_entry.id,
-                    "chat_id": message.chat_id,
-                    "message_id": message.message_id,
-                }
-                keyboard = InlineKeyboardMarkup(
-                    [
-                        [
-                            InlineKeyboardButton(
-                                "сахар",
-                                callback_data=f"edit_field:{existing_entry.id}:sugar",
-                            )
-                        ],
-                        [
-                            InlineKeyboardButton(
-                                "xe", callback_data=f"edit_field:{existing_entry.id}:xe"
-                            )
-                        ],
-                        [
-                            InlineKeyboardButton(
-                                "dose", callback_data=f"edit_field:{existing_entry.id}:dose"
-                            )
-                        ],
-                    ]
-                )
-                await query.edit_message_reply_markup(reply_markup=keyboard)
-                return
-    elif data.startswith("edit_field:"):
-        try:
-            _, entry_id_str, field = data.split(":")
-            edit_entry_id = int(entry_id_str)
-        except ValueError:
-            logger.warning("Invalid edit_field data: %s", data)
-            await query.edit_message_text("Некорректные данные для редактирования.")
-            return
-        user_data_raw = context.user_data
-        if user_data_raw is None:
-            return
-        user_data = cast(UserData, user_data_raw)
-        user_data["edit_id"] = edit_entry_id
-        user_data["edit_field"] = field
-        user_data["edit_query"] = query
-        prompt = {
-            "sugar": "Введите уровень сахара (ммоль/л).",
-            "xe": "Введите количество ХЕ.",
-            "dose": "Введите дозу инсулина (ед.).",
-        }.get(field, "Введите значение")
-        message = query.message
-        if message is None:
-            return
-        await message.reply_text(prompt, reply_markup=ForceReply(selective=True))
-        return
-    else:
-        logger.warning("Unrecognized callback data: %s", data)
-        await query.edit_message_text("Команда не распознана")
+    logger.warning("Unrecognized callback data: %s", data)
+    await query.edit_message_text("Команда не распознана")
 

--- a/tests/test_router_mapping.py
+++ b/tests/test_router_mapping.py
@@ -1,0 +1,50 @@
+import os
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+
+class DummyQuery:
+    def __init__(self, data: str) -> None:
+        self.data = data
+        self.answered = False
+        self.called: list[tuple[str, dict[str, Any]]] = []
+
+    async def answer(self) -> None:  # pragma: no cover - trivial
+        self.answered = True
+
+    async def edit_message_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover
+        self.called.append((text, kwargs))
+
+
+@pytest.mark.asyncio
+async def test_callback_router_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
+    import services.api.app.diabetes.handlers.router as router
+
+    called: list[str] = []
+
+    async def fake_handler(
+        update: Update,
+        context: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        query: DummyQuery,
+        data: str,
+    ) -> None:
+        called.append(data)
+
+    monkeypatch.setitem(router.callback_handlers, "confirm_entry", fake_handler)
+    query = DummyQuery("confirm_entry")
+    update = cast(Update, SimpleNamespace(callback_query=query))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
+    )
+
+    await router.callback_router(update, context)
+
+    assert called == ["confirm_entry"]


### PR DESCRIPTION
## Summary
- refactor callback router by introducing explicit handlers and a dispatch map
- cover routing map dispatch in tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a312e4e4ec832ab40836d4d1f183c5