### PR TITLE
[tests] refine useTelegram hook error assertions

### DIFF
--- a/tests/useTelegram.test.ts
+++ b/tests/useTelegram.test.ts
@@ -32,7 +32,8 @@ describe('useTelegram hook fallback', () => {
       expect(result.current.isReady).toBe(true);
     });
     await waitFor(() => {
-      expect(result.current.error).toBe('no-user');
+      expect(result.current.error?.code).toBe('no-user');
+      expect(result.current.error?.message).toBeUndefined();
     });
     expect(result.current.user).toBeNull();
   });
@@ -60,7 +61,8 @@ describe('useTelegram hook init error', () => {
   it('sets error when initialization fails', async () => {
     const { result } = renderHook(() => useTelegram(false));
     await waitFor(() => {
-      expect(result.current.error).toBe('init failed');
+      expect(result.current.error?.code).toBe('unknown');
+      expect(result.current.error?.message).toBe('init failed');
     });
     expect(result.current.isReady).toBe(true);
   });


### PR DESCRIPTION
## Summary
- adjust `useTelegram` hook tests to expect structured error codes and messages

## Testing
- `npx vitest tests/useTelegram.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a362e0a7bc832ab9c43cb41fc259a5