### PR TITLE
[schemas] Postpone annotations for union types

### DIFF
--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 

--- a/services/api/app/schemas/reminders.py
+++ b/services/api/app/schemas/reminders.py
@@ -1,4 +1,6 @@
-from datetime import time
+from __future__ import annotations
+
+from datetime import time as time_
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
@@ -8,7 +10,7 @@ class ReminderSchema(BaseModel):
     id: int | None = None
     type: str
     title: str | None = None
-    time: time | None = None
+    time: time_ | None = None
     intervalHours: int | None = None
     minutesAfter: int | None = None
     isEnabled: bool = True


### PR DESCRIPTION
## Summary
- use postponed evaluation of annotations in schema modules with PEP 604 unions
- avoid type resolution conflict in `ReminderSchema` by aliasing `datetime.time`

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: ModuleNotFoundError: No module named 'diabetes_sdk.models.role_schema')*
- `mypy --strict .` *(fails: sessionmaker expects no type arguments, 7 errors)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9bf87233c832a9e7e764cd0763079