### PR TITLE
[webapp] refine API_BASE fallback handling

### DIFF
--- a/services/webapp/ui/src/api/base.api.test.ts
+++ b/services/webapp/ui/src/api/base.api.test.ts
@@ -6,14 +6,13 @@ describe('API_BASE', () => {
     vi.resetModules();
   });
 
-  it('defaults to /api when VITE_API_URL is empty', async () => {
-    vi.stubEnv('VITE_API_URL', '');
-    vi.resetModules();
+  it('defaults to /api when VITE_API_URL is undefined', async () => {
     const { API_BASE } = await import('./base');
     expect(API_BASE).toBe('/api');
   });
 
-  it('defaults to /api when VITE_API_URL is undefined', async () => {
+  it('defaults to /api when VITE_API_URL is empty', async () => {
+    vi.stubEnv('VITE_API_URL', '   ');
     const { API_BASE } = await import('./base');
     expect(API_BASE).toBe('/api');
   });

--- a/services/webapp/ui/src/api/base.ts
+++ b/services/webapp/ui/src/api/base.ts
@@ -1,2 +1,8 @@
-const url = import.meta.env.VITE_API_URL?.trim();
-export const API_BASE = url ? url.replace(/\/$/, '') : '/api';
+const rawUrl = import.meta.env.VITE_API_URL;
+const trimmedUrl =
+  typeof rawUrl === 'string' ? rawUrl.trim() : undefined;
+
+export const API_BASE =
+  trimmedUrl === undefined || trimmedUrl === ''
+    ? '/api'
+    : trimmedUrl.replace(/\/$/, '');


### PR DESCRIPTION
## Summary
- ensure API_BASE uses VITE_API_URL unless it is undefined or empty
- expand API_BASE tests for undefined and empty env values

## Testing
- `npm --workspace services/webapp/ui exec vitest run src/api/base.api.test.ts` *(fails: Cannot find package 'vite/index.js')*
- `pytest tests/test_config.py -q` *(hangs, interrupted)*
- `mypy --strict services/api/app/diabetes` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a763c12794832a8f176bbc5e299719