### PR TITLE
[ts-sdk] rename package to @offonika/diabetes-ts-sdk

### DIFF
--- a/libs/ts-sdk/package.json
+++ b/libs/ts-sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@saharlight/ts-sdk",
+  "name": "@offonika/diabetes-ts-sdk",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ importers:
 
   .: {}
 
+  libs/ts-sdk: {}
+
   services/clinic-panel:
     dependencies:
       '@offonika/diabetes-ts-sdk':
@@ -40,9 +42,7 @@ importers:
         version: 3.10.0(react-hook-form@7.62.0(react@18.3.1))
       '@offonika/diabetes-ts-sdk':
         specifier: file:../../../libs/ts-sdk
-
         version: ts-sdk@file:libs/ts-sdk
-
       '@radix-ui/react-accordion':
         specifier: ^1.2.11
         version: 1.2.12(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Summary
- rename ts-sdk package to `@offonika/diabetes-ts-sdk`
- update lockfile to reflect new package name

## Testing
- `pnpm install`
- `pnpm --filter './services/webapp/ui' run build`
- `pytest -q --cov` *(fails: TypeError unsupported operand type(s) for |: 'NoneType' and 'NoneType')*
- `mypy --strict .` *(fails: Found 7 errors in 3 files)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9ba1de994832a83436e4f85c6aaba