### PR TITLE
[reminders] Handle missing webapp URL

### DIFF
--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -31,6 +31,7 @@ class DummyWebAppMessage(DummyMessage):
         super().__init__()
         self.web_app_data = DummyWebAppData(data)
 
+
 def make_user(user_id: int) -> MagicMock:
     user = MagicMock(spec=User)
     user.id = user_id
@@ -149,3 +150,9 @@ def test_build_webapp_url(monkeypatch: pytest.MonkeyPatch, base_url: str) -> Non
     url = reminder_handlers.build_webapp_url("/ui/reminders")
     assert url == "https://example.com/ui/reminders"
     assert "//" not in url.split("://", 1)[1]
+
+
+def test_build_webapp_url_without_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "webapp_url", None)
+    path = "/ui/reminders"
+    assert reminder_handlers.build_webapp_url(path) == path


### PR DESCRIPTION
## Summary
- return the original path when settings.webapp_url is not set
- add coverage for build_webapp_url and adjust reminder test session stub

## Testing
- `pytest -q tests`
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminder_handlers.py tests/test_dose_calc_unit.py`
- `ruff check .`
- `mypy --strict .` *(fails: sessionmaker expects no type arguments in several existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c8b2c0e4832a8dce61c36a7dd8ab