### PR TITLE
[api] Dispose OpenAI client on shutdown

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -34,12 +34,18 @@ from .schemas.role import RoleSchema
 from .schemas.user import UserContext
 from .services.user_roles import get_user_role, set_user_role
 from .telegram_auth import require_tg_user
+from services.api.app.diabetes.utils.openai_utils import dispose_http_client
 
 # ────────── init ──────────
 logger = logging.getLogger(__name__)
 init_db()  # создаёт/инициализирует БД
 
 app = FastAPI(title="Diabetes Assistant API", version="1.0.0")
+
+
+@app.on_event("shutdown")
+async def shutdown_openai_client() -> None:
+    dispose_http_client()
 
 
 # ────────── роуты статистики / legacy ──────────

--- a/tests/test_shutdown_openai_client.py
+++ b/tests/test_shutdown_openai_client.py
@@ -1,0 +1,9 @@
+from unittest.mock import patch
+
+from services.api.app.main import shutdown_openai_client
+
+
+async def test_shutdown_openai_client_disposes() -> None:
+    with patch("services.api.app.main.dispose_http_client") as dispose:
+        await shutdown_openai_client()
+        dispose.assert_called_once()


### PR DESCRIPTION
## Summary
- dispose OpenAI HTTP client on FastAPI shutdown
- cover OpenAI client shutdown with a unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alembic')*
- `mypy --strict services/api/app/main.py tests/test_shutdown_openai_client.py` *(fails: Interrupted)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68a97a9fde70832aa8a36c2adad59be8