### PR TITLE
[api] consolidate profiles endpoint

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -11,13 +11,13 @@ router = APIRouter()
 router.include_router(reminders_router)
 
 
-@router.post("/profiles")
-async def profiles_post(data: ProfileSchema) -> dict[str, str]:
+@router.post("/profiles", operation_id="profilesPost", tags=["profiles"])
+async def profiles_post(data: ProfileSchema) -> ProfileSchema:
     await save_profile(data)
-    return {"status": "ok"}
+    return data
 
 
-@router.get("/profiles")
+@router.get("/profiles", operation_id="profilesGet", tags=["profiles"])
 async def profiles_get(
     telegramId: int | None = Query(None),
     telegram_id: int | None = Query(None, alias="telegram_id"),

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -13,7 +13,7 @@ if __name__ == "__main__" and __package__ is None:  # pragma: no cover
     __package__ = "services.api.app"
 
 # ────────── std / 3-rd party ──────────
-from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import AliasChoices, BaseModel, Field
 from sqlalchemy.orm import Session
@@ -40,25 +40,6 @@ logger = logging.getLogger(__name__)
 init_db()  # создаёт/инициализирует БД
 
 app = FastAPI(title="Diabetes Assistant API", version="1.0.0")
-
-
-# ────────── profiles (front expects list) ──────────
-@app.get("/api/profiles", operation_id="profilesGet", tags=["profiles"])
-@app.get("/profiles", include_in_schema=False)  # legacy-путь
-async def get_profiles(
-    telegramId: int | None = Query(None),
-    telegram_id: int | None = Query(None, alias="telegram_id"),
-    user: UserContext = Depends(require_tg_user),
-) -> list[UserContext]:
-    """
-    Telegram-Web-App ждёт массив профилей.
-    Бэкенд однопользовательский → возвращаем список из одного текущего пользователя.
-    Если query-параметр указан и не совпадает с auth-пользователем — 403.
-    """
-    tid = telegramId or telegram_id
-    if tid is not None and tid != user["id"]:
-        raise HTTPException(status_code=403, detail="telegram id mismatch")
-    return [user]
 
 
 # ────────── роуты статистики / legacy ──────────


### PR DESCRIPTION
## Summary
- Deduplicate `/api/profiles` by routing through `legacy.py` only
- Return `ProfileSchema` from profiles API with explicit `operation_id`s

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9624916cc832abafc559fd7245843