### PR TITLE
[sdk] Export Reminder model for webapp

### DIFF
--- a/libs/ts-sdk/models/index.ts
+++ b/libs/ts-sdk/models/index.ts
@@ -6,6 +6,7 @@ export * from './HTTPValidationError';
 export * from './HistoryRecordSchemaInput';
 export * from './HistoryRecordSchemaOutput';
 export * from './ProfileSchema';
+export * from './Reminder';
 export * from './ReminderSchema';
 export * from './ResponseApiRemindersRemindersGet';
 export * from './Timezone';

--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -7,15 +7,26 @@ const mockRemindersPatch = vi.hoisted(() => vi.fn());
 const mockRemindersDelete = vi.hoisted(() => vi.fn());
 const mockInstanceOfReminder = vi.hoisted(() => vi.fn());
 
-vi.mock('@sdk', () => ({
-  DefaultApi: vi.fn(() => ({
-    remindersGet: mockRemindersGet,
-    remindersPost: mockRemindersPost,
-    remindersPatch: mockRemindersPatch,
-    remindersDelete: mockRemindersDelete,
-  })),
-  instanceOfReminder: mockInstanceOfReminder,
-}), { virtual: true });
+vi.mock(
+  '@sdk',
+  () => ({
+    DefaultApi: vi.fn(() => ({
+      remindersGet: mockRemindersGet,
+      remindersPost: mockRemindersPost,
+      remindersPatch: mockRemindersPatch,
+      remindersDelete: mockRemindersDelete,
+    })),
+  }),
+  { virtual: true },
+);
+
+vi.mock(
+  '@sdk/models',
+  () => ({
+    instanceOfReminder: mockInstanceOfReminder,
+  }),
+  { virtual: true },
+);
 
 import {
   getReminder,

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,6 @@
-import { DefaultApi, instanceOfReminder, type Reminder } from '@sdk';
+import { DefaultApi } from '@sdk';
 import { Configuration, ResponseError } from '@sdk/runtime';
+import { instanceOfReminder, type Reminder } from '@sdk/models';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 


### PR DESCRIPTION
## Summary
- export Reminder model from ts-sdk index so instanceOfReminder is available
- update webapp reminder API to import model utilities from `@sdk/models`
- adjust reminder API tests to mock `@sdk/models`

## Testing
- `npm run build`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a7768a8a08832a9c4ea0f01bec67e5