### PR TITLE
[contracts] document 403 responses for stats endpoints

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -370,6 +370,8 @@ paths:
                 $ref: '#/components/schemas/DayStats'
         '204':
           description: No Content - no statistics available.
+        '403':
+          description: Forbidden
         '422':
           description: Validation Error
           content:
@@ -405,6 +407,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/AnalyticsPoint'
                 title: Response Get Analytics Analytics Get
+        '403':
+          description: Forbidden
         '422':
           description: Validation Error
           content:

--- a/libs/ts-sdk/.openapi-generator/FILES
+++ b/libs/ts-sdk/.openapi-generator/FILES
@@ -1,4 +1,3 @@
-.openapi-generator-ignore
 apis/DefaultApi.ts
 apis/HistoryApi.ts
 apis/ProfilesApi.ts

--- a/services/webapp/ui/src/api/stats.ts
+++ b/services/webapp/ui/src/api/stats.ts
@@ -1,5 +1,5 @@
 import { DefaultApi } from '@offonika/diabetes-ts-sdk';
-import { Configuration } from '@offonika/diabetes-ts-sdk/runtime';
+import { Configuration, ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 
@@ -89,6 +89,9 @@ export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint
     }
     return data as AnalyticsPoint[];
   } catch (error) {
+    if (error instanceof ResponseError && error.response.status === 403) {
+      return getFallbackAnalytics();
+    }
     console.error('Failed to fetch analytics:', error);
     return getFallbackAnalytics();
   }
@@ -119,6 +122,9 @@ export async function fetchDayStats(telegramId: number): Promise<DayStats> {
 
     return { sugar, breadUnits, insulin };
   } catch (error) {
+    if (error instanceof ResponseError && error.response.status === 403) {
+      return getFallbackDayStats();
+    }
     console.error('Failed to fetch day stats:', error);
     return getFallbackDayStats();
   }

--- a/tests/test_stats_api.py
+++ b/tests/test_stats_api.py
@@ -95,6 +95,18 @@ def test_analytics_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     assert body and body[0].get("date")
 
 
+def test_analytics_mismatched_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    init_data = build_init_data(1)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/analytics",
+            params={"telegramId": 2},
+            headers={TG_INIT_DATA_HEADER: init_data},
+        )
+    assert resp.status_code == 403
+
+
 def test_stats_no_data(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     init_data = build_init_data(5)


### PR DESCRIPTION
## Summary
- document 403 responses for stats and analytics
- handle 403 responses in stats API client
- test analytics 403 responses

## Testing
- `pnpm --filter vite_react_shadcn_ts exec vitest run src/api/stats.api.test.ts`
- `pytest -q` (fails: async def functions are not natively supported)
- `mypy --strict .` (fails: Module has no attribute ...)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9cef7c700832ab76968269c36bc21