### PR TITLE
[webapp] warn on missing hardware acceleration

### DIFF
--- a/services/webapp/ui/README.md
+++ b/services/webapp/ui/README.md
@@ -60,6 +60,14 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Hardware acceleration
+
+The web client prefers hardware-accelerated rendering via WebGL. If the browser
+falls back to software rendering, the application will show a warning and some
+graphics features may be disabled. In trusted environments that still require
+software rendering, start the browser with
+`--enable-unsafe-swiftshader` to allow SwiftShader.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/a6cc1696-4643-4e14-b587-2421843125e1) and click on Share -> Publish.

--- a/services/webapp/ui/src/App.tsx
+++ b/services/webapp/ui/src/App.tsx
@@ -6,6 +6,12 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Routes, Route } from "react-router-dom";
 import { ThemeProvider } from "next-themes";
 import { Suspense, lazy } from "react";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
+import useHardwareAcceleration from "@/hooks/use-hardware-acceleration";
 import { useTelegramContext } from "@/contexts/telegram-context";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
@@ -24,6 +30,7 @@ const queryClient = new QueryClient();
 
 const AppContent = () => {
   const { isReady, error, tg } = useTelegramContext();
+  const hasAcceleration = useHardwareAcceleration();
 
   const openInTelegram = (
     <div className="min-h-screen bg-background flex items-center justify-center">
@@ -70,6 +77,18 @@ const AppContent = () => {
   return (
     <Suspense fallback={<div>Загрузка...</div>}>
       <ErrorBoundary>
+        {!hasAcceleration && (
+          <div className="m-4">
+            <Alert variant="destructive">
+              <AlertTitle>Аппаратное ускорение недоступно</AlertTitle>
+              <AlertDescription>
+                Графические функции могут быть отключены. В доверенной среде можно
+                запустить браузер с флагом <code>--enable-unsafe-swiftshader</code> для
+                программного рендеринга.
+              </AlertDescription>
+            </Alert>
+          </div>
+        )}
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/profile" element={<Profile />} />

--- a/services/webapp/ui/src/hooks/use-hardware-acceleration.test.tsx
+++ b/services/webapp/ui/src/hooks/use-hardware-acceleration.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { isHardwareAccelerationEnabled } from "./use-hardware-acceleration";
+
+describe("isHardwareAccelerationEnabled", () => {
+  it("returns false when WebGL context is unavailable", () => {
+    const original = document.createElement;
+    document.createElement = vi
+      .fn()
+      .mockReturnValue({ getContext: () => null } as unknown as HTMLCanvasElement);
+    expect(isHardwareAccelerationEnabled()).toBe(false);
+    document.createElement = original;
+  });
+
+  it("returns false for software renderers", () => {
+    const original = document.createElement;
+    document.createElement = vi.fn().mockReturnValue(
+      {
+        getContext: () => ({
+          getExtension: () => ({ UNMASKED_RENDERER_WEBGL: "r" }),
+          getParameter: () => "SwiftShader",
+        }),
+      } as unknown as HTMLCanvasElement,
+    );
+    expect(isHardwareAccelerationEnabled()).toBe(false);
+    document.createElement = original;
+  });
+
+  it("returns true for hardware renderers", () => {
+    const original = document.createElement;
+    document.createElement = vi.fn().mockReturnValue(
+      {
+        getContext: () => ({
+          getExtension: () => ({ UNMASKED_RENDERER_WEBGL: "r" }),
+          getParameter: () => "GeForce",
+        }),
+      } as unknown as HTMLCanvasElement,
+    );
+    expect(isHardwareAccelerationEnabled()).toBe(true);
+    document.createElement = original;
+  });
+});

--- a/services/webapp/ui/src/hooks/use-hardware-acceleration.ts
+++ b/services/webapp/ui/src/hooks/use-hardware-acceleration.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+
+export const isHardwareAccelerationEnabled = (): boolean => {
+  const canvas = document.createElement("canvas");
+  const gl =
+    canvas.getContext("webgl2") ||
+    canvas.getContext("webgl") ||
+    canvas.getContext("experimental-webgl");
+
+  if (!gl) {
+    return false;
+  }
+
+  const debugInfo = (gl as WebGLRenderingContext).getExtension(
+    "WEBGL_debug_renderer_info",
+  ) as WebGLDebugRendererInfo | null;
+
+  if (debugInfo) {
+    const renderer = (gl as WebGLRenderingContext).getParameter(
+      debugInfo.UNMASKED_RENDERER_WEBGL,
+    ) as string;
+    if (/swiftshader|software|llvmpipe/i.test(renderer)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export const useHardwareAcceleration = (): boolean => {
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    setEnabled(isHardwareAccelerationEnabled());
+  }, []);
+
+  return enabled;
+};
+
+export default useHardwareAcceleration;


### PR DESCRIPTION
## Summary
- check WebGL renderer to detect hardware acceleration
- warn users when only software rendering is available
- document `--enable-unsafe-swiftshader` flag for trusted environments

## Testing
- `npx vitest run` *(fails: Error: Failed to resolve import "react-test-renderer"...)*
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `npm --workspace services/webapp/ui run lint` *(fails: Unexpected any. Specify a different type)*
- `npm --workspace services/webapp/ui run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a6effd45e8832a9a44fa9ff22d21c0