### PR TITLE
[py-sdk] Add type hints for ApiClient helpers

### DIFF
--- a/libs/py-sdk/diabetes_sdk/api_client.py
+++ b/libs/py-sdk/diabetes_sdk/api_client.py
@@ -21,24 +21,17 @@ import mimetypes
 import os
 import re
 import tempfile
-
+from types import TracebackType
 from urllib.parse import quote
-from typing import Tuple, Optional, List, Dict, Union
+from typing import Dict, List, Optional, Tuple, Type, Union
+
 from pydantic import SecretStr
 
 from diabetes_sdk.configuration import Configuration
 from diabetes_sdk.api_response import ApiResponse, T as ApiResponseT
 import diabetes_sdk.models
 from diabetes_sdk import rest
-from diabetes_sdk.exceptions import (
-    ApiValueError,
-    ApiException,
-    BadRequestException,
-    UnauthorizedException,
-    ForbiddenException,
-    NotFoundException,
-    ServiceException
-)
+from diabetes_sdk.exceptions import ApiException, ApiValueError
 
 RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
 
@@ -93,22 +86,27 @@ class ApiClient:
         self.user_agent = 'OpenAPI-Generator/1.0.0/python'
         self.client_side_validation = configuration.client_side_validation
 
-    def __enter__(self):
+    def __enter__(self) -> "ApiClient":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         pass
 
     @property
-    def user_agent(self):
+    def user_agent(self) -> str:
         """User agent for this API client"""
         return self.default_headers['User-Agent']
 
     @user_agent.setter
-    def user_agent(self, value):
+    def user_agent(self, value: str) -> None:
         self.default_headers['User-Agent'] = value
 
-    def set_default_header(self, header_name, header_value):
+    def set_default_header(self, header_name: str, header_value: str) -> None:
         self.default_headers[header_name] = header_value
 
 
@@ -457,7 +455,7 @@ class ApiClient:
 
         if klass in self.PRIMITIVE_TYPES:
             return self.__deserialize_primitive(data, klass)
-        elif klass == object:
+        elif klass is object:
             return self.__deserialize_object(data)
         elif klass == datetime.date:
             return self.__deserialize_date(data)


### PR DESCRIPTION
## Summary
- annotate ApiClient context manager and header helpers
- clean up ApiClient imports and comparison logic

## Testing
- `ruff check libs/py-sdk/diabetes_sdk/api_client.py`
- `mypy --strict libs/py-sdk/`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'reportlab')*


------
https://chatgpt.com/codex/tasks/task_e_68a977a88968832a87ed2c0686def1c6