### PR TITLE
[webapp] Adjust profile API to new SDK

### DIFF
--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,5 +1,8 @@
 import { ProfilesApi } from '@offonika/diabetes-ts-sdk';
-import type { Profile } from '@offonika/diabetes-ts-sdk/models';
+import {
+  instanceOfProfileSchema as instanceOfProfile,
+  type ProfileSchema as Profile,
+} from '@offonika/diabetes-ts-sdk/models';
 import { Configuration, ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
@@ -10,7 +13,14 @@ const api = new ProfilesApi(
 
 export async function getProfile(telegramId: number): Promise<Profile | null> {
   try {
-    return await api.profilesGet({ telegramId });
+    const data = await api.profilesGetProfilesGet({ telegramId });
+
+    if (!instanceOfProfile(data)) {
+      console.error('Unexpected profile API response:', data);
+      throw new Error('Некорректный ответ API');
+    }
+
+    return data;
   } catch (error) {
     console.error('Failed to fetch profile:', error);
     if (error instanceof ResponseError && error.response.status === 404) {
@@ -25,7 +35,11 @@ export async function getProfile(telegramId: number): Promise<Profile | null> {
 
 export async function saveProfile(profile: Profile) {
   try {
-    return await api.profilesPost({ profile });
+    const data = await api.profilesPostProfilesPost({ profileSchema: profile });
+    if (data.status !== 'ok') {
+      throw new Error(data.detail || 'Не удалось сохранить профиль');
+    }
+    return data;
   } catch (error) {
     console.error('Failed to save profile:', error);
     if (error instanceof Error) {


### PR DESCRIPTION
## Summary
- align profile client with regenerated SDK methods and models
- update tests for new unified response structure

## Testing
- `npx vitest run services/webapp/ui/src/api/profile.api.test.ts`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9629bb138832a9a3a55b4d340af18