### PR TITLE
[services] Use commit helper for reminders

### DIFF
--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from ..diabetes.services.db import Reminder, SessionLocal, User, run_db
+from ..diabetes.services.repository import commit
 from ..schemas.reminders import ReminderSchema
 
 
@@ -34,7 +35,7 @@ async def save_reminder(data: ReminderSchema) -> int:
         rem.interval_hours = data.intervalHours
         rem.minutes_after = data.minutesAfter
         rem.is_enabled = data.isEnabled
-        session.commit()
+        commit(session)
         session.refresh(rem)
         return rem.id
 
@@ -47,6 +48,6 @@ async def delete_reminder(telegram_id: int, reminder_id: int) -> None:
         if rem is None or rem.telegram_id != telegram_id:
             raise HTTPException(status_code=404, detail="reminder not found")
         session.delete(rem)
-        session.commit()
+        commit(session)
 
     await run_db(_delete, sessionmaker=SessionLocal)


### PR DESCRIPTION
## Summary
- use repository commit helper in reminder service

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'diabetes_sdk.models.role_schema')*
- `mypy --strict .` *(fails: "sessionmaker" expects no type arguments, but 1 given)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68a9c8aec8d8832ab6381b3911877c96