### PR TITLE
[handlers] Refactor doc handler file passing

### DIFF
--- a/tests/handlers/test_photo_handler_recognition.py
+++ b/tests/handlers/test_photo_handler_recognition.py
@@ -394,11 +394,9 @@ async def test_doc_handler_valid_image(
     result = await photo_handlers.doc_handler(update, context)
 
     assert result == photo_handlers.PHOTO_SUGAR
-    user_data_valid = context.user_data
-    assert user_data_valid is not None
-    assert "__file_path" in user_data_valid
-    assert message.photo == ()
-    photo_mock.assert_called_once()
+    assert context.user_data == {}
+    assert message.photo is None
+    photo_mock.assert_awaited_once_with(update, context, file_path="photos/1_uid.png")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Pass downloaded document path directly to `photo_handler` instead of mutating `message.photo`
- Guard document downloads with TelegramError/OSError handling and user warnings
- Cover document handler path passing and error cases with new tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a4a0d1dca0832ab787848b38ec0226