### PR TITLE
[webapp] Normalize API base URL

### DIFF
--- a/services/webapp/ui/src/api/base.api.test.ts
+++ b/services/webapp/ui/src/api/base.api.test.ts
@@ -6,11 +6,11 @@ describe('API_BASE', () => {
     vi.resetModules();
   });
 
-  it('is empty string when VITE_API_URL is empty', async () => {
+  it('defaults to /api when VITE_API_URL is empty', async () => {
     vi.stubEnv('VITE_API_URL', '');
     vi.resetModules();
     const { API_BASE } = await import('./base');
-    expect(API_BASE).toBe('');
+    expect(API_BASE).toBe('/api');
   });
 
   it('defaults to /api when VITE_API_URL is undefined', async () => {

--- a/services/webapp/ui/src/api/base.ts
+++ b/services/webapp/ui/src/api/base.ts
@@ -1,1 +1,2 @@
-export const API_BASE = import.meta.env.VITE_API_URL ?? '/api';
+const url = import.meta.env.VITE_API_URL?.trim();
+export const API_BASE = url ? url.replace(/\/$/, '') : '/api';


### PR DESCRIPTION
## Summary
- trim VITE_API_URL and default to /api
- adjust API base tests for empty or undefined values

## Testing
- `npm --workspace services/webapp/ui exec vitest run src/api/base.api.test.ts`
- `npm --workspace services/webapp/ui exec vitest run` *(fails: document/window is not defined; react-test-renderer missing)*
- `npm --workspace services/webapp/ui run lint` *(fails: Unexpected any in existing files)*
- `npm --workspace services/webapp/ui run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a73ee9564c832ab0d96d7afd76c163