### PR TITLE
[ci] enable pnpm via corepack

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -22,10 +22,7 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 10
-          run_install: false
+      - run: corepack enable pnpm
       - run: pnpm install
       - name: Generate SDKs
         run: pnpm run generate:sdk

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,7 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 10
-          run_install: false
+      - run: corepack enable pnpm
       - run: pnpm install
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- enable pnpm via corepack in tests workflow
- enable pnpm via corepack in SDK generation workflow

## Testing
- `pytest -q --cov`
- `mypy --strict .` (fails: Function is missing a return type annotation)
- `ruff check .` (fails: Redefinition of unused `StrictInt` from line 15)


------
https://chatgpt.com/codex/tasks/task_e_68a93b320cdc832a880ec4da5010a3ec