### PR TITLE
[contracts] document 404 response for profiles

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -55,6 +55,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+        '404':
+          description: profile not found
     get:
       tags:
       - Profiles
@@ -88,6 +90,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+        '404':
+          description: profile not found
   /reminders:
     get:
       tags:

--- a/libs/ts-sdk/.openapi-generator/FILES
+++ b/libs/ts-sdk/.openapi-generator/FILES
@@ -1,4 +1,3 @@
-.openapi-generator-ignore
 apis/DefaultApi.ts
 apis/HistoryApi.ts
 apis/ProfilesApi.ts

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -11,6 +11,10 @@ const api = new ProfilesApi(
   new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
 );
 
+/**
+ * Fetch profile by telegramId.
+ * Returns null if profile is not found (404).
+ */
 export async function getProfile(telegramId: number): Promise<Profile | null> {
   try {
     const data = await api.profilesGet({ telegramId });


### PR DESCRIPTION
## Summary
- describe 404 response for GET /profiles in the OpenAPI spec
- document 404 handling for `getProfile`
- regenerate TypeScript SDK

## Testing
- `pnpm --filter ./services/webapp/ui exec vitest run` *(fails: ReferenceError: document is not defined)*
- `pytest -q --cov` *(fails: async def functions are not natively supported; 331 failed)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9cef4ec0c832a8689fe83ecccc4ca