### PR TITLE
[webapp] Normalize router base path

### DIFF
--- a/services/webapp/ui/src/main.tsx
+++ b/services/webapp/ui/src/main.tsx
@@ -16,9 +16,11 @@ if (rootElement === null) {
   throw new Error('Root element with id "root" not found')
 }
 
+const basename = import.meta.env.BASE_URL.replace(/\/$/, '')
+
 createRoot(rootElement).render(
   <React.StrictMode>
-    <BrowserRouter basename={import.meta.env.BASE_URL}>
+    <BrowserRouter basename={basename}>
       <TelegramProvider>
         <App />
       </TelegramProvider>


### PR DESCRIPTION
## Summary
- normalize BrowserRouter basename using BASE_URL without trailing slash

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `npm --workspace services/webapp/ui run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6b56015fc832a93f9a435081c0735