### PR TITLE
[tests] Increase coverage threshold

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ asyncio_mode = auto
 addopts =
     --cov=services.api.app.diabetes
     --cov-report=term-missing
-    --cov-fail-under=74
+    --cov-fail-under=85
 markers =
     asyncio: mark a coroutine test
 filterwarnings =


### PR DESCRIPTION
## Summary
- enforce 85% coverage threshold in pytest

## Testing
- `pytest --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a71c55d888832a93aa7d234f96d53c