### PR TITLE
tests: replace run_db with None

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -401,7 +401,13 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             return "error", db_user, limit, count
         return "ok", db_user, limit, reminder.id
 
-    status, db_user, limit, rid_or_count = await run_db(db_add, sessionmaker=SessionLocal)
+    if not callable(run_db):
+        with SessionLocal() as session:
+            status, db_user, limit, rid_or_count = db_add(session)
+    else:
+        status, db_user, limit, rid_or_count = await run_db(
+            db_add, sessionmaker=SessionLocal
+        )
 
     if status == "limit":
         count = rid_or_count

--- a/tests/handlers/test_gpt_handlers.py
+++ b/tests/handlers/test_gpt_handlers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
-from types import SimpleNamespace
+from types import SimpleNamespace, TracebackType
 from typing import Any, cast
 
 from telegram import Update
@@ -23,6 +23,28 @@ class DummyMessage:
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append((text, kwargs))
+
+
+class DummySession:
+    def __enter__(self) -> "DummySession":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        pass
+
+    def add(self, obj: Any) -> None:  # noqa: D401 - no action
+        pass
+
+    def commit(self) -> None:  # noqa: D401 - no action
+        pass
+
+    def get(self, *args: Any, **kwargs: Any) -> Any:
+        return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
 
 def make_update(message: DummyMessage) -> Update:
@@ -124,18 +146,10 @@ async def test_pending_entry_commit(monkeypatch: pytest.MonkeyPatch) -> None:
     entry = {"telegram_id": 1, "event_time": dt.datetime.now(dt.timezone.utc)}
     user_data = {"pending_entry": entry, "pending_fields": ["sugar"]}
 
-    async def fake_run_db(func: Any, sessionmaker: Any = None) -> bool:
-        class DummySession:
-            def add(self, obj: Any) -> None:  # noqa: D401 - no action
-                pass
-
-        result = func(DummySession())
-        return bool(result)
-
     async def fake_check_alert(update: Any, context: Any, sugar: float) -> None:
         pass
-
-    monkeypatch.setattr(gpt_handlers, "run_db", fake_run_db)
+    monkeypatch.setattr(gpt_handlers, "run_db", None)
+    monkeypatch.setattr(gpt_handlers, "SessionLocal", lambda: DummySession())
     context = make_context(user_data)
     await gpt_handlers.freeform_handler(
         update,
@@ -193,18 +207,10 @@ async def test_smart_input_complete(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_smart_input(text: str) -> dict[str, float | None]:
         return {"sugar": 5.0, "xe": 1.0, "dose": 2.0}
 
-    async def fake_run_db(func: Any, sessionmaker: Any = None) -> bool:
-        class DummySession:
-            def add(self, obj: Any) -> None:
-                pass
-
-        result = func(DummySession())
-        return bool(result)
-
     async def fake_check_alert(update: Any, context: Any, sugar: float) -> None:
         pass
-
-    monkeypatch.setattr(gpt_handlers, "run_db", fake_run_db)
+    monkeypatch.setattr(gpt_handlers, "run_db", None)
+    monkeypatch.setattr(gpt_handlers, "SessionLocal", lambda: DummySession())
     message = DummyMessage("all")
     update = make_update(message)
     context = make_context({})

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -94,11 +94,7 @@ async def test_entry_without_dose_has_no_unit(
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
-    async def fake_run_db(fn: Any, *args: Any, **kwargs: Any) -> Any:
-        with session_factory() as session:
-            return fn(session)
-
-    monkeypatch.setattr(gpt_handlers, "run_db", fake_run_db)
+    monkeypatch.setattr(gpt_handlers, "run_db", None)
 
     await dose_calc.freeform_handler(update, context)
 
@@ -155,11 +151,7 @@ async def test_entry_without_sugar_has_placeholder(
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
-    async def fake_run_db(fn: Any, *args: Any, **kwargs: Any) -> Any:
-        with session_factory() as session:
-            return fn(session)
-
-    monkeypatch.setattr(gpt_handlers, "run_db", fake_run_db)
+    monkeypatch.setattr(gpt_handlers, "run_db", None)
 
     await dose_calc.freeform_handler(update, context)
 

--- a/tests/test_gpt_handlers_blocks.py
+++ b/tests/test_gpt_handlers_blocks.py
@@ -216,19 +216,11 @@ async def test_handle_pending_entry_complete(monkeypatch: pytest.MonkeyPatch) ->
         SimpleNamespace(),
     )
 
-    async def fake_run_db(func: Any, sessionmaker: Any) -> bool:
-        class DummySession:
-            def add(self, obj: Any) -> None:
-                pass
-
-        return bool(func(DummySession()))
-
     async def fake_check_alert(
         update: Update, context: CallbackContext[Any, Any, Any, Any], sugar: float
     ) -> None:
         return None
-
-    monkeypatch.setattr(gpt_handlers, "run_db", fake_run_db)
+    monkeypatch.setattr(gpt_handlers, "run_db", None)
 
     handled = await gpt_handlers._handle_pending_entry(
         "5",


### PR DESCRIPTION
## Summary
- handle `run_db=None` in reminder handler's `add_reminder`
- switch tests to use `run_db=None` with dummy sessions

## Testing
- `pytest tests/test_gpt_handlers.py tests/test_gpt_handlers_db_errors.py tests/test_gpt_handlers_blocks.py tests/handlers/test_gpt_handlers.py tests/test_dose_info_unit.py tests/test_handlers_doc.py tests/test_handlers_freeform_pending.py tests/test_reminder_handlers.py tests/test_handlers_photo_sugar_save.py -q`
- `mypy --strict .` *(fails: Missing type parameters for generic type "sessionmaker", Module has no attribute "parse_command", Module has no attribute "ParserTimeoutError", Module has no attribute "BASE_DIR", Module has no attribute "UI_DIR", Argument "SessionLocal" to "freeform_handler" has incompatible type "Callable[[], SimpleSession]"; expected "sessionmaker[Any]", Argument "SessionLocal" to "freeform_handler" has incompatible type "Callable[[], DummySession]"; expected "sessionmaker[Any]", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker", Missing type parameters for generic type "sessionmaker"*)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9d23a494c832aa418e9db9c8e8205