### PR TITLE
[api] add stats service and mount under api

### DIFF
--- a/services/api/app/routers/stats.py
+++ b/services/api/app/routers/stats.py
@@ -1,0 +1,41 @@
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+
+from ..schemas.stats import AnalyticsPoint, DayStats
+from ..schemas.user import UserContext
+from ..services.stats import get_day_stats
+from ..telegram_auth import require_tg_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/stats", response_model=DayStats, responses={204: {"description": "No Content"}})
+async def get_stats(
+    telegram_id: int = Query(alias="telegramId"),
+    user: UserContext = Depends(require_tg_user),
+) -> DayStats | Response:
+    if telegram_id != user["id"]:
+        raise HTTPException(status_code=403, detail="telegram id mismatch")
+    stats = await get_day_stats(telegram_id)
+    if stats is None:
+        return Response(status_code=204)
+    return stats
+
+
+@router.get("/analytics")
+async def get_analytics(
+    telegram_id: int = Query(alias="telegramId"),
+    user: UserContext = Depends(require_tg_user),
+) -> list[AnalyticsPoint]:
+    if telegram_id != user["id"]:
+        raise HTTPException(status_code=403, detail="telegram id mismatch")
+    return [
+        AnalyticsPoint(date="2024-01-01", sugar=5.5),
+        AnalyticsPoint(date="2024-01-02", sugar=6.1),
+        AnalyticsPoint(date="2024-01-03", sugar=5.8),
+        AnalyticsPoint(date="2024-01-04", sugar=6.0),
+        AnalyticsPoint(date="2024-01-05", sugar=5.4),
+    ]

--- a/services/api/app/schemas/stats.py
+++ b/services/api/app/schemas/stats.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class DayStats(BaseModel):
+    sugar: float
+    breadUnits: float
+    insulin: float
+
+
+class AnalyticsPoint(BaseModel):
+    date: str
+    sugar: float

--- a/services/api/app/services/__init__.py
+++ b/services/api/app/services/__init__.py
@@ -2,6 +2,7 @@ from ..diabetes.services.db import init_db
 
 from .profile import save_profile, set_timezone
 from .reminders import list_reminders, save_reminder
+from .stats import get_day_stats
 
 __all__ = [
     "init_db",
@@ -9,4 +10,5 @@ __all__ = [
     "save_profile",
     "list_reminders",
     "save_reminder",
+    "get_day_stats",
 ]

--- a/services/api/app/services/stats.py
+++ b/services/api/app/services/stats.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import datetime
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from ..diabetes.services.db import HistoryRecord as HistoryRecordDB, SessionLocal, run_db
+from ..schemas.stats import DayStats
+
+
+async def get_day_stats(telegram_id: int, date: datetime.date | None = None) -> DayStats | None:
+    """Return aggregated stats for a given user's day."""
+    day = date or datetime.date.today()
+
+    def _query(session: Session) -> DayStats | None:
+        avg_sugar, sum_bu, sum_insulin = (
+            session.query(
+                func.avg(HistoryRecordDB.sugar),
+                func.sum(HistoryRecordDB.bread_units),
+                func.sum(HistoryRecordDB.insulin),
+            )
+            .filter(
+                HistoryRecordDB.telegram_id == telegram_id,
+                HistoryRecordDB.date == day.isoformat(),
+            )
+            .one()
+        )
+        if avg_sugar is None and sum_bu is None and sum_insulin is None:
+            return None
+        return DayStats(
+            sugar=float(avg_sugar or 0),
+            breadUnits=float(sum_bu or 0),
+            insulin=float(sum_insulin or 0),
+        )
+
+    return await run_db(_query, sessionmaker=SessionLocal)

--- a/tests/test_legacy_reminders_auth.py
+++ b/tests/test_legacy_reminders_auth.py
@@ -58,7 +58,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]
 def test_post_and_get_reminders_with_auth(client: TestClient) -> None:
     init_data = build_init_data()
     resp_post = client.post(
-        "/reminders",
+        "/api/reminders",
         json={"telegramId": 1, "type": "sugar"},
         headers={"X-Telegram-Init-Data": init_data},
     )
@@ -66,7 +66,7 @@ def test_post_and_get_reminders_with_auth(client: TestClient) -> None:
     reminder_id = resp_post.json()["id"]
 
     resp_get = client.get(
-        "/reminders",
+        "/api/reminders",
         params={"telegramId": 1},
         headers={"X-Telegram-Init-Data": init_data},
     )
@@ -75,14 +75,14 @@ def test_post_and_get_reminders_with_auth(client: TestClient) -> None:
 
 
 def test_reminders_missing_auth(client: TestClient) -> None:
-    resp = client.get("/reminders", params={"telegramId": 1})
+    resp = client.get("/api/reminders", params={"telegramId": 1})
     assert resp.status_code == 401
 
 
 def test_reminders_matching_id(client: TestClient) -> None:
     init_data = build_init_data()
     resp = client.get(
-        "/reminders",
+        "/api/reminders",
         params={"telegramId": 1},
         headers={"X-Telegram-Init-Data": init_data},
     )
@@ -99,7 +99,7 @@ def test_reminders_mismatched_id(
         logging.WARNING, logger="services.api.app.routers.reminders"
     ):
         resp = client.get(
-            "/reminders",
+            "/api/reminders",
             params={"telegramId": 2},
             headers={
                 "X-Telegram-Init-Data": init_data,
@@ -115,7 +115,7 @@ def test_reminders_mismatched_id(
 def test_reminders_invalid_telegram_id(client: TestClient) -> None:
     init_data = build_init_data(user_id=999)
     resp = client.get(
-        "/reminders",
+        "/api/reminders",
         params={"telegramId": 999},
         headers={"X-Telegram-Init-Data": init_data},
     )

--- a/tests/test_stats_service.py
+++ b/tests/test_stats_service.py
@@ -1,0 +1,64 @@
+import datetime
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.services.db import Base, HistoryRecord
+from services.api.app.services import stats
+
+
+@pytest.fixture()
+def session_factory() -> Generator[sessionmaker, None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    try:
+        yield TestSession
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_get_day_stats(monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker) -> None:
+    today = datetime.date.today().isoformat()
+    with session_factory() as session:
+        session.add(
+            HistoryRecord(
+                id="1",
+                telegram_id=1,
+                date=today,
+                time="08:00",
+                sugar=5.0,
+                bread_units=1.0,
+                insulin=2.0,
+                type="sugar",
+            )
+        )
+        session.add(
+            HistoryRecord(
+                id="2",
+                telegram_id=1,
+                date=today,
+                time="12:00",
+                sugar=7.0,
+                bread_units=2.0,
+                insulin=3.0,
+                type="sugar",
+            )
+        )
+        session.commit()
+
+    monkeypatch.setattr(stats, "SessionLocal", session_factory)
+
+    result = await stats.get_day_stats(1)
+    assert result is not None
+    assert result.sugar == pytest.approx(6.0)
+    assert result.breadUnits == pytest.approx(3.0)
+    assert result.insulin == pytest.approx(5.0)

--- a/tests/test_webapp_reminders_auth.py
+++ b/tests/test_webapp_reminders_auth.py
@@ -58,7 +58,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]
 def test_reminders_authorized_without_role(client: TestClient) -> None:
     init_data = build_init_data()
     resp = client.get(
-        "/reminders",
+        "/api/reminders",
         params={"telegramId": 1},
         headers={TG_INIT_DATA_HEADER: init_data},
     )


### PR DESCRIPTION
## Summary
- mount legacy and stats routers under `/api`
- add day stats service backed by database
- move stats endpoints into dedicated router
- adjust reminders API tests for `/api` prefix

## Testing
- `ruff check services/api/app tests`
- `mypy --strict services/api/app tests` *(fails: tests/test_dose_calc_unit.py redundant cast)*
- `mypy --strict services/api/app/main.py services/api/app/routers/stats.py services/api/app/services/stats.py tests/test_stats_api.py tests/test_stats_service.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87940cea8832aa3420d191aa4fc3c