### PR TITLE
[contracts] add TelegramInitData security scheme

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -27,15 +27,8 @@ paths:
       - Profiles
       summary: Profiles Post
       operationId: profilesPost
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       requestBody:
         required: true
         content:
@@ -69,14 +62,8 @@ paths:
         schema:
           type: integer
           title: Telegram Id
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       responses:
         '200':
           description: Successful Response. Returns profile.
@@ -105,14 +92,8 @@ paths:
         schema:
           type: integer
           title: Telegram Id
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       responses:
         '200':
           description: >-
@@ -139,15 +120,8 @@ paths:
       - Reminders
       summary: Reminders Post
       operationId: reminders_post
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       requestBody:
         required: true
         content:
@@ -175,15 +149,8 @@ paths:
       - Reminders
       summary: Reminders Patch
       operationId: reminders_patch
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       requestBody:
         required: true
         content:
@@ -224,14 +191,8 @@ paths:
         schema:
           type: integer
           title: Id
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       responses:
         '200':
           description: Successful Response
@@ -268,14 +229,8 @@ paths:
         schema:
           type: integer
           title: Telegram Id
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       responses:
         '200':
           description: Successful Response
@@ -295,15 +250,8 @@ paths:
     get:
       summary: Get Timezone
       operationId: get_timezone_timezone_get
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       responses:
         '200':
           description: Successful Response
@@ -323,15 +271,8 @@ paths:
     put:
       summary: Put Timezone
       operationId: put_timezone_timezone_put
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       requestBody:
         required: true
         content:
@@ -358,15 +299,8 @@ paths:
     get:
       summary: Profile Self
       operationId: profile_self_profile_self_get
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       responses:
         '200':
           description: Successful Response
@@ -391,14 +325,8 @@ paths:
         schema:
           type: integer
           title: Telegramid
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       responses:
         '200':
           description: Successful Response. Returns statistics for the day.
@@ -427,14 +355,8 @@ paths:
         schema:
           type: integer
           title: Telegramid
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       responses:
         '200':
           description: Successful Response
@@ -458,15 +380,8 @@ paths:
       summary: Create User
       description: Ensure a user exists in the database.
       operationId: create_user_user_post
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       requestBody:
         required: true
         content:
@@ -549,15 +464,8 @@ paths:
       summary: Post History
       description: Save or update a history record in the database.
       operationId: historyPost
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       requestBody:
         required: true
         content:
@@ -586,15 +494,8 @@ paths:
       summary: Get History
       description: Return history records for the authenticated user.
       operationId: historyGet
-      parameters:
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       responses:
         '200':
           description: Successful Response
@@ -625,14 +526,8 @@ paths:
         schema:
           type: string
           title: Id
-      - name: X-Telegram-Init-Data
-        in: header
-        required: false
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: X-Telegram-Init-Data
+      security:
+      - TelegramInitData: []
       responses:
         '200':
           description: Successful Response
@@ -650,6 +545,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
 components:
+  securitySchemes:
+    TelegramInitData:
+      type: apiKey
+      in: header
+      name: X-Telegram-Init-Data
   schemas:
     AnalyticsPoint:
       properties:

--- a/libs/py-sdk/README.md
+++ b/libs/py-sdk/README.md
@@ -61,17 +61,26 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.HistoryApi(api_client)
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Get History
-        api_response = api_instance.history_get(x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.history_get()
         print("The response of HistoryApi->history_get:\n")
         pprint(api_response)
     except ApiException as e:
@@ -126,7 +135,14 @@ Class | Method | HTTP request | Description
 <a id="documentation-for-authorization"></a>
 ## Documentation For Authorization
 
-Endpoints do not require authorization.
+
+Authentication schemes defined for the API:
+<a id="TelegramInitData"></a>
+### TelegramInitData
+
+- **Type**: API key
+- **API key parameter name**: X-Telegram-Init-Data
+- **Location**: HTTP header
 
 
 ## Author

--- a/libs/py-sdk/diabetes_sdk/api/default_api.py
+++ b/libs/py-sdk/diabetes_sdk/api/default_api.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
 from pydantic import StrictInt, StrictStr
-from typing import Dict, List, Optional
+from typing import Dict, List
 from diabetes_sdk.models.analytics_point import AnalyticsPoint
 from diabetes_sdk.models.day_stats import DayStats
 from diabetes_sdk.models.role_schema import RoleSchema
@@ -47,7 +47,6 @@ class DefaultApi:
     def create_user_user_post(
         self,
         web_user: WebUser,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -67,8 +66,6 @@ class DefaultApi:
 
         :param web_user: (required)
         :type web_user: WebUser
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -93,7 +90,6 @@ class DefaultApi:
 
         _param = self._create_user_user_post_serialize(
             web_user=web_user,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -119,7 +115,6 @@ class DefaultApi:
     def create_user_user_post_with_http_info(
         self,
         web_user: WebUser,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -139,8 +134,6 @@ class DefaultApi:
 
         :param web_user: (required)
         :type web_user: WebUser
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -165,7 +158,6 @@ class DefaultApi:
 
         _param = self._create_user_user_post_serialize(
             web_user=web_user,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -191,7 +183,6 @@ class DefaultApi:
     def create_user_user_post_without_preload_content(
         self,
         web_user: WebUser,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -211,8 +202,6 @@ class DefaultApi:
 
         :param web_user: (required)
         :type web_user: WebUser
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -237,7 +226,6 @@ class DefaultApi:
 
         _param = self._create_user_user_post_serialize(
             web_user=web_user,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -258,7 +246,6 @@ class DefaultApi:
     def _create_user_user_post_serialize(
         self,
         web_user,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -282,8 +269,6 @@ class DefaultApi:
         # process the path parameters
         # process the query parameters
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
         if web_user is not None:
@@ -314,6 +299,7 @@ class DefaultApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(
@@ -338,7 +324,6 @@ class DefaultApi:
     def get_analytics_analytics_get(
         self,
         telegram_id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -357,8 +342,6 @@ class DefaultApi:
 
         :param telegram_id: (required)
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -383,7 +366,6 @@ class DefaultApi:
 
         _param = self._get_analytics_analytics_get_serialize(
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -392,6 +374,7 @@ class DefaultApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "List[AnalyticsPoint]",
+            '403': None,
             '422': "HTTPValidationError",
         }
         response_data = self.api_client.call_api(
@@ -409,7 +392,6 @@ class DefaultApi:
     def get_analytics_analytics_get_with_http_info(
         self,
         telegram_id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -428,8 +410,6 @@ class DefaultApi:
 
         :param telegram_id: (required)
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -454,7 +434,6 @@ class DefaultApi:
 
         _param = self._get_analytics_analytics_get_serialize(
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -463,6 +442,7 @@ class DefaultApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "List[AnalyticsPoint]",
+            '403': None,
             '422': "HTTPValidationError",
         }
         response_data = self.api_client.call_api(
@@ -480,7 +460,6 @@ class DefaultApi:
     def get_analytics_analytics_get_without_preload_content(
         self,
         telegram_id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -499,8 +478,6 @@ class DefaultApi:
 
         :param telegram_id: (required)
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -525,7 +502,6 @@ class DefaultApi:
 
         _param = self._get_analytics_analytics_get_serialize(
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -534,6 +510,7 @@ class DefaultApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "List[AnalyticsPoint]",
+            '403': None,
             '422': "HTTPValidationError",
         }
         response_data = self.api_client.call_api(
@@ -546,7 +523,6 @@ class DefaultApi:
     def _get_analytics_analytics_get_serialize(
         self,
         telegram_id,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -574,8 +550,6 @@ class DefaultApi:
             _query_params.append(('telegramId', telegram_id))
             
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
 
@@ -591,6 +565,7 @@ class DefaultApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(
@@ -875,7 +850,6 @@ class DefaultApi:
     def get_stats_stats_get(
         self,
         telegram_id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -894,8 +868,6 @@ class DefaultApi:
 
         :param telegram_id: (required)
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -920,7 +892,6 @@ class DefaultApi:
 
         _param = self._get_stats_stats_get_serialize(
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -930,6 +901,7 @@ class DefaultApi:
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "DayStats",
             '204': None,
+            '403': None,
             '422': "HTTPValidationError",
         }
         response_data = self.api_client.call_api(
@@ -947,7 +919,6 @@ class DefaultApi:
     def get_stats_stats_get_with_http_info(
         self,
         telegram_id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -966,8 +937,6 @@ class DefaultApi:
 
         :param telegram_id: (required)
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -992,7 +961,6 @@ class DefaultApi:
 
         _param = self._get_stats_stats_get_serialize(
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1002,6 +970,7 @@ class DefaultApi:
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "DayStats",
             '204': None,
+            '403': None,
             '422': "HTTPValidationError",
         }
         response_data = self.api_client.call_api(
@@ -1019,7 +988,6 @@ class DefaultApi:
     def get_stats_stats_get_without_preload_content(
         self,
         telegram_id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1038,8 +1006,6 @@ class DefaultApi:
 
         :param telegram_id: (required)
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1064,7 +1030,6 @@ class DefaultApi:
 
         _param = self._get_stats_stats_get_serialize(
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1074,6 +1039,7 @@ class DefaultApi:
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "DayStats",
             '204': None,
+            '403': None,
             '422': "HTTPValidationError",
         }
         response_data = self.api_client.call_api(
@@ -1086,7 +1052,6 @@ class DefaultApi:
     def _get_stats_stats_get_serialize(
         self,
         telegram_id,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -1114,8 +1079,6 @@ class DefaultApi:
             _query_params.append(('telegramId', telegram_id))
             
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
 
@@ -1131,6 +1094,7 @@ class DefaultApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(
@@ -1154,7 +1118,6 @@ class DefaultApi:
     @validate_call
     def get_timezone_timezone_get(
         self,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1171,8 +1134,6 @@ class DefaultApi:
         """Get Timezone
 
 
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1196,7 +1157,6 @@ class DefaultApi:
         """ # noqa: E501
 
         _param = self._get_timezone_timezone_get_serialize(
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1221,7 +1181,6 @@ class DefaultApi:
     @validate_call
     def get_timezone_timezone_get_with_http_info(
         self,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1238,8 +1197,6 @@ class DefaultApi:
         """Get Timezone
 
 
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1263,7 +1220,6 @@ class DefaultApi:
         """ # noqa: E501
 
         _param = self._get_timezone_timezone_get_serialize(
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1288,7 +1244,6 @@ class DefaultApi:
     @validate_call
     def get_timezone_timezone_get_without_preload_content(
         self,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1305,8 +1260,6 @@ class DefaultApi:
         """Get Timezone
 
 
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1330,7 +1283,6 @@ class DefaultApi:
         """ # noqa: E501
 
         _param = self._get_timezone_timezone_get_serialize(
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1350,7 +1302,6 @@ class DefaultApi:
 
     def _get_timezone_timezone_get_serialize(
         self,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -1374,8 +1325,6 @@ class DefaultApi:
         # process the path parameters
         # process the query parameters
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
 
@@ -1391,6 +1340,7 @@ class DefaultApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(
@@ -1656,7 +1606,6 @@ class DefaultApi:
     @validate_call
     def profile_self_profile_self_get(
         self,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1673,8 +1622,6 @@ class DefaultApi:
         """Profile Self
 
 
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1698,7 +1645,6 @@ class DefaultApi:
         """ # noqa: E501
 
         _param = self._profile_self_profile_self_get_serialize(
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1723,7 +1669,6 @@ class DefaultApi:
     @validate_call
     def profile_self_profile_self_get_with_http_info(
         self,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1740,8 +1685,6 @@ class DefaultApi:
         """Profile Self
 
 
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1765,7 +1708,6 @@ class DefaultApi:
         """ # noqa: E501
 
         _param = self._profile_self_profile_self_get_serialize(
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1790,7 +1732,6 @@ class DefaultApi:
     @validate_call
     def profile_self_profile_self_get_without_preload_content(
         self,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1807,8 +1748,6 @@ class DefaultApi:
         """Profile Self
 
 
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1832,7 +1771,6 @@ class DefaultApi:
         """ # noqa: E501
 
         _param = self._profile_self_profile_self_get_serialize(
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1852,7 +1790,6 @@ class DefaultApi:
 
     def _profile_self_profile_self_get_serialize(
         self,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -1876,8 +1813,6 @@ class DefaultApi:
         # process the path parameters
         # process the query parameters
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
 
@@ -1893,6 +1828,7 @@ class DefaultApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(
@@ -2205,7 +2141,6 @@ class DefaultApi:
     def put_timezone_timezone_put(
         self,
         timezone: Timezone,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2224,8 +2159,6 @@ class DefaultApi:
 
         :param timezone: (required)
         :type timezone: Timezone
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2250,7 +2183,6 @@ class DefaultApi:
 
         _param = self._put_timezone_timezone_put_serialize(
             timezone=timezone,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2276,7 +2208,6 @@ class DefaultApi:
     def put_timezone_timezone_put_with_http_info(
         self,
         timezone: Timezone,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2295,8 +2226,6 @@ class DefaultApi:
 
         :param timezone: (required)
         :type timezone: Timezone
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2321,7 +2250,6 @@ class DefaultApi:
 
         _param = self._put_timezone_timezone_put_serialize(
             timezone=timezone,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2347,7 +2275,6 @@ class DefaultApi:
     def put_timezone_timezone_put_without_preload_content(
         self,
         timezone: Timezone,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2366,8 +2293,6 @@ class DefaultApi:
 
         :param timezone: (required)
         :type timezone: Timezone
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2392,7 +2317,6 @@ class DefaultApi:
 
         _param = self._put_timezone_timezone_put_serialize(
             timezone=timezone,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2413,7 +2337,6 @@ class DefaultApi:
     def _put_timezone_timezone_put_serialize(
         self,
         timezone,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -2437,8 +2360,6 @@ class DefaultApi:
         # process the path parameters
         # process the query parameters
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
         if timezone is not None:
@@ -2469,6 +2390,7 @@ class DefaultApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(

--- a/libs/py-sdk/diabetes_sdk/api/history_api.py
+++ b/libs/py-sdk/diabetes_sdk/api/history_api.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
 from pydantic import StrictStr
-from typing import Dict, List, Optional
+from typing import Dict, List
 from diabetes_sdk.models.history_record_schema_input import HistoryRecordSchemaInput
 from diabetes_sdk.models.history_record_schema_output import HistoryRecordSchemaOutput
 
@@ -42,7 +42,6 @@ class HistoryApi:
     @validate_call
     def history_get(
         self,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -60,8 +59,6 @@ class HistoryApi:
 
         Return history records for the authenticated user.
 
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -85,7 +82,6 @@ class HistoryApi:
         """ # noqa: E501
 
         _param = self._history_get_serialize(
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -110,7 +106,6 @@ class HistoryApi:
     @validate_call
     def history_get_with_http_info(
         self,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -128,8 +123,6 @@ class HistoryApi:
 
         Return history records for the authenticated user.
 
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -153,7 +146,6 @@ class HistoryApi:
         """ # noqa: E501
 
         _param = self._history_get_serialize(
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -178,7 +170,6 @@ class HistoryApi:
     @validate_call
     def history_get_without_preload_content(
         self,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -196,8 +187,6 @@ class HistoryApi:
 
         Return history records for the authenticated user.
 
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -221,7 +210,6 @@ class HistoryApi:
         """ # noqa: E501
 
         _param = self._history_get_serialize(
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -241,7 +229,6 @@ class HistoryApi:
 
     def _history_get_serialize(
         self,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -265,8 +252,6 @@ class HistoryApi:
         # process the path parameters
         # process the query parameters
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
 
@@ -282,6 +267,7 @@ class HistoryApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(
@@ -306,7 +292,6 @@ class HistoryApi:
     def history_id_delete(
         self,
         id: StrictStr,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -326,8 +311,6 @@ class HistoryApi:
 
         :param id: (required)
         :type id: str
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -352,7 +335,6 @@ class HistoryApi:
 
         _param = self._history_id_delete_serialize(
             id=id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -378,7 +360,6 @@ class HistoryApi:
     def history_id_delete_with_http_info(
         self,
         id: StrictStr,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -398,8 +379,6 @@ class HistoryApi:
 
         :param id: (required)
         :type id: str
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -424,7 +403,6 @@ class HistoryApi:
 
         _param = self._history_id_delete_serialize(
             id=id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -450,7 +428,6 @@ class HistoryApi:
     def history_id_delete_without_preload_content(
         self,
         id: StrictStr,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -470,8 +447,6 @@ class HistoryApi:
 
         :param id: (required)
         :type id: str
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -496,7 +471,6 @@ class HistoryApi:
 
         _param = self._history_id_delete_serialize(
             id=id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -517,7 +491,6 @@ class HistoryApi:
     def _history_id_delete_serialize(
         self,
         id,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -543,8 +516,6 @@ class HistoryApi:
             _path_params['id'] = id
         # process the query parameters
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
 
@@ -560,6 +531,7 @@ class HistoryApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(
@@ -584,7 +556,6 @@ class HistoryApi:
     def history_post(
         self,
         history_record_schema_input: HistoryRecordSchemaInput,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -604,8 +575,6 @@ class HistoryApi:
 
         :param history_record_schema_input: (required)
         :type history_record_schema_input: HistoryRecordSchemaInput
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -630,7 +599,6 @@ class HistoryApi:
 
         _param = self._history_post_serialize(
             history_record_schema_input=history_record_schema_input,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -656,7 +624,6 @@ class HistoryApi:
     def history_post_with_http_info(
         self,
         history_record_schema_input: HistoryRecordSchemaInput,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -676,8 +643,6 @@ class HistoryApi:
 
         :param history_record_schema_input: (required)
         :type history_record_schema_input: HistoryRecordSchemaInput
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -702,7 +667,6 @@ class HistoryApi:
 
         _param = self._history_post_serialize(
             history_record_schema_input=history_record_schema_input,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -728,7 +692,6 @@ class HistoryApi:
     def history_post_without_preload_content(
         self,
         history_record_schema_input: HistoryRecordSchemaInput,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -748,8 +711,6 @@ class HistoryApi:
 
         :param history_record_schema_input: (required)
         :type history_record_schema_input: HistoryRecordSchemaInput
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -774,7 +735,6 @@ class HistoryApi:
 
         _param = self._history_post_serialize(
             history_record_schema_input=history_record_schema_input,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -795,7 +755,6 @@ class HistoryApi:
     def _history_post_serialize(
         self,
         history_record_schema_input,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -819,8 +778,6 @@ class HistoryApi:
         # process the path parameters
         # process the query parameters
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
         if history_record_schema_input is not None:
@@ -851,6 +808,7 @@ class HistoryApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(

--- a/libs/py-sdk/diabetes_sdk/api/profiles_api.py
+++ b/libs/py-sdk/diabetes_sdk/api/profiles_api.py
@@ -16,7 +16,7 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import StrictInt, StrictStr
+from pydantic import StrictInt
 from typing import Optional
 from diabetes_sdk.models.profile_schema import ProfileSchema
 
@@ -42,7 +42,6 @@ class ProfilesApi:
     def profiles_get(
         self,
         telegram_id: Optional[StrictInt] = None,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -61,8 +60,6 @@ class ProfilesApi:
 
         :param telegram_id:
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -87,7 +84,6 @@ class ProfilesApi:
 
         _param = self._profiles_get_serialize(
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -97,6 +93,7 @@ class ProfilesApi:
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ProfileSchema",
             '422': "HTTPValidationError",
+            '404': None,
         }
         response_data = self.api_client.call_api(
             *_param,
@@ -113,7 +110,6 @@ class ProfilesApi:
     def profiles_get_with_http_info(
         self,
         telegram_id: Optional[StrictInt] = None,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -132,8 +128,6 @@ class ProfilesApi:
 
         :param telegram_id:
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -158,7 +152,6 @@ class ProfilesApi:
 
         _param = self._profiles_get_serialize(
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -168,6 +161,7 @@ class ProfilesApi:
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ProfileSchema",
             '422': "HTTPValidationError",
+            '404': None,
         }
         response_data = self.api_client.call_api(
             *_param,
@@ -184,7 +178,6 @@ class ProfilesApi:
     def profiles_get_without_preload_content(
         self,
         telegram_id: Optional[StrictInt] = None,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -203,8 +196,6 @@ class ProfilesApi:
 
         :param telegram_id:
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -229,7 +220,6 @@ class ProfilesApi:
 
         _param = self._profiles_get_serialize(
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -239,6 +229,7 @@ class ProfilesApi:
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ProfileSchema",
             '422': "HTTPValidationError",
+            '404': None,
         }
         response_data = self.api_client.call_api(
             *_param,
@@ -250,7 +241,6 @@ class ProfilesApi:
     def _profiles_get_serialize(
         self,
         telegram_id,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -278,8 +268,6 @@ class ProfilesApi:
             _query_params.append(('telegramId', telegram_id))
             
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
 
@@ -295,6 +283,7 @@ class ProfilesApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(
@@ -319,7 +308,6 @@ class ProfilesApi:
     def profiles_post(
         self,
         profile_schema: ProfileSchema,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -338,8 +326,6 @@ class ProfilesApi:
 
         :param profile_schema: (required)
         :type profile_schema: ProfileSchema
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -364,7 +350,6 @@ class ProfilesApi:
 
         _param = self._profiles_post_serialize(
             profile_schema=profile_schema,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -374,6 +359,7 @@ class ProfilesApi:
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ProfileSchema",
             '422': "HTTPValidationError",
+            '404': None,
         }
         response_data = self.api_client.call_api(
             *_param,
@@ -390,7 +376,6 @@ class ProfilesApi:
     def profiles_post_with_http_info(
         self,
         profile_schema: ProfileSchema,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -409,8 +394,6 @@ class ProfilesApi:
 
         :param profile_schema: (required)
         :type profile_schema: ProfileSchema
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -435,7 +418,6 @@ class ProfilesApi:
 
         _param = self._profiles_post_serialize(
             profile_schema=profile_schema,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -445,6 +427,7 @@ class ProfilesApi:
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ProfileSchema",
             '422': "HTTPValidationError",
+            '404': None,
         }
         response_data = self.api_client.call_api(
             *_param,
@@ -461,7 +444,6 @@ class ProfilesApi:
     def profiles_post_without_preload_content(
         self,
         profile_schema: ProfileSchema,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -480,8 +462,6 @@ class ProfilesApi:
 
         :param profile_schema: (required)
         :type profile_schema: ProfileSchema
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -506,7 +486,6 @@ class ProfilesApi:
 
         _param = self._profiles_post_serialize(
             profile_schema=profile_schema,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -516,6 +495,7 @@ class ProfilesApi:
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "ProfileSchema",
             '422': "HTTPValidationError",
+            '404': None,
         }
         response_data = self.api_client.call_api(
             *_param,
@@ -527,7 +507,6 @@ class ProfilesApi:
     def _profiles_post_serialize(
         self,
         profile_schema,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -551,8 +530,6 @@ class ProfilesApi:
         # process the path parameters
         # process the query parameters
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
         if profile_schema is not None:
@@ -583,6 +560,7 @@ class ProfilesApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(

--- a/libs/py-sdk/diabetes_sdk/api/reminders_api.py
+++ b/libs/py-sdk/diabetes_sdk/api/reminders_api.py
@@ -16,8 +16,8 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import StrictInt, StrictStr
-from typing import Any, Dict, List, Optional
+from pydantic import StrictInt
+from typing import Any, Dict, List
 from diabetes_sdk.models.reminder_schema import ReminderSchema
 
 from diabetes_sdk.api_client import ApiClient, RequestSerialized
@@ -43,7 +43,6 @@ class RemindersApi:
         self,
         telegram_id: StrictInt,
         id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -64,8 +63,6 @@ class RemindersApi:
         :type telegram_id: int
         :param id: (required)
         :type id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -91,7 +88,6 @@ class RemindersApi:
         _param = self._reminders_delete_serialize(
             telegram_id=telegram_id,
             id=id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -119,7 +115,6 @@ class RemindersApi:
         self,
         telegram_id: StrictInt,
         id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -140,8 +135,6 @@ class RemindersApi:
         :type telegram_id: int
         :param id: (required)
         :type id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -167,7 +160,6 @@ class RemindersApi:
         _param = self._reminders_delete_serialize(
             telegram_id=telegram_id,
             id=id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -195,7 +187,6 @@ class RemindersApi:
         self,
         telegram_id: StrictInt,
         id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -216,8 +207,6 @@ class RemindersApi:
         :type telegram_id: int
         :param id: (required)
         :type id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -243,7 +232,6 @@ class RemindersApi:
         _param = self._reminders_delete_serialize(
             telegram_id=telegram_id,
             id=id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -266,7 +254,6 @@ class RemindersApi:
         self,
         telegram_id,
         id,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -298,8 +285,6 @@ class RemindersApi:
             _query_params.append(('id', id))
             
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
 
@@ -315,6 +300,7 @@ class RemindersApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(
@@ -339,7 +325,6 @@ class RemindersApi:
     def reminders_get(
         self,
         telegram_id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -358,8 +343,6 @@ class RemindersApi:
 
         :param telegram_id: (required)
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -384,7 +367,6 @@ class RemindersApi:
 
         _param = self._reminders_get_serialize(
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -411,7 +393,6 @@ class RemindersApi:
     def reminders_get_with_http_info(
         self,
         telegram_id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -430,8 +411,6 @@ class RemindersApi:
 
         :param telegram_id: (required)
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -456,7 +435,6 @@ class RemindersApi:
 
         _param = self._reminders_get_serialize(
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -483,7 +461,6 @@ class RemindersApi:
     def reminders_get_without_preload_content(
         self,
         telegram_id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -502,8 +479,6 @@ class RemindersApi:
 
         :param telegram_id: (required)
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -528,7 +503,6 @@ class RemindersApi:
 
         _param = self._reminders_get_serialize(
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -550,7 +524,6 @@ class RemindersApi:
     def _reminders_get_serialize(
         self,
         telegram_id,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -578,8 +551,6 @@ class RemindersApi:
             _query_params.append(('telegramId', telegram_id))
             
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
 
@@ -595,6 +566,7 @@ class RemindersApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(
@@ -620,7 +592,6 @@ class RemindersApi:
         self,
         id: StrictInt,
         telegram_id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -641,8 +612,6 @@ class RemindersApi:
         :type id: int
         :param telegram_id: (required)
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -668,7 +637,6 @@ class RemindersApi:
         _param = self._reminders_id_get_serialize(
             id=id,
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -696,7 +664,6 @@ class RemindersApi:
         self,
         id: StrictInt,
         telegram_id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -717,8 +684,6 @@ class RemindersApi:
         :type id: int
         :param telegram_id: (required)
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -744,7 +709,6 @@ class RemindersApi:
         _param = self._reminders_id_get_serialize(
             id=id,
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -772,7 +736,6 @@ class RemindersApi:
         self,
         id: StrictInt,
         telegram_id: StrictInt,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -793,8 +756,6 @@ class RemindersApi:
         :type id: int
         :param telegram_id: (required)
         :type telegram_id: int
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -820,7 +781,6 @@ class RemindersApi:
         _param = self._reminders_id_get_serialize(
             id=id,
             telegram_id=telegram_id,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -843,7 +803,6 @@ class RemindersApi:
         self,
         id,
         telegram_id,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -873,8 +832,6 @@ class RemindersApi:
             _query_params.append(('telegramId', telegram_id))
             
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
 
@@ -890,6 +847,7 @@ class RemindersApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(
@@ -914,7 +872,6 @@ class RemindersApi:
     def reminders_patch(
         self,
         reminder: ReminderSchema,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -933,8 +890,6 @@ class RemindersApi:
 
         :param reminder: (required)
         :type reminder: ReminderSchema
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -959,7 +914,6 @@ class RemindersApi:
 
         _param = self._reminders_patch_serialize(
             reminder=reminder,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -985,7 +939,6 @@ class RemindersApi:
     def reminders_patch_with_http_info(
         self,
         reminder: ReminderSchema,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1004,8 +957,6 @@ class RemindersApi:
 
         :param reminder: (required)
         :type reminder: ReminderSchema
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1030,7 +981,6 @@ class RemindersApi:
 
         _param = self._reminders_patch_serialize(
             reminder=reminder,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1056,7 +1006,6 @@ class RemindersApi:
     def reminders_patch_without_preload_content(
         self,
         reminder: ReminderSchema,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1075,8 +1024,6 @@ class RemindersApi:
 
         :param reminder: (required)
         :type reminder: ReminderSchema
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1101,7 +1048,6 @@ class RemindersApi:
 
         _param = self._reminders_patch_serialize(
             reminder=reminder,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1122,7 +1068,6 @@ class RemindersApi:
     def _reminders_patch_serialize(
         self,
         reminder,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -1146,8 +1091,6 @@ class RemindersApi:
         # process the path parameters
         # process the query parameters
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
         if reminder is not None:
@@ -1178,6 +1121,7 @@ class RemindersApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(
@@ -1202,7 +1146,6 @@ class RemindersApi:
     def reminders_post(
         self,
         reminder: ReminderSchema,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1221,8 +1164,6 @@ class RemindersApi:
 
         :param reminder: (required)
         :type reminder: ReminderSchema
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1247,7 +1188,6 @@ class RemindersApi:
 
         _param = self._reminders_post_serialize(
             reminder=reminder,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1273,7 +1213,6 @@ class RemindersApi:
     def reminders_post_with_http_info(
         self,
         reminder: ReminderSchema,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1292,8 +1231,6 @@ class RemindersApi:
 
         :param reminder: (required)
         :type reminder: ReminderSchema
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1318,7 +1255,6 @@ class RemindersApi:
 
         _param = self._reminders_post_serialize(
             reminder=reminder,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1344,7 +1280,6 @@ class RemindersApi:
     def reminders_post_without_preload_content(
         self,
         reminder: ReminderSchema,
-        x_telegram_init_data: Optional[StrictStr] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1363,8 +1298,6 @@ class RemindersApi:
 
         :param reminder: (required)
         :type reminder: ReminderSchema
-        :param x_telegram_init_data:
-        :type x_telegram_init_data: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1389,7 +1322,6 @@ class RemindersApi:
 
         _param = self._reminders_post_serialize(
             reminder=reminder,
-            x_telegram_init_data=x_telegram_init_data,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1410,7 +1342,6 @@ class RemindersApi:
     def _reminders_post_serialize(
         self,
         reminder,
-        x_telegram_init_data,
         _request_auth,
         _content_type,
         _headers,
@@ -1434,8 +1365,6 @@ class RemindersApi:
         # process the path parameters
         # process the query parameters
         # process the header parameters
-        if x_telegram_init_data is not None:
-            _header_params['X-Telegram-Init-Data'] = x_telegram_init_data
         # process the form parameters
         # process the body parameter
         if reminder is not None:
@@ -1466,6 +1395,7 @@ class RemindersApi:
 
         # authentication setting
         _auth_settings: List[str] = [
+            'TelegramInitData'
         ]
 
         return self.api_client.param_serialize(

--- a/libs/py-sdk/diabetes_sdk/configuration.py
+++ b/libs/py-sdk/diabetes_sdk/configuration.py
@@ -113,6 +113,7 @@ HTTPSignatureAuthSetting = TypedDict(
 AuthSettings = TypedDict(
     "AuthSettings",
     {
+        "TelegramInitData": APIKeyAuthSetting,
     },
     total=False,
 )
@@ -163,6 +164,26 @@ class Configuration:
     :param ca_cert_data: verify the peer using concatenated CA certificate data
       in PEM (str) or DER (bytes) format.
 
+    :Example:
+
+    API Key Authentication Example.
+    Given the following security scheme in the OpenAPI specification:
+      components:
+        securitySchemes:
+          cookieAuth:         # name for the security scheme
+            type: apiKey
+            in: cookie
+            name: JSESSIONID  # cookie name
+
+    You can programmatically set the cookie:
+
+conf = diabetes_sdk.Configuration(
+    api_key={'cookieAuth': 'abc123'}
+    api_key_prefix={'cookieAuth': 'JSESSIONID'}
+)
+
+    The following cookie will be added to the HTTP request:
+       Cookie: JSESSIONID abc123
     """
 
     _default: ClassVar[Optional[Self]] = None
@@ -490,6 +511,15 @@ class Configuration:
         :return: The Auth Settings information dict.
         """
         auth: AuthSettings = {}
+        if 'TelegramInitData' in self.api_key:
+            auth['TelegramInitData'] = {
+                'type': 'api_key',
+                'in': 'header',
+                'key': 'X-Telegram-Init-Data',
+                'value': self.get_api_key_with_prefix(
+                    'TelegramInitData',
+                ),
+            }
         return auth
 
     def to_debug_report(self) -> str:

--- a/libs/py-sdk/docs/DefaultApi.md
+++ b/libs/py-sdk/docs/DefaultApi.md
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 
 
 # **create_user_user_post**
-> Dict[str, str] create_user_user_post(web_user, x_telegram_init_data=x_telegram_init_data)
+> Dict[str, str] create_user_user_post(web_user)
 
 Create User
 
@@ -24,6 +24,7 @@ Ensure a user exists in the database.
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -37,17 +38,26 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.DefaultApi(api_client)
     web_user = diabetes_sdk.WebUser() # WebUser | 
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Create User
-        api_response = api_instance.create_user_user_post(web_user, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.create_user_user_post(web_user)
         print("The response of DefaultApi->create_user_user_post:\n")
         pprint(api_response)
     except Exception as e:
@@ -62,7 +72,6 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **web_user** | [**WebUser**](WebUser.md)|  | 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -70,7 +79,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -87,12 +96,13 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **get_analytics_analytics_get**
-> List[AnalyticsPoint] get_analytics_analytics_get(telegram_id, x_telegram_init_data=x_telegram_init_data)
+> List[AnalyticsPoint] get_analytics_analytics_get(telegram_id)
 
 Get Analytics
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -106,17 +116,26 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.DefaultApi(api_client)
     telegram_id = 56 # int | 
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Get Analytics
-        api_response = api_instance.get_analytics_analytics_get(telegram_id, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.get_analytics_analytics_get(telegram_id)
         print("The response of DefaultApi->get_analytics_analytics_get:\n")
         pprint(api_response)
     except Exception as e:
@@ -131,7 +150,6 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **telegram_id** | **int**|  | 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -139,7 +157,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -151,6 +169,7 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | Successful Response |  -  |
+**403** | Forbidden |  -  |
 **422** | Validation Error |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
@@ -223,12 +242,13 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **get_stats_stats_get**
-> DayStats get_stats_stats_get(telegram_id, x_telegram_init_data=x_telegram_init_data)
+> DayStats get_stats_stats_get(telegram_id)
 
 Get Stats
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -242,17 +262,26 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.DefaultApi(api_client)
     telegram_id = 56 # int | 
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Get Stats
-        api_response = api_instance.get_stats_stats_get(telegram_id, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.get_stats_stats_get(telegram_id)
         print("The response of DefaultApi->get_stats_stats_get:\n")
         pprint(api_response)
     except Exception as e:
@@ -267,7 +296,6 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **telegram_id** | **int**|  | 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -275,7 +303,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -288,17 +316,19 @@ No authorization required
 |-------------|-------------|------------------|
 **200** | Successful Response. Returns statistics for the day. |  -  |
 **204** | No Content - no statistics available. |  -  |
+**403** | Forbidden |  -  |
 **422** | Validation Error |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **get_timezone_timezone_get**
-> Dict[str, str] get_timezone_timezone_get(x_telegram_init_data=x_telegram_init_data)
+> Dict[str, str] get_timezone_timezone_get()
 
 Get Timezone
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -311,16 +341,25 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.DefaultApi(api_client)
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Get Timezone
-        api_response = api_instance.get_timezone_timezone_get(x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.get_timezone_timezone_get()
         print("The response of DefaultApi->get_timezone_timezone_get:\n")
         pprint(api_response)
     except Exception as e:
@@ -331,10 +370,7 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **x_telegram_init_data** | **str**|  | [optional] 
+This endpoint does not need any parameter.
 
 ### Return type
 
@@ -342,7 +378,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -420,12 +456,13 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **profile_self_profile_self_get**
-> UserContext profile_self_profile_self_get(x_telegram_init_data=x_telegram_init_data)
+> UserContext profile_self_profile_self_get()
 
 Profile Self
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -439,16 +476,25 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.DefaultApi(api_client)
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Profile Self
-        api_response = api_instance.profile_self_profile_self_get(x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.profile_self_profile_self_get()
         print("The response of DefaultApi->profile_self_profile_self_get:\n")
         pprint(api_response)
     except Exception as e:
@@ -459,10 +505,7 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **x_telegram_init_data** | **str**|  | [optional] 
+This endpoint does not need any parameter.
 
 ### Return type
 
@@ -470,7 +513,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -556,12 +599,13 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **put_timezone_timezone_put**
-> Dict[str, str] put_timezone_timezone_put(timezone, x_telegram_init_data=x_telegram_init_data)
+> Dict[str, str] put_timezone_timezone_put(timezone)
 
 Put Timezone
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -575,17 +619,26 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.DefaultApi(api_client)
     timezone = diabetes_sdk.Timezone() # Timezone | 
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Put Timezone
-        api_response = api_instance.put_timezone_timezone_put(timezone, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.put_timezone_timezone_put(timezone)
         print("The response of DefaultApi->put_timezone_timezone_put:\n")
         pprint(api_response)
     except Exception as e:
@@ -600,7 +653,6 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **timezone** | [**Timezone**](Timezone.md)|  | 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -608,7 +660,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 

--- a/libs/py-sdk/docs/HistoryApi.md
+++ b/libs/py-sdk/docs/HistoryApi.md
@@ -10,7 +10,7 @@ Method | HTTP request | Description
 
 
 # **history_get**
-> List[HistoryRecordSchemaOutput] history_get(x_telegram_init_data=x_telegram_init_data)
+> List[HistoryRecordSchemaOutput] history_get()
 
 Get History
 
@@ -18,6 +18,7 @@ Return history records for the authenticated user.
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -31,16 +32,25 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.HistoryApi(api_client)
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Get History
-        api_response = api_instance.history_get(x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.history_get()
         print("The response of HistoryApi->history_get:\n")
         pprint(api_response)
     except Exception as e:
@@ -51,10 +61,7 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 
 ### Parameters
 
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **x_telegram_init_data** | **str**|  | [optional] 
+This endpoint does not need any parameter.
 
 ### Return type
 
@@ -62,7 +69,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -79,7 +86,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **history_id_delete**
-> Dict[str, str] history_id_delete(id, x_telegram_init_data=x_telegram_init_data)
+> Dict[str, str] history_id_delete(id)
 
 Delete History
 
@@ -87,6 +94,7 @@ Delete a history record after verifying ownership.
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -99,17 +107,26 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.HistoryApi(api_client)
     id = 'id_example' # str | 
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Delete History
-        api_response = api_instance.history_id_delete(id, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.history_id_delete(id)
         print("The response of HistoryApi->history_id_delete:\n")
         pprint(api_response)
     except Exception as e:
@@ -124,7 +141,6 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **str**|  | 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -132,7 +148,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -149,7 +165,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **history_post**
-> Dict[str, str] history_post(history_record_schema_input, x_telegram_init_data=x_telegram_init_data)
+> Dict[str, str] history_post(history_record_schema_input)
 
 Post History
 
@@ -157,6 +173,7 @@ Save or update a history record in the database.
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -170,17 +187,26 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.HistoryApi(api_client)
     history_record_schema_input = diabetes_sdk.HistoryRecordSchemaInput() # HistoryRecordSchemaInput | 
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Post History
-        api_response = api_instance.history_post(history_record_schema_input, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.history_post(history_record_schema_input)
         print("The response of HistoryApi->history_post:\n")
         pprint(api_response)
     except Exception as e:
@@ -195,7 +221,6 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **history_record_schema_input** | [**HistoryRecordSchemaInput**](HistoryRecordSchemaInput.md)|  | 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -203,7 +228,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 

--- a/libs/py-sdk/docs/ProfilesApi.md
+++ b/libs/py-sdk/docs/ProfilesApi.md
@@ -9,12 +9,13 @@ Method | HTTP request | Description
 
 
 # **profiles_get**
-> ProfileSchema profiles_get(telegram_id=telegram_id, x_telegram_init_data=x_telegram_init_data)
+> ProfileSchema profiles_get(telegram_id=telegram_id)
 
 Profiles Get
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -28,17 +29,26 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.ProfilesApi(api_client)
     telegram_id = 56 # int |  (optional)
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Profiles Get
-        api_response = api_instance.profiles_get(telegram_id=telegram_id, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.profiles_get(telegram_id=telegram_id)
         print("The response of ProfilesApi->profiles_get:\n")
         pprint(api_response)
     except Exception as e:
@@ -53,7 +63,6 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **telegram_id** | **int**|  | [optional] 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -61,7 +70,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -74,16 +83,18 @@ No authorization required
 |-------------|-------------|------------------|
 **200** | Successful Response. Returns profile. |  -  |
 **422** | Validation Error |  -  |
+**404** | profile not found |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **profiles_post**
-> ProfileSchema profiles_post(profile_schema, x_telegram_init_data=x_telegram_init_data)
+> ProfileSchema profiles_post(profile_schema)
 
 Profiles Post
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -97,17 +108,26 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.ProfilesApi(api_client)
     profile_schema = diabetes_sdk.ProfileSchema() # ProfileSchema | 
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Profiles Post
-        api_response = api_instance.profiles_post(profile_schema, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.profiles_post(profile_schema)
         print("The response of ProfilesApi->profiles_post:\n")
         pprint(api_response)
     except Exception as e:
@@ -122,7 +142,6 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **profile_schema** | [**ProfileSchema**](ProfileSchema.md)|  | 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -130,7 +149,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -143,6 +162,7 @@ No authorization required
 |-------------|-------------|------------------|
 **200** | Successful Response. Returns profile. |  -  |
 **422** | Validation Error |  -  |
+**404** | profile not found |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/libs/py-sdk/docs/RemindersApi.md
+++ b/libs/py-sdk/docs/RemindersApi.md
@@ -12,12 +12,13 @@ Method | HTTP request | Description
 
 
 # **reminders_delete**
-> Dict[str, object] reminders_delete(telegram_id, id, x_telegram_init_data=x_telegram_init_data)
+> Dict[str, object] reminders_delete(telegram_id, id)
 
 Reminders Delete
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -30,6 +31,16 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
@@ -37,11 +48,10 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
     api_instance = diabetes_sdk.RemindersApi(api_client)
     telegram_id = 56 # int | 
     id = 56 # int | 
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Reminders Delete
-        api_response = api_instance.reminders_delete(telegram_id, id, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.reminders_delete(telegram_id, id)
         print("The response of RemindersApi->reminders_delete:\n")
         pprint(api_response)
     except Exception as e:
@@ -57,7 +67,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **telegram_id** | **int**|  | 
  **id** | **int**|  | 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -65,7 +74,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -83,12 +92,13 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **reminders_get**
-> List[ReminderSchema] reminders_get(telegram_id, x_telegram_init_data=x_telegram_init_data)
+> List[ReminderSchema] reminders_get(telegram_id)
 
 Reminders Get
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -102,17 +112,26 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.RemindersApi(api_client)
     telegram_id = 56 # int | 
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Reminders Get
-        api_response = api_instance.reminders_get(telegram_id, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.reminders_get(telegram_id)
         print("The response of RemindersApi->reminders_get:\n")
         pprint(api_response)
     except Exception as e:
@@ -127,7 +146,6 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **telegram_id** | **int**|  | 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -135,7 +153,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -153,12 +171,13 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **reminders_id_get**
-> ReminderSchema reminders_id_get(id, telegram_id, x_telegram_init_data=x_telegram_init_data)
+> ReminderSchema reminders_id_get(id, telegram_id)
 
 Reminders Id Get
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -172,6 +191,16 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
@@ -179,11 +208,10 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
     api_instance = diabetes_sdk.RemindersApi(api_client)
     id = 56 # int | 
     telegram_id = 56 # int | 
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Reminders Id Get
-        api_response = api_instance.reminders_id_get(id, telegram_id, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.reminders_id_get(id, telegram_id)
         print("The response of RemindersApi->reminders_id_get:\n")
         pprint(api_response)
     except Exception as e:
@@ -199,7 +227,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **int**|  | 
  **telegram_id** | **int**|  | 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -207,7 +234,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -225,12 +252,13 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **reminders_patch**
-> Dict[str, object] reminders_patch(reminder, x_telegram_init_data=x_telegram_init_data)
+> Dict[str, object] reminders_patch(reminder)
 
 Reminders Patch
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -244,17 +272,26 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.RemindersApi(api_client)
     reminder = diabetes_sdk.ReminderSchema() # ReminderSchema | 
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Reminders Patch
-        api_response = api_instance.reminders_patch(reminder, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.reminders_patch(reminder)
         print("The response of RemindersApi->reminders_patch:\n")
         pprint(api_response)
     except Exception as e:
@@ -269,7 +306,6 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **reminder** | [**ReminderSchema**](ReminderSchema.md)|  | 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -277,7 +313,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 
@@ -294,12 +330,13 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **reminders_post**
-> Dict[str, object] reminders_post(reminder, x_telegram_init_data=x_telegram_init_data)
+> Dict[str, object] reminders_post(reminder)
 
 Reminders Post
 
 ### Example
 
+* Api Key Authentication (TelegramInitData):
 
 ```python
 import diabetes_sdk
@@ -313,17 +350,26 @@ configuration = diabetes_sdk.Configuration(
     host = "http://localhost"
 )
 
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure API key authorization: TelegramInitData
+configuration.api_key['TelegramInitData'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['TelegramInitData'] = 'Bearer'
 
 # Enter a context with an instance of the API client
 with diabetes_sdk.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = diabetes_sdk.RemindersApi(api_client)
     reminder = diabetes_sdk.ReminderSchema() # ReminderSchema | 
-    x_telegram_init_data = 'x_telegram_init_data_example' # str |  (optional)
 
     try:
         # Reminders Post
-        api_response = api_instance.reminders_post(reminder, x_telegram_init_data=x_telegram_init_data)
+        api_response = api_instance.reminders_post(reminder)
         print("The response of RemindersApi->reminders_post:\n")
         pprint(api_response)
     except Exception as e:
@@ -338,7 +384,6 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **reminder** | [**ReminderSchema**](ReminderSchema.md)|  | 
- **x_telegram_init_data** | **str**|  | [optional] 
 
 ### Return type
 
@@ -346,7 +391,7 @@ Name | Type | Description  | Notes
 
 ### Authorization
 
-No authorization required
+[TelegramInitData](../README.md#TelegramInitData)
 
 ### HTTP request headers
 

--- a/libs/ts-sdk/apis/DefaultApi.ts
+++ b/libs/ts-sdk/apis/DefaultApi.ts
@@ -42,12 +42,10 @@ import {
 
 export interface CreateUserUserPostRequest {
     webUser: WebUser;
-    xTelegramInitData?: string | null;
 }
 
 export interface GetAnalyticsAnalyticsGetRequest {
     telegramId: number;
-    xTelegramInitData?: string | null;
 }
 
 export interface GetRoleUserUserIdRoleGetRequest {
@@ -56,15 +54,6 @@ export interface GetRoleUserUserIdRoleGetRequest {
 
 export interface GetStatsStatsGetRequest {
     telegramId: number;
-    xTelegramInitData?: string | null;
-}
-
-export interface GetTimezoneTimezoneGetRequest {
-    xTelegramInitData?: string | null;
-}
-
-export interface ProfileSelfProfileSelfGetRequest {
-    xTelegramInitData?: string | null;
 }
 
 export interface PutRoleUserUserIdRolePutRequest {
@@ -74,7 +63,6 @@ export interface PutRoleUserUserIdRolePutRequest {
 
 export interface PutTimezoneTimezonePutRequest {
     timezone: Timezone;
-    xTelegramInitData?: string | null;
 }
 
 /**
@@ -100,8 +88,8 @@ export class DefaultApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -146,8 +134,8 @@ export class DefaultApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -227,8 +215,8 @@ export class DefaultApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -262,13 +250,13 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Get Timezone
      */
-    async getTimezoneTimezoneGetRaw(requestParameters: GetTimezoneTimezoneGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string; }>> {
+    async getTimezoneTimezoneGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -287,8 +275,8 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Get Timezone
      */
-    async getTimezoneTimezoneGet(requestParameters: GetTimezoneTimezoneGetRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string; }> {
-        const response = await this.getTimezoneTimezoneGetRaw(requestParameters, initOverrides);
+    async getTimezoneTimezoneGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string; }> {
+        const response = await this.getTimezoneTimezoneGetRaw(initOverrides);
         return await response.value();
     }
 
@@ -324,13 +312,13 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Profile Self
      */
-    async profileSelfProfileSelfGetRaw(requestParameters: ProfileSelfProfileSelfGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserContext>> {
+    async profileSelfProfileSelfGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserContext>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -349,8 +337,8 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Profile Self
      */
-    async profileSelfProfileSelfGet(requestParameters: ProfileSelfProfileSelfGetRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<UserContext> {
-        const response = await this.profileSelfProfileSelfGetRaw(requestParameters, initOverrides);
+    async profileSelfProfileSelfGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<UserContext> {
+        const response = await this.profileSelfProfileSelfGetRaw(initOverrides);
         return await response.value();
     }
 
@@ -418,8 +406,8 @@ export class DefaultApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 

--- a/libs/ts-sdk/apis/HistoryApi.ts
+++ b/libs/ts-sdk/apis/HistoryApi.ts
@@ -28,18 +28,12 @@ import {
     HistoryRecordSchemaOutputToJSON,
 } from '../models/index';
 
-export interface HistoryGetRequest {
-    xTelegramInitData?: string | null;
-}
-
 export interface HistoryIdDeleteRequest {
     id: string;
-    xTelegramInitData?: string | null;
 }
 
 export interface HistoryPostRequest {
     historyRecordSchemaInput: HistoryRecordSchemaInput;
-    xTelegramInitData?: string | null;
 }
 
 /**
@@ -51,13 +45,13 @@ export class HistoryApi extends runtime.BaseAPI {
      * Return history records for the authenticated user.
      * Get History
      */
-    async historyGetRaw(requestParameters: HistoryGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<HistoryRecordSchemaOutput>>> {
+    async historyGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<HistoryRecordSchemaOutput>>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -77,8 +71,8 @@ export class HistoryApi extends runtime.BaseAPI {
      * Return history records for the authenticated user.
      * Get History
      */
-    async historyGet(requestParameters: HistoryGetRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<HistoryRecordSchemaOutput>> {
-        const response = await this.historyGetRaw(requestParameters, initOverrides);
+    async historyGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<HistoryRecordSchemaOutput>> {
+        const response = await this.historyGetRaw(initOverrides);
         return await response.value();
     }
 
@@ -98,8 +92,8 @@ export class HistoryApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -143,8 +137,8 @@ export class HistoryApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 

--- a/libs/ts-sdk/apis/ProfilesApi.ts
+++ b/libs/ts-sdk/apis/ProfilesApi.ts
@@ -27,12 +27,10 @@ import {
 
 export interface ProfilesGetRequest {
     telegramId?: number;
-    xTelegramInitData?: string | null;
 }
 
 export interface ProfilesPostRequest {
     profileSchema: ProfileSchema;
-    xTelegramInitData?: string | null;
 }
 
 /**
@@ -52,8 +50,8 @@ export class ProfilesApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -94,8 +92,8 @@ export class ProfilesApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 

--- a/libs/ts-sdk/apis/RemindersApi.ts
+++ b/libs/ts-sdk/apis/RemindersApi.ts
@@ -28,28 +28,23 @@ import {
 export interface RemindersDeleteRequest {
     telegramId: number;
     id: number;
-    xTelegramInitData?: string | null;
 }
 
 export interface RemindersGetRequest {
     telegramId: number;
-    xTelegramInitData?: string | null;
 }
 
 export interface RemindersIdGetRequest {
     id: number;
     telegramId: number;
-    xTelegramInitData?: string | null;
 }
 
 export interface RemindersPatchRequest {
     reminder: ReminderSchema;
-    xTelegramInitData?: string | null;
 }
 
 export interface RemindersPostRequest {
     reminder: ReminderSchema;
-    xTelegramInitData?: string | null;
 }
 
 /**
@@ -87,8 +82,8 @@ export class RemindersApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -131,8 +126,8 @@ export class RemindersApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -182,8 +177,8 @@ export class RemindersApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -225,8 +220,8 @@ export class RemindersApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 
@@ -268,8 +263,8 @@ export class RemindersApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (requestParameters['xTelegramInitData'] != null) {
-            headerParameters['X-Telegram-Init-Data'] = String(requestParameters['xTelegramInitData']);
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // TelegramInitData authentication
         }
 
 


### PR DESCRIPTION
## Summary
- add TelegramInitData security scheme and apply to protected endpoints
- regenerate TypeScript and Python SDKs

## Testing
- `pnpm run generate:sdk`
- `pnpm --filter=./services/webapp/ui run build`
- `pytest -q --cov` *(fails: 83 errors during collection)*
- `mypy --strict .` *(fails: Found 76 errors in 24 files)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9d44927d4832a8b7c3019815cb4c0