### PR TITLE
[webapp] use local ts-sdk file dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,10 @@
       "workspaces": [
         "services/webapp/ui",
         "libs/ts-sdk"
-      ]
+      ],
+      "engines": {
+        "node": ">=20"
+      }
     },
     "libs/ts-sdk": {
       "name": "@offonika/diabetes-ts-sdk",
@@ -7995,7 +7998,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
-        "@offonika/diabetes-ts-sdk": "file:../../libs/ts-sdk",
+        "@offonika/diabetes-ts-sdk": "file:../../../libs/ts-sdk",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/services/webapp/ui/package.json
+++ b/services/webapp/ui/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
-    "@offonika/diabetes-ts-sdk": "workspace:*",
+    "@offonika/diabetes-ts-sdk": "file:../../../libs/ts-sdk",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-aspect-ratio": "^1.1.7",


### PR DESCRIPTION
## Summary
- use local ts-sdk package instead of workspace reference in webapp UI

## Testing
- `npm install`
- `npm ci`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a95bdd31e4832a920617077c0bbc1b