### PR TITLE
[tests] Use pnpm for JS build helper

### DIFF
--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for tests."""

--- a/tests/utils/js_helpers.py
+++ b/tests/utils/js_helpers.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+
+
+def build_vite_project() -> None:
+    """Install dependencies and build the Vite project using pnpm."""
+    subprocess.run(
+        ["pnpm", "i", "--frozen-lockfile"],
+        cwd=ROOT_DIR,
+        check=True,
+    )
+    subprocess.run(
+        ["pnpm", "--filter", "vite_react_shadcn_ts", "run", "build"],
+        cwd=ROOT_DIR,
+        check=True,
+    )


### PR DESCRIPTION
## Summary
- add tests/utils/js_helpers.py to build vite project with pnpm
- introduce tests/utils package for shared test utilities

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'telegram')*
- `mypy --strict .` *(fails: missing setuptools stubs)*
- `ruff check .` *(fails: unused imports in libs/py-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d8b9a1f8832ab28ad5bd6c0b1489