### PR TITLE
[services] use commit helper in reminders service

### DIFF
--- a/tests/test_services_reminders.py
+++ b/tests/test_services_reminders.py
@@ -1,8 +1,9 @@
-import pytest
 from collections.abc import Generator
+
+import pytest
+from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.exc import SQLAlchemyError
 
 from services.api.app.diabetes.services.db import Base, User, Reminder
 from services.api.app.schemas.reminders import ReminderSchema
@@ -70,5 +71,6 @@ async def test_save_reminder_not_found_or_wrong_user(
         session.commit()
 
     schema = ReminderSchema(id=rem_id, telegram_id=telegram_id, type="sugar")
-    with pytest.raises(SQLAlchemyError):
+    with pytest.raises(HTTPException) as exc:
         await reminders.save_reminder(schema)
+    assert exc.value.status_code == 404


### PR DESCRIPTION
## Summary
- replace SQLAlchemyError usage in reminders service with HTTPException
- rely on repository commit helper and handle commit failures
- adjust reminder service tests for new exception

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a31a4a4308832a8a6f6df7a33e724a