### PR TITLE
[tests] add UI routes tests

### DIFF
--- a/services/webapp/ui/real-file.js
+++ b/services/webapp/ui/real-file.js
@@ -1,0 +1,1 @@
+console.log('real file');

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -1,0 +1,41 @@
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.api.app.main import UI_DIR, app
+
+
+@pytest.fixture()
+def client() -> Iterator[TestClient]:
+    with TestClient(app) as client:
+        yield client
+
+
+def _index_html() -> str:
+    return (UI_DIR / "index.html").read_text()
+
+
+def test_ui_root_returns_index(client: TestClient) -> None:
+    expected = _index_html()
+    response = client.get("/ui")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert response.text == expected
+
+
+def test_ui_any_path_returns_index(client: TestClient) -> None:
+    expected = _index_html()
+    response = client.get("/ui/anything")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert response.text == expected
+
+
+def test_ui_existing_file_returns_file(client: TestClient) -> None:
+    file_path = UI_DIR / "real-file.js"
+    expected = file_path.read_text()
+    response = client.get("/ui/real-file.js")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/javascript")
+    assert response.text == expected


### PR DESCRIPTION
## Summary
- add tests ensuring `/ui` paths serve `index.html` and existing files are returned
- include a real JS file for testing static assets

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68a6be713b20832abe865c14c262e8ba