### PR TITLE
[api] use HTTPException for reminder save

### DIFF
--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List
 
-from sqlalchemy.exc import SQLAlchemyError
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from ..diabetes.services.db import Reminder, SessionLocal, run_db
@@ -21,7 +21,7 @@ async def save_reminder(data: ReminderSchema) -> int:
         if data.id is not None:
             rem = session.get(Reminder, data.id)
             if rem is None or rem.telegram_id != data.telegram_id:
-                raise SQLAlchemyError("not found")
+                raise HTTPException(status_code=404, detail="reminder not found")
         else:
             rem = Reminder(telegram_id=data.telegram_id)
             session.add(rem)

--- a/tests/test_services_reminders.py
+++ b/tests/test_services_reminders.py
@@ -2,7 +2,7 @@ import pytest
 from collections.abc import Generator
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.exc import SQLAlchemyError
+from fastapi import HTTPException
 
 from services.api.app.diabetes.services.db import Base, User, Reminder
 from services.api.app.schemas.reminders import ReminderSchema
@@ -70,5 +70,5 @@ async def test_save_reminder_not_found_or_wrong_user(
         session.commit()
 
     schema = ReminderSchema(id=rem_id, telegram_id=telegram_id, type="sugar")
-    with pytest.raises(SQLAlchemyError):
+    with pytest.raises(HTTPException):
         await reminders.save_reminder(schema)


### PR DESCRIPTION
## Summary
- raise HTTPException when saving a reminder fails because it was not found
- adjust tests for HTTPException

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a31a55fd88832ab4618559c4ef6bee