### PR TITLE
[db] use date/time columns for history records

### DIFF
--- a/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
+++ b/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
@@ -5,6 +5,7 @@ Revises: 20250816a_expand_alembic_version_len
 Create Date: 2025-08-17 00:00:00.000000
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -35,8 +36,8 @@ def upgrade() -> None:
             "history_records",
             sa.Column("id", sa.String(), primary_key=True),
             sa.Column("telegram_id", sa.BigInteger(), nullable=False),
-            sa.Column("date", sa.String(), nullable=False),
-            sa.Column("time", sa.String(), nullable=False),
+            sa.Column("date", sa.Date(), nullable=False),
+            sa.Column("time", sa.Time(), nullable=False),
             sa.Column("sugar", sa.Float(), nullable=True),
             sa.Column("carbs", sa.Float(), nullable=True),
             sa.Column("bread_units", sa.Float(), nullable=True),
@@ -56,4 +57,3 @@ def downgrade() -> None:
 
     if "timezones" in tables:
         op.drop_table("timezones")
-

--- a/services/api/alembic/versions/20250819_change_history_date_time_types.py
+++ b/services/api/alembic/versions/20250819_change_history_date_time_types.py
@@ -1,0 +1,28 @@
+"""change history date and time column types"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "20250819_change_history_date_time_types"
+down_revision: Union[str, None] = "20250818_add_name_fields_to_users"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE history_records ALTER COLUMN date TYPE DATE USING date::DATE"
+    )
+    op.execute(
+        "ALTER TABLE history_records ALTER COLUMN time TYPE TIME USING time::TIME"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE history_records ALTER COLUMN date TYPE VARCHAR USING date::TEXT"
+    )
+    op.execute(
+        "ALTER TABLE history_records ALTER COLUMN time TYPE VARCHAR USING time::TEXT"
+    )

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
-from datetime import datetime
+from datetime import date, datetime, time
 from typing import Callable, Concatenate, ParamSpec, Protocol, TypeVar
 
 from sqlalchemy import (
@@ -18,6 +18,8 @@ from sqlalchemy import (
     TIMESTAMP,
     ForeignKey,
     Boolean,
+    Date,
+    Time,
     func,
 )
 from sqlalchemy.engine import URL, Engine
@@ -251,8 +253,8 @@ class HistoryRecord(Base):
     __tablename__ = "history_records"
     id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
     telegram_id: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
-    date: Mapped[str] = mapped_column(String, nullable=False)
-    time: Mapped[str] = mapped_column(String, nullable=False)
+    date: Mapped[date] = mapped_column(Date, nullable=False)
+    time: Mapped[time] = mapped_column(Time, nullable=False)
     sugar: Mapped[float | None] = mapped_column(Float)
     carbs: Mapped[float | None] = mapped_column(Float)
     bread_units: Mapped[float | None] = mapped_column(Float)

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -193,8 +193,8 @@ async def post_history(
         if obj is None:
             obj = HistoryRecordDB(id=data.id, telegram_id=user["id"])
             session.add(obj)
-        obj.date = data.date.isoformat()
-        obj.time = data.time.strftime("%H:%M")
+        obj.date = data.date
+        obj.time = data.time
         obj.sugar = data.sugar
         obj.carbs = data.carbs
         obj.bread_units = data.breadUnits

--- a/services/api/app/schemas/history.py
+++ b/services/api/app/schemas/history.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from datetime import date, time
 from typing import Literal, Optional, cast, get_args
 
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel
 
 
 HistoryType = Literal["measurement", "meal", "insulin"]
 
-ALLOWED_HISTORY_TYPES: set[HistoryType] = cast(set[HistoryType], set(get_args(HistoryType)))
+ALLOWED_HISTORY_TYPES: set[HistoryType] = cast(
+    set[HistoryType], set(get_args(HistoryType))
+)
 
 
 class HistoryRecordSchema(BaseModel):
@@ -23,11 +25,3 @@ class HistoryRecordSchema(BaseModel):
     insulin: Optional[float] = None
     notes: Optional[str] = None
     type: HistoryType
-
-    @field_serializer("date")
-    def _serialize_date(self, value: date) -> str:
-        return value.isoformat()
-
-    @field_serializer("time")
-    def _serialize_time(self, value: time) -> str:
-        return value.strftime("%H:%M")

--- a/services/api/app/services/stats.py
+++ b/services/api/app/services/stats.py
@@ -4,11 +4,17 @@ import datetime
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from ..diabetes.services.db import HistoryRecord as HistoryRecordDB, SessionLocal, run_db
+from ..diabetes.services.db import (
+    HistoryRecord as HistoryRecordDB,
+    SessionLocal,
+    run_db,
+)
 from ..schemas.stats import DayStats
 
 
-async def get_day_stats(telegram_id: int, date: datetime.date | None = None) -> DayStats | None:
+async def get_day_stats(
+    telegram_id: int, date: datetime.date | None = None
+) -> DayStats | None:
     """Return aggregated stats for a given user's day."""
     day = date or datetime.date.today()
 
@@ -21,7 +27,7 @@ async def get_day_stats(telegram_id: int, date: datetime.date | None = None) -> 
             )
             .filter(
                 HistoryRecordDB.telegram_id == telegram_id,
-                HistoryRecordDB.date == day.isoformat(),
+                HistoryRecordDB.date == day,
             )
             .one()
         )


### PR DESCRIPTION
## Summary
- store history dates and times using DATE and TIME columns
- handle date/time objects directly in API and stats logic
- migrate history tables to proper date/time types

## Testing
- `ruff check services/api/app/diabetes/services/db.py services/api/app/main.py services/api/app/schemas/history.py services/api/app/services/stats.py tests/test_webapp_history.py tests/test_stats_service.py services/api/alembic/versions/20250817_add_timezone_and_history_tables.py services/api/alembic/versions/20250819_change_history_date_time_types.py`
- `mypy --strict services/api/app/diabetes/services/db.py services/api/app/main.py services/api/app/schemas/history.py services/api/app/services/stats.py tests/test_webapp_history.py tests/test_stats_service.py`
- `pytest tests/test_webapp_history.py tests/test_stats_service.py -q` *(fails: async def functions are not natively supported; total coverage 7.52% < 85)*

------
https://chatgpt.com/codex/tasks/task_e_68a977150560832a90933eb86d5bcd7b