### PR TITLE
[webapp] Support SOS profile fields

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -705,6 +705,14 @@ components:
         high:
           type: number
           title: High
+        sosContact:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Sos Contact
+        sosAlertsEnabled:
+          type: boolean
+          title: Sos Alerts Enabled
         orgId:
           anyOf:
           - type: integer

--- a/libs/py-sdk/diabetes_sdk/models/profile_schema.py
+++ b/libs/py-sdk/diabetes_sdk/models/profile_schema.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional, Union
 from typing import Optional, Set
 from typing_extensions import Self
@@ -32,8 +32,10 @@ class ProfileSchema(BaseModel):
     target: Union[StrictFloat, StrictInt]
     low: Union[StrictFloat, StrictInt]
     high: Union[StrictFloat, StrictInt]
+    sos_contact: Optional[StrictStr] = Field(default=None, alias="sosContact")
+    sos_alerts_enabled: Optional[StrictBool] = Field(default=None, alias="sosAlertsEnabled")
     org_id: Optional[StrictInt] = Field(default=None, alias="orgId")
-    __properties: ClassVar[List[str]] = ["telegramId", "icr", "cf", "target", "low", "high", "orgId"]
+    __properties: ClassVar[List[str]] = ["telegramId", "icr", "cf", "target", "low", "high", "sosContact", "sosAlertsEnabled", "orgId"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -74,6 +76,11 @@ class ProfileSchema(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # set to None if sos_contact (nullable) is None
+        # and model_fields_set contains the field
+        if self.sos_contact is None and "sos_contact" in self.model_fields_set:
+            _dict['sosContact'] = None
+
         # set to None if org_id (nullable) is None
         # and model_fields_set contains the field
         if self.org_id is None and "org_id" in self.model_fields_set:
@@ -97,6 +104,8 @@ class ProfileSchema(BaseModel):
             "target": obj.get("target"),
             "low": obj.get("low"),
             "high": obj.get("high"),
+            "sosContact": obj.get("sosContact"),
+            "sosAlertsEnabled": obj.get("sosAlertsEnabled"),
             "orgId": obj.get("orgId")
         })
         return _obj

--- a/libs/py-sdk/docs/ProfileSchema.md
+++ b/libs/py-sdk/docs/ProfileSchema.md
@@ -11,6 +11,8 @@ Name | Type | Description | Notes
 **target** | **float** |  | 
 **low** | **float** |  | 
 **high** | **float** |  | 
+**sos_contact** | **str** |  | [optional] 
+**sos_alerts_enabled** | **bool** |  | [optional] 
 **org_id** | **int** |  | [optional] 
 
 ## Example

--- a/libs/ts-sdk/models/ProfileSchema.ts
+++ b/libs/ts-sdk/models/ProfileSchema.ts
@@ -57,6 +57,18 @@ export interface ProfileSchema {
     high: number;
     /**
      * 
+     * @type {string}
+     * @memberof ProfileSchema
+     */
+    sosContact?: string | null;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ProfileSchema
+     */
+    sosAlertsEnabled?: boolean;
+    /**
+     * 
      * @type {number}
      * @memberof ProfileSchema
      */
@@ -92,6 +104,8 @@ export function ProfileSchemaFromJSONTyped(json: any, ignoreDiscriminator: boole
         'target': json['target'],
         'low': json['low'],
         'high': json['high'],
+        'sosContact': json['sosContact'] == null ? undefined : json['sosContact'],
+        'sosAlertsEnabled': json['sosAlertsEnabled'] == null ? undefined : json['sosAlertsEnabled'],
         'orgId': json['orgId'] == null ? undefined : json['orgId'],
     };
 }
@@ -113,6 +127,8 @@ export function ProfileSchemaToJSONTyped(value?: ProfileSchema | null, ignoreDis
         'target': value['target'],
         'low': value['low'],
         'high': value['high'],
+        'sosContact': value['sosContact'],
+        'sosAlertsEnabled': value['sosAlertsEnabled'],
         'orgId': value['orgId'],
     };
 }

--- a/services/webapp/ui/src/api/profile.api.test.ts
+++ b/services/webapp/ui/src/api/profile.api.test.ts
@@ -32,6 +32,21 @@ describe('getProfile', () => {
     mockProfilesGet.mockRejectedValueOnce(err);
     await expect(getProfile(1)).rejects.toBe(err);
   });
+
+  it('returns profile with sos fields', async () => {
+    const profile = {
+      telegramId: 1,
+      icr: 0,
+      cf: 0,
+      target: 0,
+      low: 0,
+      high: 0,
+      sosContact: '+79998887766',
+      sosAlertsEnabled: true,
+    } as Profile;
+    mockProfilesGet.mockResolvedValueOnce(profile);
+    await expect(getProfile(1)).resolves.toEqual(profile);
+  });
 });
 
 describe('saveProfile', () => {
@@ -43,6 +58,8 @@ describe('saveProfile', () => {
       target: 0,
       low: 0,
       high: 0,
+      sosContact: '+79998887766',
+      sosAlertsEnabled: true,
     } as Profile;
     mockProfilesPost.mockResolvedValueOnce(profile);
     await expect(saveProfile(profile)).resolves.toBe(profile);

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -20,7 +20,11 @@ export async function getProfile(telegramId: number): Promise<Profile | null> {
       throw new Error('Некорректный ответ API');
     }
 
-    return data;
+    return {
+      ...data,
+      sosContact: data.sosContact,
+      sosAlertsEnabled: data.sosAlertsEnabled,
+    };
   } catch (error) {
     console.error('Failed to fetch profile:', error);
     if (error instanceof ResponseError && error.response.status === 404) {
@@ -35,7 +39,13 @@ export async function getProfile(telegramId: number): Promise<Profile | null> {
 
 export async function saveProfile(profile: Profile): Promise<Profile> {
   try {
-    const data = await api.profilesPost({ profileSchema: profile });
+    const data = await api.profilesPost({
+      profileSchema: {
+        ...profile,
+        sosContact: profile.sosContact,
+        sosAlertsEnabled: profile.sosAlertsEnabled,
+      },
+    });
     if (!instanceOfProfile(data)) {
       console.error('Unexpected profile API response:', data);
       throw new Error('Некорректный ответ API');

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -6,25 +6,40 @@ import { useToast } from '@/hooks/use-toast';
 import MedicalButton from '@/components/MedicalButton';
 import { getProfile, saveProfile } from '@/api/profile';
 import { useTelegramContext } from '@/contexts/telegram-context';
+import { Switch } from '@/components/ui/switch';
 
 type ProfileField =
   | 'icr'
   | 'correctionFactor'
   | 'targetSugar'
   | 'lowThreshold'
-  | 'highThreshold';
+  | 'highThreshold'
+  | 'sosContact'
+  | 'sosAlertsEnabled';
+
+interface ProfileState {
+  icr: string;
+  correctionFactor: string;
+  targetSugar: string;
+  lowThreshold: string;
+  highThreshold: string;
+  sosContact: string;
+  sosAlertsEnabled: boolean;
+}
 
 const Profile = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
   const { user } = useTelegramContext();
 
-  const [profile, setProfile] = useState<Record<ProfileField, string>>({
+  const [profile, setProfile] = useState<ProfileState>({
     icr: '',
     correctionFactor: '',
     targetSugar: '',
     lowThreshold: '',
     highThreshold: '',
+    sosContact: '',
+    sosAlertsEnabled: false,
   });
   const [isLoading, setIsLoading] = useState(false);
 
@@ -44,6 +59,8 @@ const Profile = () => {
             targetSugar: String(data.target ?? ''),
             lowThreshold: String(data.low ?? ''),
             highThreshold: String(data.high ?? ''),
+            sosContact: String(data.sosContact ?? ''),
+            sosAlertsEnabled: Boolean(data.sosAlertsEnabled ?? false),
           });
         }
       } catch (error) {
@@ -65,8 +82,11 @@ const Profile = () => {
     };
   }, [user?.id, toast]);
 
-  const handleInputChange = (field: ProfileField, value: string) => {
-    setProfile(prev => ({ ...prev, [field]: value }));
+  const handleInputChange = (
+    field: ProfileField,
+    value: string | boolean,
+  ) => {
+    setProfile(prev => ({ ...prev, [field]: value } as ProfileState));
   };
 
   const handleSave = async () => {
@@ -101,6 +121,8 @@ const Profile = () => {
         target,
         low,
         high,
+        sosContact: profile.sosContact || undefined,
+        sosAlertsEnabled: profile.sosAlertsEnabled,
       });
       toast({
         title: 'Профиль сохранен',
@@ -236,6 +258,37 @@ const Profile = () => {
                       </span>
                     </div>
                   </div>
+                </div>
+
+                {/* SOS Contact */}
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-2">
+                    SOS контакт
+                  </label>
+                  <input
+                    type="text"
+                    value={profile.sosContact}
+                    onChange={(e) => handleInputChange('sosContact', e.target.value)}
+                    className="medical-input"
+                    placeholder="+79998887766"
+                  />
+                </div>
+
+                {/* SOS Alerts Toggle */}
+                <div className="flex items-center justify-between">
+                  <label
+                    htmlFor="sos-alerts"
+                    className="block text-sm font-medium text-foreground"
+                  >
+                    Включить SOS-уведомления
+                  </label>
+                  <Switch
+                    id="sos-alerts"
+                    checked={profile.sosAlertsEnabled}
+                    onCheckedChange={(checked) =>
+                      handleInputChange('sosAlertsEnabled', checked)
+                    }
+                  />
                 </div>
 
                 {/* Кнопка сохранения */}


### PR DESCRIPTION
## Summary
- add sosContact and sosAlertsEnabled to OpenAPI spec and regenerate SDKs
- expose SOS fields in profile API wrapper and tests
- allow editing SOS contact and alerts on profile page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68a96e51e230832ab79815369494592f