### PR TITLE
[ui] Add tests for history update and delete

### DIFF
--- a/services/webapp/ui/src/api/history.api.test.ts
+++ b/services/webapp/ui/src/api/history.api.test.ts
@@ -4,7 +4,8 @@ const mockTgFetch = vi.hoisted(() => vi.fn());
 
 vi.mock('../lib/tgFetch', () => ({ tgFetch: mockTgFetch }));
 
-import { getHistory } from './history';
+import { API_BASE } from './base';
+import { getHistory, updateRecord, deleteRecord } from './history';
 
 afterEach(() => {
   mockTgFetch.mockReset();
@@ -29,6 +30,59 @@ describe('getHistory', () => {
     );
     await expect(getHistory()).rejects.toThrow(
       'Некорректная запись истории',
+    );
+  });
+});
+
+describe('updateRecord', () => {
+  const record = {
+    id: '1',
+    date: '2024-01-01',
+    time: '12:00',
+    type: 'meal',
+  };
+
+  it('sends record to API and returns ok status', async () => {
+    const ok = { status: 'ok' };
+    mockTgFetch.mockResolvedValueOnce(new Response(JSON.stringify(ok)));
+    await expect(updateRecord(record)).resolves.toEqual(ok);
+    expect(mockTgFetch).toHaveBeenCalledWith(
+      `${API_BASE}/history`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(record),
+      },
+    );
+  });
+
+  it('throws on error status', async () => {
+    mockTgFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 'error' })),
+    );
+    await expect(updateRecord(record)).rejects.toThrow(
+      'Не удалось обновить запись',
+    );
+  });
+});
+
+describe('deleteRecord', () => {
+  it('calls API with DELETE and returns ok status', async () => {
+    const ok = { status: 'ok' };
+    mockTgFetch.mockResolvedValueOnce(new Response(JSON.stringify(ok)));
+    await expect(deleteRecord('1')).resolves.toEqual(ok);
+    expect(mockTgFetch).toHaveBeenCalledWith(
+      `${API_BASE}/history/1`,
+      { method: 'DELETE' },
+    );
+  });
+
+  it('throws on error status', async () => {
+    mockTgFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 'error' })),
+    );
+    await expect(deleteRecord('1')).rejects.toThrow(
+      'Не удалось удалить запись',
     );
   });
 });


### PR DESCRIPTION
## Summary
- add coverage for updateRecord with success and error paths
- add tests for deleteRecord including bad status handling

## Testing
- `npx vitest services/webapp/ui/src/api/history.api.test.ts`
- `npm --workspace services/webapp/ui run lint` *(fails: Unexpected any in vite.config.ts)*
- `ruff check .`
- `mypy --strict .`


------
https://chatgpt.com/codex/tasks/task_e_68a362e924c0832a8f29381b77ca14e0