### PR TITLE
[ci] use pnpm filter for webapp build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,10 +29,7 @@ jobs:
       - name: Generate SDK
         run: pnpm run generate:sdk
       - name: Build webapp UI
-        working-directory: services/webapp/ui
-        run: |
-          npm ci
-          npm run build
+        run: pnpm --filter vite_react_shadcn_ts run build
       - name: Type-check webapp UI
         working-directory: services/webapp/ui
         run: npm run typecheck


### PR DESCRIPTION
## Summary
- build webapp using pnpm filter vite_react_shadcn_ts

## Testing
- `pytest -q --cov=services.api.app.diabetes --cov-report=term-missing --cov-report=xml --cov-fail-under=85` *(fails: connection to PostgreSQL refused)*
- `mypy --strict .` *(fails: found 66 errors)*
- `ruff check .` *(fails: 28 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d16c23c8832ab15b76e49524b777