### PR TITLE
[handlers] raise when WEBAPP_URL missing

### DIFF
--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -153,6 +153,7 @@ def test_build_webapp_url(monkeypatch: pytest.MonkeyPatch, base_url: str) -> Non
 
 
 def test_build_webapp_url_without_base(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "webapp_url", None)
     path = "/ui/reminders"
-    assert reminder_handlers.build_webapp_url(path) == path
+    monkeypatch.setattr(settings, "webapp_url", "")
+    with pytest.raises(RuntimeError, match="WEBAPP_URL not configured"):
+        reminder_handlers.build_webapp_url(path)


### PR DESCRIPTION
## Summary
- error out when WEBAPP_URL config is missing
- add a regression test for missing WEBAPP_URL

## Testing
- `pytest -q --cov` *(fails: No module named 'diabetes_sdk.models.role_schema')*
- `pytest -q tests/test_reminder_handlers.py::test_build_webapp_url_without_base -o addopts=`
- `mypy --strict .` *(fails: Found 15 errors in 5 files)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9cc9c143c832a9f758214470e8ef1