### PR TITLE
[webapp] Apply radio roles to SegmentedControl

### DIFF
--- a/services/webapp/ui/src/components/SegmentedControl.test.tsx
+++ b/services/webapp/ui/src/components/SegmentedControl.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useState } from 'react'
+import { SegmentedControl, type SegmentedItem } from './SegmentedControl'
+
+const items: SegmentedItem[] = [
+  { value: 'a', label: 'A' },
+  { value: 'b', label: 'B' },
+  { value: 'c', label: 'C' },
+]
+
+const Wrapper = () => {
+  const [value, setValue] = useState('a')
+  return <SegmentedControl value={value} onChange={setValue} items={items} />
+}
+
+describe('SegmentedControl', () => {
+  it('uses radio roles and reflects selection with aria-checked', () => {
+    render(<Wrapper />)
+    expect(screen.getByRole('radiogroup')).toBeTruthy()
+    const radios = screen.getAllByRole('radio')
+    expect(radios).toHaveLength(3)
+    expect(radios[0].getAttribute('aria-checked')).toBe('true')
+    expect(radios[1].getAttribute('aria-checked')).toBe('false')
+  })
+
+  it('changes selection with arrow keys', () => {
+    render(<Wrapper />)
+    const radios = screen.getAllByRole('radio')
+    radios[0].focus()
+    fireEvent.keyDown(radios[0], { key: 'ArrowRight' })
+    const updatedRadios = screen.getAllByRole('radio')
+    expect(updatedRadios[1].getAttribute('aria-checked')).toBe('true')
+    expect(updatedRadios[0].getAttribute('aria-checked')).toBe('false')
+  })
+})

--- a/services/webapp/ui/src/components/SegmentedControl.tsx
+++ b/services/webapp/ui/src/components/SegmentedControl.tsx
@@ -39,13 +39,14 @@ export const SegmentedControl = ({ value, onChange, items }: SegmentedControlPro
   };
 
   return (
-    <div className="segmented" role="group">
+    <div className="segmented" role="radiogroup">
       {items.map((item, index) => (
         <div className="segmented__item" key={item.value}>
           <button
             ref={(el) => (itemRefs.current[index] = el!)}
             type="button"
-            aria-pressed={value === item.value}
+            role="radio"
+            aria-checked={value === item.value}
             tabIndex={value === item.value ? 0 : -1}
             onKeyDown={(e) => handleKeyDown(e, index)}
             onClick={() => onChange(item.value)}


### PR DESCRIPTION
## Summary
- use `radiogroup` and `radio` roles for SegmentedControl
- add tests ensuring ARIA semantics and keyboard navigation

## Testing
- `npx vitest run services/webapp/ui/src/components/SegmentedControl.test.tsx`
- `pytest -q --cov` *(fails: KeyboardInterrupt)*
- `mypy --strict .` *(fails: Interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a473b7dd18832a8cede6dc57a1c8a8