### PR TITLE
[webapp] fix telegram init script path

### DIFF
--- a/services/webapp/ui/index.html
+++ b/services/webapp/ui/index.html
@@ -33,7 +33,7 @@
 
     <!-- Telegram SDK + инициализация темы (не бандлим, грузим отдельным скриптом) -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <script type="module" src="/telegram-init.js"></script>
+    <script type="module" src="%VITE_BASE_URL%telegram-init.js"></script>
 
     <!-- Open Graph / Twitter -->
     <meta property="og:title" content="СахарФото — ассистент для диабетиков" />


### PR DESCRIPTION
## Summary
- use Vite base URL when loading telegram-init

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a403c3da30832ab9eca666e4e7dfa8