### PR TITLE
[webapp] Exclude telegram init from bundling

### DIFF
--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig(async ({ mode }) => {
   const port   = 5173                                   // или оставьте 8080 и укажите его в .lovable.yml
   const rollupOptions = {
     ...(mode === 'development' ? { treeshake: false } : {}),
+    external: ['/telegram-init.js'],
     input: {
       main: path.resolve(__dirname, 'index.html'),
       'telegram-theme': path.resolve(


### PR DESCRIPTION
## Summary
- prevent rollup from resolving `telegram-init.js`
- ensure plugin can emit telegram scripts during build

## Testing
- `npm run build`
- `make ci` *(fails: No rule to make target 'ci')*
- `pytest -q --cov` *(fails: unrecognized arguments: --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=74 --cov)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a34bf8a6a4832a918e27707d913b44