### PR TITLE
[setup] Install pnpm if missing

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,16 @@ pip install --upgrade pip || { echo "Pip upgrade failed" >&2; exit 1; }
 pip install -r requirements.txt || { echo "Python dependencies installation failed" >&2; exit 1; }
 
 echo "Установка JavaScript-зависимостей…"
+if ! command -v pnpm >/dev/null 2>&1; then
+    echo "pnpm не найден, пытаюсь установить…"
+    if command -v node >/dev/null 2>&1 && command -v corepack >/dev/null 2>&1 && [ "$(printf '%s\n' '16.13.0' "$(node -v | sed 's/^v//')" | sort -V | head -n1)" = '16.13.0' ]; then
+        corepack enable pnpm || { echo "corepack enable pnpm failed" >&2; exit 1; }
+    else
+        npm install -g pnpm || { echo "npm install -g pnpm failed" >&2; exit 1; }
+    fi
+    command -v pnpm >/dev/null 2>&1 || { echo "pnpm installation failed" >&2; exit 1; }
+fi
+
 pnpm install || { echo "pnpm install failed" >&2; exit 1; }
 
 echo "Сборка фронтенда…"


### PR DESCRIPTION
## Summary
- ensure pnpm is installed via corepack or npm before frontend dependency install

## Testing
- `pytest -q --cov` *(fails: unrecognized arguments: --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=85 --cov)*
- `mypy --strict .` *(fails: Found 15 errors in 5 files)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9c568ee7c832abb83dda8284a3f70