### PR TITLE
[schemas] Use object instead of Any for command fields

### DIFF
--- a/services/api/app/schemas/command.py
+++ b/services/api/app/schemas/command.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -11,4 +11,4 @@ class CommandSchema(BaseModel):
     action: str
     entry_date: Optional[str] = None
     time: Optional[str] = None
-    fields: dict[str, Any]
+    fields: dict[str, object]

--- a/tests/handlers/test_gpt_handlers.py
+++ b/tests/handlers/test_gpt_handlers.py
@@ -67,7 +67,9 @@ async def test_report_date_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_report_date_valid(monkeypatch: pytest.MonkeyPatch) -> None:
     called: dict[str, Any] = {}
 
-    async def fake_send_report(update: Any, context: Any, date_from: dt.datetime, period: str) -> None:
+    async def fake_send_report(
+        update: Any, context: Any, date_from: dt.datetime, period: str
+    ) -> None:
         called["date_from"] = date_from
         called["period"] = period
 
@@ -217,7 +219,7 @@ async def test_parse_command_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_smart_input(text: str) -> dict[str, float | None]:
         return {"sugar": None, "xe": None, "dose": None}
 
-    async def fake_parse(text: str) -> dict[str, Any] | None:
+    async def fake_parse(text: str) -> dict[str, object] | None:
         return None
 
     monkeypatch.setattr(gpt_handlers, "smart_input", fake_smart_input)
@@ -234,7 +236,7 @@ async def test_parse_command_negative(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_smart_input(text: str) -> dict[str, float | None]:
         return {"sugar": None, "xe": None, "dose": None}
 
-    async def fake_parse(text: str) -> dict[str, Any]:
+    async def fake_parse(text: str) -> dict[str, object]:
         return {"action": "add_entry", "fields": {"sugar_before": -1}}
 
     monkeypatch.setattr(gpt_handlers, "smart_input", fake_smart_input)
@@ -251,7 +253,7 @@ async def test_parse_command_valid_time(monkeypatch: pytest.MonkeyPatch) -> None
     def fake_smart_input(text: str) -> dict[str, float | None]:
         return {"sugar": None, "xe": None, "dose": None}
 
-    async def fake_parse(text: str) -> dict[str, Any]:
+    async def fake_parse(text: str) -> dict[str, object]:
         return {
             "action": "add_entry",
             "fields": {"sugar_before": 5, "xe": 1, "dose": 2},

--- a/tests/test_gpt_handlers.py
+++ b/tests/test_gpt_handlers.py
@@ -425,7 +425,7 @@ async def test_freeform_handler_parse_command_unknown(
     def fake_smart_input(text: str) -> dict[str, float | None]:
         return {"sugar": None, "xe": None, "dose": None}
 
-    async def fake_parse_command(text: str) -> dict[str, Any] | None:
+    async def fake_parse_command(text: str) -> dict[str, object] | None:
         return None
 
     monkeypatch.setattr(gpt_handlers, "smart_input", fake_smart_input)
@@ -472,7 +472,7 @@ async def test_freeform_handler_parser_timeout(monkeypatch: pytest.MonkeyPatch) 
     def fake_smart_input(text: str) -> dict[str, float | None]:
         return {"sugar": None, "xe": None, "dose": None}
 
-    async def fake_parse_command(text: str) -> dict[str, Any] | None:
+    async def fake_parse_command(text: str) -> dict[str, object] | None:
         raise gpt_handlers.ParserTimeoutError
 
     monkeypatch.setattr(gpt_handlers, "smart_input", fake_smart_input)
@@ -626,7 +626,7 @@ async def test_freeform_handler_parse_command_negative(
     def fake_smart_input(text: str) -> dict[str, float | None]:
         return {"sugar": None, "xe": None, "dose": None}
 
-    async def fake_parse(text: str) -> dict[str, Any]:
+    async def fake_parse(text: str) -> dict[str, object]:
         return {"action": "add_entry", "fields": {"sugar_before": -1}}
 
     monkeypatch.setattr(gpt_handlers, "smart_input", fake_smart_input)
@@ -652,7 +652,7 @@ async def test_freeform_handler_parse_command_bad_fields(
     def fake_smart_input(text: str) -> dict[str, float | None]:
         return {"sugar": None, "xe": None, "dose": None}
 
-    async def fake_parse(text: str) -> dict[str, Any]:
+    async def fake_parse(text: str) -> dict[str, object]:
         return {"action": "add_entry", "fields": None}
 
     monkeypatch.setattr(gpt_handlers, "smart_input", fake_smart_input)
@@ -679,7 +679,7 @@ async def test_freeform_handler_parse_command_valid_time(
     def fake_smart_input(text: str) -> dict[str, float | None]:
         return {"sugar": None, "xe": None, "dose": None}
 
-    async def fake_parse(text: str) -> dict[str, Any]:
+    async def fake_parse(text: str) -> dict[str, object]:
         return {
             "action": "add_entry",
             "fields": {"sugar_before": 5, "xe": 1, "dose": 2},
@@ -711,7 +711,7 @@ async def test_freeform_handler_parse_command_bad_time(
     def fake_smart_input(text: str) -> dict[str, float | None]:
         return {"sugar": None, "xe": None, "dose": None}
 
-    async def fake_parse(text: str) -> dict[str, Any]:
+    async def fake_parse(text: str) -> dict[str, object]:
         return {
             "action": "add_entry",
             "fields": {"sugar_before": 5},

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -19,7 +19,9 @@ T = TypeVar("T")
 
 
 class DummyMessage:
-    def __init__(self, text: str | None = None, photo: tuple[PhotoSize, ...] | None = None) -> None:
+    def __init__(
+        self, text: str | None = None, photo: tuple[PhotoSize, ...] | None = None
+    ) -> None:
         self.text: str | None = text
         self.photo: tuple[PhotoSize, ...] = () if photo is None else photo
         self.replies: list[str] = []
@@ -79,8 +81,10 @@ class DummySession(Session):
 
 
 @pytest.mark.asyncio
-async def test_photo_flow_saves_entry(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    async def fake_parse_command(text: str) -> dict[str, Any]:
+async def test_photo_flow_saves_entry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    async def fake_parse_command(text: str) -> dict[str, object]:
         return {"action": "add_entry", "fields": {}, "entry_date": None, "time": None}
 
     monkeypatch.setattr(gpt_handlers, "parse_command", fake_parse_command)
@@ -98,7 +102,9 @@ async def test_photo_flow_saves_entry(monkeypatch: pytest.MonkeyPatch, tmp_path:
         Mock(spec=CallbackContext),
     )
     user_data_ref: dict[str, Any] = {}
-    setattr(cast(Any, type(context)), "user_data", PropertyMock(return_value=user_data_ref))
+    setattr(
+        cast(Any, type(context)), "user_data", PropertyMock(return_value=user_data_ref)
+    )
     setattr(cast(Any, type(context)), "job_queue", PropertyMock(return_value=None))
 
     assert context.user_data is not None
@@ -135,7 +141,11 @@ async def test_photo_flow_saves_entry(monkeypatch: pytest.MonkeyPatch, tmp_path:
                         data=[
                             SimpleNamespace(
                                 role="assistant",
-                                content=[SimpleNamespace(text=SimpleNamespace(value="carbs 30g xe 2"))],
+                                content=[
+                                    SimpleNamespace(
+                                        text=SimpleNamespace(value="carbs 30g xe 2")
+                                    )
+                                ],
                             )
                         ]
                     )
@@ -145,7 +155,9 @@ async def test_photo_flow_saves_entry(monkeypatch: pytest.MonkeyPatch, tmp_path:
 
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
-    monkeypatch.setattr(photo_handlers, "extract_nutrition_info", lambda text: (30.0, 2.0))
+    monkeypatch.setattr(
+        photo_handlers, "extract_nutrition_info", lambda text: (30.0, 2.0)
+    )
     user_data["thread_id"] = "tid"
 
     msg_photo = DummyMessage(photo=cast(tuple[PhotoSize, ...], (DummyPhoto(),)))
@@ -228,7 +240,9 @@ async def test_photo_handler_removes_file_on_failure(
         Mock(spec=CallbackContext),
     )
     user_data_ref: dict[str, Any] = {"thread_id": "tid"}
-    setattr(cast(Any, type(context)), "user_data", PropertyMock(return_value=user_data_ref))
+    setattr(
+        cast(Any, type(context)), "user_data", PropertyMock(return_value=user_data_ref)
+    )
     fake_bot = SimpleNamespace(get_file=fake_get_file)
     setattr(cast(Any, type(context)), "bot", PropertyMock(return_value=fake_bot))
 


### PR DESCRIPTION
## Summary
- replace `CommandSchema.fields` typing with `dict[str, object]`
- adjust tests to match stricter types

## Testing
- `pytest -q tests/test_gpt_handlers.py tests/handlers/test_gpt_handlers.py tests/test_handlers_photo_sugar_save.py --cov --cov-fail-under=0`
- `mypy --strict .` *(fails: sessionmaker expects no type arguments, invalid ReminderSchema time, missing attributes in tests)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9c8bbef94832a9fd5358a03faf9d8