### PR TITLE
[ui] replace @sdk alias with diabetes-ts-sdk package

### DIFF
--- a/services/webapp/ui/package-lock.json
+++ b/services/webapp/ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
+        "@offonika/diabetes-ts-sdk": "workspace:*",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/services/webapp/ui/package.json
+++ b/services/webapp/ui/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
+    "@offonika/diabetes-ts-sdk": "workspace:*",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/services/webapp/ui/src/api/profile.api.test.ts
+++ b/services/webapp/ui/src/api/profile.api.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ResponseError } from '@sdk/runtime';
-import type { Profile } from '@sdk/models';
+import { ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
+import type { Profile } from '@offonika/diabetes-ts-sdk/models';
 
 const mockProfilesGet = vi.hoisted(() => vi.fn());
 const mockProfilesPost = vi.hoisted(() => vi.fn());
 
-vi.mock('@sdk', () => ({
+vi.mock('@offonika/diabetes-ts-sdk', () => ({
   DefaultApi: vi.fn(() => ({
     profilesGet: mockProfilesGet,
     profilesPost: mockProfilesPost,

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,6 +1,6 @@
-import { DefaultApi } from '@sdk';
-import type { Profile } from '@sdk/models';
-import { Configuration, ResponseError } from '@sdk/runtime';
+import { DefaultApi } from '@offonika/diabetes-ts-sdk';
+import type { Profile } from '@offonika/diabetes-ts-sdk/models';
+import { Configuration, ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 

--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ResponseError } from '@sdk/runtime';
+import { ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
 
 const mockApiRemindersRemindersGet = vi.hoisted(() => vi.fn());
 const mockApiRemindersPostRemindersPost = vi.hoisted(() => vi.fn());
@@ -8,7 +8,7 @@ const mockApiRemindersRemindersDelete = vi.hoisted(() => vi.fn());
 const mockInstanceOfReminder = vi.hoisted(() => vi.fn());
 
 vi.mock(
-  '@sdk',
+  '@offonika/diabetes-ts-sdk',
   () => ({
     DefaultApi: vi.fn(() => ({
       apiRemindersRemindersGet: mockApiRemindersRemindersGet,
@@ -21,7 +21,7 @@ vi.mock(
 );
 
 vi.mock(
-  '@sdk/models',
+  '@offonika/diabetes-ts-sdk/models',
   () => ({
     instanceOfReminder: mockInstanceOfReminder,
   }),

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,9 +1,9 @@
-import { DefaultApi } from '@sdk';
-import { Configuration, ResponseError } from '@sdk/runtime';
+import { DefaultApi } from '@offonika/diabetes-ts-sdk';
+import { Configuration, ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
 import {
   instanceOfReminderSchema as instanceOfReminder,
   type ReminderSchema as Reminder,
-} from '@sdk/models';
+} from '@offonika/diabetes-ts-sdk/models';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -13,7 +13,7 @@ import {
   type NormalizedReminderType,
 } from '@/lib/reminders'
 import { parseTimeToMinutes } from '@/lib/time'
-import type { Reminder as ApiReminder } from '@sdk/models'
+import type { Reminder as ApiReminder } from '@offonika/diabetes-ts-sdk/models'
 import type { Reminder } from '@/types/reminder'
 
 const TYPE_LABEL: Record<NormalizedReminderType, string> = {

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { MedicalButton, Sheet } from "@/components";
 import { cn } from "@/lib/utils";
 import { createReminder, updateReminder, getReminder } from "@/api/reminders";
-import { Reminder as ApiReminder } from "@sdk";
+import { Reminder as ApiReminder } from "@offonika/diabetes-ts-sdk";
 import { useTelegramContext } from "@/contexts/telegram-context";
 import { useToast } from "@/hooks/use-toast";
 import {

--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -7,8 +7,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@sdk/*": ["../../../libs/ts-sdk/*"]
+      "@/*": ["./src/*"]
     },
     "noImplicitAny": true,
     "noUnusedParameters": true,

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -77,7 +77,6 @@ export default defineConfig(async ({ mode, command }) => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),
-        '@sdk': path.resolve(__dirname, '../../../libs/ts-sdk'),
       },
     },
     server: { host: '::', port },


### PR DESCRIPTION
## Summary
- add `@offonika/diabetes-ts-sdk` workspace dependency for UI
- switch all `@sdk` imports to `@offonika/diabetes-ts-sdk`
- drop `@sdk` path alias from `tsconfig.json` and `vite.config.ts`

## Testing
- `npm --workspace services/webapp/ui test` *(fails: Missing script "test")*
- `pytest -q --cov` *(fails: No module named 'sqlalchemy')*
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named "sqlalchemy.pool" and others)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a8c0baf2e8832ab37132e56d996548