### PR TITLE
[diabetes] Use compiled regex for API key masking

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -43,15 +43,17 @@ SYSTEM_PROMPT = (
 )
 
 
+API_KEY_RE = re.compile(
+    r"\b(?=[A-Za-z0-9_-]*[a-z])"
+    r"(?=[A-Za-z0-9_-]*[A-Z])"
+    r"(?=[A-Za-z0-9_-]*\d)"
+    r"[A-Za-z0-9_-]{40,}\b"
+)
+
+
 def _sanitize_sensitive_data(text: str) -> str:
     """Mask potentially sensitive tokens in *text* before logging."""
-    api_key_pattern = (
-        r"\b(?=[A-Za-z0-9_-]*[a-z])"
-        r"(?=[A-Za-z0-9_-]*[A-Z])"
-        r"(?=[A-Za-z0-9_-]*\d)"
-        r"[A-Za-z0-9_-]{40,}\b"
-    )
-    return re.sub(api_key_pattern, "[REDACTED]", text)
+    return API_KEY_RE.sub("[REDACTED]", text)
 
 
 def _extract_first_json(text: str) -> dict[str, object] | None:

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -299,6 +299,16 @@ def test_sanitize_leaves_numeric_strings() -> None:
     assert gpt_command_parser._sanitize_sensitive_data(text) == text
 
 
+def test_sanitize_masks_multiple_tokens() -> None:
+    token1 = "sk-" + "A1b2_" * 8 + "Z9"
+    token2 = "ghp_" + "A1b2" * 9 + "Cd"
+    text = f"{token1} middle {token2}"
+    assert (
+        gpt_command_parser._sanitize_sensitive_data(text)
+        == "[REDACTED] middle [REDACTED]"
+    )
+
+
 def test_extract_first_json_multiple_objects() -> None:
     text = '{"action":"add_entry","fields":{}} ' '{"action":"delete_entry","fields":{}}'
     assert gpt_command_parser._extract_first_json(text) == {


### PR DESCRIPTION
## Summary
- move API-key matching regex to module-level and use compiled pattern
- sanitize text with compiled regex
- test masking multiple API-like tokens

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a34dc0fc50832a94f726dd6a7c8061