### PR TITLE
[ui] add profile api tests

### DIFF
--- a/services/webapp/ui/src/api/profile.api.test.ts
+++ b/services/webapp/ui/src/api/profile.api.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ResponseError } from '@sdk/runtime';
+import type { Profile } from '@sdk/models';
+
+const mockProfilesGet = vi.hoisted(() => vi.fn());
+const mockProfilesPost = vi.hoisted(() => vi.fn());
+
+vi.mock('@sdk', () => ({
+  DefaultApi: vi.fn(() => ({
+    profilesGet: mockProfilesGet,
+    profilesPost: mockProfilesPost,
+  })),
+}));
+
+import { getProfile, saveProfile } from './profile';
+
+afterEach(() => {
+  mockProfilesGet.mockReset();
+  mockProfilesPost.mockReset();
+});
+
+describe('getProfile', () => {
+  it('returns null on 404 response', async () => {
+    const err = new ResponseError(new Response(null, { status: 404 }));
+    mockProfilesGet.mockRejectedValueOnce(err);
+    await expect(getProfile(1)).resolves.toBeNull();
+  });
+
+  it('rethrows other errors', async () => {
+    const err = new ResponseError(new Response(null, { status: 500 }));
+    mockProfilesGet.mockRejectedValueOnce(err);
+    await expect(getProfile(1)).rejects.toBe(err);
+  });
+});
+
+describe('saveProfile', () => {
+  it('posts profile successfully', async () => {
+    const profile = {} as unknown as Profile;
+    const response = { ok: true };
+    mockProfilesPost.mockResolvedValueOnce(response);
+    await expect(saveProfile(profile)).resolves.toBe(response);
+    expect(mockProfilesPost).toHaveBeenCalledWith({ profile });
+  });
+
+  it('rethrows errors from API', async () => {
+    const error = new Error('fail');
+    mockProfilesPost.mockRejectedValueOnce(error);
+    await expect(saveProfile({} as unknown as Profile)).rejects.toBe(error);
+  });
+
+  it('throws generic error for non-Error values', async () => {
+    mockProfilesPost.mockRejectedValueOnce('bad');
+    await expect(saveProfile({} as unknown as Profile)).rejects.toThrow('Не удалось сохранить профиль');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for profile API

## Testing
- `npx vitest --config services/webapp/ui/vite.config.ts services/webapp/ui/src/api/profile.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a362dfee3c832ab10620fca26e34b8