### PR TITLE
[webapp] use specialized SDK APIs

### DIFF
--- a/services/webapp/ui/src/api/history.ts
+++ b/services/webapp/ui/src/api/history.ts
@@ -1,45 +1,27 @@
-import { z } from 'zod';
+import { HistoryApi, Configuration } from '@offonika/diabetes-ts-sdk';
+import type {
+  HistoryRecordSchemaInput,
+  HistoryRecordSchemaOutput,
+} from '@offonika/diabetes-ts-sdk/models';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 
-export interface HistoryRecord {
-  id: string;
-  date: string;
-  time: string;
-  sugar?: number;
-  carbs?: number;
-  breadUnits?: number;
-  insulin?: number;
-  notes?: string;
-  type: 'measurement' | 'meal' | 'insulin';
+export type HistoryRecord = HistoryRecordSchemaOutput;
+
+const api = new HistoryApi(
+  new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
+);
+
+function toInput(record: HistoryRecord): HistoryRecordSchemaInput {
+  const { date, ...rest } = record;
+  return { ...rest, date: new Date(date) } as HistoryRecordSchemaInput;
 }
 
-const historyRecordSchema = z.object({
-  id: z.string(),
-  date: z.string(),
-  time: z.string(),
-  sugar: z.number().optional(),
-  carbs: z.number().optional(),
-  breadUnits: z.number().optional(),
-  insulin: z.number().optional(),
-  notes: z.string().optional(),
-  type: z.enum(['measurement', 'meal', 'insulin']),
-});
-
-export async function getHistory(signal?: AbortSignal): Promise<HistoryRecord[]> {
+export async function getHistory(
+  signal?: AbortSignal,
+): Promise<HistoryRecord[]> {
   try {
-    const res = await tgFetch(`${API_BASE}/history`, { signal });
-    const data = await res.json();
-    if (!Array.isArray(data)) {
-      throw new Error('Некорректный ответ API');
-    }
-    const parsed = z.array(historyRecordSchema).safeParse(data);
-    if (!parsed.success) {
-      const issue = parsed.error.issues[0];
-      const path = issue.path.join('.') || 'элемент';
-      throw new Error(`Некорректная запись истории: ${path} ${issue.message}`);
-    }
-    return parsed.data as HistoryRecord[];
+    return await api.historyGet({}, { signal });
   } catch (error) {
     console.error('Failed to fetch history:', error);
     if (error instanceof Error) {
@@ -51,16 +33,7 @@ export async function getHistory(signal?: AbortSignal): Promise<HistoryRecord[]>
 
 export async function updateRecord(record: HistoryRecord) {
   try {
-    const res = await tgFetch(`${API_BASE}/history`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(record),
-    });
-    const data = await res.json().catch(() => ({}));
-    if (data.status !== 'ok') {
-      throw new Error(data.detail || 'Не удалось обновить запись');
-    }
-    return data;
+    return await api.historyPost({ historyRecordSchemaInput: toInput(record) });
   } catch (error) {
     console.error('Failed to update history record:', error);
     if (error instanceof Error) {
@@ -72,12 +45,7 @@ export async function updateRecord(record: HistoryRecord) {
 
 export async function deleteRecord(id: string) {
   try {
-    const res = await tgFetch(`${API_BASE}/history/${encodeURIComponent(id)}`, { method: 'DELETE' });
-    const data = await res.json().catch(() => ({}));
-    if (data.status !== 'ok') {
-      throw new Error(data.detail || 'Не удалось удалить запись');
-    }
-    return data;
+    return await api.historyDelete({ recordId: id });
   } catch (error) {
     console.error('Failed to delete history record:', error);
     if (error instanceof Error) {

--- a/services/webapp/ui/src/api/profile.api.test.ts
+++ b/services/webapp/ui/src/api/profile.api.test.ts
@@ -6,10 +6,11 @@ const mockProfilesGet = vi.hoisted(() => vi.fn());
 const mockProfilesPost = vi.hoisted(() => vi.fn());
 
 vi.mock('@offonika/diabetes-ts-sdk', () => ({
-  DefaultApi: vi.fn(() => ({
+  ProfilesApi: vi.fn(() => ({
     profilesGet: mockProfilesGet,
     profilesPost: mockProfilesPost,
   })),
+  Configuration: class {},
 }));
 
 import { getProfile, saveProfile } from './profile';

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,10 +1,10 @@
-import { DefaultApi } from '@offonika/diabetes-ts-sdk';
+import { ProfilesApi, Configuration } from '@offonika/diabetes-ts-sdk';
 import type { Profile } from '@offonika/diabetes-ts-sdk/models';
-import { Configuration, ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
+import { ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 
-const api = new DefaultApi(
+const api = new ProfilesApi(
   new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
 );
 

--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -10,12 +10,13 @@ const mockInstanceOfReminder = vi.hoisted(() => vi.fn());
 vi.mock(
   '@offonika/diabetes-ts-sdk',
   () => ({
-    DefaultApi: vi.fn(() => ({
+    RemindersApi: vi.fn(() => ({
       apiRemindersRemindersGet: mockApiRemindersRemindersGet,
       apiRemindersPostRemindersPost: mockApiRemindersPostRemindersPost,
       apiRemindersRemindersPatch: mockApiRemindersRemindersPatch,
       apiRemindersRemindersDelete: mockApiRemindersRemindersDelete,
     })),
+    Configuration: class {},
   }),
   { virtual: true },
 );

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,5 @@
-import { DefaultApi } from '@offonika/diabetes-ts-sdk';
-import { Configuration, ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
+import { RemindersApi, Configuration } from '@offonika/diabetes-ts-sdk';
+import { ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
 import {
   instanceOfReminderSchema as instanceOfReminder,
   type ReminderSchema as Reminder,
@@ -7,7 +7,7 @@ import {
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 
-const api = new DefaultApi(
+const api = new RemindersApi(
   new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
 );
 


### PR DESCRIPTION
## Summary
- use specific ProfilesApi, RemindersApi, HistoryApi, AnalyticsApi, and StatsApi from diabetes SDK
- rework history API helpers and stats fetching to call SDK methods
- update API tests for new SDK clients

## Testing
- `npx vitest run` *(fails: Need to install the following packages: vitest)*
- `pytest -q --cov` *(fails: 98 errors during collection)*
- `mypy --strict .` *(fails: Found 97 errors in 34 files)*
- `ruff check .` *(fails: Found 28 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d8b2fba0832abaf191510eb546b5