### PR TITLE
[functions] Ignore NaN and infinite floats

### DIFF
--- a/services/api/app/diabetes/utils/functions.py
+++ b/services/api/app/diabetes/utils/functions.py
@@ -1,6 +1,7 @@
 """Утилиты для расчёта болюса и разбора пищевой информации."""
 
 from dataclasses import dataclass
+import math
 import re
 from decimal import Decimal, localcontext
 
@@ -87,7 +88,8 @@ def _safe_float(value: object) -> float | None:
         value: Произвольный объект. Нестроковые значения приводят к ``None``.
 
     Returns:
-        Число с плавающей точкой или ``None``.
+        Число с плавающей точкой или ``None``. Значения ``NaN`` и
+        бесконечности также преобразуются в ``None``.
 
     Examples:
         >>> _safe_float("1,5")
@@ -96,9 +98,10 @@ def _safe_float(value: object) -> float | None:
     if not isinstance(value, str):
         return None
     try:
-        return float(value.strip().replace(",", "."))
+        result = float(value.strip().replace(",", "."))
     except ValueError:
         return None
+    return result if math.isfinite(result) else None
 
 
 @dataclass

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -21,6 +21,11 @@ def test_safe_float_none() -> None:
     assert _safe_float(None) is None
 
 
+@pytest.mark.parametrize("value", ["NaN", "inf", "-inf"])
+def test_safe_float_non_finite(value: str) -> None:
+    assert _safe_float(value) is None
+
+
 def test_calc_bolus_basic() -> None:
     profile = PatientProfile(icr=12, cf=2, target_bg=6)
     result = calc_bolus(carbs_g=60, current_bg=8, profile=profile)


### PR DESCRIPTION
## Summary
- ensure `_safe_float` rejects non-finite values using `math.isfinite`
- add unit tests for `NaN`, `inf`, and `-inf` cases

## Testing
- `pytest -q --cov | tail -n 5`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a71c555bd8832abb6a8ef89ba9da34