### PR TITLE
[build] add ts sdk workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 {
   "name": "saharlight-monorepo",
   "private": true,
-  "workspaces": ["services/webapp/ui"],
+  "workspaces": ["services/webapp/ui", "libs/ts-sdk"],
   "scripts": {
     "dev":       "npm --workspace services/webapp/ui run dev",
     "build":     "npm --workspace services/webapp/ui run build",


### PR DESCRIPTION
## Summary
- include `libs/ts-sdk` in root npm workspaces

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `mypy --strict .` *(fails: missing imports such as `sqlalchemy`)*
- `ruff check .` *(fails: 28 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bebcbb28832a9d665382aeb16a76