### PR TITLE
[handlers] add typed EntryData for diary saves

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -1,8 +1,22 @@
 """Handlers package public exports and shared types."""
 
+import datetime
 from typing import TypedDict
 
 from telegram import CallbackQuery
+
+
+class EntryDataRequired(TypedDict):
+    telegram_id: int
+    event_time: datetime.datetime
+
+
+class EntryData(EntryDataRequired, total=False):
+    sugar_before: float | None
+    xe: float | None
+    dose: float | None
+    carbs_g: float | None
+    photo_path: str | None
 
 
 class UserData(TypedDict, total=False):
@@ -10,7 +24,7 @@ class UserData(TypedDict, total=False):
 
     awaiting_report_date: bool
     thread_id: str
-    pending_entry: dict[str, object]
+    pending_entry: EntryData
     pending_fields: list[str]
     dose_method: str
     edit_id: int | None
@@ -28,5 +42,4 @@ class UserData(TypedDict, total=False):
 
 from .dose_calc import _cancel_then  # noqa: E402
 
-__all__ = ["_cancel_then", "UserData"]
-
+__all__ = ["_cancel_then", "EntryData", "UserData"]

--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -23,7 +23,7 @@ from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.functions import extract_nutrition_info
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
-from . import UserData
+from . import EntryData, UserData
 
 logger = logging.getLogger(__name__)
 
@@ -224,10 +224,14 @@ async def photo_handler(
             )
             return END
 
-        pending_entry = user_data.get("pending_entry") or {
-            "telegram_id": user_id,
-            "event_time": datetime.datetime.now(datetime.timezone.utc),
-        }
+        pending_entry = cast(
+            EntryData,
+            user_data.get("pending_entry")
+            or {
+                "telegram_id": user_id,
+                "event_time": datetime.datetime.now(datetime.timezone.utc),
+            },
+        )
         pending_entry.update({"carbs_g": carbs_g, "xe": xe, "photo_path": file_path})
         user_data["pending_entry"] = pending_entry
         if status_message and hasattr(status_message, "delete"):


### PR DESCRIPTION
## Summary
- define `EntryData` TypedDict for diary entry persistence
- accept `EntryData` in `_save_entry` and sugar handler DB helpers
- adjust handlers to construct and cast `EntryData`

## Testing
- `pytest -q` *(fails: 83 errors during collection)*
- `mypy --strict .` *(fails: Missing type parameters and stubs)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9d81e7390832a8bffbe3d781ab766