### PR TITLE
[api][sdk] expose health in schema and regenerate SDK

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -7,6 +7,20 @@ tags:
   - name: History
   - name: Reminders
 paths:
+  /health:
+    get:
+      summary: Health
+      operationId: healthGet
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                title: Response Health Get
   /profiles:
     post:
       tags:

--- a/libs/py-sdk/README.md
+++ b/libs/py-sdk/README.md
@@ -98,6 +98,7 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**get_analytics_analytics_get**](docs/DefaultApi.md#get_analytics_analytics_get) | **GET** /analytics | Get Analytics
 *DefaultApi* | [**get_stats_stats_get**](docs/DefaultApi.md#get_stats_stats_get) | **GET** /stats | Get Stats
 *DefaultApi* | [**get_timezone_timezone_get**](docs/DefaultApi.md#get_timezone_timezone_get) | **GET** /timezone | Get Timezone
+*DefaultApi* | [**health_get**](docs/DefaultApi.md#health_get) | **GET** /health | Health
 *DefaultApi* | [**profile_self_profile_self_get**](docs/DefaultApi.md#profile_self_profile_self_get) | **GET** /profile/self | Profile Self
 *DefaultApi* | [**put_timezone_timezone_put**](docs/DefaultApi.md#put_timezone_timezone_put) | **PUT** /timezone | Put Timezone
 

--- a/libs/py-sdk/diabetes_sdk/api/default_api.py
+++ b/libs/py-sdk/diabetes_sdk/api/default_api.py
@@ -1151,6 +1151,248 @@ class DefaultApi:
 
 
     @validate_call
+    def health_get(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> Dict[str, str]:
+        """Health
+
+
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._health_get_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Dict[str, str]",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def health_get_with_http_info(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[Dict[str, str]]:
+        """Health
+
+
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._health_get_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Dict[str, str]",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def health_get_without_preload_content(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Health
+
+
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._health_get_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "Dict[str, str]",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _health_get_serialize(
+        self,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'application/json'
+                ]
+            )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/health',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
     def profile_self_profile_self_get(
         self,
         x_telegram_init_data: Optional[StrictStr] = None,

--- a/libs/py-sdk/docs/DefaultApi.md
+++ b/libs/py-sdk/docs/DefaultApi.md
@@ -8,6 +8,7 @@ Method | HTTP request | Description
 [**get_analytics_analytics_get**](DefaultApi.md#get_analytics_analytics_get) | **GET** /analytics | Get Analytics
 [**get_stats_stats_get**](DefaultApi.md#get_stats_stats_get) | **GET** /stats | Get Stats
 [**get_timezone_timezone_get**](DefaultApi.md#get_timezone_timezone_get) | **GET** /timezone | Get Timezone
+[**health_get**](DefaultApi.md#health_get) | **GET** /health | Health
 [**profile_self_profile_self_get**](DefaultApi.md#profile_self_profile_self_get) | **GET** /profile/self | Profile Self
 [**put_timezone_timezone_put**](DefaultApi.md#put_timezone_timezone_put) | **PUT** /timezone | Put Timezone
 
@@ -285,6 +286,67 @@ No authorization required
 |-------------|-------------|------------------|
 **200** | Successful Response |  -  |
 **422** | Validation Error |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **health_get**
+> Dict[str, str] health_get()
+
+Health
+
+### Example
+
+
+```python
+import diabetes_sdk
+from diabetes_sdk.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost
+# See configuration.py for a list of all supported configuration parameters.
+configuration = diabetes_sdk.Configuration(
+    host = "http://localhost"
+)
+
+
+# Enter a context with an instance of the API client
+with diabetes_sdk.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = diabetes_sdk.DefaultApi(api_client)
+
+    try:
+        # Health
+        api_response = api_instance.health_get()
+        print("The response of DefaultApi->health_get:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling DefaultApi->health_get: %s\n" % e)
+```
+
+
+
+### Parameters
+
+This endpoint does not need any parameter.
+
+### Return type
+
+**Dict[str, str]**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+### HTTP response details
+
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful Response |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/libs/ts-sdk/apis/DefaultApi.ts
+++ b/libs/ts-sdk/apis/DefaultApi.ts
@@ -244,6 +244,35 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
+     * Health
+     */
+    async healthGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string; }>> {
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+
+        let urlPath = `/health`;
+
+        const response = await this.request({
+            path: urlPath,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse<any>(response);
+    }
+
+    /**
+     * Health
+     */
+    async healthGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string; }> {
+        const response = await this.healthGetRaw(initOverrides);
+        return await response.value();
+    }
+
+    /**
      * Profile Self
      */
     async profileSelfProfileSelfGetRaw(requestParameters: ProfileSelfProfileSelfGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserContext>> {

--- a/libs/ts-sdk/package.json
+++ b/libs/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@offonika/diabetes-ts-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "index.ts",
   "types": "index.ts",
   "exports": {

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -76,7 +76,7 @@ def _validate_history_type(value: str, status_code: int = 400) -> HistoryType:
 
 
 # ────────── health & misc ──────────
-@app.get("/health", include_in_schema=False)
+@app.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}
 

--- a/services/clinic-panel/package-lock.json
+++ b/services/clinic-panel/package-lock.json
@@ -21,7 +21,7 @@
     },
     "../../libs/ts-sdk": {
       "name": "@offonika/diabetes-ts-sdk",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     "node_modules/@next/env": {
       "version": "14.1.0",

--- a/services/clinic-panel/pages/index.tsx
+++ b/services/clinic-panel/pages/index.tsx
@@ -4,11 +4,13 @@ import { DefaultApi } from '@offonika/diabetes-ts-sdk';
 export default function Home() {
   useEffect(() => {
     const api = new DefaultApi();
-    api.healthGet().then((res) => {
-      console.log('API client ready', res);
-    }).catch((err) => {
-      console.error('API client error', err);
-    });
+    api.healthGet()
+      .then(({ status }) => {
+        console.log('API client ready', status);
+      })
+      .catch((err) => {
+        console.error('API client error', err);
+      });
   }, []);
 
   return <main>Clinic Panel</main>;


### PR DESCRIPTION
## Summary
- expose `/health` route in API schema
- regenerate TS SDK and bump to v0.1.1
- wire clinic panel to typed `healthGet` call

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError, 81 errors)*
- `mypy --strict .` *(fails: 82 errors)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a96f9f89bc832aa259b703ef7cf086