### PR TITLE
[webapp] rename VITE_API_BASE to VITE_API_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,16 @@ sudo apt install python3.12 python3.12-venv
 Приложение автоматически загружает переменные окружения из этого файла в корне проекта.
 
 - обязательные значения: `TELEGRAM_TOKEN` (токен бота), `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
-- дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `VITE_API_BASE`, `UVICORN_WORKERS`
+- дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `VITE_API_URL`, `UVICORN_WORKERS`
 - при необходимости настройте прокси для OpenAI через переменные окружения
-Переменная `VITE_API_BASE` задаёт базовый URL API для WebApp и используется SDK‑клиентом.
+Переменная `VITE_API_URL` задаёт базовый URL API для WebApp и используется SDK‑клиентом.
 Если переменная не задана, используется путь `/api`.
 Чтобы отправлять запросы на тот же домен без префикса, укажите пустое значение:
 
 ```env
-VITE_API_BASE=
+VITE_API_URL=
 # или задайте полный URL
-# VITE_API_BASE=http://localhost:8000
+# VITE_API_URL=http://localhost:8000
 ```
 
 Telegram‑клиенты не могут обращаться к `localhost`, поэтому `WEBAPP_URL` должен быть публичным **HTTPS**‑адресом. Для локальной разработки используйте туннель (например, [ngrok](https://ngrok.com/)).

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -20,7 +20,7 @@ JWT_EXPIRE_DAYS=7
 WEBAPP_URL=http://localhost:3000
 API_URL=http://localhost:8000
 # Optional base API URL for webapp; defaults to '/api'
-# VITE_API_BASE=http://localhost:8000
+# VITE_API_URL=http://localhost:8000
 
 # OpenAI configuration
 OPENAI_API_KEY=your-openai-api-key

--- a/services/webapp/ui/src/api/base.api.test.ts
+++ b/services/webapp/ui/src/api/base.api.test.ts
@@ -6,14 +6,14 @@ describe('API_BASE', () => {
     vi.resetModules();
   });
 
-  it('is empty string when VITE_API_BASE is empty', async () => {
-    vi.stubEnv('VITE_API_BASE', '');
+  it('is empty string when VITE_API_URL is empty', async () => {
+    vi.stubEnv('VITE_API_URL', '');
     vi.resetModules();
     const { API_BASE } = await import('./base');
     expect(API_BASE).toBe('');
   });
 
-  it('defaults to /api when VITE_API_BASE is undefined', async () => {
+  it('defaults to /api when VITE_API_URL is undefined', async () => {
     const { API_BASE } = await import('./base');
     expect(API_BASE).toBe('/api');
   });

--- a/services/webapp/ui/src/api/base.ts
+++ b/services/webapp/ui/src/api/base.ts
@@ -1,1 +1,1 @@
-export const API_BASE = import.meta.env.VITE_API_BASE ?? '/api';
+export const API_BASE = import.meta.env.VITE_API_URL ?? '/api';

--- a/services/webapp/ui/src/vite-env.d.ts
+++ b/services/webapp/ui/src/vite-env.d.ts
@@ -4,7 +4,7 @@
 declare global {
   interface ImportMetaEnv {
     readonly VITE_TELEGRAM_BOT?: string;
-    readonly VITE_API_BASE?: string;
+    readonly VITE_API_URL?: string;
     readonly VITE_FORCE_LIGHT?: string;
   }
   interface ImportMeta {


### PR DESCRIPTION
## Summary
- switch VITE_API_BASE environment variable to VITE_API_URL
- align docs and env example with new variable
- update API base constant and tests

## Testing
- `npx vitest run` *(fails: Cannot find package 'react-test-renderer'; document is not defined)*
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a6a9a00a14832aba088b8f13246566