### PR TITLE
[webapp] Use Date objects for history records

### DIFF
--- a/services/webapp/ui/src/pages/History.tsx
+++ b/services/webapp/ui/src/pages/History.tsx
@@ -40,7 +40,8 @@ const History = () => {
   }, [toast]);
 
   const filteredRecords = records.filter(record => {
-    const dateMatch = !selectedDate || record.date === selectedDate;
+    const recordDate = record.date.toISOString().slice(0, 10);
+    const dateMatch = !selectedDate || recordDate === selectedDate;
     const typeMatch = selectedType === 'all' || record.type === selectedType;
     return dateMatch && typeMatch;
   });
@@ -213,7 +214,7 @@ const History = () => {
                   <div className="flex items-center justify-between mb-1">
                     <div className="flex items-center gap-2">
                       <span className="text-sm text-muted-foreground">
-                        {new Date(record.date).toLocaleDateString('ru-RU')}
+                        {record.date.toLocaleDateString('ru-RU')}
                       </span>
                       <span className="text-sm font-medium">{record.time}</span>
                     </div>
@@ -294,10 +295,10 @@ const History = () => {
                 </label>
                 <input
                   type="date"
-                  value={editingRecord.date}
+                  value={editingRecord.date.toISOString().slice(0, 10)}
                   onChange={e =>
                     setEditingRecord(prev =>
-                      prev ? { ...prev, date: e.target.value } : prev
+                      prev ? { ...prev, date: new Date(e.target.value) } : prev
                     )
                   }
                   className="medical-input"

--- a/services/webapp/ui/src/pages/NewMeal.tsx
+++ b/services/webapp/ui/src/pages/NewMeal.tsx
@@ -25,7 +25,7 @@ const NewMeal = () => {
     const now = new Date();
     const record: HistoryRecord = {
       id: Date.now().toString(),
-      date: now.toISOString().split('T')[0],
+      date: new Date(now.toISOString().split('T')[0]),
       time: now.toTimeString().slice(0, 5),
       type: 'meal',
       notes: meal,

--- a/services/webapp/ui/src/pages/NewMeasurement.tsx
+++ b/services/webapp/ui/src/pages/NewMeasurement.tsx
@@ -24,7 +24,7 @@ const NewMeasurement = () => {
     const now = new Date();
     const record: HistoryRecord = {
       id: Date.now().toString(),
-      date: now.toISOString().split('T')[0],
+      date: new Date(now.toISOString().split('T')[0]),
       time: now.toTimeString().slice(0, 5),
       sugar: sugarValue,
       type: 'measurement',


### PR DESCRIPTION
## Summary
- parse history record dates as `Date` objects and convert before posting
- adjust UI components for Date-based records
- test `HistoryApi` serializes dates to ISO strings

## Testing
- `npm --workspace services/webapp/ui run typecheck`
- `npx vitest run services/webapp/ui/src/api/history.api.test.ts`
- `npx vitest run` *(fails: missing `react-test-renderer` and mocked exports)*
- `pytest -q --cov` *(fails: `pydantic-settings` not installed)*
- `mypy --strict .` *(fails: missing stubs and packages)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a96813f04c832a903d8f6b5c0dcee3