### PR TITLE
[docs] Add SDK usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ pnpm --filter vite_react_shadcn_ts run build
 
 Это пересобирает фронтенд, чтобы изменения SDK попали в бандл UI.
 
+### Использование SDK
+
+Сгенерированный TypeScript SDK доступен как workspace‑пакет
+`@offonika/diabetes-ts-sdk`, поэтому алиас пути не требуется.
+
+```ts
+import { Configuration, ProfilesApi } from '@offonika/diabetes-ts-sdk';
+
+const api = new ProfilesApi(new Configuration({ basePath: '/api' }));
+const profile = await api.profilesGet({ telegramId: 123 });
+```
+
 ## Сервисный запуск
 
 В каталоге `docs/deploy/` лежат примерные конфигурации для запуска приложения как службы.


### PR DESCRIPTION
## Summary
- document how to use the generated TypeScript SDK

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'telegram')*
- `mypy --strict .` *(fails: missing stubs and type errors)*
- `ruff check .` *(fails: found 28 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d8bc6808832a8271ac0afb63d5f5