### PR TITLE
[ui] Safeguard focus trapping

### DIFF
--- a/services/webapp/ui/src/components/Modal.tsx
+++ b/services/webapp/ui/src/components/Modal.tsx
@@ -22,7 +22,7 @@ const Modal = ({ open, onClose, title, footer, children }: ModalProps) => {
       'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
     const focusable = modalRef.current?.querySelectorAll<HTMLElement>(focusableSelectors);
     const first = focusable?.[0];
-    const last = focusable?.[focusable.length - 1];
+    const last = focusable ? focusable[focusable.length - 1] : undefined;
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {

--- a/services/webapp/ui/src/components/Sheet.tsx
+++ b/services/webapp/ui/src/components/Sheet.tsx
@@ -19,7 +19,7 @@ const Sheet = ({ open, onClose, side = 'bottom', children }: SheetProps) => {
       'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
     const focusable = panelRef.current?.querySelectorAll<HTMLElement>(selector);
     const first = focusable?.[0];
-    const last = focusable?.[focusable.length - 1];
+    const last = focusable ? focusable[focusable.length - 1] : undefined;
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {


### PR DESCRIPTION
## Summary
- avoid indexing undefined node lists in modal focus trap
- prevent focus trap errors in sheet component

## Testing
- `pytest -q --cov` (fails: 83 errors during collection)
- `mypy --strict .` (fails: 64 errors)
- `ruff check .`
- `npx --yes --package vitest vitest --run` (fails: unresolved modules, failing tests)
- `npm --workspace services/webapp/ui run lint` (fails: 19 errors)
- `npm --workspace services/webapp/ui run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a97e82ca3c832aa7e0b58c3724c0c5