### PR TITLE
[handlers] Use CallbackQuery for edit_query user state

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -2,6 +2,8 @@
 
 from typing import TypedDict
 
+from telegram import CallbackQuery
+
 
 class UserData(TypedDict, total=False):
     """Mutable mapping used to store per-user state in handlers."""
@@ -14,7 +16,7 @@ class UserData(TypedDict, total=False):
     edit_id: int | None
     edit_entry: dict[str, object]
     edit_field: str
-    edit_query: str
+    edit_query: CallbackQuery | None
     profile_icr: float
     profile_cf: float
     profile_target: float


### PR DESCRIPTION
## Summary
- annotate `UserData.edit_query` as `CallbackQuery | None`
- import `CallbackQuery` for shared handler types

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a4a0b2c744832aa2cc09c6c3ff1ce7