### PR TITLE
[webapp] Redirect to reminders on start param

### DIFF
--- a/services/webapp/ui/src/hooks/use-mobile.test.tsx
+++ b/services/webapp/ui/src/hooks/use-mobile.test.tsx
@@ -10,9 +10,13 @@ describe("useIsMobile", () => {
       result = useIsMobile();
       return null;
     };
+    const originalWindow = (global as any).window;
+    // @ts-expect-error simulate absence of window
+    delete (global as any).window;
     act(() => {
       TestRenderer.create(<TestComponent />);
     });
+    (global as any).window = originalWindow;
     expect(result).toBe(false);
-  }, { environment: "node" });
+  });
 });

--- a/services/webapp/ui/src/hooks/use-telegram.test.tsx
+++ b/services/webapp/ui/src/hooks/use-telegram.test.tsx
@@ -1,0 +1,44 @@
+import { render, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { useTelegram } from "./useTelegram";
+
+const navigate = vi.fn();
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigate,
+}));
+
+vi.mock("../lib/telegram-theme", () => ({
+  __esModule: true,
+  default: () => "light",
+}));
+
+describe("useTelegram start_param", () => {
+  afterEach(() => {
+    delete (window as any).Telegram;
+    navigate.mockReset();
+  });
+
+  it("navigates to reminders when start_param is reminders", async () => {
+    (window as any).Telegram = {
+      WebApp: {
+        initDataUnsafe: { user: { id: 1 }, start_param: "reminders" },
+        initData: "",
+        expand: vi.fn(),
+        ready: vi.fn(),
+        onEvent: vi.fn(),
+        offEvent: vi.fn(),
+      },
+    };
+
+    const TestComponent = () => {
+      useTelegram();
+      return null;
+    };
+
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith("/reminders");
+    });
+  });
+});

--- a/tests/useTelegram.test.ts
+++ b/tests/useTelegram.test.ts
@@ -2,6 +2,11 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { useTelegram } from '../services/webapp/ui/src/hooks/useTelegram';
 
+const navigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+}));
+
 describe('useTelegram hook fallback', () => {
   beforeEach(() => {
     (window as any).Telegram = {
@@ -23,6 +28,7 @@ describe('useTelegram hook fallback', () => {
 
   afterEach(() => {
     delete (window as any).Telegram;
+    navigate.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -55,6 +61,7 @@ describe('useTelegram hook init error', () => {
 
   afterEach(() => {
     delete (window as any).Telegram;
+    navigate.mockReset();
     vi.restoreAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- redirect to `/reminders` when Telegram start param equals `reminders`
- add tests for start param redirection and adjust existing tests

## Testing
- `npx vitest run`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a6d0509e0c832a8f6a92981d2d85eb