### PR TITLE
[handlers] ensure webapp URLs join correctly

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -8,6 +8,7 @@ import logging
 import re
 from datetime import time, timedelta, timezone
 from typing import Callable, Literal, cast
+from urllib.parse import urljoin
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy.orm import Session, sessionmaker
@@ -51,6 +52,12 @@ DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]
 PLAN_LIMITS = {"free": 5, "pro": 10}
 
 from . import UserData
+
+def build_webapp_url(path: str) -> str:
+    base = settings.webapp_url.rstrip("/") + "/"
+    if not path.startswith("/"):
+        path = "/" + path
+    return urljoin(base, path)
 
 # Map reminder type codes to display names
 REMINDER_NAMES = {
@@ -152,7 +159,7 @@ def _render_reminders(
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
-                web_app=WebAppInfo(f"{settings.webapp_url}/ui/reminders"),
+                web_app=WebAppInfo(build_webapp_url("/ui/reminders")),
             )
         ]
     if not rems:
@@ -180,7 +187,9 @@ def _render_reminders(
             row.append(
                 InlineKeyboardButton(
                     "✏️",
-                    web_app=WebAppInfo(f"{settings.webapp_url}/ui/reminders?id={r.id}"),
+                    web_app=WebAppInfo(
+                        build_webapp_url(f"/ui/reminders?id={r.id}")
+                    ),
                 )
             )
         row.extend(

--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -7,6 +7,7 @@ from telegram import Update, User
 from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
+from services.api.app.config import settings
 from services.api.app.diabetes.utils.helpers import INVALID_TIME_MSG
 
 
@@ -132,3 +133,19 @@ async def test_reminder_webapp_save_unknown_type() -> None:
     await reminder_handlers.reminder_webapp_save(update, context)
 
     assert message.texts == ["Неизвестный тип напоминания."]
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://example.com",
+        "https://example.com/",
+        "https://example.com/ui",
+        "https://example.com/ui/",
+    ],
+)
+def test_build_webapp_url(monkeypatch: pytest.MonkeyPatch, base_url: str) -> None:
+    monkeypatch.setattr(settings, "webapp_url", base_url)
+    url = reminder_handlers.build_webapp_url("/ui/reminders")
+    assert url == "https://example.com/ui/reminders"
+    assert "//" not in url.split("://", 1)[1]


### PR DESCRIPTION
## Summary
- add `build_webapp_url` helper to join `WEBAPP_URL` paths safely
- use helper in reminder buttons to avoid double slashes
- test URL builder for bases with and without `/ui`

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a6be9a3df4832a9d082531f64c2d34