### PR TITLE
[docs] Use workspace-aware build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,22 @@ sudo apt install python3.12 python3.12-venv
    source venv/bin/activate
    ```
    Все последующие команды `python` и `pip` выполняйте внутри этого окружения.
-3. **Установите зависимости и соберите фронтенд (`npm ci && npm run build`):**
-   В проекте используется менеджер пакетов **npm** (Bun не поддерживается).
-   Локальный Python SDK подключается из каталога `libs/py-sdk`, поэтому он будет установлен вместе с зависимостями:
-   ```bash
-   pip install -r requirements.txt
+3. **Установите зависимости и соберите фронтенд:**
+    В проекте используется менеджер пакетов **npm** (Bun не поддерживается).
+    Локальный Python SDK подключается из каталога `libs/py-sdk`, поэтому он будет
+    установлен вместе с зависимостями. При использовании npm workspaces все
+    команды выполняйте из корня репозитория:
+    ```bash
+    pip install -r requirements.txt
 
-   (cd services/webapp/ui && npm ci && npm run build)
+    npm ci
+    npm --workspace services/webapp/ui run build
 
-   ```
-   Используйте только `npm run build` (production) для деплоя — попытка собрать с `--mode development` завершится ошибкой.
-   Все команды фронтенда (`npm run dev`, `npm run build` и т.д.) запускайте в каталоге `services/webapp/ui`.
+    ```
+    Используйте только `npm run build` (production) для деплоя — попытка
+    собрать с `--mode development` завершится ошибкой. Команды фронтенда
+    (`npm --workspace services/webapp/ui run dev`, `npm --workspace
+    services/webapp/ui run build` и т.д.) запускайте из корня проекта.
 4. **Скопируйте шаблон .env и заполните своими данными:**
    ```bash
    cp infra/env/.env.example .env


### PR DESCRIPTION
## Summary
- run webapp build via npm workspaces from repo root
- note that all npm commands should execute at the repository root

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `mypy --strict .` *(fails: Library stubs not installed for "setuptools")*
- `ruff check .` *(fails: Invalid rule code provided to `# noqa` at libs/py-sdk/setup.py:15: H301)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d8a25154832aa4f0a27e3a97e3ef