### PR TITLE
[docs] Update SDK generation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ API контейнер запускает `uvicorn` напрямую как ко
 
 ## Генерация SDK
 
-Файл `libs/contracts/openapi.yaml` содержит спецификацию API. По нему генерируются SDK:
+Файл `libs/contracts/openapi.yaml` содержит спецификацию API. По нему генерируются SDK. Перед генерацией выполните `pnpm install`, чтобы зависимость workspace была доступна в UI:
 
 ```bash
-npx @openapitools/openapi-generator-cli generate -i libs/contracts/openapi.yaml -g python -o libs/py-sdk
-npx @openapitools/openapi-generator-cli generate -i libs/contracts/openapi.yaml -g typescript-fetch -o libs/ts-sdk
+pnpm install
+pnpm run generate:sdk
 ```
 
 ## Сервисный запуск


### PR DESCRIPTION
## Summary
- document pnpm commands for SDK generation and mention dependency install for UI

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `mypy --strict .` *(fails: Found 189 errors in 63 files)*
- `ruff check .` *(fails: Found 28 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c70997bc832a92381022c45decf5