### PR TITLE
ci: setup pnpm before SDK generation

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -21,8 +21,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Enable Corepack
-        run: corepack enable
+          cache: pnpm
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+          run_install: false
+      - run: pnpm install
       - name: Generate SDKs
         run: pnpm run generate:sdk
       - name: Commit SDKs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+          run_install: false
+      - run: pnpm install
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'


### PR DESCRIPTION
## Summary
- install pnpm in CI workflows
- run pnpm install before generating SDKs and building UI

## Testing
- `pip install -r requirements.txt`
- `pip install -r services/api/app/requirements-dev.txt`
- `pytest -q --cov` *(fails: connection to server at "localhost" (::1), port 5432 failed)*
- `mypy --strict .` *(fails: Library stubs not installed for "setuptools")*
- `ruff check .` *(fails: F401 `warnings` imported but unused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dc008944832a8311e854b4eea030