### PR TITLE
[handlers] make run_db optional

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import logging
 import re
+from collections.abc import Awaitable, Callable
 from typing import Any, TypedDict, cast
 
 from telegram import (
@@ -15,7 +16,14 @@ from telegram import (
 from telegram.ext import ContextTypes
 from sqlalchemy.orm import Session
 
-from services.api.app.diabetes.services.db import SessionLocal, Entry, Profile, run_db
+from services.api.app.diabetes.services.db import SessionLocal, Entry, Profile
+
+try:
+    from services.api.app.diabetes.services.db import run_db as _run_db
+except Exception:
+    _run_db = None
+
+run_db: Callable[..., Awaitable[Any]] | None = _run_db
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.functions import (
     PatientProfile,
@@ -60,7 +68,9 @@ async def _handle_report_request(
         await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
         return True
     try:
-        date_from = datetime.datetime.strptime(raw_text, "%Y-%m-%d").replace(tzinfo=datetime.timezone.utc)
+        date_from = datetime.datetime.strptime(raw_text, "%Y-%m-%d").replace(
+            tzinfo=datetime.timezone.utc
+        )
     except ValueError:
         await message.reply_text("❗ Некорректная дата. Используйте формат YYYY-MM-DD.")
         return True
@@ -77,7 +87,7 @@ async def _save_entry(entry_data: dict[str, Any]) -> bool:
         session.add(entry)
         return bool(commit(session))
 
-    if not callable(run_db):
+    if run_db is None:
         with SessionLocal() as session:
             return _db_save(session)
     return await run_db(_db_save, sessionmaker=SessionLocal)
@@ -158,7 +168,10 @@ async def _handle_pending_entry(
         return True
 
     text = raw_text.lower()
-    if re.fullmatch(r"-?\d+(?:[.,]\d+)?", text) and pending_entry.get("sugar_before") is None:
+    if (
+        re.fullmatch(r"-?\d+(?:[.,]\d+)?", text)
+        and pending_entry.get("sugar_before") is None
+    ):
         try:
             sugar = float(text.replace(",", "."))
         except ValueError:
@@ -168,24 +181,31 @@ async def _handle_pending_entry(
             await message.reply_text("Сахар не может быть отрицательным.")
             return True
         pending_entry["sugar_before"] = sugar
-        if pending_entry.get("carbs_g") is not None or pending_entry.get("xe") is not None:
+        if (
+            pending_entry.get("carbs_g") is not None
+            or pending_entry.get("xe") is not None
+        ):
             xe_val = pending_entry.get("xe")
             carbs_g = pending_entry.get("carbs_g")
             if carbs_g is None and xe_val is not None:
                 carbs_g = XE_GRAMS * xe_val
                 pending_entry["carbs_g"] = carbs_g
-            if not callable(run_db):
+            if run_db is None:
                 with SessionLocal() as session:
                     profile = session.get(Profile, user_id)
             else:
-                profile = await run_db(lambda s: s.get(Profile, user_id), sessionmaker=SessionLocal)
+                profile = await run_db(
+                    lambda s: s.get(Profile, user_id), sessionmaker=SessionLocal
+                )
             if (
                 profile is not None
                 and profile.icr is not None
                 and profile.cf is not None
                 and profile.target_bg is not None
             ):
-                patient = PatientProfile(icr=profile.icr, cf=profile.cf, target_bg=profile.target_bg)
+                patient = PatientProfile(
+                    icr=profile.icr, cf=profile.cf, target_bg=profile.target_bg
+                )
                 dose = calc_bolus(carbs_g, sugar, patient)
                 pending_entry["dose"] = dose
                 await message.reply_text(
@@ -193,7 +213,9 @@ async def _handle_pending_entry(
                     reply_markup=confirm_keyboard(),
                 )
                 return True
-        await message.reply_text("Введите количество углеводов или ХЕ.", reply_markup=menu_keyboard)
+        await message.reply_text(
+            "Введите количество углеводов или ХЕ.", reply_markup=menu_keyboard
+        )
         return True
 
     # not handled here
@@ -236,7 +258,7 @@ async def _handle_edit_entry(
         session.refresh(entry)
         return entry
 
-    if not callable(run_db):
+    if run_db is None:
         with SessionLocal() as session:
             entry = db_edit(session)
     else:
@@ -301,10 +323,16 @@ async def _handle_smart_input(
             )
         return
 
-    carbs_match = re.search(r"(?:carbs|углеводов)\s*=\s*(-?\d+(?:[.,]\d+)?)", raw_text, re.I)
+    carbs_match = re.search(
+        r"(?:carbs|углеводов)\s*=\s*(-?\d+(?:[.,]\d+)?)", raw_text, re.I
+    )
     pending_entry = user_data.get("pending_entry")
     edit_id = user_data.get("edit_id")
-    if pending_entry is not None and edit_id is None and (any(v is not None for v in quick.values()) or carbs_match):
+    if (
+        pending_entry is not None
+        and edit_id is None
+        and (any(v is not None for v in quick.values()) or carbs_match)
+    ):
         if quick["sugar"] is not None:
             pending_entry["sugar_before"] = quick["sugar"]
         if quick["xe"] is not None:
@@ -438,9 +466,13 @@ async def _handle_smart_input(
         try:
             hh, mm = map(int, time_obj.split(":"))
             today = datetime.datetime.now(datetime.timezone.utc).date()
-            event_dt = datetime.datetime.combine(today, datetime.time(hh, mm), tzinfo=datetime.timezone.utc)
+            event_dt = datetime.datetime.combine(
+                today, datetime.time(hh, mm), tzinfo=datetime.timezone.utc
+            )
         except (ValueError, TypeError):
-            await message.reply_text("⏰ Неверный формат времени. Использую текущее время.")
+            await message.reply_text(
+                "⏰ Неверный формат времени. Использую текущее время."
+            )
             event_dt = datetime.datetime.now(datetime.timezone.utc)
     else:
         event_dt = datetime.datetime.now(datetime.timezone.utc)
@@ -467,7 +499,9 @@ async def _handle_smart_input(
     sugar_part = f"Сахар: {sugar_val}\u202fммоль/л" if sugar_val is not None else ""
     lines = "  \n- ".join(filter(None, [xe_part or carb_part, dose_part, sugar_part]))
 
-    reply = f"💉 Расчёт завершён:\n\n{date_str}  \n- {lines}\n\nСохранить это в дневник?"
+    reply = (
+        f"💉 Расчёт завершён:\n\n{date_str}  \n- {lines}\n\nСохранить это в дневник?"
+    )
     await message.reply_text(text=reply, reply_markup=confirm_keyboard())
 
 
@@ -492,7 +526,9 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
     if await _handle_report_request(raw_text, user_data, message, update, context):
         return
-    if await _handle_pending_entry(raw_text, user_data, message, update, context, user_id):
+    if await _handle_pending_entry(
+        raw_text, user_data, message, update, context, user_id
+    ):
         return
     if await _handle_edit_entry(raw_text, user_data, message, context):
         return


### PR DESCRIPTION
## Summary
- treat `run_db` as optional in `gpt_handlers`
- cover synchronous path when `run_db` is `None`

## Testing
- `pytest tests -q`
- `mypy --strict services/api/app/diabetes/handlers/gpt_handlers.py tests/handlers/test_gpt_handlers.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9cc9761d4832a877e9f411138a1ea