### PR TITLE
[models] Remove duplicate Optional and Set imports

### DIFF
--- a/libs/py-sdk/diabetes_sdk/models/history_record_schema_input.py
+++ b/libs/py-sdk/diabetes_sdk/models/history_record_schema_input.py
@@ -19,8 +19,7 @@ import json
 
 from datetime import date
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, field_validator
-from typing import Any, ClassVar, Dict, List, Optional, Union
-from typing import Optional, Set
+from typing import Any, ClassVar, Dict, List, Optional, Set, Union
 from typing_extensions import Self
 
 class HistoryRecordSchemaInput(BaseModel):

--- a/libs/py-sdk/diabetes_sdk/models/history_record_schema_output.py
+++ b/libs/py-sdk/diabetes_sdk/models/history_record_schema_output.py
@@ -18,8 +18,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr, field_validator
-from typing import Any, ClassVar, Dict, List, Optional, Union
-from typing import Optional, Set
+from typing import Any, ClassVar, Dict, List, Optional, Set, Union
 from typing_extensions import Self
 
 class HistoryRecordSchemaOutput(BaseModel):

--- a/libs/py-sdk/diabetes_sdk/models/http_validation_error.py
+++ b/libs/py-sdk/diabetes_sdk/models/http_validation_error.py
@@ -18,9 +18,8 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional, Set
 from diabetes_sdk.models.validation_error import ValidationError
-from typing import Optional, Set
 from typing_extensions import Self
 
 class HTTPValidationError(BaseModel):

--- a/libs/py-sdk/diabetes_sdk/models/profile_schema.py
+++ b/libs/py-sdk/diabetes_sdk/models/profile_schema.py
@@ -18,8 +18,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt
-from typing import Any, ClassVar, Dict, List, Optional, Union
-from typing import Optional, Set
+from typing import Any, ClassVar, Dict, List, Optional, Set, Union
 from typing_extensions import Self
 
 class ProfileSchema(BaseModel):

--- a/libs/py-sdk/diabetes_sdk/models/reminder_schema.py
+++ b/libs/py-sdk/diabetes_sdk/models/reminder_schema.py
@@ -18,8 +18,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
-from typing import Optional, Set
+from typing import Any, ClassVar, Dict, List, Optional, Set
 from typing_extensions import Self
 
 class ReminderSchema(BaseModel):

--- a/libs/py-sdk/diabetes_sdk/models/user_context.py
+++ b/libs/py-sdk/diabetes_sdk/models/user_context.py
@@ -18,8 +18,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, StrictBool, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
-from typing import Optional, Set
+from typing import Any, ClassVar, Dict, List, Optional, Set
 from typing_extensions import Self
 
 class UserContext(BaseModel):


### PR DESCRIPTION
## Summary
- consolidate typing imports in diabetes_sdk model schemas by removing duplicate `Optional`/`Set` imports

## Testing
- `ruff check libs/py-sdk/diabetes_sdk/models` *(fails: F401/F811 in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a85efa3568832a9cc351e88694b418