### PR TITLE
[webapp] Abortable history fetches

### DIFF
--- a/services/webapp/ui/src/api/history.api.test.ts
+++ b/services/webapp/ui/src/api/history.api.test.ts
@@ -32,6 +32,16 @@ describe('getHistory', () => {
       'Некорректная запись истории',
     );
   });
+
+  it('forwards signal to tgFetch', async () => {
+    const controller = new AbortController();
+    mockTgFetch.mockResolvedValueOnce(new Response(JSON.stringify([])));
+    await getHistory(controller.signal);
+    expect(mockTgFetch).toHaveBeenCalledWith(
+      `${API_BASE}/history`,
+      { signal: controller.signal },
+    );
+  });
 });
 
 describe('updateRecord', () => {

--- a/services/webapp/ui/src/api/history.ts
+++ b/services/webapp/ui/src/api/history.ts
@@ -26,9 +26,9 @@ const historyRecordSchema = z.object({
   type: z.enum(['measurement', 'meal', 'insulin']),
 });
 
-export async function getHistory(): Promise<HistoryRecord[]> {
+export async function getHistory(signal?: AbortSignal): Promise<HistoryRecord[]> {
   try {
-    const res = await tgFetch(`${API_BASE}/history`);
+    const res = await tgFetch(`${API_BASE}/history`, { signal });
     const data = await res.json();
     if (!Array.isArray(data)) {
       throw new Error('Некорректный ответ API');

--- a/services/webapp/ui/src/pages/History.tsx
+++ b/services/webapp/ui/src/pages/History.tsx
@@ -18,27 +18,24 @@ const History = () => {
   const [editingRecord, setEditingRecord] = useState<HistoryRecord | null>(null);
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
     (async () => {
       try {
-        const data = await getHistory();
-        if (!cancelled) {
-          setRecords(data);
-        }
+        const data = await getHistory(controller.signal);
+        setRecords(data);
       } catch (err) {
-        if (!cancelled) {
-          const message =
-            err instanceof Error ? err.message : 'Неизвестная ошибка';
-          toast({
-            title: 'Ошибка',
-            description: message,
-            variant: 'destructive',
-          });
-        }
+        if (controller.signal.aborted) return;
+        const message =
+          err instanceof Error ? err.message : 'Неизвестная ошибка';
+        toast({
+          title: 'Ошибка',
+          description: message,
+          variant: 'destructive',
+        });
       }
     })();
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [toast]);
 


### PR DESCRIPTION
## Summary
- Allow history fetch API to accept optional AbortSignal
- Use AbortController in History page effect
- Test that getHistory forwards fetch abort signal

## Testing
- `npm --workspace services/webapp/ui exec eslint src/api/history.ts src/api/history.api.test.ts src/pages/History.tsx`
- `npm --workspace services/webapp/ui run typecheck`
- `npm --workspace services/webapp/ui exec vitest run src/api/history.api.test.ts`
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`
- `npm --workspace services/webapp/ui run lint` *(fails: Unexpected any)*
- `npm --workspace services/webapp/ui exec vitest run` *(fails: missing react-test-renderer & jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68a473b7ed0c832a8829fa73770efefd