### PR TITLE
[api] Remove api prefix from routes

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -42,7 +42,7 @@ async def profiles_get(telegram_id: int) -> ProfileSchema:
     )
 
 
-@router.get("/api/reminders", dependencies=[Depends(require_tg_user)])
+@router.get("/reminders", dependencies=[Depends(require_tg_user)])
 async def api_reminders(
     telegram_id: int,
     request: Request,
@@ -75,7 +75,7 @@ async def api_reminders(
     return {}
 
 
-@router.post("/api/reminders", dependencies=[Depends(require_tg_user)])
+@router.post("/reminders", dependencies=[Depends(require_tg_user)])
 async def api_reminders_post(data: ReminderSchema) -> dict[str, object]:
     rid = await save_reminder(data)
     return {"status": "ok", "id": rid}

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -122,12 +122,12 @@ async def put_timezone(
     return {"status": "ok"}
 
 
-@app.get("/api/profile/self")
+@app.get("/profile/self")
 async def profile_self(user: UserContext = Depends(require_tg_user)) -> UserContext:
     return user
 
 
-@app.get("/api/stats")
+@app.get("/stats")
 async def get_stats(
     telegram_id: int = Query(alias="telegramId"),
     user: UserContext = Depends(require_tg_user),
@@ -137,7 +137,7 @@ async def get_stats(
     return DayStats(sugar=5.7, breadUnits=3, insulin=10)
 
 
-@app.get("/api/analytics")
+@app.get("/analytics")
 async def get_analytics(
     telegram_id: int = Query(alias="telegramId"),
     user: UserContext = Depends(require_tg_user),
@@ -170,7 +170,7 @@ async def catch_root_ui() -> FileResponse:
     return await catch_all_ui("")
 
 
-@app.post("/api/user")
+@app.post("/user")
 async def create_user(
     data: WebUser,
     user: UserContext = Depends(require_tg_user),
@@ -195,7 +195,7 @@ async def create_user(
     return {"status": "ok"}
 
 
-@app.post("/api/history")
+@app.post("/history")
 async def post_history(
     data: HistoryRecordSchema, user: UserContext = Depends(require_tg_user)
 ) -> dict[str, str]:
@@ -243,7 +243,7 @@ async def post_history(
     return {"status": "ok"}
 
 
-@app.get("/api/history")
+@app.get("/history")
 async def get_history(
     user: UserContext = Depends(require_tg_user),
 ) -> list[HistoryRecordSchema]:
@@ -281,7 +281,7 @@ async def get_history(
     return result
 
 
-@app.delete("/api/history/{record_id}")
+@app.delete("/history/{record_id}")
 async def delete_history(
     record_id: str, user: UserContext = Depends(require_tg_user)
 ) -> dict[str, str]:

--- a/tests/test_legacy_reminders_auth.py
+++ b/tests/test_legacy_reminders_auth.py
@@ -57,7 +57,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]
 def test_post_and_get_reminders_with_auth(client: TestClient) -> None:
     init_data = build_init_data()
     resp_post = client.post(
-        "/api/reminders",
+        "/reminders",
         json={"telegram_id": 1, "type": "sugar"},
         headers={"X-Telegram-Init-Data": init_data},
     )
@@ -65,7 +65,7 @@ def test_post_and_get_reminders_with_auth(client: TestClient) -> None:
     reminder_id = resp_post.json()["id"]
 
     resp_get = client.get(
-        "/api/reminders",
+        "/reminders",
         params={"telegram_id": 1},
         headers={"X-Telegram-Init-Data": init_data},
     )
@@ -74,5 +74,5 @@ def test_post_and_get_reminders_with_auth(client: TestClient) -> None:
 
 
 def test_reminders_missing_auth(client: TestClient) -> None:
-    resp = client.get("/api/reminders", params={"telegram_id": 1})
+    resp = client.get("/reminders", params={"telegram_id": 1})
     assert resp.status_code == 401

--- a/tests/test_profile_self.py
+++ b/tests/test_profile_self.py
@@ -28,7 +28,7 @@ def test_profile_self_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     init_data = build_init_data(42)
     with TestClient(app) as client:
         resp = client.get(
-            "/api/profile/self", headers={TG_INIT_DATA_HEADER: init_data}
+            "/profile/self", headers={TG_INIT_DATA_HEADER: init_data}
         )
     assert resp.status_code == 200
     assert resp.json()["id"] == 42
@@ -36,7 +36,7 @@ def test_profile_self_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_profile_self_missing_header() -> None:
     with TestClient(app) as client:
-        resp = client.get("/api/profile/self")
+        resp = client.get("/profile/self")
     assert resp.status_code == 401
 
 
@@ -44,6 +44,6 @@ def test_profile_self_invalid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     with TestClient(app) as client:
         resp = client.get(
-            "/api/profile/self", headers={TG_INIT_DATA_HEADER: "bad"}
+            "/profile/self", headers={TG_INIT_DATA_HEADER: "bad"}
         )
     assert resp.status_code == 401

--- a/tests/test_stats_api.py
+++ b/tests/test_stats_api.py
@@ -28,7 +28,7 @@ def test_stats_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     init_data = build_init_data(42)
     with TestClient(app) as client:
         resp = client.get(
-            "/api/stats",
+            "/stats",
             params={"telegramId": 42},
             headers={TG_INIT_DATA_HEADER: init_data},
         )
@@ -39,7 +39,7 @@ def test_stats_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_stats_missing_header() -> None:
     with TestClient(app) as client:
-        resp = client.get("/api/stats", params={"telegramId": 1})
+        resp = client.get("/stats", params={"telegramId": 1})
     assert resp.status_code == 401
 
 
@@ -48,7 +48,7 @@ def test_stats_mismatched_id(monkeypatch: pytest.MonkeyPatch) -> None:
     init_data = build_init_data(1)
     with TestClient(app) as client:
         resp = client.get(
-            "/api/stats",
+            "/stats",
             params={"telegramId": 2},
             headers={TG_INIT_DATA_HEADER: init_data},
         )
@@ -60,7 +60,7 @@ def test_analytics_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     init_data = build_init_data(7)
     with TestClient(app) as client:
         resp = client.get(
-            "/api/analytics",
+            "/analytics",
             params={"telegramId": 7},
             headers={TG_INIT_DATA_HEADER: init_data},
         )

--- a/tests/test_webapp_reminders_auth.py
+++ b/tests/test_webapp_reminders_auth.py
@@ -58,7 +58,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]
 def test_reminders_authorized_without_role(client: TestClient) -> None:
     init_data = build_init_data()
     resp = client.get(
-        "/api/reminders",
+        "/reminders",
         params={"telegram_id": 1},
         headers={TG_INIT_DATA_HEADER: init_data},
     )

--- a/tests/test_webapp_user.py
+++ b/tests/test_webapp_user.py
@@ -51,7 +51,7 @@ def test_create_user_authorized(monkeypatch: pytest.MonkeyPatch) -> None:
     init_data = build_init_data(42)
     with TestClient(server.app) as client:
         resp = client.post(
-            "/api/user",
+            "/user",
             json={"telegram_id": 42},
             headers={TG_INIT_DATA_HEADER: init_data},
         )
@@ -69,7 +69,7 @@ def test_create_user_unauthorized(monkeypatch: pytest.MonkeyPatch) -> None:
     init_data = build_init_data(1)
     with TestClient(server.app) as client:
         resp = client.post(
-            "/api/user",
+            "/user",
             json={"telegram_id": 42},
             headers={TG_INIT_DATA_HEADER: init_data},
         )


### PR DESCRIPTION
## Summary
- drop `/api` prefix from FastAPI routes
- update tests for new paths without `/api`

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a767cdcec8832ab67a79a27fb2f706