### PR TITLE
[py-sdk] Specify MIT license in pyproject

### DIFF
--- a/libs/py-sdk/pyproject.toml
+++ b/libs/py-sdk/pyproject.toml
@@ -5,7 +5,7 @@ description = "Diabetes Assistant API"
 maintainers = [
   {name = "Offonika", email = "arseniikeshtov@gmail.com"},
 ]
-license = {file = "LICENSE"}
+license = { text = "MIT" }
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Diabetes Assistant API"]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- declare MIT license for Python SDK

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'diabetes_sdk.models.role_schema')*
- `mypy --strict .` *(fails: "sessionmaker" expects no type arguments; "ReminderSchema" time incompatible)*
- `ruff check .`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a9c7733114832a85c3ec7049b17fd7