### PR TITLE
[handlers] Inject dependencies into GPT freeform handler

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -280,14 +280,16 @@ from . import gpt_handlers as _gpt_handlers  # noqa: E402
 
 
 async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    _gpt_handlers.SessionLocal = SessionLocal
-    _gpt_handlers.commit = commit
-    _gpt_handlers.check_alert = check_alert
-    _gpt_handlers.menu_keyboard = menu_keyboard
-    _gpt_handlers.smart_input = smart_input
-    _gpt_handlers.parse_command = parse_command
-    _gpt_handlers.send_report = send_report
-    return await _gpt_handlers.freeform_handler(update, context)
+    deps = _gpt_handlers.FreeformDeps(
+        SessionLocal=SessionLocal,
+        commit=commit,
+        check_alert=check_alert,
+        menu_keyboard=menu_keyboard,
+        smart_input=smart_input,
+        parse_command=parse_command,
+        send_report=send_report,
+    )
+    return await _gpt_handlers.freeform_handler(update, context, deps=deps)
 
 
 chat_with_gpt = _gpt_handlers.chat_with_gpt

--- a/tests/test_dose_calc_reexports.py
+++ b/tests/test_dose_calc_reexports.py
@@ -15,12 +15,13 @@ async def test_reexported_names_available(monkeypatch: pytest.MonkeyPatch) -> No
     smart_marker = object()
     send_report_marker = object()
 
-    async def dummy_freeform_handler(update: Any, context: Any) -> None:
-        handlers = dose_calc._gpt_handlers  # type: ignore[attr-defined]
-        assert handlers.commit is commit_marker
-        assert handlers.parse_command is parse_marker
-        assert handlers.smart_input is smart_marker
-        assert handlers.send_report is send_report_marker
+    async def dummy_freeform_handler(
+        update: Any, context: Any, deps: Any
+    ) -> None:
+        assert deps.commit is commit_marker
+        assert deps.parse_command is parse_marker
+        assert deps.smart_input is smart_marker
+        assert deps.send_report is send_report_marker
 
     monkeypatch.setattr(dose_calc, "commit", commit_marker)
     monkeypatch.setattr(dose_calc, "parse_command", parse_marker)

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -265,7 +265,6 @@ async def test_photo_then_freeform_calculates_dose(monkeypatch: pytest.MonkeyPat
 
     session_factory = cast(Any, sessionmaker(class_=DummySession))
     photo_handlers.SessionLocal = session_factory
-    gpt_handlers.SessionLocal = session_factory
 
     async def fake_run_db(
         func: Callable[[Session], T],
@@ -284,7 +283,9 @@ async def test_photo_then_freeform_calculates_dose(monkeypatch: pytest.MonkeyPat
         SimpleNamespace(message=sugar_msg, effective_user=SimpleNamespace(id=1)),
     )
 
-    await gpt_handlers.freeform_handler(update_sugar, context)
+    deps = gpt_handlers.default_deps()
+    deps.SessionLocal = session_factory
+    await gpt_handlers.freeform_handler(update_sugar, context, deps=deps)
 
     reply = sugar_msg.texts[0]
     assert reply == "💉\u202fРасчёт дозы: 1.0\u202fЕд.\nСахар: 5.0\u202fммоль/л"

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -99,7 +99,6 @@ async def test_freeform_handler_adds_sugar_to_photo_entry(
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
     session_factory = cast(Any, sessionmaker(class_=DummySession))
-    handlers.SessionLocal = session_factory
 
     async def fake_run_db(fn: Any, *args: Any, **kwargs: Any) -> Any:
         with session_factory() as session:
@@ -116,7 +115,9 @@ async def test_freeform_handler_adds_sugar_to_photo_entry(
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 
-    await handlers.freeform_handler(update, context)
+    deps = handlers.default_deps()
+    deps.SessionLocal = session_factory
+    await handlers.freeform_handler(update, context, deps=deps)
 
     assert context.user_data is not None
     user_data = context.user_data

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -170,7 +170,6 @@ async def test_photo_flow_saves_entry(monkeypatch: pytest.MonkeyPatch, tmp_path:
     )
     session_factory = cast(Any, sessionmaker(class_=DummySession))
     photo_handlers.SessionLocal = session_factory
-    gpt_handlers.SessionLocal = session_factory
 
     async def fake_run_db(
         func: Callable[..., T],
@@ -185,7 +184,9 @@ async def test_photo_flow_saves_entry(monkeypatch: pytest.MonkeyPatch, tmp_path:
             session.close()
 
     monkeypatch.setattr(gpt_handlers, "run_db", fake_run_db)
-    await gpt_handlers.freeform_handler(update_sugar, context)
+    deps = gpt_handlers.default_deps()
+    deps.SessionLocal = session_factory
+    await gpt_handlers.freeform_handler(update_sugar, context, deps=deps)
     assert user_data["pending_entry"]["sugar_before"] == 5.5
 
     monkeypatch.setattr(router, "SessionLocal", session_factory)


### PR DESCRIPTION
## Summary
- Allow GPT freeform handler to receive its dependencies explicitly
- Pass required dependencies from dose calculation module
- Refactor tests to use explicit dependency objects

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a35ae19728832abf6aa7b170d14967