### PR TITLE
[py-sdk] Reference MIT license in pyproject

### DIFF
--- a/libs/py-sdk/pyproject.toml
+++ b/libs/py-sdk/pyproject.toml
@@ -5,7 +5,6 @@ description = "Diabetes Assistant API"
 authors = [
   {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
 ]
-license = "NoLicense"
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Diabetes Assistant API"]
 requires-python = ">=3.9"
@@ -19,6 +18,9 @@ dependencies = [
 
 [project.urls]
 Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
+
+[project.license]
+file = "LICENSE"
 
 [tool.poetry]
 requires-poetry = ">=2.0"


### PR DESCRIPTION
## Summary
- reference MIT license file in `libs/py-sdk` pyproject metadata

## Testing
- `pytest -q --cov`
- `mypy --strict .` *(fails: "Missing type parameters for generic type 'sessionmaker'")*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a97a97c434832a88eb0518bb40d7ac