### PR TITLE
[legacy] log mismatched reminder access

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -50,17 +50,17 @@ async def api_reminders(
     id: int | None = None,
     user: UserContext = Depends(require_tg_user),
 ) -> list[dict[str, object]] | dict[str, object]:
-    # NOTE: Access checks comparing the provided telegram_id with the
-    # authenticated user's id have been removed. Previously, mismatches
-    # triggered an HTTP 403 error. The API now allows retrieving reminders
-    # for any `telegram_id` without enforcing this restriction.
-    # if telegram_id != user["id"]:
-    #     logger.warning(
-    #         "telegram_id=%s does not match user_id=%s",
-    #         telegram_id,
-    #         user["id"],
-    #     )
-    #     raise HTTPException(status_code=403)
+    if telegram_id != user["id"]:
+        request_id = request.headers.get("X-Request-ID") or request.headers.get(
+            "X-Request-Id"
+        )
+        logger.warning(
+            "request_id=%s telegram_id=%s does not match user_id=%s",
+            request_id,
+            telegram_id,
+            user["id"],
+        )
+        raise HTTPException(status_code=403)
     log_patient_access(getattr(request.state, "user_id", None), telegram_id)
     rems = await list_reminders(telegram_id)
     if id is None:

--- a/tests/test_dose_calc_unit.py
+++ b/tests/test_dose_calc_unit.py
@@ -47,7 +47,7 @@ async def test_cancel_then_calls_cancel_first(monkeypatch: pytest.MonkeyPatch) -
         update: Update, context: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
     ) -> int:
         calls.append("cancel")
-        return ConversationHandler.END
+        return cast(int, ConversationHandler.END)
 
     async def handler(
         update: Update, context: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]

--- a/tests/test_legacy_reminders_auth.py
+++ b/tests/test_legacy_reminders_auth.py
@@ -93,11 +93,18 @@ def test_reminders_mismatched_id(
     client: TestClient, caplog: pytest.LogCaptureFixture
 ) -> None:
     init_data = build_init_data()
+    request_id = "req-1"
     with caplog.at_level(logging.WARNING, logger="services.api.app.legacy"):
         resp = client.get(
             "/reminders",
             params={"telegram_id": 2},
-            headers={"X-Telegram-Init-Data": init_data},
+            headers={
+                "X-Telegram-Init-Data": init_data,
+                "X-Request-ID": request_id,
+            },
         )
-    assert resp.status_code == 200
-    assert "does not match" not in caplog.text
+    assert resp.status_code == 403
+    assert (
+        f"request_id={request_id} telegram_id=2 does not match user_id=1"
+        in caplog.text
+    )


### PR DESCRIPTION
## Summary
- enforce telegram id matches authenticated user when fetching reminders
- log request id, url parameter, and authenticated user id on mismatch
- test mismatched reminder access and fix mypy strictness

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a81cd01988832a9b99a3206baa9715