### PR TITLE
[schemas] Add SOS fields to profile schema

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -710,6 +710,15 @@ components:
           - type: integer
           - type: 'null'
           title: Org Id
+        sosContact:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Sos Contact
+        sosAlertsEnabled:
+          type: boolean
+          title: Sos Alerts Enabled
+          default: true
       type: object
       required:
       - telegramId

--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -9,5 +9,17 @@ class ProfileSchema(BaseModel):
     low: float
     high: float
     orgId: int | None = None
+    sosContact: str | None = Field(
+        default=None,
+        alias="sosContact",
+        validation_alias=AliasChoices("sosContact", "sos_contact"),
+    )
+    sosAlertsEnabled: bool = Field(
+        default=True,
+        alias="sosAlertsEnabled",
+        validation_alias=AliasChoices(
+            "sosAlertsEnabled", "sos_alerts_enabled"
+        ),
+    )
 
     model_config = ConfigDict(populate_by_name=True)


### PR DESCRIPTION
## Summary
- add SOS contact and alert fields to profile schema
- document SOS contact fields in OpenAPI spec

## Testing
- `pytest -q --cov` *(fails: async plugin missing)*
- `mypy --strict .` *(fails: Missing type parameters for sessionmaker)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68a96e4739f8832a8764a232fa7b9271