### PR TITLE
tests: build webapp assets via workspace

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,9 +46,15 @@ def _build_ui_assets() -> Iterator[None]:
     """Build webapp UI if static assets are missing."""
     from services.api.app.main import BASE_DIR, UI_DIR
 
+    repo_root = BASE_DIR.parent
+
     if not (UI_DIR / "real-file.js").is_file():
-        subprocess.run(["npm", "ci"], cwd=BASE_DIR / "ui", check=True)
-        subprocess.run(["npm", "run", "build"], cwd=BASE_DIR / "ui", check=True)
+        subprocess.run(["npm", "ci"], cwd=repo_root, check=True)
+        subprocess.run(
+            ["npm", "--workspace", "services/webapp/ui", "run", "build"],
+            cwd=repo_root,
+            check=True,
+        )
     yield
 
 


### PR DESCRIPTION
## Summary
- build UI from monorepo workspace during tests

## Testing
- `pytest -q --cov` *(fails: No module named 'sqlalchemy')*
- `mypy --strict .` *(fails: Cannot find implementation or library stubs for modules such as 'sqlalchemy', 'fastapi', etc.)*
- `ruff check .` *(fails: Found 28 errors)*
- `ruff check tests/conftest.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8d89f5c30832aaea6ab4c508aa46a