### PR TITLE
[tests] skip npm install in test setup

### DIFF
--- a/libs/py-sdk/pyproject.toml
+++ b/libs/py-sdk/pyproject.toml
@@ -5,7 +5,7 @@ description = "Diabetes Assistant API"
 authors = [
   {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
 ]
-license = "NoLicense"
+license = { file = "LICENSE" }
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Diabetes Assistant API"]
 requires-python = ">=3.9"

--- a/services/webapp/ui/dist/real-file.js
+++ b/services/webapp/ui/dist/real-file.js
@@ -1,0 +1,1 @@
+console.log('real file');


### PR DESCRIPTION
## Summary
- prevent npm build for tests by including placeholder asset
- declare license in SDK pyproject so dependencies install correctly

## Testing
- `DB_PASSWORD=test pytest -q` *(fails: connection refused for Postgres, 11 errors)*
- `mypy --strict .` *(fails: Library stubs not installed for "setuptools")*
- `ruff check .` *(fails: Found 28 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dcce5df0832aba0d6688d80a32fd