### PR TITLE
[webapp] centralize telegram init data header

### DIFF
--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -15,6 +15,9 @@ from .schemas.user import UserContext
 
 logger = logging.getLogger(__name__)
 
+# Header carrying Telegram WebApp init data
+TG_INIT_DATA_HEADER = "X-Telegram-Init-Data"
+
 # Maximum allowed age of auth_date in seconds (24 hours)
 AUTH_DATE_MAX_AGE = 24 * 60 * 60
 
@@ -62,7 +65,7 @@ def parse_and_verify_init_data(init_data: str, token: str) -> dict[str, Any]:
 
 
 def require_tg_user(
-    init_data: str | None = Header(None, alias="X-Telegram-Init-Data"),
+    init_data: str | None = Header(None, alias=TG_INIT_DATA_HEADER),
 ) -> UserContext:
     """Dependency ensuring request contains valid Telegram user info."""
     if not init_data:

--- a/services/webapp/ui/src/lib/tgFetch.test.ts
+++ b/services/webapp/ui/src/lib/tgFetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import { tgFetch, REQUEST_TIMEOUT_MESSAGE } from './tgFetch';
+import { tgFetch, REQUEST_TIMEOUT_MESSAGE, TG_INIT_DATA_HEADER } from './tgFetch';
 
 interface TelegramWebApp {
   initData?: string;
@@ -24,12 +24,12 @@ describe('tgFetch', () => {
     vi.useRealTimers();
   });
 
-  it('attaches X-Telegram-Init-Data header when init data is present', async () => {
+  it(`attaches ${TG_INIT_DATA_HEADER} header when init data is present`, async () => {
     (window as TelegramWindow).Telegram = { WebApp: { initData: 'test-data' } };
     await tgFetch('/api/profile/self');
     const [, options] = (global.fetch as Mock).mock.calls[0] as [unknown, RequestInit];
     const headers = options.headers as Headers;
-    expect(headers.get('X-Telegram-Init-Data')).toBe('test-data');
+    expect(headers.get(TG_INIT_DATA_HEADER)).toBe('test-data');
     expect(options.credentials).toBe('include');
   });
 
@@ -38,7 +38,7 @@ describe('tgFetch', () => {
     await tgFetch('/api/profile/self');
     const [, options] = (global.fetch as Mock).mock.calls[0] as [unknown, RequestInit];
     const headers = options.headers as Headers;
-    expect(headers.has('X-Telegram-Init-Data')).toBe(false);
+    expect(headers.has(TG_INIT_DATA_HEADER)).toBe(false);
     expect(options.credentials).toBe('include');
   });
 

--- a/services/webapp/ui/src/lib/tgFetch.ts
+++ b/services/webapp/ui/src/lib/tgFetch.ts
@@ -1,3 +1,4 @@
+export const TG_INIT_DATA_HEADER = "X-Telegram-Init-Data";
 export const REQUEST_TIMEOUT_MESSAGE = "Превышено время ожидания запроса";
 const REQUEST_TIMEOUT = 10_000; // 10 seconds
 
@@ -16,7 +17,7 @@ export async function tgFetch(
   const headers = new Headers(init.headers || {});
   const tg = (window as TelegramWindow).Telegram?.WebApp;
   if (tg?.initData) {
-    headers.set("X-Telegram-Init-Data", tg.initData);
+    headers.set(TG_INIT_DATA_HEADER, tg.initData);
   }
 
   const controller = new AbortController();

--- a/tests/test_profile_self.py
+++ b/tests/test_profile_self.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from services.api.app.config import settings
 from services.api.app.main import app
+from services.api.app.telegram_auth import TG_INIT_DATA_HEADER
 
 TOKEN = "test-token"
 
@@ -27,7 +28,7 @@ def test_profile_self_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     init_data = build_init_data(42)
     with TestClient(app) as client:
         resp = client.get(
-            "/api/profile/self", headers={"X-Telegram-Init-Data": init_data}
+            "/api/profile/self", headers={TG_INIT_DATA_HEADER: init_data}
         )
     assert resp.status_code == 200
     assert resp.json()["id"] == 42
@@ -43,6 +44,6 @@ def test_profile_self_invalid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     with TestClient(app) as client:
         resp = client.get(
-            "/api/profile/self", headers={"X-Telegram-Init-Data": "bad"}
+            "/api/profile/self", headers={TG_INIT_DATA_HEADER: "bad"}
         )
     assert resp.status_code == 401

--- a/tests/test_webapp_history.py
+++ b/tests/test_webapp_history.py
@@ -15,6 +15,7 @@ from sqlalchemy.pool import StaticPool
 
 import services.api.app.main as server
 from services.api.app.diabetes.services import db
+from services.api.app.telegram_auth import TG_INIT_DATA_HEADER
 
 TOKEN = "test-token"
 
@@ -52,7 +53,7 @@ def test_history_auth_required(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_history_invalid_date_time(monkeypatch: pytest.MonkeyPatch) -> None:
     setup_db(monkeypatch)
     monkeypatch.setenv("TELEGRAM_TOKEN", TOKEN)
-    headers = {"X-Telegram-Init-Data": build_init_data(1)}
+    headers = {TG_INIT_DATA_HEADER: build_init_data(1)}
     with TestClient(server.app) as client:
         bad_date = {"id": "1", "date": "2024-13-01", "time": "12:00", "type": "measurement"}
         resp = client.post("/api/history", json=bad_date, headers=headers)
@@ -65,8 +66,8 @@ def test_history_invalid_date_time(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_history_persist_and_update(monkeypatch: pytest.MonkeyPatch) -> None:
     Session = setup_db(monkeypatch)
     monkeypatch.setenv("TELEGRAM_TOKEN", TOKEN)
-    headers1 = {"X-Telegram-Init-Data": build_init_data(1)}
-    headers2 = {"X-Telegram-Init-Data": build_init_data(2)}
+    headers1 = {TG_INIT_DATA_HEADER: build_init_data(1)}
+    headers2 = {TG_INIT_DATA_HEADER: build_init_data(2)}
     with TestClient(server.app) as client:
         rec1 = {
             "id": "1",
@@ -123,7 +124,7 @@ def test_history_persist_and_update(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_history_concurrent_writes(monkeypatch: pytest.MonkeyPatch) -> None:
     Session = setup_db(monkeypatch)
     monkeypatch.setenv("TELEGRAM_TOKEN", TOKEN)
-    headers = {"X-Telegram-Init-Data": build_init_data(1)}
+    headers = {TG_INIT_DATA_HEADER: build_init_data(1)}
     records = [{"id": str(i), "date": "2024-01-01", "time": "12:00", "type": "measurement"} for i in range(5)]
 
     async def post_record(rec: dict[str, Any]) -> None:

--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -16,6 +16,7 @@ from sqlalchemy.pool import StaticPool
 
 import services.api.app.main as server
 from services.api.app.diabetes.services import db
+from services.api.app.telegram_auth import TG_INIT_DATA_HEADER
 
 TOKEN = "test-token"
 
@@ -32,7 +33,7 @@ def build_init_data(user_id: int = 1) -> str:
 @pytest.fixture
 def auth_headers(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
     monkeypatch.setenv("TELEGRAM_TOKEN", TOKEN)
-    return {"X-Telegram-Init-Data": build_init_data()}
+    return {TG_INIT_DATA_HEADER: build_init_data()}
 
 
 def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker:

--- a/tests/test_webapp_user.py
+++ b/tests/test_webapp_user.py
@@ -14,6 +14,7 @@ from sqlalchemy.pool import StaticPool
 import services.api.app.main as server
 from services.api.app.config import settings
 from services.api.app.diabetes.services import db
+from services.api.app.telegram_auth import TG_INIT_DATA_HEADER
 
 
 def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker:
@@ -52,7 +53,7 @@ def test_create_user_authorized(monkeypatch: pytest.MonkeyPatch) -> None:
         resp = client.post(
             "/api/user",
             json={"telegram_id": 42},
-            headers={"X-Telegram-Init-Data": init_data},
+            headers={TG_INIT_DATA_HEADER: init_data},
         )
     assert resp.status_code == 200
 
@@ -70,6 +71,6 @@ def test_create_user_unauthorized(monkeypatch: pytest.MonkeyPatch) -> None:
         resp = client.post(
             "/api/user",
             json={"telegram_id": 42},
-            headers={"X-Telegram-Init-Data": init_data},
+            headers={TG_INIT_DATA_HEADER: init_data},
         )
     assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- centralize Telegram init data header name in `TG_INIT_DATA_HEADER`
- replace hardcoded header in webapp fetch helper and tests
- expose header constant in backend auth and align tests

## Testing
- `npm --workspace services/webapp/ui exec vitest run` *(fails: Cannot find package 'react-test-renderer'; ReferenceError: document is not defined)*
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a5e6cb7af4832a956488c34f1953fa