### PR TITLE
[handlers] Use _safe_float for numeric inputs

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -15,8 +15,9 @@ from telegram.ext import (
 from services.api.app.diabetes.services.db import SessionLocal, Profile
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.functions import (
-    calc_bolus,
     PatientProfile,
+    _safe_float,
+    calc_bolus,
     smart_input,
 )
 from services.api.app.diabetes.utils.ui import (
@@ -104,10 +105,8 @@ async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     user = update.effective_user
     if user is None:
         return END
-    text = text.strip().replace(",", ".")
-    try:
-        xe = float(text)
-    except ValueError:
+    xe = _safe_float(text)
+    if xe is None:
         await message.reply_text("Введите число ХЕ.")
         return DOSE_XE
     if xe < 0:
@@ -137,10 +136,8 @@ async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     user = update.effective_user
     if user is None:
         return END
-    text = text.strip().replace(",", ".")
-    try:
-        carbs = float(text)
-    except ValueError:
+    carbs = _safe_float(text)
+    if carbs is None:
         await message.reply_text("Введите углеводы числом в граммах.")
         return DOSE_CARBS
     if carbs < 0:
@@ -170,10 +167,8 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     user = update.effective_user
     if user is None:
         return END
-    text = text.strip().replace(",", ".")
-    try:
-        sugar = float(text)
-    except ValueError:
+    sugar = _safe_float(text)
+    if sugar is None:
         await message.reply_text("Введите сахар числом в ммоль/л.")
         return DOSE_SUGAR
     if sugar < 0:

--- a/services/api/app/diabetes/handlers/sugar_handlers.py
+++ b/services/api/app/diabetes/handlers/sugar_handlers.py
@@ -13,6 +13,7 @@ from telegram.ext import (
 
 from services.api.app.diabetes.services.db import SessionLocal, Entry
 from services.api.app.diabetes.services.repository import commit
+from services.api.app.diabetes.utils.functions import _safe_float
 from services.api.app.diabetes.utils.ui import menu_keyboard, sugar_keyboard
 
 from .alert_handlers import check_alert
@@ -71,10 +72,8 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     user = update.effective_user
     if user is None:
         return END
-    text = text.strip().replace(",", ".")
-    try:
-        sugar = float(text)
-    except ValueError:
+    sugar = _safe_float(text)
+    if sugar is None:
         await message.reply_text("Введите сахар числом в ммоль/л.")
         return SUGAR_VAL
     if sugar < 0:


### PR DESCRIPTION
## Summary
- use `_safe_float` instead of `float` in dose and sugar handlers
- unify numeric validation for sugar messages

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a496271880832a813fae0439df9d1a