### PR TITLE
[webapp] test reminders api

### DIFF
--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -2,16 +2,33 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { ResponseError } from '@sdk/runtime';
 
 const mockRemindersGet = vi.hoisted(() => vi.fn());
+const mockRemindersPost = vi.hoisted(() => vi.fn());
+const mockRemindersPatch = vi.hoisted(() => vi.fn());
+const mockRemindersDelete = vi.hoisted(() => vi.fn());
 
 vi.mock('@sdk', () => ({
-  DefaultApi: vi.fn(() => ({ remindersGet: mockRemindersGet })),
+  DefaultApi: vi.fn(() => ({
+    remindersGet: mockRemindersGet,
+    remindersPost: mockRemindersPost,
+    remindersPatch: mockRemindersPatch,
+    remindersDelete: mockRemindersDelete,
+  })),
   instanceOfReminder: vi.fn(),
-}));
+}), { virtual: true });
 
-import { getReminder, getReminders } from './reminders';
+import {
+  getReminder,
+  getReminders,
+  createReminder,
+  updateReminder,
+  deleteReminder,
+} from './reminders';
 
 afterEach(() => {
   mockRemindersGet.mockReset();
+  mockRemindersPost.mockReset();
+  mockRemindersPatch.mockReset();
+  mockRemindersDelete.mockReset();
 });
 
 describe('getReminder', () => {
@@ -44,5 +61,52 @@ describe('getReminders', () => {
     const abortErr = new DOMException('Aborted', 'AbortError');
     mockRemindersGet.mockRejectedValueOnce(abortErr);
     await expect(getReminders(1, controller.signal)).rejects.toBe(abortErr);
+  });
+});
+
+describe('createReminder', () => {
+  it('returns API response on success', async () => {
+    const reminder = { id: 1 } as any;
+    const apiResponse = { ok: true } as any;
+    mockRemindersPost.mockResolvedValueOnce(apiResponse);
+    await expect(createReminder(reminder)).resolves.toBe(apiResponse);
+    expect(mockRemindersPost).toHaveBeenCalledWith({ reminder });
+  });
+
+  it('rethrows API errors', async () => {
+    const error = new Error('api error');
+    mockRemindersPost.mockRejectedValueOnce(error);
+    await expect(createReminder({} as any)).rejects.toBe(error);
+  });
+});
+
+describe('updateReminder', () => {
+  it('returns API response on success', async () => {
+    const reminder = { id: 1 } as any;
+    const apiResponse = { ok: true } as any;
+    mockRemindersPatch.mockResolvedValueOnce(apiResponse);
+    await expect(updateReminder(reminder)).resolves.toBe(apiResponse);
+    expect(mockRemindersPatch).toHaveBeenCalledWith({ reminder });
+  });
+
+  it('rethrows API errors', async () => {
+    const error = new Error('api error');
+    mockRemindersPatch.mockRejectedValueOnce(error);
+    await expect(updateReminder({} as any)).rejects.toBe(error);
+  });
+});
+
+describe('deleteReminder', () => {
+  it('returns API response on success', async () => {
+    const apiResponse = { ok: true } as any;
+    mockRemindersDelete.mockResolvedValueOnce(apiResponse);
+    await expect(deleteReminder(1, 2)).resolves.toBe(apiResponse);
+    expect(mockRemindersDelete).toHaveBeenCalledWith({ telegramId: 1, id: 2 });
+  });
+
+  it('rethrows API errors', async () => {
+    const error = new Error('api error');
+    mockRemindersDelete.mockRejectedValueOnce(error);
+    await expect(deleteReminder(1, 2)).rejects.toBe(error);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,13 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
   },
-})
+  resolve: {
+    alias: {
+      '@sdk': path.resolve(__dirname, './libs/ts-sdk'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- cover reminder create, update, delete API wrappers with success and error tests
- configure Vitest to resolve @sdk imports

## Testing
- `npx vitest run services/webapp/ui/src/api/reminders.api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a362ed6ac8832a895516070f565901