### PR TITLE
[ci] Install root requirements in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: |
-          pip install -r services/api/app/requirements.txt
+          pip install -r requirements.txt
           pip install -r services/api/app/requirements-dev.txt
       - name: Generate SDK
         run: npm run generate:sdk


### PR DESCRIPTION
## Summary
- install root requirements in tests workflow before dev requirements

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68a9737367cc832aa9ae8ffcf8765457