### PR TITLE
tests: add stats and reminders API coverage

### DIFF
--- a/tests/test_stats_api.py
+++ b/tests/test_stats_api.py
@@ -55,6 +55,22 @@ def test_stats_mismatched_id(monkeypatch: pytest.MonkeyPatch) -> None:
     assert resp.status_code == 403
 
 
+def test_empty_stats_returns_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    init_data = build_init_data(11)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/stats",
+            params={"telegramId": 11},
+            headers={TG_INIT_DATA_HEADER: init_data},
+        )
+    assert resp.status_code in (200, 204)
+    if resp.status_code == 200:
+        assert resp.json() == {"sugar": 5.7, "breadUnits": 3, "insulin": 10}
+    else:
+        assert resp.content == b""
+
+
 def test_analytics_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     init_data = build_init_data(7)


### PR DESCRIPTION
## Summary
- add test for empty stats default response
- cover reminders API with empty, non-empty, and 404 scenarios

## Testing
- `pytest -q`
- `mypy --strict .` *(fails: Missing return statements and annotations in libs/py-sdk)*
- `ruff check .` *(fails: F401/F811 errors in libs/py-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68a879523600832a82df0181eb539964