### PR TITLE
[ci] Generate SDK before building UI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           pip install -r services/api/app/requirements.txt
           pip install -r services/api/app/requirements-dev.txt
+      - name: Generate SDK
+        run: pnpm run generate:sdk
       - name: Build webapp UI
         working-directory: services/webapp/ui
         run: |


### PR DESCRIPTION
## Summary
- run pnpm run generate:sdk before building webapp UI in tests workflow

## Testing
- `pytest -q --cov` (fails: DB_PASSWORD environment variable must be set)
- `mypy --strict .` (fails: library stubs missing and return type annotations)
- `ruff check .` (fails: unused imports and redefinitions)


------
https://chatgpt.com/codex/tasks/task_e_68a8c3cbe684832aa7549dedda590f3d