### PR TITLE
[legacy] enforce user id for reminders

### DIFF
--- a/tests/test_legacy_reminders_auth.py
+++ b/tests/test_legacy_reminders_auth.py
@@ -76,3 +76,23 @@ def test_post_and_get_reminders_with_auth(client: TestClient) -> None:
 def test_reminders_missing_auth(client: TestClient) -> None:
     resp = client.get("/reminders", params={"telegram_id": 1})
     assert resp.status_code == 401
+
+
+def test_reminders_matching_id(client: TestClient) -> None:
+    init_data = build_init_data()
+    resp = client.get(
+        "/reminders",
+        params={"telegram_id": 1},
+        headers={"X-Telegram-Init-Data": init_data},
+    )
+    assert resp.status_code == 200
+
+
+def test_reminders_mismatched_id(client: TestClient) -> None:
+    init_data = build_init_data()
+    resp = client.get(
+        "/reminders",
+        params={"telegram_id": 2},
+        headers={"X-Telegram-Init-Data": init_data},
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- require user context in legacy reminders API and verify telegram_id matches authenticated user
- add tests for matching and mismatched IDs

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named "alembic.context" and others)*
- `pytest -q --cov` *(fails: Coverage failure and numerous async plugin errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fef136a8832ab4a02007073a78e0