### PR TITLE
[profile] raise ProfileSaveError on local save failure

### DIFF
--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -12,6 +12,10 @@ from services.api.app.diabetes.services.repository import commit
 logger = logging.getLogger(__name__)
 
 
+class ProfileSaveError(Exception):
+    """Raised when persisting profile data fails."""
+
+
 @dataclass
 class LocalProfile:
     """Minimal profile model used when the external SDK is unavailable."""
@@ -55,7 +59,7 @@ class LocalProfileAPI:
                 profile.high or 0.0,
             )
             if not ok:
-                raise Exception("Failed to save profile")
+                raise ProfileSaveError("Failed to save profile")
 
     def profiles_get(self, telegram_id: int) -> LocalProfile | None:
         """Return a profile for ``telegram_id`` from the database."""

--- a/tests/handlers/profile/test_api.py
+++ b/tests/handlers/profile/test_api.py
@@ -132,6 +132,16 @@ def test_save_profile_commit_failure(
         assert prof is None
 
 
+def test_local_profiles_post_failure(
+    monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker
+) -> None:
+    api = profile_api.LocalProfileAPI()
+    monkeypatch.setattr(api, "_sessionmaker", lambda: session_factory)
+    monkeypatch.setattr(profile_api, "save_profile", lambda *a, **k: False)
+    with pytest.raises(profile_api.ProfileSaveError):
+        api.profiles_post(profile_api.LocalProfile(telegram_id=1))
+
+
 def test_set_timezone_persists(session_factory: sessionmaker) -> None:
     with session_factory() as session:
         session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))


### PR DESCRIPTION
## Summary
- add ProfileSaveError for failed local profile persistence
- test LocalProfileAPI.profiles_post raises ProfileSaveError

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a71c561428832ab542fe337fea531b