### PR TITLE
[api] Return 404 for missing reminders

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -108,6 +108,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+        '404':
+          description: Reminder not found or telegramId mismatch
     post:
       tags:
       - Reminders
@@ -221,6 +223,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+        '404':
+          description: Reminder not found
   /timezone:
     get:
       summary: Get Timezone

--- a/services/api/app/routers/reminders.py
+++ b/services/api/app/routers/reminders.py
@@ -37,7 +37,7 @@ async def get_reminders(
             tid,
             user["id"],
         )
-        return []  # 200 OK — пустой список
+        raise HTTPException(status_code=404, detail="reminder not found")
     log_patient_access(getattr(request.state, "user_id", None), tid)
 
     rems = await list_reminders(tid)
@@ -69,7 +69,7 @@ async def get_reminders(
                 "isEnabled": r.is_enabled,
                 "orgId": r.org_id,
             }
-    return []  # 200 OK — пустой список
+    raise HTTPException(status_code=404, detail="reminder not found")
 
 
 @router.post("/reminders", dependencies=[Depends(require_tg_user)])

--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -8,6 +8,21 @@ const mockRemindersDelete = vi.hoisted(() => vi.fn());
 const mockInstanceOfReminder = vi.hoisted(() => vi.fn());
 
 vi.mock(
+  '@offonika/diabetes-ts-sdk/runtime',
+  () => ({
+    ResponseError: class extends Error {
+      response: Response;
+      constructor(response: Response) {
+        super('ResponseError');
+        this.response = response;
+      }
+    },
+    Configuration: class {},
+  }),
+  { virtual: true },
+);
+
+vi.mock(
   '@offonika/diabetes-ts-sdk',
   () => ({
     RemindersApi: vi.fn(() => ({
@@ -86,6 +101,13 @@ describe('getReminders', () => {
       { telegramId: 1 },
       { signal: controller.signal },
     );
+  });
+
+  it('returns empty array on 404 response', async () => {
+    mockRemindersGet.mockRejectedValueOnce(
+      new ResponseError(new Response(null, { status: 404 })),
+    );
+    await expect(getReminders(1)).resolves.toEqual([]);
   });
 
   it('rethrows AbortError', async () => {

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -33,6 +33,9 @@ export async function getReminders(
       throw error;
     }
     console.error('Failed to fetch reminders:', error);
+    if (error instanceof ResponseError && error.response.status === 404) {
+      return [];
+    }
     if (error instanceof Error) {
       throw error;
     }

--- a/tests/test_legacy_reminders_auth.py
+++ b/tests/test_legacy_reminders_auth.py
@@ -105,8 +105,8 @@ def test_reminders_mismatched_id(
                 "X-Request-ID": request_id,
             },
         )
-    assert resp.status_code == 200
-    assert resp.json() == []
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "reminder not found"}
     assert (
         f"request_id={request_id} telegramId=2 does not match user_id=1" in caplog.text
     )

--- a/tests/test_reminders_api.py
+++ b/tests/test_reminders_api.py
@@ -91,8 +91,8 @@ def test_invalid_telegram_id_returns_empty_list(client: TestClient) -> None:
 
 def test_mismatched_telegram_id_returns_404(client: TestClient) -> None:
     resp = client.get("/api/reminders", params={"telegramId": 2})
-    assert resp.status_code == 200
-    assert resp.json() == []
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "reminder not found"}
 
 
 def test_patch_updates_reminder(


### PR DESCRIPTION
## Summary
- return 404 if user id mismatches or reminder is absent
- document 404 responses in OpenAPI
- handle 404 responses for reminders list in webapp

## Testing
- `npx --yes vitest run services/webapp/ui/src/api/reminders.api.test.ts` *(fails: Cannot find module 'vitest/config')*
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a95cc47540832a8c416726d9064889