### PR TITLE
[handlers] inject SessionLocal into LocalProfileAPI

### DIFF
--- a/tests/handlers/profile/test_api.py
+++ b/tests/handlers/profile/test_api.py
@@ -73,7 +73,15 @@ def test_post_profile_error() -> None:
             raise ApiExc("boom")
 
     class DummyProfile:
-        def __init__(self, telegram_id: int, icr: float, cf: float, target: float, low: float, high: float) -> None:
+        def __init__(
+            self,
+            telegram_id: int,
+            icr: float,
+            cf: float,
+            target: float,
+            low: float,
+            high: float,
+        ) -> None:
             self.telegram_id = telegram_id
             self.icr = icr
             self.cf = cf
@@ -125,7 +133,9 @@ def test_save_profile_persists(session_factory: sessionmaker) -> None:
         assert prof.sos_alerts_enabled is False
 
 
-def test_save_profile_commit_failure(monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker) -> None:
+def test_save_profile_commit_failure(
+    monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker
+) -> None:
     def fail_commit(session: object) -> bool:
         return False
 
@@ -141,17 +151,17 @@ def test_save_profile_commit_failure(monkeypatch: pytest.MonkeyPatch, session_fa
         assert prof is None
 
 
-def test_local_profiles_post_failure(monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker) -> None:
-    api = profile_api.LocalProfileAPI()
-    monkeypatch.setattr(api, "_sessionmaker", lambda: session_factory)
+def test_local_profiles_post_failure(
+    monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker
+) -> None:
+    api = profile_api.LocalProfileAPI(session_factory)
     monkeypatch.setattr(profile_api, "save_profile", lambda *a, **k: False)
     with pytest.raises(profile_api.ProfileSaveError):
         api.profiles_post(profile_api.LocalProfile(telegram_id=1))
 
 
-def test_local_profiles_roundtrip(monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker) -> None:
-    api = profile_api.LocalProfileAPI()
-    monkeypatch.setattr(api, "_sessionmaker", lambda: session_factory)
+def test_local_profiles_roundtrip(session_factory: sessionmaker) -> None:
+    api = profile_api.LocalProfileAPI(session_factory)
 
     with session_factory() as session:
         session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
@@ -187,7 +197,9 @@ def test_set_timezone_persists(session_factory: sessionmaker) -> None:
         assert user.timezone == "Europe/Moscow"
 
 
-def test_set_timezone_commit_failure(monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker) -> None:
+def test_set_timezone_commit_failure(
+    monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker
+) -> None:
     def fail_commit(session: object) -> bool:
         return False
 
@@ -204,7 +216,9 @@ def test_set_timezone_commit_failure(monkeypatch: pytest.MonkeyPatch, session_fa
         assert user.timezone == "UTC"
 
 
-def test_set_timezone_user_missing(monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker) -> None:
+def test_set_timezone_user_missing(
+    monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker
+) -> None:
     commit_mock = MagicMock(return_value=True)
     monkeypatch.setattr(profile_api, "commit", commit_mock)
     with session_factory() as session:

--- a/tests/test_profile_no_sdk.py
+++ b/tests/test_profile_no_sdk.py
@@ -18,7 +18,9 @@ class DummyMessage:
         self.markups: list[Any] = []
         self.kwargs: list[dict[str, Any]] = []
 
-    async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - simple helper
+    async def reply_text(
+        self, text: str, **kwargs: Any
+    ) -> None:  # pragma: no cover - simple helper
         self.texts.append(text)
         self.markups.append(kwargs.get("reply_markup"))
         self.kwargs.append(kwargs)
@@ -27,7 +29,9 @@ class DummyMessage:
         pass
 
 
-def _patch_import(monkeypatch: pytest.MonkeyPatch, *, exc: type[Exception] = ImportError) -> None:
+def _patch_import(
+    monkeypatch: pytest.MonkeyPatch, *, exc: type[Exception] = ImportError
+) -> None:
     """Force ``exc`` for any ``diabetes_sdk`` imports."""
 
     real_import = builtins.__import__
@@ -46,7 +50,9 @@ def _patch_import(monkeypatch: pytest.MonkeyPatch, *, exc: type[Exception] = Imp
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
 
-def test_get_api_falls_back_to_local_client(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+def test_get_api_falls_back_to_local_client(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """``get_api`` should provide a local client and log a warning on ``ImportError``."""
 
     _patch_import(monkeypatch)
@@ -66,7 +72,9 @@ def test_get_api_falls_back_to_local_client(monkeypatch: pytest.MonkeyPatch, cap
     assert "diabetes_sdk is not installed" in caplog.text
 
 
-def test_get_api_handles_runtime_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+def test_get_api_handles_runtime_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """``get_api`` should fall back when ``RuntimeError`` occurs during import."""
 
     _patch_import(monkeypatch, exc=RuntimeError)
@@ -97,19 +105,27 @@ async def test_profile_command_and_view_without_sdk(
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
+    import importlib
+
+    profile_api = importlib.import_module(
+        "services.api.app.diabetes.handlers.profile.api"
+    )
     from services.api.app.diabetes.handlers import profile as handlers
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(handlers, "SessionLocal", TestSession)
+    monkeypatch.setattr(profile_api, "SessionLocal", TestSession)
 
     with TestSession() as session:
         session.add(User(telegram_id=123, thread_id="t"))
         session.commit()
 
     msg = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=123)))
+    update = cast(
+        Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=123))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=["8", "3", "6", "4", "9"], user_data={}),
@@ -128,7 +144,9 @@ async def test_profile_command_and_view_without_sdk(
         assert prof.sos_alerts_enabled is True
 
     msg2 = DummyMessage()
-    update2 = cast(Update, SimpleNamespace(message=msg2, effective_user=SimpleNamespace(id=123)))
+    update2 = cast(
+        Update, SimpleNamespace(message=msg2, effective_user=SimpleNamespace(id=123))
+    )
     context2 = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),


### PR DESCRIPTION
## Summary
- import SessionLocal directly in profile API and allow sessionmaker injection
- drop dynamic _sessionmaker helper
- adapt profile API tests for constructor-based session injection

## Testing
- `ruff check services/api/app/diabetes/handlers/profile/api.py tests/handlers/profile/test_api.py tests/test_profile_no_sdk.py`
- `mypy --strict services/api/app/diabetes/handlers/profile/api.py tests/handlers/profile/test_api.py tests/test_profile_no_sdk.py`
- `mypy --strict .` *(fails: "sessionmaker expects no type arguments" in unrelated tests)*
- `pytest tests/handlers/profile/test_api.py tests/test_profile_no_sdk.py -q` *(fails: Required test coverage of 85% not reached. Total coverage: 25.19%)*


------
https://chatgpt.com/codex/tasks/task_e_68a9cc927b84832a8e5218c5d943fffb