### PR TITLE
[changelog] Document /api/reminders empty response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## Unreleased
 - Fixed missing role in AuthMiddleware causing 403 on authorized `/api/reminders` requests.
-
+- Changed `/api/reminders`: now returns `200 OK` with an empty list instead of `404` when the user has no active reminders.


### PR DESCRIPTION
## Summary
- note that `/api/reminders` now returns `200 OK` with an empty list instead of `404` when no reminders are active

## Testing
- `pytest tests/test_onboarding_flow.py -q` *(fails: No module named 'pydantic_settings')*
- `mypy --strict .` *(fails: Library stubs not installed for "setuptools" [import-untyped])*
- `ruff check .` *(fails: Found 13 errors, 12 fixable with `--fix`)*

------
https://chatgpt.com/codex/tasks/task_e_68a86cb9313c832a93864d7ccf5cd219