### PR TITLE
[ci] Configure pnpm installation in workflows

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -24,6 +24,9 @@ jobs:
           cache: pnpm
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: '9'
+          run_install: false
       - run: pnpm install
       - name: Generate SDKs
         run: pnpm run generate:sdk

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,9 @@ jobs:
           cache: pnpm
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: '9'
+          run_install: false
       - run: pnpm install
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- explicitly install pnpm v9 in CI workflows
- ensure pnpm commands run after setup step

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: "module has no attribute" errors in tests)*
- `pytest --cov=services.api.app.diabetes --cov-report=term-missing --cov-report=xml --cov-fail-under=85` *(fails: errors during collection in libs/py-sdk tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cea38d6c832aaa9b9999a2157623