### PR TITLE
[docs] Update changelog for default API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 - Fixed missing role in AuthMiddleware causing 403 on authorized `/api/reminders` requests.
-- Changed `/api/reminders`: now returns `200 OK` with an empty list instead of `404` when the user has no active reminders.
+- Changed `/api/reminders`: returns `200` with an empty list instead of `404` when no reminders exist.
+- Changed `/api/stats`: now returns default stats (or `204`) instead of `404` when no data is available.


### PR DESCRIPTION
## Summary
- note default `200` response when no reminders exist
- note default stats or `204` response for empty stats

## Testing
- `pytest -q --cov` *(fails: No module named 'telegram')*
- `mypy --strict .` *(fails: Library stubs not installed for "setuptools" and others)*
- `ruff check .` *(fails: F401, F811 and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8795694a8832abb7e2bbc517bdc4b