### PR TITLE
[auth] Add user role management

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -140,6 +140,14 @@ class User(Base):
     )
 
 
+class UserRole(Base):
+    __tablename__ = "user_roles"
+    user_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
+    )
+    role: Mapped[str] = mapped_column(String, nullable=False, default="patient")
+
+
 class Profile(Base):
     __tablename__ = "profiles"
     telegram_id: Mapped[int] = mapped_column(

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -29,6 +29,8 @@ from .diabetes.services.db import (
     User as UserDB,
     run_db,
 )
+from .schemas.role import RoleSchema
+from .services.user_roles import get_user_role, set_user_role
 from .diabetes.services.repository import commit
 from .legacy import router
 from .schemas.history import ALLOWED_HISTORY_TYPES, HistoryRecordSchema, HistoryType
@@ -193,6 +195,18 @@ async def create_user(
         logger.exception("database error while creating user")
         raise HTTPException(status_code=500, detail="database error") from exc
     return {"status": "ok"}
+
+
+@app.get("/user/{user_id}/role")
+async def get_role(user_id: int) -> RoleSchema:
+    role = await get_user_role(user_id)
+    return RoleSchema(role=role or "patient")
+
+
+@app.put("/user/{user_id}/role")
+async def put_role(user_id: int, data: RoleSchema) -> RoleSchema:
+    await set_user_role(user_id, data.role)
+    return RoleSchema(role=data.role)
 
 
 @app.post("/history")

--- a/services/api/app/schemas/role.py
+++ b/services/api/app/schemas/role.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class RoleSchema(BaseModel):
+    role: str

--- a/services/api/app/services/user_roles.py
+++ b/services/api/app/services/user_roles.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from ..diabetes.services.db import SessionLocal, UserRole, run_db
+from ..diabetes.services.repository import commit
+
+ALLOWED_ROLES = {"patient", "clinician", "org_admin", "superadmin"}
+
+
+async def get_user_role(user_id: int) -> str | None:
+    def _get(session: Session) -> str | None:
+        obj = session.get(UserRole, user_id)
+        return obj.role if obj else None
+
+    return await run_db(_get, sessionmaker=SessionLocal)
+
+
+async def set_user_role(user_id: int, role: str) -> None:
+    if role not in ALLOWED_ROLES:
+        raise HTTPException(status_code=400, detail="invalid role")
+
+    def _save(session: Session) -> None:
+        obj = session.get(UserRole, user_id)
+        if obj is None:
+            obj = UserRole(user_id=user_id, role=role)
+            session.add(obj)
+        else:
+            obj.role = role
+        if not commit(session):
+            raise HTTPException(status_code=500, detail="db commit failed")
+
+    await run_db(_save, sessionmaker=SessionLocal)

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from services.api.app.config import settings
 from services.api.app.middleware.auth import AuthMiddleware, require_role
+import services.api.app.middleware.auth as auth_module
 from services.api.app.telegram_auth import TG_INIT_DATA_HEADER
 
 
@@ -25,7 +26,11 @@ def create_app() -> FastAPI:
     return app
 
 
-def test_valid_user_id_header() -> None:
+def test_valid_user_id_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_user_role(_user_id: int) -> str | None:
+        return None
+
+    monkeypatch.setattr(auth_module, "get_user_role", fake_get_user_role)
     app = create_app()
     with TestClient(app) as client:
         response = client.get("/whoami", headers={"X-User-Id": "123"})

--- a/tests/test_user_roles.py
+++ b/tests/test_user_roles.py
@@ -1,0 +1,61 @@
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import services.api.app.main as server
+from services.api.app.diabetes.services import db
+from services.api.app.middleware.auth import AuthMiddleware
+from services.api.app.services import user_roles
+
+
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(user_roles, "SessionLocal", SessionLocal)
+    return SessionLocal
+
+
+def test_role_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+    SessionLocal = setup_db(monkeypatch)
+    with TestClient(server.app) as client:
+        resp = client.get("/user/1/role")
+        assert resp.status_code == 200
+        assert resp.json() == {"role": "patient"}
+        resp = client.put("/user/1/role", json={"role": "clinician"})
+        assert resp.status_code == 200
+        assert resp.json() == {"role": "clinician"}
+        resp = client.get("/user/1/role")
+        assert resp.status_code == 200
+        assert resp.json() == {"role": "clinician"}
+
+    with SessionLocal() as session:
+        obj = session.get(db.UserRole, 1)
+        assert obj is not None
+        assert obj.role == "clinician"
+
+
+def test_middleware_reads_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    SessionLocal = setup_db(monkeypatch)
+    with SessionLocal() as session:
+        session.add(db.UserRole(user_id=5, role="org_admin"))
+        session.commit()
+
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware)
+
+    @app.get("/whoami")
+    async def whoami(req: Request) -> dict[str, int | str]:
+        return {"user_id": req.state.user_id, "role": req.state.role}
+
+    with TestClient(app) as client:
+        resp = client.get("/whoami", headers={"X-User-Id": "5"})
+        assert resp.status_code == 200
+        assert resp.json() == {"user_id": 5, "role": "org_admin"}


### PR DESCRIPTION
## Summary
- add `user_roles` table and service to store roles
- load roles from DB in auth middleware and provide REST endpoints
- cover role retrieval and updates with tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a80e647540832a906700a57ea65b2a