### PR TITLE
[ci] fix pnpm setup order in workflows

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -17,12 +17,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: pnpm/action-setup@v4
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: pnpm
-      - uses: pnpm/action-setup@v4
       - run: pnpm install
       - name: Generate SDKs
         run: pnpm run generate:sdk

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: pnpm
-      - uses: pnpm/action-setup@v4
       - run: pnpm install
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- ensure pnpm is installed before configuring Node cache in CI workflows

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: "sessionmaker" expects no type arguments, but 1 given)*
- `pytest --cov=services.api.app.diabetes --cov-report=term-missing --cov-report=xml --cov-fail-under=85` *(fails: 10 errors during collection)*
- `./bin/act -n -W .github/workflows/tests.yml -j tests` *(fails: Couldn't get a valid docker connection)*
- `./bin/act -n -W .github/workflows/sdk.yml -j generate` *(fails: Couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c7b48c38832a83fc4a814fa4455c