### PR TITLE
[webapp] Handle aborted reminders fetch

### DIFF
--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -8,7 +8,7 @@ vi.mock('@sdk', () => ({
   instanceOfReminder: vi.fn(),
 }));
 
-import { getReminder } from './reminders';
+import { getReminder, getReminders } from './reminders';
 
 afterEach(() => {
   mockRemindersGet.mockReset();
@@ -25,5 +25,24 @@ describe('getReminder', () => {
       new ResponseError(new Response(null, { status: 404 })),
     );
     await expect(getReminder(1, 1)).resolves.toBeNull();
+  });
+});
+
+describe('getReminders', () => {
+  it('passes signal to API', async () => {
+    const controller = new AbortController();
+    mockRemindersGet.mockResolvedValueOnce([]);
+    await getReminders(1, controller.signal);
+    expect(mockRemindersGet).toHaveBeenCalledWith(
+      { telegramId: 1 },
+      { signal: controller.signal },
+    );
+  });
+
+  it('rethrows AbortError', async () => {
+    const controller = new AbortController();
+    const abortErr = new DOMException('Aborted', 'AbortError');
+    mockRemindersGet.mockRejectedValueOnce(abortErr);
+    await expect(getReminders(1, controller.signal)).rejects.toBe(abortErr);
   });
 });

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -7,9 +7,12 @@ const api = new DefaultApi(
   new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
 );
 
-export async function getReminders(telegramId: number): Promise<Reminder[]> {
+export async function getReminders(
+  telegramId: number,
+  signal?: AbortSignal,
+): Promise<Reminder[]> {
   try {
-    const data = await api.remindersGet({ telegramId });
+    const data = await api.remindersGet({ telegramId }, { signal });
 
     if (!data) {
       return [];
@@ -22,6 +25,9 @@ export async function getReminders(telegramId: number): Promise<Reminder[]> {
 
     return data;
   } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error;
+    }
     console.error('Failed to fetch reminders:', error);
     if (error instanceof Error) {
       throw error;


### PR DESCRIPTION
## Summary
- pass AbortSignal from useEffect to reminders API and skip toast on AbortError
- document API to rethrow aborts and add tests for signal handling

## Testing
- `npx vitest run` *(fails: Failed to resolve import "@sdk/runtime" from "services/webapp/ui/src/api/reminders.api.test.ts"; missing modules)*
- `npm --workspace services/webapp/ui run lint`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a327744248832aaeb39947fb48d0aa