### PR TITLE
[gpt_client] Delete temp file on upload failure

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -111,7 +111,6 @@ async def send_message(
     ]
     if image_path:
         try:
-
             def _upload() -> FileObject:
                 with open(image_path, "rb") as f:
                     return client.files.create(file=f, purpose="vision")
@@ -130,6 +129,7 @@ async def send_message(
                 "image_file": {"file_id": file.id},
             }
             message_content = [image_block, text_block]
+        finally:
             if not keep_image:
                 try:
                     await asyncio.to_thread(os.remove, image_path)

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -84,7 +84,9 @@ async def test_create_thread_openaierror(
 
 
 @pytest.mark.asyncio
-async def test_send_message_upload_error_keeps_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_send_message_upload_error_removes_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     img = tmp_path / "img.jpg"
     img.write_bytes(b"data")
 
@@ -97,7 +99,7 @@ async def test_send_message_upload_error_keeps_file(tmp_path: Path, monkeypatch:
     with pytest.raises(OpenAIError):
         await gpt_client.send_message(thread_id="t", image_path=str(img))
 
-    assert img.exists()
+    assert not img.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ensure temporary images are always removed when OpenAI upload fails
- test deleting temporary files on `client.files.create` failure

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a34db701c4832aa8a3b7e13b965a45