### PR TITLE
[handlers] Remove redundant import aliases

### DIFF
--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import asyncio
 # Re-export for tests and type checkers
-import datetime as datetime
-import os as os
+import datetime
+import os
 
 import html
 import logging


### PR DESCRIPTION
## Summary
- use standard datetime and os imports in reporting_handlers

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a496321430832a890f092a2d290f6f