### PR TITLE
[services] Document default image prompt

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -87,6 +87,8 @@ async def send_message(
         Target thread identifier.
     content: str | None
         Text message to send.  Must be provided if ``image_path`` is ``None``.
+        When ``image_path`` is provided and ``content`` is ``None``, the
+        message defaults to ``"Что изображено на фото?"``.
     image_path: str | None
         Path to an image to upload alongside the text.
     keep_image: bool, default ``False``
@@ -96,6 +98,12 @@ async def send_message(
     -------
     run
         The created run object.
+
+    Examples
+    --------
+    Send only an image and let the default prompt be used:
+
+    >>> await send_message(thread_id="abc", image_path="/tmp/photo.jpg")
     """
     if content is None and image_path is None:
         raise ValueError("Either 'content' or 'image_path' must be provided")


### PR DESCRIPTION
## Summary
- document default prompt used when `send_message` sends only an image

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'reportlab', 'openai', 'fastapi')*
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named "alembic.context", ...)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a97a9d1efc832a854cba70a7673cd6