### PR TITLE
[profile] Save SOS fields

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -43,4 +43,10 @@ async def profiles_get(
         low=float(low_threshold) if low_threshold is not None else 0.0,
         high=float(high_threshold) if high_threshold is not None else 0.0,
         orgId=profile.org_id,
+        sosContact=profile.sos_contact or "",
+        sosAlertsEnabled=(
+            profile.sos_alerts_enabled
+            if profile.sos_alerts_enabled is not None
+            else True
+        ),
     )

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -24,7 +24,14 @@ async def set_timezone(telegram_id: int, tz: str) -> None:
 
 def _validate_profile(data: ProfileSchema) -> None:
     """Validate business rules for a patient profile."""
-    if data.icr <= 0 or data.cf <= 0 or data.target <= 0 or data.low <= 0 or data.high <= 0 or data.low >= data.high:
+    if (
+        data.icr <= 0
+        or data.cf <= 0
+        or data.target <= 0
+        or data.low <= 0
+        or data.high <= 0
+        or data.low >= data.high
+    ):
         raise ValueError("invalid profile values")
 
     if not (data.low < data.target < data.high):
@@ -46,6 +53,10 @@ async def save_profile(data: ProfileSchema) -> None:
         profile.target_bg = data.target
         profile.low_threshold = data.low
         profile.high_threshold = data.high
+        profile.sos_contact = data.sosContact or ""
+        profile.sos_alerts_enabled = (
+            data.sosAlertsEnabled if data.sosAlertsEnabled is not None else True
+        )
         if not commit(session):
             raise HTTPException(status_code=500, detail="db commit failed")
 

--- a/tests/test_profile_sos_fields.py
+++ b/tests/test_profile_sos_fields.py
@@ -1,0 +1,61 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.api.app.diabetes.services.db import Base, User
+from services.api.app.schemas.profile import ProfileSchema
+from services.api.app.services import profile as profile_service
+
+
+@pytest.mark.asyncio
+async def test_save_profile_stores_sos_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.commit()
+    data = ProfileSchema(
+        telegramId=1,
+        icr=1.0,
+        cf=2.0,
+        target=3.0,
+        low=1.0,
+        high=5.0,
+        sosContact="112",
+        sosAlertsEnabled=False,
+    )
+    await profile_service.save_profile(data)
+    prof = await profile_service.get_profile(1)
+    assert prof is not None
+    assert prof.sos_contact == "112"
+    assert prof.sos_alerts_enabled is False
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_save_profile_defaults_sos_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    with TestSession() as session:
+        session.add(User(telegram_id=2, thread_id="t", timezone="UTC"))
+        session.commit()
+    data = ProfileSchema(
+        telegramId=2,
+        icr=1.0,
+        cf=2.0,
+        target=3.0,
+        low=1.0,
+        high=5.0,
+    )
+    await profile_service.save_profile(data)
+    prof = await profile_service.get_profile(2)
+    assert prof is not None
+    assert prof.sos_contact == ""
+    assert prof.sos_alerts_enabled is True
+    engine.dispose()


### PR DESCRIPTION
## Summary
- persist sos contact and alerts flag in profile service
- expose sos fields via legacy profiles API
- test sos field storage and defaults

## Testing
- `pytest -q --cov` *(fails: No module named 'telegram.ext._basehandler')*
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named "alembic.context" and others)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68a97085c670832a9ba78bb5d13c36b9