### PR TITLE
[api] remove telegram id check in legacy reminders

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -50,13 +50,17 @@ async def api_reminders(
     id: int | None = None,
     user: UserContext = Depends(require_tg_user),
 ) -> list[dict[str, object]] | dict[str, object]:
-    if telegram_id != user["id"]:
-        logger.warning(
-            "telegram_id=%s does not match user_id=%s",
-            telegram_id,
-            user["id"],
-        )
-        raise HTTPException(status_code=403)
+    # NOTE: Access checks comparing the provided telegram_id with the
+    # authenticated user's id have been removed. Previously, mismatches
+    # triggered an HTTP 403 error. The API now allows retrieving reminders
+    # for any `telegram_id` without enforcing this restriction.
+    # if telegram_id != user["id"]:
+    #     logger.warning(
+    #         "telegram_id=%s does not match user_id=%s",
+    #         telegram_id,
+    #         user["id"],
+    #     )
+    #     raise HTTPException(status_code=403)
     log_patient_access(getattr(request.state, "user_id", None), telegram_id)
     rems = await list_reminders(telegram_id)
     if id is None:

--- a/tests/test_legacy_reminders_auth.py
+++ b/tests/test_legacy_reminders_auth.py
@@ -99,6 +99,5 @@ def test_reminders_mismatched_id(
             params={"telegram_id": 2},
             headers={"X-Telegram-Init-Data": init_data},
         )
-    assert resp.status_code == 403
-    assert "telegram_id=2" in caplog.text
-    assert "user_id=1" in caplog.text
+    assert resp.status_code == 200
+    assert "does not match" not in caplog.text


### PR DESCRIPTION
## Summary
- allow retrieving reminders for any `telegram_id`
- update legacy reminders auth test

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `PYTHONPATH=. uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000 --reload` (startup)


------
https://chatgpt.com/codex/tasks/task_e_68a8186f51dc832a88c53578f8b78e52