### PR TITLE
[py-sdk] add license declaration

### DIFF
--- a/libs/py-sdk/LICENSE
+++ b/libs/py-sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/py-sdk/pyproject.toml
+++ b/libs/py-sdk/pyproject.toml
@@ -5,7 +5,7 @@ description = "Diabetes Assistant API"
 authors = [
   {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
 ]
-license = "NoLicense"
+license = { file = "LICENSE" }
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Diabetes Assistant API"]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- declare py-sdk license using MIT license file
- add MIT LICENSE file for py-sdk

## Testing
- `pip install -r requirements.txt`
- `pytest -q --cov`
- `mypy --strict .` *(fails: Function is missing a return type annotation, etc.)*
- `ruff check .` *(fails: F401 unused imports, F811 redefinitions, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a85ed21824832aacb2299a0ee89eb7