### PR TITLE
[py-sdk] fix repository url

### DIFF
--- a/libs/py-sdk/pyproject.toml
+++ b/libs/py-sdk/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.urls]
-Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
+Repository = "https://github.com/Offonika/saharlight-ux"
 
 [tool.poetry]
 requires-poetry = ">=2.0"


### PR DESCRIPTION
## Summary
- point py-sdk's project URL to the saharlight-ux GitHub repository

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'telegram.ext._basehandler')*
- `mypy --strict .` *(fails: Missing type parameters for generic type "sessionmaker" ...)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a97a9b991c832a85f3dc7f96ed3b7b