### PR TITLE
[ci] Enable pnpm via Corepack

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -22,11 +22,8 @@ jobs:
         with:
           node-version: "20"
           cache: pnpm
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: '9'
-          run_install: false
+      - name: Enable pnpm
+        run: corepack enable pnpm
       - run: pnpm install
       - name: Generate SDKs
         run: pnpm run generate:sdk

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,8 @@ jobs:
         with:
           node-version: "20"
           cache: pnpm
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: '9'
-          run_install: false
+      - name: Enable pnpm
+        run: corepack enable pnpm
       - run: pnpm install
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- ensure pnpm is available in CI workflows using corepack

## Testing
- `pip install -r requirements.txt` *(fails: invalid pyproject.toml config: `project.license`)*
- `pip install -r services/api/app/requirements-dev.txt`
- `pip install -r services/api/app/requirements.txt`
- `pytest --cov=services.api.app.diabetes --cov-report=term-missing --cov-report=xml --cov-fail-under=85` *(fails: 10 failed, 576 passed)*
- `mypy --strict .` *(fails: Found 15 errors in 5 files)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9d43a849c832a8494a16e101d2105