### PR TITLE
tests: add reminders API endpoint coverage

### DIFF
--- a/tests/test_reminders_api.py
+++ b/tests/test_reminders_api.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from typing import cast
+
+from services.api.app.diabetes.services.db import Base, Reminder, User
+from services.api.app import legacy
+from services.api.app.legacy import router
+from services.api.app.services import reminders
+from services.api.app.telegram_auth import require_tg_user
+
+
+@pytest.fixture()
+def session_factory() -> Generator[sessionmaker, None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    try:
+        yield TestSession
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture()
+def client(
+    monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker
+) -> Generator[TestClient, None, None]:
+    monkeypatch.setattr(reminders, "SessionLocal", session_factory)
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_empty_returns_200(client: TestClient) -> None:
+    resp = client.get("/api/reminders", params={"telegramId": 1})
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_nonempty_returns_list(
+    client: TestClient, session_factory: sessionmaker
+) -> None:
+    with session_factory() as session:
+        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(
+            Reminder(
+                id=1,
+                telegram_id=1,
+                type="sugar",
+                time="08:00",
+                interval_hours=3,
+            )
+        )
+        session.commit()
+    resp = client.get("/api/reminders", params={"telegramId": 1})
+    assert resp.status_code == 200
+    assert resp.json() == [
+        {
+            "id": 1,
+            "type": "sugar",
+            "title": "sugar",
+            "time": "08:00",
+            "active": True,
+            "interval": 3,
+        }
+    ]
+
+
+def test_real_404(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def fake_list_reminders(_tid: int) -> list[Reminder]:  # pragma: no cover - helper
+        raise HTTPException(status_code=404, detail="not found")
+
+    monkeypatch.setattr(legacy, "list_reminders", fake_list_reminders)
+    fastapi_app = cast(FastAPI, client.app)
+    fastapi_app.dependency_overrides[require_tg_user] = lambda: {"id": 2}
+    resp = client.get("/api/reminders", params={"telegramId": 2})
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add API tests verifying `/api/reminders` empty, list, and 404 behaviors

## Testing
- `pytest -q --cov`
- `mypy --strict .` *(fails: Function is missing a return type annotation)*
- `ruff check .` *(fails: Found 13 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a86cb370e8832aaa61f932c3cb7741