### PR TITLE
[services] relax reminders user check

### DIFF
--- a/services/api/app/routers/reminders.py
+++ b/services/api/app/routers/reminders.py
@@ -33,7 +33,7 @@ async def get_reminders(
             tid,
             user["id"],
         )
-        raise HTTPException(status_code=403)
+        raise HTTPException(status_code=404, detail="invalid telegramId")
     log_patient_access(getattr(request.state, "user_id", None), tid)
 
     rems = await list_reminders(tid)

--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -12,7 +12,7 @@ from ..schemas.reminders import ReminderSchema
 async def list_reminders(telegram_id: int) -> List[Reminder]:
     def _list(session: Session) -> List[Reminder]:
         if session.get(User, telegram_id) is None:
-            raise HTTPException(status_code=404, detail="user not found")
+            return []
         return session.query(Reminder).filter_by(telegram_id=telegram_id).all()
 
     return await run_db(_list, sessionmaker=SessionLocal)

--- a/tests/test_legacy_reminders_auth.py
+++ b/tests/test_legacy_reminders_auth.py
@@ -106,7 +106,7 @@ def test_reminders_mismatched_id(
                 "X-Request-ID": request_id,
             },
         )
-    assert resp.status_code == 403
+    assert resp.status_code == 404
     assert (
         f"request_id={request_id} telegramId=2 does not match user_id=1" in caplog.text
     )
@@ -119,4 +119,5 @@ def test_reminders_invalid_telegram_id(client: TestClient) -> None:
         params={"telegramId": 999},
         headers={"X-Telegram-Init-Data": init_data},
     )
-    assert resp.status_code == 404
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/tests/test_reminders_api.py
+++ b/tests/test_reminders_api.py
@@ -81,8 +81,14 @@ def test_nonempty_returns_list(
     ]
 
 
-def test_invalid_telegram_id(client: TestClient) -> None:
+def test_invalid_telegram_id_returns_empty_list(client: TestClient) -> None:
     fastapi_app = cast(FastAPI, client.app)
     fastapi_app.dependency_overrides[require_tg_user] = lambda: {"id": 2}
+    resp = client.get("/api/reminders", params={"telegramId": 2})
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_mismatched_telegram_id_returns_404(client: TestClient) -> None:
     resp = client.get("/api/reminders", params={"telegramId": 2})
     assert resp.status_code == 404

--- a/tests/test_services_reminders.py
+++ b/tests/test_services_reminders.py
@@ -75,5 +75,5 @@ async def test_list_reminders_invalid_user(
     monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker
 ) -> None:
     monkeypatch.setattr(reminders, "SessionLocal", session_factory)
-    with pytest.raises(HTTPException):
-        await reminders.list_reminders(999)
+    reminders_list = await reminders.list_reminders(999)
+    assert reminders_list == []


### PR DESCRIPTION
## Summary
- Return an empty list when listing reminders for a non-existent user
- Treat mismatched telegramId as a 404 in the reminders API
- Update reminder tests for new semantics

## Testing
- `pytest -q`
- `mypy --strict .` *(fails: Function is missing a return type annotation)*
- `ruff check .` *(fails: `pydantic.Field` imported but unused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8794d6be8832a97c139eeab3d86c8