### PR TITLE
[ci] Use pnpm/action-setup@v4 in workflows

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -22,9 +22,7 @@ jobs:
         with:
           node-version: "20"
           cache: pnpm
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 8
+      - uses: pnpm/action-setup@v4
       - run: pnpm install
       - name: Generate SDKs
         run: pnpm run generate:sdk

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,6 @@ jobs:
           node-version: "20"
           cache: pnpm
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
       - run: pnpm install
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- use `pnpm/action-setup@v4` in SDK and test workflows
- drop explicit pnpm version to track latest stable

## Testing
- `pytest -q --cov` *(fails: ValueError: too many values to unpack; AttributeError: 'DummySession' object has no attribute 'get_bind')*
- `mypy --strict .` *(fails: "sessionmaker" expects no type arguments, but 1 given)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9c56dc748832a97f70c34c54c5c95