### PR TITLE
[middleware] Disable role checks

### DIFF
--- a/services/api/app/middleware/auth.py
+++ b/services/api/app/middleware/auth.py
@@ -69,14 +69,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
         return response
 
 
-def require_role(*roles: str) -> Callable[[Request], Awaitable[None]]:
-    async def dependency(request: Request) -> None:
-        if getattr(request.state, "role", None) not in roles:
-            logger.warning(
-                "Forbidden access for role %r to %s %s",
-                getattr(request.state, "role", None),
-                request.method,
-                request.url.path,
-            )
-            raise HTTPException(status_code=403, detail="forbidden")
+def require_role(*_roles: str) -> Callable[[Request], Awaitable[None]]:
+    async def dependency(_request: Request) -> None:
+        return
+
     return dependency

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -71,7 +71,7 @@ def test_invalid_role_header_logs_warning(
     assert "Invalid X-Role" in caplog.text
 
 
-def test_require_role_logs_attempt(caplog: pytest.LogCaptureFixture) -> None:
+def test_require_role_no_check(caplog: pytest.LogCaptureFixture) -> None:
     app = FastAPI()
     app.add_middleware(AuthMiddleware)
 
@@ -81,11 +81,9 @@ def test_require_role_logs_attempt(caplog: pytest.LogCaptureFixture) -> None:
 
     with TestClient(app) as client:
         caplog.set_level(logging.WARNING, logger="services.api.app.middleware.auth")
-        response = client.get(
-            "/admin", headers={"X-User-Id": "1", "X-Role": "patient"}
-        )
-        assert response.status_code == 403
-    assert "Forbidden access for role 'patient'" in caplog.text
+        response = client.get("/admin", headers={"X-User-Id": "1", "X-Role": "patient"})
+        assert response.status_code == 200
+    assert "Forbidden access" not in caplog.text
 
 
 TOKEN = "test-token"


### PR DESCRIPTION
## Summary
- stub out `require_role` dependency so it performs no authorization
- update middleware tests accordingly

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `python services/api/app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a80a9bafc0832a859ac4993fe9624f