### PR TITLE
[deps] Move pytest to dev requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ sudo apt install python3.12 python3.12-venv
     каждого пакета запускайте из корня репозитория через `npm --workspace <путь>`:
     ```bash
     pip install -r requirements.txt
+    # зависимости для тестов и линтеров
+    pip install -r services/api/app/requirements-dev.txt
 
     npm ci
     npm --workspace services/webapp/ui run build
@@ -198,6 +200,7 @@ const profile = await api.profilesGet({ telegramId: 123 });
 
 ```bash
 pip install -r services/api/app/requirements.txt
+pip install -r services/api/app/requirements-dev.txt
 ```
 
 Тесты используют переменные `OPENAI_API_KEY`, `DB_PASSWORD` и другие из `.env`.

--- a/services/api/app/requirements-dev.txt
+++ b/services/api/app/requirements-dev.txt
@@ -1,5 +1,7 @@
 ruff
 pre-commit
+pytest
+pytest-asyncio
 pytest-cov
 mypy
 playwright

--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -24,8 +24,6 @@ pydantic_core==2.33.2
 pydantic-settings==2.10.1
 pypdf==5.9.0
 pyparsing==3.2.3
-pytest==8.4.1
-pytest-asyncio==1.1.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 python-telegram-bot[job-queue]==20.4


### PR DESCRIPTION
## Summary
- move pytest and pytest-asyncio to dev requirements
- document installing dev dependencies

## Testing
- `pytest -q --cov --cov-fail-under=85` (fails: TypeError: unsupported operand type(s) for |: 'NoneType' and 'NoneType')
- `mypy --strict .` (fails: "sessionmaker" expects no type arguments)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9b870d1d8832a92354f27f1949823