### PR TITLE
[ci] Use pnpm setup action in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,9 @@ jobs:
         with:
           node-version: "20"
           cache: pnpm
-      - name: Enable pnpm
-        run: corepack enable pnpm
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
       - run: pnpm install
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- install pnpm using pnpm/action-setup in tests workflow
- remove manual corepack step

## Testing
- `pip install -r requirements.txt` *(fails: invalid pyproject.toml `project.license`)*
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named "sqlalchemy.pool" and others)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9d81981dc832a95ecca15682a2bf0