### PR TITLE
[legacy] Require Telegram auth for reminders

### DIFF
--- a/tests/test_legacy_reminders_auth.py
+++ b/tests/test_legacy_reminders_auth.py
@@ -1,0 +1,78 @@
+import hashlib
+import hmac
+import json
+import time
+import urllib.parse
+from collections.abc import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import services.api.app.main as server
+from services.api.app.config import settings
+from services.api.app.diabetes.services.db import Base, User
+from services.api.app.services import reminders
+
+TOKEN = "test-token"
+
+
+def build_init_data(token: str = TOKEN, user_id: int = 1) -> str:
+    user = json.dumps({"id": user_id, "first_name": "A"}, separators=(",", ":"))
+    params = {
+        "auth_date": str(int(time.time())),
+        "query_id": "abc",
+        "user": user,
+    }
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
+    secret = hmac.new(b"WebAppData", token.encode(), hashlib.sha256).digest()
+    params["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return urllib.parse.urlencode(params)
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setenv("TELEGRAM_TOKEN", TOKEN)
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    monkeypatch.setattr(reminders, "SessionLocal", TestSession)
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.commit()
+    try:
+        with TestClient(server.app) as test_client:
+            yield test_client
+    finally:
+        engine.dispose()
+
+
+def test_post_and_get_reminders_with_auth(client: TestClient) -> None:
+    init_data = build_init_data()
+    resp_post = client.post(
+        "/api/reminders",
+        json={"telegram_id": 1, "type": "sugar"},
+        headers={"X-Telegram-Init-Data": init_data},
+    )
+    assert resp_post.status_code == 200
+    reminder_id = resp_post.json()["id"]
+
+    resp_get = client.get(
+        "/api/reminders",
+        params={"telegram_id": 1},
+        headers={"X-Telegram-Init-Data": init_data},
+    )
+    assert resp_get.status_code == 200
+    assert any(r["id"] == reminder_id for r in resp_get.json())
+
+
+def test_reminders_missing_auth(client: TestClient) -> None:
+    resp = client.get("/api/reminders", params={"telegram_id": 1})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- enforce Telegram WebApp auth on legacy reminders endpoints
- add tests for reminders API with init data validation

## Testing
- `ruff check services/api/app/legacy.py tests/test_legacy_reminders_auth.py`
- `mypy --strict services/api/app/legacy.py tests/test_legacy_reminders_auth.py`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68a73d8e4088832a856be4bbb2454065