### PR TITLE
fix(auth): default role in middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+- Fixed missing role in AuthMiddleware causing 403 on authorized `/api/reminders` requests.
+


### PR DESCRIPTION
## Summary
- ensure AuthMiddleware always sets a role, defaulting to `patient`
- test reminders endpoint authentication scenarios for init data and doctor role
- document fix for missing role causing 403 errors

## Testing
- `pytest tests/test_auth_middleware.py -q --override-ini="addopts=" --cov=services/api/app/middleware/auth.py --cov-report=term --cov-fail-under=0`
- `mypy --strict services/api/app/middleware/auth.py tests/test_auth_middleware.py`
- `ruff check services/api/app/middleware/auth.py tests/test_auth_middleware.py`

------
https://chatgpt.com/codex/tasks/task_e_68a859bad200832aa15834386cb0d26a