### PR TITLE
[utils] avoid global decimal precision leak

### DIFF
--- a/services/api/app/diabetes/utils/functions.py
+++ b/services/api/app/diabetes/utils/functions.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 import re
-from decimal import Decimal, getcontext
+from decimal import Decimal, localcontext
 
 # ---------------------------------------------------------------------------
 # Regex helpers
@@ -142,17 +142,18 @@ def calc_bolus(carbs_g: float, current_bg: float, profile: PatientProfile) -> fl
         raise ValueError("carbs_g must be non-negative")
     if current_bg < 0:
         raise ValueError("current_bg must be non-negative")
-    getcontext().prec = 6
-    carbs = Decimal(str(carbs_g))
-    icr = Decimal(str(profile.icr))
-    cf = Decimal(str(profile.cf))
-    target_bg = Decimal(str(profile.target_bg))
-    current = Decimal(str(current_bg))
-    meal = carbs / icr
-    correction = (current - target_bg) / cf
-    if correction < 0:
-        correction = Decimal("0")
-    return float(round(meal + correction, 1))
+    with localcontext() as ctx:
+        ctx.prec = 6
+        carbs = Decimal(str(carbs_g))
+        icr = Decimal(str(profile.icr))
+        cf = Decimal(str(profile.cf))
+        target_bg = Decimal(str(profile.target_bg))
+        current = Decimal(str(current_bg))
+        meal = carbs / icr
+        correction = (current - target_bg) / cf
+        if correction < 0:
+            correction = Decimal("0")
+        return float(round(meal + correction, 1))
 
 
 def extract_nutrition_info(text: object) -> tuple[float | None, float | None]:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,5 +1,7 @@
 # test_functions.py
 
+from decimal import getcontext
+
 import pytest
 
 from services.api.app.diabetes.utils.functions import (
@@ -37,6 +39,16 @@ def test_calc_bolus_decimal_precision() -> None:
     profile = PatientProfile(icr=3, cf=1, target_bg=5)
     result = calc_bolus(carbs_g=1, current_bg=5, profile=profile)
     assert result == 0.3
+
+
+def test_calc_bolus_no_precision_leak() -> None:
+    ctx = getcontext()
+    original = ctx.prec
+    ctx.prec = 10
+    profile = PatientProfile(icr=12, cf=2, target_bg=6)
+    calc_bolus(carbs_g=60, current_bg=8, profile=profile)
+    assert ctx.prec == 10
+    ctx.prec = original
 
 
 def test_calc_bolus_invalid_icr() -> None:


### PR DESCRIPTION
## Summary
- use `localcontext` to confine decimal precision in bolus calculation
- test that `calc_bolus` doesn't leak global decimal precision

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a34db19e74832a892400558653c02d