### PR TITLE
[api] align reminders fields with spec

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -618,6 +618,11 @@ components:
         type:
           type: string
           title: Type
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
         time:
           anyOf:
           - type: string

--- a/libs/py-sdk/diabetes_sdk/models/reminder_schema.py
+++ b/libs/py-sdk/diabetes_sdk/models/reminder_schema.py
@@ -29,12 +29,13 @@ class ReminderSchema(BaseModel):
     telegram_id: StrictInt = Field(alias="telegramId")
     id: Optional[StrictInt] = None
     type: StrictStr
+    title: Optional[StrictStr] = None
     time: Optional[StrictStr] = None
     interval_hours: Optional[StrictInt] = Field(default=None, alias="intervalHours")
     minutes_after: Optional[StrictInt] = Field(default=None, alias="minutesAfter")
     is_enabled: Optional[StrictBool] = Field(default=True, alias="isEnabled")
     org_id: Optional[StrictInt] = Field(default=None, alias="orgId")
-    __properties: ClassVar[List[str]] = ["telegramId", "id", "type", "time", "intervalHours", "minutesAfter", "isEnabled", "orgId"]
+    __properties: ClassVar[List[str]] = ["telegramId", "id", "type", "title", "time", "intervalHours", "minutesAfter", "isEnabled", "orgId"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -80,6 +81,11 @@ class ReminderSchema(BaseModel):
         if self.id is None and "id" in self.model_fields_set:
             _dict['id'] = None
 
+        # set to None if title (nullable) is None
+        # and model_fields_set contains the field
+        if self.title is None and "title" in self.model_fields_set:
+            _dict['title'] = None
+
         # set to None if time (nullable) is None
         # and model_fields_set contains the field
         if self.time is None and "time" in self.model_fields_set:
@@ -115,6 +121,7 @@ class ReminderSchema(BaseModel):
             "telegramId": obj.get("telegramId"),
             "id": obj.get("id"),
             "type": obj.get("type"),
+            "title": obj.get("title"),
             "time": obj.get("time"),
             "intervalHours": obj.get("intervalHours"),
             "minutesAfter": obj.get("minutesAfter"),

--- a/libs/ts-sdk/models/ReminderSchema.ts
+++ b/libs/ts-sdk/models/ReminderSchema.ts
@@ -32,13 +32,19 @@ export interface ReminderSchema {
      */
     id?: number | null;
     /**
-     * 
+     *
      * @type {string}
      * @memberof ReminderSchema
      */
     type: string;
     /**
-     * 
+     *
+     * @type {string}
+     * @memberof ReminderSchema
+     */
+    title?: string | null;
+    /**
+     *
      * @type {string}
      * @memberof ReminderSchema
      */
@@ -91,6 +97,7 @@ export function ReminderSchemaFromJSONTyped(json: any, ignoreDiscriminator: bool
         'telegramId': json['telegramId'],
         'id': json['id'] == null ? undefined : json['id'],
         'type': json['type'],
+        'title': json['title'] == null ? undefined : json['title'],
         'time': json['time'] == null ? undefined : json['time'],
         'intervalHours': json['intervalHours'] == null ? undefined : json['intervalHours'],
         'minutesAfter': json['minutesAfter'] == null ? undefined : json['minutesAfter'],
@@ -113,6 +120,7 @@ export function ReminderSchemaToJSONTyped(value?: ReminderSchema | null, ignoreD
         'telegramId': value['telegramId'],
         'id': value['id'],
         'type': value['type'],
+        'title': value['title'],
         'time': value['time'],
         'intervalHours': value['intervalHours'],
         'minutesAfter': value['minutesAfter'],

--- a/services/api/app/routers/reminders.py
+++ b/services/api/app/routers/reminders.py
@@ -40,24 +40,30 @@ async def get_reminders(
     if id is None:
         return [
             {
+                "telegramId": r.telegram_id,
                 "id": r.id,
                 "type": r.type,
                 "title": r.type,
                 "time": r.time,
-                "active": r.is_enabled,
-                "interval": r.interval_hours,
+                "intervalHours": r.interval_hours,
+                "minutesAfter": r.minutes_after,
+                "isEnabled": r.is_enabled,
+                "orgId": r.org_id,
             }
             for r in rems
         ]
     for r in rems:
         if r.id == id:
             return {
+                "telegramId": r.telegram_id,
                 "id": r.id,
                 "type": r.type,
                 "title": r.type,
                 "time": r.time,
-                "active": r.is_enabled,
-                "interval": r.interval_hours,
+                "intervalHours": r.interval_hours,
+                "minutesAfter": r.minutes_after,
+                "isEnabled": r.is_enabled,
+                "orgId": r.org_id,
             }
     return []  # 200 OK — пустой список
 

--- a/services/api/app/schemas/reminders.py
+++ b/services/api/app/schemas/reminders.py
@@ -5,6 +5,7 @@ class ReminderSchema(BaseModel):
     telegramId: int = Field(alias="telegramId", validation_alias=AliasChoices("telegramId", "telegram_id"))
     id: int | None = None
     type: str
+    title: str | None = None
     time: str | None = None
     intervalHours: int | None = None
     minutesAfter: int | None = None

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -13,7 +13,7 @@ import {
   type NormalizedReminderType,
 } from '@/lib/reminders'
 import { parseTimeToMinutes } from '@/lib/time'
-import type { Reminder as ApiReminder } from '@offonika/diabetes-ts-sdk/models'
+import type { ReminderSchema as ApiReminder } from '@offonika/diabetes-ts-sdk/models'
 import type { Reminder } from '@/types/reminder'
 
 const TYPE_LABEL: Record<NormalizedReminderType, string> = {

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -628,12 +628,15 @@ def test_nonempty_returns_list(
     assert resp.status_code == 200
     assert resp.json() == [
         {
+            "telegramId": 1,
             "id": 1,
             "type": "sugar",
             "title": "sugar",
             "time": "08:00",
-            "active": True,
-            "interval": 3,
+            "intervalHours": 3,
+            "minutesAfter": None,
+            "isEnabled": True,
+            "orgId": None,
         }
     ]
 

--- a/tests/test_reminders_api.py
+++ b/tests/test_reminders_api.py
@@ -71,12 +71,15 @@ def test_nonempty_returns_list(
     assert resp.status_code == 200
     assert resp.json() == [
         {
+            "telegramId": 1,
             "id": 1,
             "type": "sugar",
             "title": "sugar",
             "time": "08:00",
-            "active": True,
-            "interval": 3,
+            "intervalHours": 3,
+            "minutesAfter": None,
+            "isEnabled": True,
+            "orgId": None,
         }
     ]
 


### PR DESCRIPTION
## Summary
- return spec-compliant reminder fields from API
- document reminder schema and regenerate SDK models
- adjust webapp reminder mapping to new schema

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a952afb754832a9de1c1207a5f616c