### PR TITLE
ci: switch workflows to npm

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -21,11 +21,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
-      - run: corepack enable pnpm
-      - run: pnpm install
+          cache: npm
+      - run: npm ci
       - name: Generate SDKs
-        run: pnpm run generate:sdk
+        run: npm run generate:sdk
       - name: Commit SDKs
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,9 +22,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
-      - run: corepack enable pnpm
-      - run: pnpm install
+          cache: npm
+      - run: npm ci
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
@@ -33,9 +32,9 @@ jobs:
           pip install -r services/api/app/requirements.txt
           pip install -r services/api/app/requirements-dev.txt
       - name: Generate SDK
-        run: pnpm run generate:sdk
+        run: npm run generate:sdk
       - name: Build webapp UI
-        run: pnpm --filter vite_react_shadcn_ts run build
+        run: npm --workspace services/webapp/ui run build
       - name: Type-check webapp UI
         working-directory: services/webapp/ui
         run: npm run typecheck


### PR DESCRIPTION
## Summary
- use npm instead of pnpm in sdk generation workflow
- use npm instead of pnpm in test workflow

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest --cov=services.api.app.diabetes --cov-report=term-missing --cov-report=xml --cov-fail-under=85`

------
https://chatgpt.com/codex/tasks/task_e_68a9504a7d28832aac0a2f4504dede41