### PR TITLE
[ui] Mock SDK classes in API tests

### DIFF
--- a/services/webapp/ui/src/api/profile.api.test.ts
+++ b/services/webapp/ui/src/api/profile.api.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
+import { ResponseError, Configuration } from '@offonika/diabetes-ts-sdk/runtime';
 import type { Profile } from '@offonika/diabetes-ts-sdk/models';
 
 const mockProfilesGet = vi.hoisted(() => vi.fn());
 const mockProfilesPost = vi.hoisted(() => vi.fn());
 
 vi.mock('@offonika/diabetes-ts-sdk', () => ({
-  DefaultApi: vi.fn(() => ({
+  ProfilesApi: vi.fn(() => ({
     profilesGet: mockProfilesGet,
     profilesPost: mockProfilesPost,
   })),
+  Configuration,
 }));
 
 import { getProfile, saveProfile } from './profile';

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,10 +1,10 @@
-import { DefaultApi } from '@offonika/diabetes-ts-sdk';
+import { ProfilesApi } from '@offonika/diabetes-ts-sdk';
 import type { Profile } from '@offonika/diabetes-ts-sdk/models';
 import { Configuration, ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 
-const api = new DefaultApi(
+const api = new ProfilesApi(
   new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
 );
 

--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -1,21 +1,22 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
+import { ResponseError, Configuration } from '@offonika/diabetes-ts-sdk/runtime';
 
-const mockApiRemindersRemindersGet = vi.hoisted(() => vi.fn());
-const mockApiRemindersPostRemindersPost = vi.hoisted(() => vi.fn());
-const mockApiRemindersRemindersPatch = vi.hoisted(() => vi.fn());
-const mockApiRemindersRemindersDelete = vi.hoisted(() => vi.fn());
+const mockRemindersGet = vi.hoisted(() => vi.fn());
+const mockRemindersPost = vi.hoisted(() => vi.fn());
+const mockRemindersPatch = vi.hoisted(() => vi.fn());
+const mockRemindersDelete = vi.hoisted(() => vi.fn());
 const mockInstanceOfReminder = vi.hoisted(() => vi.fn());
 
 vi.mock(
   '@offonika/diabetes-ts-sdk',
   () => ({
-    DefaultApi: vi.fn(() => ({
-      apiRemindersRemindersGet: mockApiRemindersRemindersGet,
-      apiRemindersPostRemindersPost: mockApiRemindersPostRemindersPost,
-      apiRemindersRemindersPatch: mockApiRemindersRemindersPatch,
-      apiRemindersRemindersDelete: mockApiRemindersRemindersDelete,
+    RemindersApi: vi.fn(() => ({
+      remindersGet: mockRemindersGet,
+      remindersPost: mockRemindersPost,
+      remindersPatch: mockRemindersPatch,
+      remindersDelete: mockRemindersDelete,
     })),
+    Configuration,
   }),
   { virtual: true },
 );
@@ -37,21 +38,21 @@ import {
 } from './reminders';
 
 afterEach(() => {
-  mockApiRemindersRemindersGet.mockReset();
-  mockApiRemindersPostRemindersPost.mockReset();
-  mockApiRemindersRemindersPatch.mockReset();
-  mockApiRemindersRemindersDelete.mockReset();
+  mockRemindersGet.mockReset();
+  mockRemindersPost.mockReset();
+  mockRemindersPatch.mockReset();
+  mockRemindersDelete.mockReset();
   mockInstanceOfReminder.mockReset();
 });
 
 describe('getReminder', () => {
   it('throws on invalid API response', async () => {
-    mockApiRemindersRemindersGet.mockResolvedValueOnce([]);
+    mockRemindersGet.mockResolvedValueOnce([]);
     await expect(getReminder(1, 1)).rejects.toThrow('Некорректный ответ API');
   });
 
   it('returns null on 404 response', async () => {
-    mockApiRemindersRemindersGet.mockRejectedValueOnce(
+    mockRemindersGet.mockRejectedValueOnce(
       new ResponseError(new Response(null, { status: 404 })),
     );
     await expect(getReminder(1, 1)).resolves.toBeNull();
@@ -59,10 +60,10 @@ describe('getReminder', () => {
 
   it('passes signal to API', async () => {
     const controller = new AbortController();
-    mockApiRemindersRemindersGet.mockResolvedValueOnce({} as any);
+    mockRemindersGet.mockResolvedValueOnce({} as any);
     mockInstanceOfReminder.mockReturnValueOnce(true);
     await getReminder(1, 1, controller.signal);
-    expect(mockApiRemindersRemindersGet).toHaveBeenCalledWith(
+    expect(mockRemindersGet).toHaveBeenCalledWith(
       { telegramId: 1, id: 1 },
       { signal: controller.signal },
     );
@@ -71,7 +72,7 @@ describe('getReminder', () => {
   it('rethrows AbortError', async () => {
     const controller = new AbortController();
     const abortErr = new DOMException('Aborted', 'AbortError');
-    mockApiRemindersRemindersGet.mockRejectedValueOnce(abortErr);
+    mockRemindersGet.mockRejectedValueOnce(abortErr);
     await expect(getReminder(1, 1, controller.signal)).rejects.toBe(abortErr);
   });
 });
@@ -79,9 +80,9 @@ describe('getReminder', () => {
 describe('getReminders', () => {
   it('passes signal to API', async () => {
     const controller = new AbortController();
-    mockApiRemindersRemindersGet.mockResolvedValueOnce([]);
+    mockRemindersGet.mockResolvedValueOnce([]);
     await getReminders(1, controller.signal);
-    expect(mockApiRemindersRemindersGet).toHaveBeenCalledWith(
+    expect(mockRemindersGet).toHaveBeenCalledWith(
       { telegramId: 1 },
       { signal: controller.signal },
     );
@@ -90,7 +91,7 @@ describe('getReminders', () => {
   it('rethrows AbortError', async () => {
     const controller = new AbortController();
     const abortErr = new DOMException('Aborted', 'AbortError');
-    mockApiRemindersRemindersGet.mockRejectedValueOnce(abortErr);
+    mockRemindersGet.mockRejectedValueOnce(abortErr);
     await expect(getReminders(1, controller.signal)).rejects.toBe(abortErr);
   });
 });
@@ -99,14 +100,14 @@ describe('createReminder', () => {
   it('returns API response on success', async () => {
     const reminder = { id: 1 } as any;
     const apiResponse = { ok: true } as any;
-    mockApiRemindersPostRemindersPost.mockResolvedValueOnce(apiResponse);
+    mockRemindersPost.mockResolvedValueOnce(apiResponse);
     await expect(createReminder(reminder)).resolves.toBe(apiResponse);
-    expect(mockApiRemindersPostRemindersPost).toHaveBeenCalledWith({ reminder });
+    expect(mockRemindersPost).toHaveBeenCalledWith({ reminder });
   });
 
   it('rethrows API errors', async () => {
     const error = new Error('api error');
-    mockApiRemindersPostRemindersPost.mockRejectedValueOnce(error);
+    mockRemindersPost.mockRejectedValueOnce(error);
     await expect(createReminder({} as any)).rejects.toBe(error);
   });
 });
@@ -115,14 +116,14 @@ describe('updateReminder', () => {
   it('returns API response on success', async () => {
     const reminder = { id: 1 } as any;
     const apiResponse = { ok: true } as any;
-    mockApiRemindersRemindersPatch.mockResolvedValueOnce(apiResponse);
+    mockRemindersPatch.mockResolvedValueOnce(apiResponse);
     await expect(updateReminder(reminder)).resolves.toBe(apiResponse);
-    expect(mockApiRemindersRemindersPatch).toHaveBeenCalledWith({ reminder });
+    expect(mockRemindersPatch).toHaveBeenCalledWith({ reminder });
   });
 
   it('rethrows API errors', async () => {
     const error = new Error('api error');
-    mockApiRemindersRemindersPatch.mockRejectedValueOnce(error);
+    mockRemindersPatch.mockRejectedValueOnce(error);
     await expect(updateReminder({} as any)).rejects.toBe(error);
   });
 });
@@ -130,14 +131,14 @@ describe('updateReminder', () => {
 describe('deleteReminder', () => {
   it('returns API response on success', async () => {
     const apiResponse = { ok: true } as any;
-    mockApiRemindersRemindersDelete.mockResolvedValueOnce(apiResponse);
+    mockRemindersDelete.mockResolvedValueOnce(apiResponse);
     await expect(deleteReminder(1, 2)).resolves.toBe(apiResponse);
-    expect(mockApiRemindersRemindersDelete).toHaveBeenCalledWith({ telegramId: 1, id: 2 });
+    expect(mockRemindersDelete).toHaveBeenCalledWith({ telegramId: 1, id: 2 });
   });
 
   it('rethrows API errors', async () => {
     const error = new Error('api error');
-    mockApiRemindersRemindersDelete.mockRejectedValueOnce(error);
+    mockRemindersDelete.mockRejectedValueOnce(error);
     await expect(deleteReminder(1, 2)).rejects.toBe(error);
   });
 });

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,4 +1,4 @@
-import { DefaultApi } from '@offonika/diabetes-ts-sdk';
+import { RemindersApi } from '@offonika/diabetes-ts-sdk';
 import { Configuration, ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
 import {
   instanceOfReminderSchema as instanceOfReminder,
@@ -7,7 +7,7 @@ import {
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 
-const api = new DefaultApi(
+const api = new RemindersApi(
   new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
 );
 
@@ -16,7 +16,7 @@ export async function getReminders(
   signal?: AbortSignal,
 ): Promise<Reminder[]> {
   try {
-    const data = await api.apiRemindersRemindersGet({ telegramId }, { signal });
+    const data = await api.remindersGet({ telegramId }, { signal });
 
     if (!data) {
       return [];
@@ -46,7 +46,7 @@ export async function getReminder(
   signal?: AbortSignal,
 ): Promise<Reminder | null> {
   try {
-    const data = await api.apiRemindersRemindersGet({ telegramId, id }, { signal });
+    const data = await api.remindersGet({ telegramId, id }, { signal });
 
     if (!data || Array.isArray(data) || !instanceOfReminder(data)) {
       console.error('Unexpected reminder API response:', data);
@@ -71,7 +71,7 @@ export async function getReminder(
 
 export async function createReminder(reminder: Reminder) {
   try {
-    return await api.apiRemindersPostRemindersPost({ reminder });
+    return await api.remindersPost({ reminder });
   } catch (error) {
     console.error('Failed to create reminder:', error);
     if (error instanceof Error) {
@@ -83,7 +83,7 @@ export async function createReminder(reminder: Reminder) {
 
 export async function updateReminder(reminder: Reminder) {
   try {
-    return await api.apiRemindersRemindersPatch({ reminder });
+    return await api.remindersPatch({ reminder });
   } catch (error) {
     console.error('Failed to update reminder:', error);
     if (error instanceof Error) {
@@ -95,7 +95,7 @@ export async function updateReminder(reminder: Reminder) {
 
 export async function deleteReminder(telegramId: number, id: number) {
   try {
-    return await api.apiRemindersRemindersDelete({ telegramId, id });
+    return await api.remindersDelete({ telegramId, id });
   } catch (error) {
     console.error('Failed to delete reminder:', error);
     if (error instanceof Error) {

--- a/services/webapp/ui/src/api/stats.ts
+++ b/services/webapp/ui/src/api/stats.ts
@@ -1,3 +1,5 @@
+import { StatsApi } from '@offonika/diabetes-ts-sdk';
+import { Configuration } from '@offonika/diabetes-ts-sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 
@@ -26,10 +28,13 @@ export const fallbackDayStats: DayStats = {
   insulin: 12,
 };
 
+const api = new StatsApi(
+  new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
+);
+
 export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint[]> {
   try {
-    const res = await tgFetch(`${API_BASE}/analytics?telegramId=${telegramId}`);
-    const data = await res.json();
+    const data = await api.analyticsGet({ telegramId });
     if (!Array.isArray(data)) {
       console.error('Unexpected analytics API response:', data);
       return fallbackAnalytics;
@@ -43,8 +48,7 @@ export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint
 
 export async function fetchDayStats(telegramId: number): Promise<DayStats> {
   try {
-    const res = await tgFetch(`${API_BASE}/stats?telegramId=${telegramId}`);
-    const data = await res.json();
+    const data = await api.statsGet({ telegramId });
 
     if (!data || typeof data !== 'object' || Array.isArray(data)) {
       console.error('Unexpected stats API response:', data);


### PR DESCRIPTION
## Summary
- use specific SDK APIs in profile, reminders, history, and stats modules
- update API tests to mock new SDK classes and method signatures

## Testing
- `npx vitest run` *(fails: Need to install vitest and workspace dependency resolution errors)*
- `npm --workspace services/webapp/ui run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a8d8b59694832aa35ebb559a684f54