### PR TITLE
[ci] install pnpm after node setup

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -17,12 +17,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: pnpm
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
       - run: pnpm install
       - name: Generate SDKs
         run: pnpm run generate:sdk

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: pnpm
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
       - run: pnpm install
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- install pnpm after setting up Node.js in CI workflows to ensure executable is on PATH

## Testing
- `pytest -q --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=85` *(fails: ModuleNotFoundError: diabetes_sdk.models.role_schema)*
- `mypy --strict .` *(fails: Found 15 errors in 5 files)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9ca72c07c832aa53ae34c57f588cd