### PR TITLE
[config] remove sdk alias

### DIFF
--- a/services/webapp/ui/tsconfig.app.json
+++ b/services/webapp/ui/tsconfig.app.json
@@ -23,9 +23,7 @@
 
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@sdk": ["../../../libs/ts-sdk"],
-      "@sdk/*": ["../../../libs/ts-sdk/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './services/webapp/ui/src'),
-      '@sdk': path.resolve(__dirname, './libs/ts-sdk'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- remove @sdk alias from vitest config
- drop @sdk paths in webapp tsconfig

## Testing
- `pytest tests/test_webapp_user.py -q` *(fails: DB_PASSWORD environment variable must be set)*
- `mypy --strict .` *(fails: missing stubs, type annotations)
- `ruff check .` *(fails: unused imports and redefinitions)
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8d8b7f8f4832a84207582b62fd751