### PR TITLE
[py-sdk] specify MIT license in pyproject

### DIFF
--- a/libs/py-sdk/pyproject.toml
+++ b/libs/py-sdk/pyproject.toml
@@ -5,7 +5,7 @@ description = "Diabetes Assistant API"
 authors = [
   {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
 ]
-license = { file = "LICENSE" }
+license = "MIT"
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Diabetes Assistant API"]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- set MIT license in py-sdk pyproject

## Testing
- `pip install -r requirements.txt`
- `pytest -q --cov`
- `mypy --strict .` *(fails: Function is missing a return type annotation [no-untyped-def])* 
- `ruff check .` *(fails: F401 imported but unused)*

------
https://chatgpt.com/codex/tasks/task_e_68a93dc6b514832a8255b5c814146f23