### PR TITLE
[webapp] Guard root element and enable React.StrictMode

### DIFF
--- a/services/webapp/ui/src/main.tsx
+++ b/services/webapp/ui/src/main.tsx
@@ -10,10 +10,18 @@ import { TelegramProvider } from '@/contexts/TelegramProvider'
 import './styles/theme.css'
 import './index.css'
 
-createRoot(document.getElementById('root')!).render(
-  <BrowserRouter basename={import.meta.env.BASE_URL}>
-    <TelegramProvider>
-      <App />
-    </TelegramProvider>
-  </BrowserRouter>
+const rootElement = document.getElementById('root')
+
+if (rootElement === null) {
+  throw new Error('Root element with id "root" not found')
+}
+
+createRoot(rootElement).render(
+  <React.StrictMode>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
+      <TelegramProvider>
+        <App />
+      </TelegramProvider>
+    </BrowserRouter>
+  </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Guard against missing root element before rendering
- Wrap router with React.StrictMode for highlighting side-effects

## Testing
- `npm --workspace services/webapp/ui run lint` *(fails: Unexpected any in reminders.api.test.ts, vite.config.ts)*
- `npm --workspace services/webapp/ui run typecheck`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a473b85f5c832a88a3d76a1f819731