### PR TITLE
[ui] replace gray colors with theme tokens on NotFound page

### DIFF
--- a/services/webapp/ui/src/pages/NotFound.tsx
+++ b/services/webapp/ui/src/pages/NotFound.tsx
@@ -14,10 +14,10 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex items-center justify-center bg-background">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
+        <p className="text-xl text-muted-foreground mb-4">Oops! Page not found</p>
         <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
         </Link>


### PR DESCRIPTION
## Summary
- use `bg-background` and `text-muted-foreground` tokens in the NotFound page so it adapts to light/dark themes

## Testing
- `npm --workspace services/webapp/ui run lint`
- `npm --workspace services/webapp/ui run typecheck`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a327687520832a99ac6b06ac7e877e