### PR TITLE
[handlers] Handle invalid edit metadata

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -259,7 +259,9 @@ async def _handle_edit_entry(
         return True
     edit_info_raw = user_data.get("edit_entry")
     if not isinstance(edit_info_raw, dict):
-        return True
+        for key in ("edit_id", "edit_field", "edit_entry", "edit_query"):
+            user_data.pop(key, None)
+        return False
     edit_info = cast(EditMessageMeta, edit_info_raw)
     chat_id = edit_info["chat_id"]
     message_id = edit_info["message_id"]


### PR DESCRIPTION
## Summary
- clear edit state and return False when edit_entry metadata is missing
- cover missing edit_entry scenario with tests

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a4a0c39000832a88c1cb0a4ee1ffb4