### PR TITLE
[api] add sos contact fields to profile service

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -34,7 +34,6 @@ async def profiles_get(
     target_bg: float | None = profile.target_bg
     low_threshold: float | None = profile.low_threshold
     high_threshold: float | None = profile.high_threshold
-
     return ProfileSchema(
         telegramId=profile.telegram_id,
         icr=float(icr) if icr is not None else 0.0,
@@ -43,4 +42,6 @@ async def profiles_get(
         low=float(low_threshold) if low_threshold is not None else 0.0,
         high=float(high_threshold) if high_threshold is not None else 0.0,
         orgId=profile.org_id,
+        sosContact=profile.sos_contact,
+        sosAlertsEnabled=profile.sos_alerts_enabled,
     )

--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -9,5 +9,15 @@ class ProfileSchema(BaseModel):
     low: float
     high: float
     orgId: int | None = None
+    sosContact: str | None = Field(
+        default=None,
+        alias="sosContact",
+        validation_alias=AliasChoices("sosContact", "sos_contact"),
+    )
+    sosAlertsEnabled: bool | None = Field(
+        default=None,
+        alias="sosAlertsEnabled",
+        validation_alias=AliasChoices("sosAlertsEnabled", "sos_alerts_enabled"),
+    )
 
     model_config = ConfigDict(populate_by_name=True)

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -46,6 +46,8 @@ async def save_profile(data: ProfileSchema) -> None:
         profile.target_bg = data.target
         profile.low_threshold = data.low
         profile.high_threshold = data.high
+        profile.sos_contact = data.sosContact if data.sosContact is not None else None
+        profile.sos_alerts_enabled = data.sosAlertsEnabled if data.sosAlertsEnabled is not None else True
         if not commit(session):
             raise HTTPException(status_code=500, detail="db commit failed")
 

--- a/tests/test_profile_service.py
+++ b/tests/test_profile_service.py
@@ -1,0 +1,75 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from typing import Generator
+
+from services.api.app.diabetes.services.db import Base, User
+from services.api.app.schemas.profile import ProfileSchema
+from services.api.app.services import profile
+
+
+@pytest.fixture()
+def session_factory() -> Generator[sessionmaker, None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    try:
+        yield sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_save_profile_persists_sos_fields(session_factory: sessionmaker, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(profile, "SessionLocal", session_factory)
+
+    with session_factory() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.commit()
+
+    data = ProfileSchema(
+        telegramId=1,
+        icr=10.0,
+        cf=2.0,
+        target=5.0,
+        low=3.0,
+        high=8.0,
+        sosContact="@alice",
+        sosAlertsEnabled=False,
+    )
+
+    await profile.save_profile(data)
+    stored = await profile.get_profile(1)
+
+    assert stored is not None
+    assert stored.sos_contact == "@alice"
+    assert stored.sos_alerts_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_save_profile_defaults_sos_fields(session_factory: sessionmaker, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(profile, "SessionLocal", session_factory)
+
+    with session_factory() as session:
+        session.add(User(telegram_id=2, thread_id="t"))
+        session.commit()
+
+    data = ProfileSchema(
+        telegramId=2,
+        icr=10.0,
+        cf=2.0,
+        target=5.0,
+        low=3.0,
+        high=8.0,
+    )
+
+    await profile.save_profile(data)
+    stored = await profile.get_profile(2)
+
+    assert stored is not None
+    assert stored.sos_contact is None
+    assert stored.sos_alerts_enabled is True


### PR DESCRIPTION
## Summary
- persist SOS contact and alert flags in profile service
- expose SOS fields via legacy profile endpoint
- test profile service persistence and default behaviour

## Testing
- `pytest -q --cov` *(fails: No module named 'openai')*
- `mypy --strict services/api/app/services/profile.py services/api/app/legacy.py services/api/app/schemas/profile.py tests/test_profile_service.py` *(fails: interrupted)*
- `ruff check services/api/app/legacy.py services/api/app/schemas/profile.py services/api/app/services/profile.py tests/test_profile_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68a96e4b3a2c832aa7e3862f29dadd82