### PR TITLE
[docs] rebuild frontend after SDK generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,10 @@ API контейнер запускает `uvicorn` напрямую как ко
 ```bash
 pnpm install
 pnpm run generate:sdk
+pnpm --filter vite_react_shadcn_ts run build
 ```
+
+Это пересобирает фронтенд, чтобы изменения SDK попали в бандл UI.
 
 ## Сервисный запуск
 


### PR DESCRIPTION
## Summary
- document rebuilding the frontend after SDK regeneration

## Testing
- `pytest -q --cov` *(fails: ImportError: pydantic-settings is required)*
- `mypy --strict .` *(fails: missing types for setuptools)*
- `ruff check .` *(fails: Invalid rule code provided to # noqa at libs/py-sdk/setup.py:15: H301)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d09b869c832aba82eea7a72bfbf5