### PR TITLE
[webapp] Handle abort for single reminder fetch

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -39,9 +39,10 @@ export async function getReminders(
 export async function getReminder(
   telegramId: number,
   id: number,
+  signal?: AbortSignal,
 ): Promise<Reminder | null> {
   try {
-    const data = await api.remindersGet({ telegramId, id });
+    const data = await api.remindersGet({ telegramId, id }, { signal });
 
     if (!data || Array.isArray(data) || !instanceOfReminder(data)) {
       console.error('Unexpected reminder API response:', data);
@@ -50,6 +51,9 @@ export async function getReminder(
 
     return data;
   } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error;
+    }
     console.error('Failed to fetch reminder:', error);
     if (error instanceof ResponseError && error.response.status === 404) {
       return null;

--- a/services/webapp/ui/src/reminders/CreateReminder.test.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.test.tsx
@@ -7,11 +7,11 @@ vi.mock("react-router-dom", () => ({
   useParams: () => ({ id: "1" }),
 }));
 
-vi.mock("@/contexts/telegram-context", () => ({
+vi.mock("../contexts/telegram-context", () => ({
   useTelegramContext: () => ({ user: { id: 123 }, sendData: vi.fn() }),
 }));
 
-vi.mock("@/api/reminders", () => ({
+vi.mock("../api/reminders", () => ({
   getReminder: vi.fn().mockResolvedValue({
     id: 1,
     type: "sugar",
@@ -24,11 +24,13 @@ vi.mock("@/api/reminders", () => ({
 }));
 
 import CreateReminder from "./CreateReminder";
-import { getReminder } from "@/api/reminders";
+import { getReminder } from "../api/reminders";
 
 describe("CreateReminder", () => {
   it("requests reminder only once", async () => {
     render(<CreateReminder />);
     await waitFor(() => expect(getReminder).toHaveBeenCalledTimes(1));
+    const [, , signal] = vi.mocked(getReminder).mock.calls[0];
+    expect(signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      '@': path.resolve(__dirname, './services/webapp/ui/src'),
       '@sdk': path.resolve(__dirname, './libs/ts-sdk'),
     },
   },


### PR DESCRIPTION
## Summary
- add `signal` to single reminder API call and rethrow AbortError
- abort outstanding reminder fetches on unmount
- expose `@` alias in vitest config for UI tests

## Testing
- `npx vitest run services/webapp/ui/src/api/reminders.api.test.ts services/webapp/ui/src/reminders/CreateReminder.test.tsx`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a473ae6b54832aaa9f820dbb52d51f