### PR TITLE
[ui] tighten history type filter state

### DIFF
--- a/services/webapp/ui/src/pages/History.tsx
+++ b/services/webapp/ui/src/pages/History.tsx
@@ -6,13 +6,15 @@ import { useToast } from '@/hooks/use-toast';
 import MedicalButton from '@/components/MedicalButton';
 import { getHistory, updateRecord, deleteRecord, HistoryRecord } from '@/api/history';
 
+type HistoryFilter = 'all' | 'measurement' | 'meal' | 'insulin';
+
 const History = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
 
   const [records, setRecords] = useState<HistoryRecord[]>([]);
   const [selectedDate, setSelectedDate] = useState('');
-  const [selectedType, setSelectedType] = useState<string>('all');
+  const [selectedType, setSelectedType] = useState<HistoryFilter>('all');
   const [editingRecord, setEditingRecord] = useState<HistoryRecord | null>(null);
 
   useEffect(() => {
@@ -162,7 +164,7 @@ const History = () => {
               <select
                 id="history-type"
                 value={selectedType}
-                onChange={(e) => setSelectedType(e.target.value)}
+                onChange={(e) => setSelectedType(e.target.value as HistoryFilter)}
                 className="medical-input"
               >
                 <option value="all">Все записи</option>


### PR DESCRIPTION
## Summary
- define `HistoryFilter` union type
- restrict history filter state and handler to `HistoryFilter`

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a3277057bc832ab0e0b7143a01ee2d