### PR TITLE
[ui] Fix telegram init script path

### DIFF
--- a/services/webapp/ui/index.html
+++ b/services/webapp/ui/index.html
@@ -33,7 +33,7 @@
 
     <!-- Telegram SDK + инициализация темы (не бандлим, грузим отдельным скриптом) -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <script type="module" src="%VITE_BASE_URL%telegram-init.js"></script>
+    <script type="module" src="telegram-init.js"></script>
 
     <!-- Open Graph / Twitter -->
     <meta property="og:title" content="СахарФото — ассистент для диабетиков" />

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig(async ({ mode }) => {
   const port   = 5173                                   // или оставьте 8080 и укажите его в .lovable.yml
   const rollupOptions = {
     ...(mode === 'development' ? { treeshake: false } : {}),
-    external: ['/telegram-init.js'],
+    external: ['telegram-init.js', '/telegram-init.js'],
     input: {
       main: path.resolve(__dirname, 'index.html'),
       'telegram-theme': path.resolve(


### PR DESCRIPTION
## Summary
- reference Telegram init script with a relative path
- treat telegram-init.js as external in Vite build

## Testing
- `npm run build`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a40d67640c832a8791a97d780689b7