### PR TITLE
api: unify profiles endpoint

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -12,13 +12,13 @@ paths:
       tags:
       - Profiles
       summary: Profiles Post
-      operationId: profiles_post_profiles_post
+      operationId: profilesPost
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProfileSchema'
+              $ref: '#/components/schemas/Profile'
       responses:
         '200':
           description: Successful Response
@@ -28,7 +28,7 @@ paths:
                 type: object
                 additionalProperties:
                   type: string
-                title: Response Profiles Post Profiles Post
+                title: Response Profiles Post
         '422':
           description: Validation Error
           content:
@@ -39,7 +39,7 @@ paths:
       tags:
       - Profiles
       summary: Profiles Get
-      operationId: profiles_get_profiles_get
+      operationId: profilesGet
       parameters:
       - name: telegramId
         in: query
@@ -53,7 +53,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProfileSchema'
+                $ref: '#/components/schemas/Profile'
         '422':
           description: Validation Error
           content:
@@ -667,7 +667,7 @@ components:
       - type
       title: HistoryRecordSchema
       description: Schema for user history records.
-    ProfileSchema:
+    Profile:
       properties:
         telegramId:
           type: integer
@@ -700,7 +700,7 @@ components:
       - target
       - low
       - high
-      title: ProfileSchema
+      title: Profile
     ReminderSchema:
       properties:
         telegramId:

--- a/libs/ts-sdk/.openapi-generator/FILES
+++ b/libs/ts-sdk/.openapi-generator/FILES
@@ -9,7 +9,7 @@ models/DayStats.ts
 models/HTTPValidationError.ts
 models/HistoryRecordSchemaInput.ts
 models/HistoryRecordSchemaOutput.ts
-models/ProfileSchema.ts
+models/Profile.ts
 models/ReminderSchema.ts
 models/Timezone.ts
 models/UserContext.ts

--- a/libs/ts-sdk/apis/ProfilesApi.ts
+++ b/libs/ts-sdk/apis/ProfilesApi.ts
@@ -16,21 +16,21 @@
 import * as runtime from '../runtime';
 import type {
   HTTPValidationError,
-  ProfileSchema,
+  Profile,
 } from '../models/index';
 import {
     HTTPValidationErrorFromJSON,
     HTTPValidationErrorToJSON,
-    ProfileSchemaFromJSON,
-    ProfileSchemaToJSON,
+    ProfileFromJSON,
+    ProfileToJSON,
 } from '../models/index';
 
-export interface ProfilesGetProfilesGetRequest {
+export interface ProfilesGetRequest {
     telegramId: number;
 }
 
-export interface ProfilesPostProfilesPostRequest {
-    profileSchema: ProfileSchema;
+export interface ProfilesPostRequest {
+    profile: Profile;
 }
 
 /**
@@ -41,11 +41,11 @@ export class ProfilesApi extends runtime.BaseAPI {
     /**
      * Profiles Get
      */
-    async profilesGetProfilesGetRaw(requestParameters: ProfilesGetProfilesGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ProfileSchema>> {
+    async profilesGetRaw(requestParameters: ProfilesGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Profile>> {
         if (requestParameters['telegramId'] == null) {
             throw new runtime.RequiredError(
                 'telegramId',
-                'Required parameter "telegramId" was null or undefined when calling profilesGetProfilesGet().'
+                'Required parameter "telegramId" was null or undefined when calling profilesGet().'
             );
         }
 
@@ -67,25 +67,25 @@ export class ProfilesApi extends runtime.BaseAPI {
             query: queryParameters,
         }, initOverrides);
 
-        return new runtime.JSONApiResponse(response, (jsonValue) => ProfileSchemaFromJSON(jsonValue));
+        return new runtime.JSONApiResponse(response, (jsonValue) => ProfileFromJSON(jsonValue));
     }
 
     /**
      * Profiles Get
      */
-    async profilesGetProfilesGet(requestParameters: ProfilesGetProfilesGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ProfileSchema> {
-        const response = await this.profilesGetProfilesGetRaw(requestParameters, initOverrides);
+    async profilesGet(requestParameters: ProfilesGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Profile> {
+        const response = await this.profilesGetRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Profiles Post
      */
-    async profilesPostProfilesPostRaw(requestParameters: ProfilesPostProfilesPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string | null; }>> {
-        if (requestParameters['profileSchema'] == null) {
+    async profilesPostRaw(requestParameters: ProfilesPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string | null; }>> {
+        if (requestParameters['profile'] == null) {
             throw new runtime.RequiredError(
-                'profileSchema',
-                'Required parameter "profileSchema" was null or undefined when calling profilesPostProfilesPost().'
+                'profile',
+                'Required parameter "profile" was null or undefined when calling profilesPost().'
             );
         }
 
@@ -103,7 +103,7 @@ export class ProfilesApi extends runtime.BaseAPI {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: ProfileSchemaToJSON(requestParameters['profileSchema']),
+            body: ProfileToJSON(requestParameters['profile']),
         }, initOverrides);
 
         return new runtime.JSONApiResponse<any>(response);
@@ -112,8 +112,8 @@ export class ProfilesApi extends runtime.BaseAPI {
     /**
      * Profiles Post
      */
-    async profilesPostProfilesPost(requestParameters: ProfilesPostProfilesPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string | null; }> {
-        const response = await this.profilesPostProfilesPostRaw(requestParameters, initOverrides);
+    async profilesPost(requestParameters: ProfilesPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string | null; }> {
+        const response = await this.profilesPostRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/libs/ts-sdk/models/Profile.ts
+++ b/libs/ts-sdk/models/Profile.ts
@@ -16,57 +16,57 @@ import { mapValues } from '../runtime';
 /**
  * 
  * @export
- * @interface ProfileSchema
+ * @interface Profile
  */
-export interface ProfileSchema {
+export interface Profile {
     /**
      * 
      * @type {number}
-     * @memberof ProfileSchema
+     * @memberof Profile
      */
     telegramId: number;
     /**
      * 
      * @type {number}
-     * @memberof ProfileSchema
+     * @memberof Profile
      */
     icr: number;
     /**
      * 
      * @type {number}
-     * @memberof ProfileSchema
+     * @memberof Profile
      */
     cf: number;
     /**
      * 
      * @type {number}
-     * @memberof ProfileSchema
+     * @memberof Profile
      */
     target: number;
     /**
      * 
      * @type {number}
-     * @memberof ProfileSchema
+     * @memberof Profile
      */
     low: number;
     /**
      * 
      * @type {number}
-     * @memberof ProfileSchema
+     * @memberof Profile
      */
     high: number;
     /**
      * 
      * @type {number}
-     * @memberof ProfileSchema
+     * @memberof Profile
      */
     orgId?: number | null;
 }
 
 /**
- * Check if a given object implements the ProfileSchema interface.
+ * Check if a given object implements the Profile interface.
  */
-export function instanceOfProfileSchema(value: object): value is ProfileSchema {
+export function instanceOfProfile(value: object): value is Profile {
     if (!('telegramId' in value) || value['telegramId'] === undefined) return false;
     if (!('icr' in value) || value['icr'] === undefined) return false;
     if (!('cf' in value) || value['cf'] === undefined) return false;
@@ -76,11 +76,11 @@ export function instanceOfProfileSchema(value: object): value is ProfileSchema {
     return true;
 }
 
-export function ProfileSchemaFromJSON(json: any): ProfileSchema {
-    return ProfileSchemaFromJSONTyped(json, false);
+export function ProfileFromJSON(json: any): Profile {
+    return ProfileFromJSONTyped(json, false);
 }
 
-export function ProfileSchemaFromJSONTyped(json: any, ignoreDiscriminator: boolean): ProfileSchema {
+export function ProfileFromJSONTyped(json: any, ignoreDiscriminator: boolean): Profile {
     if (json == null) {
         return json;
     }
@@ -96,11 +96,11 @@ export function ProfileSchemaFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function ProfileSchemaToJSON(json: any): ProfileSchema {
-    return ProfileSchemaToJSONTyped(json, false);
+export function ProfileToJSON(json: any): Profile {
+    return ProfileToJSONTyped(json, false);
 }
 
-export function ProfileSchemaToJSONTyped(value?: ProfileSchema | null, ignoreDiscriminator: boolean = false): any {
+export function ProfileToJSONTyped(value?: Profile | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/libs/ts-sdk/models/index.ts
+++ b/libs/ts-sdk/models/index.ts
@@ -5,7 +5,7 @@ export * from './DayStats';
 export * from './HTTPValidationError';
 export * from './HistoryRecordSchemaInput';
 export * from './HistoryRecordSchemaOutput';
-export * from './ProfileSchema';
+export * from './Profile';
 export * from './ReminderSchema';
 export * from './Timezone';
 export * from './UserContext';

--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -11,13 +11,13 @@ router = APIRouter()
 router.include_router(reminders_router)
 
 
-@router.post("/profiles")
+@router.post("/profiles", operation_id="profilesPost", tags=["Profiles"])
 async def profiles_post(data: ProfileSchema) -> dict[str, str]:
     await save_profile(data)
     return {"status": "ok"}
 
 
-@router.get("/profiles")
+@router.get("/profiles", operation_id="profilesGet", tags=["Profiles"])
 async def profiles_get(
     telegramId: int | None = Query(None),
     telegram_id: int | None = Query(None, alias="telegram_id"),

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -13,7 +13,7 @@ if __name__ == "__main__" and __package__ is None:  # pragma: no cover
     __package__ = "services.api.app"
 
 # ────────── std / 3-rd party ──────────
-from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import AliasChoices, BaseModel, Field
 from sqlalchemy.orm import Session
@@ -40,24 +40,6 @@ logger = logging.getLogger(__name__)
 init_db()  # создаёт/инициализирует БД
 
 app = FastAPI(title="Diabetes Assistant API", version="1.0.0")
-
-# ────────── profiles (front expects list) ──────────
-@app.get("/api/profiles", operation_id="profilesGet", tags=["profiles"])
-@app.get("/profiles", include_in_schema=False)  # legacy-путь
-async def get_profiles(
-    telegramId: int | None = Query(None),
-    telegram_id: int | None = Query(None, alias="telegram_id"),
-    user: UserContext = Depends(require_tg_user),
-) -> list[UserContext]:
-    """
-    Telegram-Web-App ждёт массив профилей.
-    Бэкенд однопользовательский → возвращаем список из одного текущего пользователя.
-    Если query-параметр указан и не совпадает с auth-пользователем — 403.
-    """
-    tid = telegramId or telegram_id
-    if tid is not None and tid != user["id"]:
-        raise HTTPException(status_code=403, detail="telegram id mismatch")
-    return [user]
 
 # ────────── роуты статистики / legacy ──────────
 app.include_router(stats_router,   prefix="/api")

--- a/services/webapp/ui/src/api/profile.api.test.ts
+++ b/services/webapp/ui/src/api/profile.api.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ResponseError, Configuration } from '@offonika/diabetes-ts-sdk/runtime';
-import type { Profile } from '@offonika/diabetes-ts-sdk/models';
+import {
+  ResponseError,
+  Configuration,
+  type Profile,
+} from '@offonika/diabetes-ts-sdk';
 
 const mockProfilesGet = vi.hoisted(() => vi.fn());
 const mockProfilesPost = vi.hoisted(() => vi.fn());

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,6 +1,9 @@
-import { ProfilesApi } from '@offonika/diabetes-ts-sdk';
-import type { Profile } from '@offonika/diabetes-ts-sdk/models';
-import { Configuration, ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
+import {
+  ProfilesApi,
+  Configuration,
+  ResponseError,
+  type Profile,
+} from '@offonika/diabetes-ts-sdk';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 


### PR DESCRIPTION
## Summary
- drop duplicate `/api/profiles` handler from main app
- expose `/api/profiles` only via legacy router with explicit operation ids
- regenerate TypeScript SDK and update webapp profile API

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `npx vitest run` *(fails: Cannot find package 'vite')*


------
https://chatgpt.com/codex/tasks/task_e_68a95cb0ab1c832a9dcbff4f1e878e56