### PR TITLE
[webapp] Log Telegram WebApp in dev

### DIFF
--- a/services/webapp/ui/src/hooks/useTelegram.ts
+++ b/services/webapp/ui/src/hooks/useTelegram.ts
@@ -77,6 +77,9 @@ export const useTelegram = (
   );
 
   useEffect(() => {
+    if (import.meta.env.DEV) {
+      console.log(window.Telegram?.WebApp);
+    }
     let cancelled = false;
     if (!tg) {
       console.warn("[TG] not in Telegram, enabling dev fallback");


### PR DESCRIPTION
## Summary
- log `window.Telegram?.WebApp` when initializing Telegram, gated to development env

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `npm run lint` *(fails: Unexpected any.*)
- `npx vitest run` *(fails: missing react-test-renderer & document undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a936bd58832ab2d1df6a38831ec1