### PR TITLE
[middleware] log invalid auth headers

### DIFF
--- a/services/api/app/middleware/auth.py
+++ b/services/api/app/middleware/auth.py
@@ -16,14 +16,31 @@ class AuthMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         user_id_header = request.headers.get("X-User-Id")
         if user_id_header is None:
+            logger.warning(
+                "Missing X-User-Id for request %s %s",
+                request.method,
+                request.url.path,
+            )
             raise HTTPException(status_code=401, detail="invalid user id")
         try:
             user_id = int(user_id_header)
         except (TypeError, ValueError):
+            logger.warning(
+                "Invalid X-User-Id %r for request %s %s",
+                user_id_header,
+                request.method,
+                request.url.path,
+            )
             raise HTTPException(status_code=401, detail="invalid user id")
 
         role = request.headers.get("X-Role", "patient")
         if role not in ALLOWED_ROLES:
+            logger.warning(
+                "Invalid X-Role %r for request %s %s",
+                role,
+                request.method,
+                request.url.path,
+            )
             raise HTTPException(status_code=401, detail="invalid role")
         request.state.user_id = user_id
         request.state.role = role
@@ -34,5 +51,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
 def require_role(*roles: str) -> Callable[[Request], Awaitable[None]]:
     async def dependency(request: Request) -> None:
         if getattr(request.state, "role", None) not in roles:
+            logger.warning(
+                "Forbidden access for role %r to %s %s",
+                getattr(request.state, "role", None),
+                request.method,
+                request.url.path,
+            )
             raise HTTPException(status_code=403, detail="forbidden")
     return dependency

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,8 +1,10 @@
-from fastapi import FastAPI, HTTPException, Request
+import logging
+
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
 import pytest
 
-from services.api.app.middleware.auth import AuthMiddleware
+from services.api.app.middleware.auth import AuthMiddleware, require_role
 
 
 def create_app() -> FastAPI:
@@ -24,19 +26,56 @@ def test_valid_user_id_header() -> None:
         assert response.json() == {"user_id": 123}
 
 
-def test_missing_user_id_header() -> None:
+def test_missing_user_id_header(caplog: pytest.LogCaptureFixture) -> None:
     app = create_app()
     with TestClient(app) as client:
+        caplog.set_level(logging.WARNING, logger="services.api.app.middleware.auth")
         with pytest.raises(HTTPException) as exc_info:
             client.get("/whoami")
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "invalid user id"
+    assert "Missing X-User-Id" in caplog.text
 
 
-def test_invalid_user_id_header() -> None:
+def test_invalid_user_id_header(caplog: pytest.LogCaptureFixture) -> None:
     app = create_app()
     with TestClient(app) as client:
+        caplog.set_level(logging.WARNING, logger="services.api.app.middleware.auth")
         with pytest.raises(HTTPException) as exc_info:
             client.get("/whoami", headers={"X-User-Id": "abc"})
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == "invalid user id"
+    assert "Invalid X-User-Id" in caplog.text
+
+
+def test_invalid_role_header_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = create_app()
+    with TestClient(app) as client:
+        caplog.set_level(logging.WARNING, logger="services.api.app.middleware.auth")
+        with pytest.raises(HTTPException) as exc_info:
+            client.get(
+                "/whoami",
+                headers={"X-User-Id": "1", "X-Role": "hacker"},
+            )
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "invalid role"
+    assert "Invalid X-Role" in caplog.text
+
+
+def test_require_role_logs_attempt(caplog: pytest.LogCaptureFixture) -> None:
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware)
+
+    @app.get("/admin", dependencies=[Depends(require_role("superadmin"))])
+    async def admin() -> dict[str, bool]:
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        caplog.set_level(logging.WARNING, logger="services.api.app.middleware.auth")
+        response = client.get(
+            "/admin", headers={"X-User-Id": "1", "X-Role": "patient"}
+        )
+        assert response.status_code == 403
+    assert "Forbidden access for role 'patient'" in caplog.text


### PR DESCRIPTION
## Summary
- log and warn on missing or invalid `X-User-Id` and `X-Role`
- warn when `require_role` denies access
- test middleware logging with `caplog`

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a34db93cdc832a9919c0d590b25cc4