### PR TITLE
[contracts] require Telegram init data

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,18 @@ pnpm --filter services/webapp/ui run build
 Сгенерированный TypeScript SDK доступен как workspace‑пакет
 `@offonika/diabetes-ts-sdk`, поэтому алиас пути не требуется.
 
+⚠️ Все защищённые эндпоинты требуют заголовок `X-Telegram-Init-Data`,
+содержащий `initData` Telegram WebApp. Функция `tgFetch`
+(`services/webapp/ui/src/lib/tgFetch.ts`) подставляет этот заголовок
+автоматически, поэтому её нужно передать в конфигурацию SDK:
+
 ```ts
 import { Configuration, ProfilesApi } from '@offonika/diabetes-ts-sdk';
+import { tgFetch } from './tgFetch';
 
-const api = new ProfilesApi(new Configuration({ basePath: '/api' }));
+const api = new ProfilesApi(
+  new Configuration({ basePath: '/api', fetchApi: tgFetch }),
+);
 const profile = await api.profilesGet({ telegramId: 123 });
 ```
 

--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -6,9 +6,12 @@ tags:
   - name: Profiles
   - name: History
   - name: Reminders
+security:
+  - TelegramInitData: []
 paths:
   /health:
     get:
+      security: []
       summary: Health
       operationId: healthGet
       responses:
@@ -27,15 +30,6 @@ paths:
       - Profiles
       summary: Profiles Post
       operationId: profilesPost
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       requestBody:
         required: true
         content:
@@ -67,14 +61,6 @@ paths:
         schema:
           type: integer
           title: Telegram Id
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       responses:
         '200':
           description: Successful Response. Returns profile.
@@ -109,14 +95,6 @@ paths:
           - type: integer
           - type: 'null'
           title: Id
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       responses:
         '200':
           description: >-
@@ -143,15 +121,6 @@ paths:
       - Reminders
       summary: Reminders Post
       operationId: reminders_post
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       requestBody:
         required: true
         content:
@@ -179,15 +148,6 @@ paths:
       - Reminders
       summary: Reminders Patch
       operationId: reminders_patch
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       requestBody:
         required: true
         content:
@@ -228,14 +188,6 @@ paths:
         schema:
           type: integer
           title: Id
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       responses:
         '200':
           description: Successful Response
@@ -257,15 +209,6 @@ paths:
     get:
       summary: Get Timezone
       operationId: get_timezone_timezone_get
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       responses:
         '200':
           description: Successful Response
@@ -285,15 +228,6 @@ paths:
     put:
       summary: Put Timezone
       operationId: put_timezone_timezone_put
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       requestBody:
         required: true
         content:
@@ -320,15 +254,6 @@ paths:
     get:
       summary: Profile Self
       operationId: profile_self_profile_self_get
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       responses:
         '200':
           description: Successful Response
@@ -353,14 +278,6 @@ paths:
         schema:
           type: integer
           title: Telegramid
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       responses:
         '200':
           description: Successful Response. Returns statistics for the day.
@@ -387,14 +304,6 @@ paths:
         schema:
           type: integer
           title: Telegramid
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       responses:
         '200':
           description: Successful Response
@@ -416,15 +325,6 @@ paths:
       summary: Create User
       description: Ensure a user exists in the database.
       operationId: create_user_user_post
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       requestBody:
         required: true
         content:
@@ -507,15 +407,6 @@ paths:
       summary: Post History
       description: Save or update a history record in the database.
       operationId: historyPost
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       requestBody:
         required: true
         content:
@@ -544,15 +435,6 @@ paths:
       summary: Get History
       description: Return history records for the authenticated user.
       operationId: historyGet
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       responses:
         '200':
           description: Successful Response
@@ -583,14 +465,6 @@ paths:
         schema:
           type: string
           title: Id
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
       responses:
         '200':
           description: Successful Response
@@ -608,6 +482,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
 components:
+  securitySchemes:
+    TelegramInitData:
+      type: apiKey
+      in: header
+      name: X-Telegram-Init-Data
   schemas:
     AnalyticsPoint:
       properties:

--- a/libs/ts-sdk/.openapi-generator/FILES
+++ b/libs/ts-sdk/.openapi-generator/FILES
@@ -1,4 +1,3 @@
-.openapi-generator-ignore
 apis/DefaultApi.ts
 apis/HistoryApi.ts
 apis/ProfilesApi.ts

--- a/libs/ts-sdk/apis/DefaultApi.ts
+++ b/libs/ts-sdk/apis/DefaultApi.ts
@@ -42,12 +42,10 @@ import {
 
 export interface CreateUserUserPostRequest {
     webUser: WebUser;
-    xTelegramInitData?: string | null;
 }
 
 export interface GetAnalyticsAnalyticsGetRequest {
     telegramId: number;
-    xTelegramInitData?: string | null;
 }
 
 export interface GetRoleUserUserIdRoleGetRequest {
@@ -56,15 +54,6 @@ export interface GetRoleUserUserIdRoleGetRequest {
 
 export interface GetStatsStatsGetRequest {
     telegramId: number;
-    xTelegramInitData?: string | null;
-}
-
-export interface GetTimezoneTimezoneGetRequest {
-    xTelegramInitData?: string | null;
-}
-
-export interface ProfileSelfProfileSelfGetRequest {
-    xTelegramInitData?: string | null;
 }
 
 export interface PutRoleUserUserIdRolePutRequest {
@@ -74,7 +63,6 @@ export interface PutRoleUserUserIdRolePutRequest {
 
 export interface PutTimezoneTimezonePutRequest {
     timezone: Timezone;
-    xTelegramInitData?: string | null;
 }
 
 /**
@@ -100,8 +88,8 @@ export class DefaultApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -146,8 +134,8 @@ export class DefaultApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -185,6 +173,10 @@ export class DefaultApi extends runtime.BaseAPI {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
+        }
 
 
         let urlPath = `/user/{user_id}/role`;
@@ -227,8 +219,8 @@ export class DefaultApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -262,13 +254,13 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Get Timezone
      */
-    async getTimezoneTimezoneGetRaw(requestParameters: GetTimezoneTimezoneGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string; }>> {
+    async getTimezoneTimezoneGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -287,8 +279,8 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Get Timezone
      */
-    async getTimezoneTimezoneGet(requestParameters: GetTimezoneTimezoneGetRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string; }> {
-        const response = await this.getTimezoneTimezoneGetRaw(requestParameters, initOverrides);
+    async getTimezoneTimezoneGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string; }> {
+        const response = await this.getTimezoneTimezoneGetRaw(initOverrides);
         return await response.value();
     }
 
@@ -324,13 +316,13 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Profile Self
      */
-    async profileSelfProfileSelfGetRaw(requestParameters: ProfileSelfProfileSelfGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserContext>> {
+    async profileSelfProfileSelfGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserContext>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -349,8 +341,8 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Profile Self
      */
-    async profileSelfProfileSelfGet(requestParameters: ProfileSelfProfileSelfGetRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<UserContext> {
-        const response = await this.profileSelfProfileSelfGetRaw(requestParameters, initOverrides);
+    async profileSelfProfileSelfGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<UserContext> {
+        const response = await this.profileSelfProfileSelfGetRaw(initOverrides);
         return await response.value();
     }
 
@@ -377,6 +369,10 @@ export class DefaultApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
         headerParameters['Content-Type'] = 'application/json';
+
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
+        }
 
 
         let urlPath = `/user/{user_id}/role`;
@@ -418,8 +414,8 @@ export class DefaultApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 

--- a/libs/ts-sdk/apis/HistoryApi.ts
+++ b/libs/ts-sdk/apis/HistoryApi.ts
@@ -28,18 +28,12 @@ import {
     HistoryRecordSchemaOutputToJSON,
 } from '../models/index';
 
-export interface HistoryGetRequest {
-    xTelegramInitData?: string | null;
-}
-
 export interface HistoryIdDeleteRequest {
     id: string;
-    xTelegramInitData?: string | null;
 }
 
 export interface HistoryPostRequest {
     historyRecordSchemaInput: HistoryRecordSchemaInput;
-    xTelegramInitData?: string | null;
 }
 
 /**
@@ -51,13 +45,13 @@ export class HistoryApi extends runtime.BaseAPI {
      * Return history records for the authenticated user.
      * Get History
      */
-    async historyGetRaw(requestParameters: HistoryGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<HistoryRecordSchemaOutput>>> {
+    async historyGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<HistoryRecordSchemaOutput>>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -77,8 +71,8 @@ export class HistoryApi extends runtime.BaseAPI {
      * Return history records for the authenticated user.
      * Get History
      */
-    async historyGet(requestParameters: HistoryGetRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<HistoryRecordSchemaOutput>> {
-        const response = await this.historyGetRaw(requestParameters, initOverrides);
+    async historyGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<HistoryRecordSchemaOutput>> {
+        const response = await this.historyGetRaw(initOverrides);
         return await response.value();
     }
 
@@ -98,8 +92,8 @@ export class HistoryApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -143,8 +137,8 @@ export class HistoryApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 

--- a/libs/ts-sdk/apis/ProfilesApi.ts
+++ b/libs/ts-sdk/apis/ProfilesApi.ts
@@ -27,12 +27,10 @@ import {
 
 export interface ProfilesGetRequest {
     telegramId?: number;
-    xTelegramInitData?: string | null;
 }
 
 export interface ProfilesPostRequest {
     profileSchema: ProfileSchema;
-    xTelegramInitData?: string | null;
 }
 
 /**
@@ -52,8 +50,8 @@ export class ProfilesApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -94,8 +92,8 @@ export class ProfilesApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 

--- a/libs/ts-sdk/apis/RemindersApi.ts
+++ b/libs/ts-sdk/apis/RemindersApi.ts
@@ -28,23 +28,19 @@ import {
 export interface RemindersDeleteRequest {
     telegramId: number;
     id: number;
-    xTelegramInitData?: string | null;
 }
 
 export interface RemindersGetRequest {
     telegramId: number;
     id?: number | null;
-    xTelegramInitData?: string | null;
 }
 
 export interface RemindersPatchRequest {
     reminder: ReminderSchema;
-    xTelegramInitData?: string | null;
 }
 
 export interface RemindersPostRequest {
     reminder: ReminderSchema;
-    xTelegramInitData?: string | null;
 }
 
 /**
@@ -82,8 +78,8 @@ export class RemindersApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -130,8 +126,8 @@ export class RemindersApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -172,8 +168,8 @@ export class RemindersApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -215,8 +211,8 @@ export class RemindersApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 


### PR DESCRIPTION
## Summary
- declare X-Telegram-Init-Data as apiKey security and apply globally in OpenAPI spec
- regenerate TypeScript SDK with automatic header forwarding
- document need to send Telegram init data in requests

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: sessionmaker expects no type arguments, etc.)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9cf020ea0832a81104fea3b109090