### PR TITLE
chore(py-sdk): reference license file

### DIFF
--- a/libs/py-sdk/pyproject.toml
+++ b/libs/py-sdk/pyproject.toml
@@ -5,7 +5,7 @@ description = "Diabetes Assistant API"
 authors = [
   {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
 ]
-license = "MIT"
+license = {file = "LICENSE"}
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Diabetes Assistant API"]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- reference existing MIT license file in py-sdk package

## Testing
- `pip install -e libs/py-sdk`
- `pytest -q` *(fails: TypeError: unsupported operand type(s) for |: 'NoneType' and 'NoneType')*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9b862a5dc832abf23109a32535249