### PR TITLE
tests: enable postponed evaluation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Iterator
 import sqlite3
 from typing import Any, Callable
@@ -29,12 +31,15 @@ _original_create_engine: Callable[..., sqlalchemy.engine.Engine] = (
     sqlalchemy.create_engine
 )
 
+
 def _tracking_create_engine(*args: Any, **kwargs: Any) -> sqlalchemy.engine.Engine:
     engine = _original_create_engine(*args, **kwargs)
     _engines.append(engine)
     return engine
 
+
 setattr(sqlalchemy, "create_engine", _tracking_create_engine)
+
 
 @pytest.fixture(autouse=True, scope="session")
 def _close_sqlite_connections() -> Iterator[None]:


### PR DESCRIPTION
## Summary
- enable postponed annotations in test configuration

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a6aeaf3c04832a944729c6b7db2fd9