### PR TITLE
[handlers] allow dependency injection for gpt handler

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -290,14 +290,17 @@ from . import gpt_handlers as _gpt_handlers  # noqa: E402
 
 
 async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    _gpt_handlers.SessionLocal = SessionLocal
-    _gpt_handlers.commit = commit
-    _gpt_handlers.check_alert = check_alert
-    _gpt_handlers.menu_keyboard = menu_keyboard
-    _gpt_handlers.smart_input = smart_input
-    _gpt_handlers.parse_command = parse_command
-    _gpt_handlers.send_report = send_report
-    return await _gpt_handlers.freeform_handler(update, context)
+    return await _gpt_handlers.freeform_handler(
+        update,
+        context,
+        SessionLocal=SessionLocal,
+        commit=commit,
+        check_alert=check_alert,
+        menu_keyboard=menu_keyboard,
+        smart_input=smart_input,
+        parse_command=parse_command,
+        send_report=send_report,
+    )
 
 
 chat_with_gpt = _gpt_handlers.chat_with_gpt

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -18,7 +18,9 @@ T = TypeVar("T")
 
 
 class DummyMessage:
-    def __init__(self, text: str | None = None, photo: tuple[Any, ...] | None = None) -> None:
+    def __init__(
+        self, text: str | None = None, photo: tuple[Any, ...] | None = None
+    ) -> None:
         self.text: str | None = text
         self.photo: tuple[Any, ...] = () if photo is None else photo
         self.texts: list[str] = []
@@ -58,7 +60,9 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
         mime_type="image/png",
     )
     message = SimpleNamespace(document=document, photo=None)
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=dummy_bot, user_data={}),
@@ -96,7 +100,9 @@ async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> 
         mime_type=None,
     )
     message = SimpleNamespace(document=document, photo=None)
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
@@ -121,7 +127,9 @@ async def test_doc_handler_get_file_error(monkeypatch: pytest.MonkeyPatch) -> No
         mime_type="image/png",
     )
     message = SimpleNamespace(document=document, reply_text=AsyncMock())
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     bot = SimpleNamespace(get_file=AsyncMock(side_effect=TelegramError("boom")))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -149,7 +157,9 @@ async def test_doc_handler_download_error(monkeypatch: pytest.MonkeyPatch) -> No
         mime_type="image/png",
     )
     message = SimpleNamespace(document=document, reply_text=AsyncMock())
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     bot = SimpleNamespace(get_file=AsyncMock(return_value=DummyFile()))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -167,7 +177,9 @@ async def test_doc_handler_download_error(monkeypatch: pytest.MonkeyPatch) -> No
 @pytest.mark.asyncio
 async def test_photo_handler_handles_typeerror() -> None:
     message = DummyMessage(photo=None)
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
@@ -182,7 +194,9 @@ async def test_photo_handler_handles_typeerror() -> None:
 
 
 @pytest.mark.asyncio
-async def test_photo_handler_removes_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+async def test_photo_handler_removes_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.chdir(tmp_path)
 
     class DummyPhoto:
@@ -193,7 +207,9 @@ async def test_photo_handler_removes_file(monkeypatch: pytest.MonkeyPatch, tmp_p
         pass
 
     message = SimpleNamespace(photo=(DummyPhoto(),), reply_text=reply_text)
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
 
     class DummyFile:
         async def download_to_drive(self, path: str) -> None:
@@ -228,13 +244,17 @@ async def test_photo_handler_removes_file(monkeypatch: pytest.MonkeyPatch, tmp_p
                         status="completed", thread_id=thread_id, id=run_id
                     )
                 ),
-                messages=SimpleNamespace(list=lambda thread_id: SimpleNamespace(data=[])),
+                messages=SimpleNamespace(
+                    list=lambda thread_id: SimpleNamespace(data=[])
+                ),
             )
         )
 
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
-    monkeypatch.setattr(photo_handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
+    monkeypatch.setattr(
+        photo_handlers, "extract_nutrition_info", lambda text: (10.0, 1.0)
+    )
     monkeypatch.setattr(photo_handlers, "menu_keyboard", None)
     monkeypatch.setattr(
         photo_handlers.os,  # type: ignore[attr-defined]
@@ -250,7 +270,9 @@ async def test_photo_handler_removes_file(monkeypatch: pytest.MonkeyPatch, tmp_p
 
 
 @pytest.mark.asyncio
-async def test_photo_then_freeform_calculates_dose(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+async def test_photo_then_freeform_calculates_dose(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """photo_handler + freeform_handler produce dose in reply and context."""
 
     class DummyPhoto:
@@ -279,13 +301,17 @@ async def test_photo_then_freeform_calculates_dose(monkeypatch: pytest.MonkeyPat
         beta = SimpleNamespace(
             threads=SimpleNamespace(
                 runs=SimpleNamespace(retrieve=lambda thread_id, run_id: Run()),
-                messages=SimpleNamespace(list=lambda thread_id: SimpleNamespace(data=[])),
+                messages=SimpleNamespace(
+                    list=lambda thread_id: SimpleNamespace(data=[])
+                ),
             )
         )
 
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
-    monkeypatch.setattr(photo_handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
+    monkeypatch.setattr(
+        photo_handlers, "extract_nutrition_info", lambda text: (10.0, 1.0)
+    )
     monkeypatch.setattr(photo_handlers, "menu_keyboard", None)
     monkeypatch.setattr(gpt_handlers, "confirm_keyboard", lambda: None)
 
@@ -321,7 +347,6 @@ async def test_photo_then_freeform_calculates_dose(monkeypatch: pytest.MonkeyPat
 
     session_factory = cast(Any, sessionmaker(class_=DummySession))
     photo_handlers.SessionLocal = session_factory  # type: ignore[attr-defined]
-    gpt_handlers.SessionLocal = session_factory
 
     async def fake_run_db(
         func: Callable[[Session], T],
@@ -340,7 +365,9 @@ async def test_photo_then_freeform_calculates_dose(monkeypatch: pytest.MonkeyPat
         SimpleNamespace(message=sugar_msg, effective_user=SimpleNamespace(id=1)),
     )
 
-    await gpt_handlers.freeform_handler(update_sugar, context)
+    await gpt_handlers.freeform_handler(
+        update_sugar, context, SessionLocal=session_factory
+    )
 
     reply = sugar_msg.texts[0]
     assert reply == "💉\u202fРасчёт дозы: 1.0\u202fЕд.\nСахар: 5.0\u202fммоль/л"

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -87,9 +87,7 @@ async def test_photo_flow_saves_entry(
     async def fake_parse_command(text: str) -> dict[str, object]:
         return {"action": "add_entry", "fields": {}, "entry_date": None, "time": None}
 
-    monkeypatch.setattr(gpt_handlers, "parse_command", fake_parse_command)
     monkeypatch.setattr(gpt_handlers, "confirm_keyboard", lambda: None)
-    monkeypatch.setattr(gpt_handlers, "menu_keyboard", None)
     monkeypatch.setattr(photo_handlers, "menu_keyboard", None)
 
     msg_start = DummyMessage("/dose")
@@ -120,7 +118,12 @@ async def test_photo_flow_saves_entry(
     fake_bot = SimpleNamespace(get_file=fake_get_file)
     setattr(cast(Any, type(context)), "bot", PropertyMock(return_value=fake_bot))
 
-    await gpt_handlers.freeform_handler(update_start, context)
+    await gpt_handlers.freeform_handler(
+        update_start,
+        context,
+        parse_command=fake_parse_command,
+        menu_keyboard=None,
+    )
 
     monkeypatch.chdir(tmp_path)
 
@@ -197,7 +200,12 @@ async def test_photo_flow_saves_entry(
             session.close()
 
     monkeypatch.setattr(gpt_handlers, "run_db", fake_run_db)
-    await gpt_handlers.freeform_handler(update_sugar, context)
+    await gpt_handlers.freeform_handler(
+        update_sugar,
+        context,
+        parse_command=fake_parse_command,
+        menu_keyboard=None,
+    )
     assert user_data["pending_entry"]["sugar_before"] == 5.5
 
     monkeypatch.setattr(router, "SessionLocal", session_factory)


### PR DESCRIPTION
## Summary
- inject external dependencies into GPT freeform handler and helpers
- forward explicit dependencies from `dose_calc` to GPT handler
- adjust tests to supply dependencies via arguments

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: sessionmaker expects no type arguments; missing attributes in tests)*
- `pytest -q` *(fails: errors during collection in libs/py-sdk tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cc7e8960832a8e15cd426aaa4d6d