### PR TITLE
[reminders] Normalize webapp URLs and rebuild dist

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+WEBAPP_URL=https://bot.offonika.ru

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -216,7 +216,9 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                     [
                         InlineKeyboardButton(
                             "📝 Заполнить форму",
-                            web_app=WebAppInfo(f"{settings.webapp_url}/ui/profile"),
+                            web_app=WebAppInfo(
+                                reminder_handlers.build_webapp_url("/ui/profile")
+                            ),
                         )
                     ]
                 ]
@@ -255,7 +257,9 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             [
                 InlineKeyboardButton(
                     "📝 Заполнить форму",
-                    web_app=WebAppInfo(f"{settings.webapp_url}/ui/profile"),
+                    web_app=WebAppInfo(
+                        reminder_handlers.build_webapp_url("/ui/profile")
+                    ),
                 )
             ],
         )
@@ -510,7 +514,10 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         return
     if action == "add" and settings.webapp_url:
         button = InlineKeyboardButton(
-            "📝 Новое", web_app=WebAppInfo(f"{settings.webapp_url}/ui/reminders")
+            "📝 Новое",
+            web_app=WebAppInfo(
+                reminder_handlers.build_webapp_url("/ui/reminders")
+            ),
         )
         keyboard = InlineKeyboardMarkup([[button]])
         await q_message.reply_text("Создать напоминание:", reply_markup=keyboard)

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -26,7 +26,11 @@ __all__ = (
 )
 
 # ─────────────── Reply-клавиатуры (отображаются на экране чата) ───────────────
-_WEBAPP_URL = settings.webapp_url.rstrip("/") if settings.webapp_url else None
+_WEBAPP_URL = (
+    settings.webapp_url.rstrip("/").removesuffix("/ui")
+    if settings.webapp_url
+    else None
+)
 
 # Create WebApp buttons when WebApp is configured, fall back to text buttons otherwise
 profile_button = (

--- a/services/webapp/ui/dist/index.html
+++ b/services/webapp/ui/dist/index.html
@@ -21,7 +21,7 @@
     <link rel="apple-touch-icon" href="/ui/app-icon.png" />
 
     <!-- Глобальные стили (раздаются сервером как /style.css) -->
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="/ui/style.css" />
 
     <!-- Шрифты -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -33,7 +33,6 @@
 
     <!-- Telegram SDK + инициализация темы (не бандлим, грузим отдельным скриптом) -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <script type="module" src="%BASE_URL%telegram-init.js"></script>
 
     <!-- Open Graph / Twitter -->
     <meta property="og:title" content="СахарФото — ассистент для диабетиков" />
@@ -47,11 +46,14 @@
     <meta name="twitter:title" content="СахарФото — ассистент для диабетиков" />
     <meta name="twitter:description" content="Распознаёт еду по фото, считает углеводы/ХЕ и помогает с напоминаниями." />
     <meta name="twitter:image" content="/ui/app-og.png" />
+    <script type="module" crossorigin src="/ui/assets/vendor-CzhASIQC.js"></script>
+    <script type="module" crossorigin src="/ui/assets/telegram-theme.js"></script>
+    <script type="module" crossorigin src="/ui/assets/index-DD5RSBpz.js"></script>
+    <link rel="stylesheet" crossorigin href="/ui/assets/index-Wkace_xE.css">
   </head>
 
   <body>
     <div id="root"></div>
     <!-- Точка входа Vite -->
-    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/services/webapp/ui/dist/real-file.js
+++ b/services/webapp/ui/dist/real-file.js
@@ -1,1 +1,0 @@
-console.log('real file');


### PR DESCRIPTION
## Summary
- normalize `WEBAPP_URL` handling to avoid duplicate `/ui`
- update profile handler to use `build_webapp_url`
- rebuild frontend dist and set `WEBAPP_URL` in `.env`

## Testing
- `npm run build`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a757c96b68832ab6a8a88ee59cd609