### PR TITLE
[db] use typing_extensions for Concatenate and ParamSpec

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -6,7 +6,8 @@ import asyncio
 import logging
 import threading
 from datetime import date, datetime, time
-from typing import Callable, Concatenate, ParamSpec, Protocol, TypeVar
+from typing import Callable, Protocol, TypeVar
+from typing_extensions import Concatenate, ParamSpec
 
 from sqlalchemy import (
     create_engine,


### PR DESCRIPTION
## Summary
- import `Concatenate` and `ParamSpec` from `typing_extensions` for Python 3.8 compatibility in database service

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'diabetes_sdk.models.role_schema')*
- `mypy --strict .` *(fails: Found 15 errors in 5 files)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9cce7c7c8832aa4129e2f4a61f224