### PR TITLE
[handlers] Refactor callback router lookup

### DIFF
--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -145,11 +145,7 @@ async def handle_edit_or_delete(
                 )
             ],
             [InlineKeyboardButton("xe", callback_data=f"edit_field:{entry_id}:xe")],
-            [
-                InlineKeyboardButton(
-                    "dose", callback_data=f"edit_field:{entry_id}:dose"
-                )
-            ],
+            [InlineKeyboardButton("dose", callback_data=f"edit_field:{entry_id}:dose")],
         ]
     )
     await query.edit_message_reply_markup(reply_markup=keyboard)
@@ -204,11 +200,17 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     if data.startswith("rem_"):
         return
 
-    for key, handler in callback_handlers.items():
-        if data == key or data.startswith(key):
+    handler = callback_handlers.get(data)
+    if handler is not None:
+        await handler(update, context, query, data)
+        return
+
+    if ":" in data:
+        prefix = data.split(":", 1)[0] + ":"
+        handler = callback_handlers.get(prefix)
+        if handler is not None:
             await handler(update, context, query, data)
             return
 
     logger.warning("Unrecognized callback data: %s", data)
     await query.edit_message_text("Команда не распознана")
-

--- a/tests/test_router_mapping.py
+++ b/tests/test_router_mapping.py
@@ -16,12 +16,25 @@ class DummyQuery:
     async def answer(self) -> None:  # pragma: no cover - trivial
         self.answered = True
 
-    async def edit_message_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover
+    async def edit_message_text(
+        self, text: str, **kwargs: Any
+    ) -> None:  # pragma: no cover
         self.called.append((text, kwargs))
 
 
 @pytest.mark.asyncio
-async def test_callback_router_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("data", "key"),
+    [
+        ("confirm_entry", "confirm_entry"),
+        ("edit:1", "edit:"),
+        ("edit_field:1:sugar", "edit_field:"),
+        ("del:2", "del:"),
+    ],
+)
+async def test_callback_router_dispatch(
+    monkeypatch: pytest.MonkeyPatch, data: str, key: str
+) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
@@ -33,12 +46,12 @@ async def test_callback_router_dispatch(monkeypatch: pytest.MonkeyPatch) -> None
         update: Update,
         context: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         query: DummyQuery,
-        data: str,
+        payload: str,
     ) -> None:
-        called.append(data)
+        called.append(payload)
 
-    monkeypatch.setitem(router.callback_handlers, "confirm_entry", fake_handler)
-    query = DummyQuery("confirm_entry")
+    monkeypatch.setitem(router.callback_handlers, key, fake_handler)
+    query = DummyQuery(data)
     update = cast(Update, SimpleNamespace(callback_query=query))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -47,4 +60,4 @@ async def test_callback_router_dispatch(monkeypatch: pytest.MonkeyPatch) -> None
 
     await router.callback_router(update, context)
 
-    assert called == ["confirm_entry"]
+    assert called == [data]


### PR DESCRIPTION
## Summary
- optimize callback router by checking exact match before parsing prefix rather than iterating with `startswith`
- cover multiple callback data formats with a parameterized router test

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a35acc11c0832ab8d65798ac99647e