### PR TITLE
[deps] Pin compatible alembic

### DIFF
--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -1,4 +1,4 @@
-alembic==1.16.4
+alembic==1.14.1
 annotated-types==0.7.0
 anyio==4.9.0
 certifi==2025.4.26


### PR DESCRIPTION
## Summary
- pin alembic to a released 1.14.1 for SQLAlchemy 2 support

## Testing
- `pip install -r services/api/app/requirements.txt`
- `pytest --cov` *(fails: ModuleNotFoundError and TypeError in tests)*
- `mypy --strict .` *(fails: 7 errors)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9bae1d538832ab84872a704230130