### PR TITLE
[webapp] dynamic stats fallbacks

### DIFF
--- a/services/webapp/ui/src/config/stats.local.example.ts
+++ b/services/webapp/ui/src/config/stats.local.example.ts
@@ -1,0 +1,11 @@
+import type { AnalyticsPoint, DayStats } from '@/api/stats';
+
+export default {
+  analytics: [
+    { date: '2024-01-01', sugar: 5.5 },
+  ],
+  dayStats: { sugar: 6, breadUnits: 3, insulin: 10 },
+} satisfies {
+  analytics?: AnalyticsPoint[];
+  dayStats?: DayStats;
+};


### PR DESCRIPTION
## Summary
- generate analytics fallback data from recent dates
- allow overriding stats fallbacks via env vars or optional local config
- test dynamic fallbacks when API is unavailable

## Testing
- `npm --workspace services/webapp/ui run typecheck`
- `npm --workspace services/webapp/ui exec eslint src/api/stats.ts src/api/stats.api.test.ts`
- `npx vitest run services/webapp/ui/src/api/stats.api.test.ts` *(fails: Failed to resolve import "@offonika/diabetes-ts-sdk" from "services/webapp/ui/src/api/stats.ts")*
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'diabetes_sdk.models.role_schema')*
- `mypy --strict .` *(fails: "sessionmaker" expects no type arguments, but 1 given)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9b503f678832a97a1eb433ba977b7