### PR TITLE
chore(ts-sdk): update package and config

### DIFF
--- a/libs/ts-sdk/package.json
+++ b/libs/ts-sdk/package.json
@@ -1,6 +1,9 @@
 {
-  "name": "ts-sdk",
+  "name": "@offonika/diabetes-ts-sdk",
   "version": "0.1.0",
-  "main": "apis/index.ts",
-  "types": "apis/index.ts"
+  "main": "index.ts",
+  "types": "index.ts",
+  "scripts": {
+    "generate": "openapi-generator-cli generate -i ../contracts/openapi.yaml -g typescript-fetch -o . -p useSingleRequestParameter=true"
+  }
 }

--- a/libs/ts-sdk/tsconfig.json
+++ b/libs/ts-sdk/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/services/clinic-panel/next.config.js
+++ b/services/clinic-panel/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  transpilePackages: ['ts-sdk'],
+  transpilePackages: ['@offonika/diabetes-ts-sdk'],
 };
 
 module.exports = nextConfig;

--- a/services/clinic-panel/package-lock.json
+++ b/services/clinic-panel/package-lock.json
@@ -11,7 +11,7 @@
         "next": "14.1.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "ts-sdk": "file:../../libs/ts-sdk"
+        "@offonika/diabetes-ts-sdk": "file:../../libs/ts-sdk"
       },
       "devDependencies": {
         "@types/node": "20.11.1",
@@ -20,6 +20,7 @@
       }
     },
     "../../libs/ts-sdk": {
+      "name": "@offonika/diabetes-ts-sdk",
       "version": "0.1.0"
     },
     "node_modules/@next/env": {
@@ -457,7 +458,8 @@
         }
       }
     },
-    "node_modules/ts-sdk": {
+    "node_modules/@offonika/diabetes-ts-sdk": {
+      "name": "@offonika/diabetes-ts-sdk",
       "resolved": "../../libs/ts-sdk",
       "link": true
     },

--- a/services/clinic-panel/package.json
+++ b/services/clinic-panel/package.json
@@ -11,7 +11,7 @@
     "next": "14.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "ts-sdk": "file:../../libs/ts-sdk"
+    "@offonika/diabetes-ts-sdk": "file:../../libs/ts-sdk"
   },
   "devDependencies": {
     "typescript": "5.3.3",

--- a/services/clinic-panel/pages/index.tsx
+++ b/services/clinic-panel/pages/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { DefaultApi } from 'ts-sdk';
+import { DefaultApi } from '@offonika/diabetes-ts-sdk';
 
 export default function Home() {
   useEffect(() => {


### PR DESCRIPTION
## Summary
- rename TS SDK package and point entry to index
- add OpenAPI generator script and TypeScript config
- update clinic panel to consume new package name

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'telegram')*
- `mypy --strict .` *(fails: Library stubs not installed for "setuptools")*
- `ruff check .` *(fails: F401 `warnings` imported but unused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bfa53a90832ab8474b2bab5c78b8