### PR TITLE
[handlers] Introduce EntryData typed dict

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -1,8 +1,21 @@
 """Handlers package public exports and shared types."""
 
+import datetime
 from typing import TypedDict
 
 from telegram import CallbackQuery
+
+
+class EntryData(TypedDict, total=False):
+    """Data used to create or update an :class:`Entry`."""
+
+    telegram_id: int
+    event_time: datetime.datetime
+    xe: float | None
+    carbs_g: float | None
+    dose: float | None
+    sugar_before: float | None
+    photo_path: str | None
 
 
 class UserData(TypedDict, total=False):
@@ -10,7 +23,7 @@ class UserData(TypedDict, total=False):
 
     awaiting_report_date: bool
     thread_id: str
-    pending_entry: dict[str, object]
+    pending_entry: EntryData
     pending_fields: list[str]
     dose_method: str
     edit_id: int | None
@@ -28,5 +41,5 @@ class UserData(TypedDict, total=False):
 
 from .dose_calc import _cancel_then  # noqa: E402
 
-__all__ = ["_cancel_then", "UserData"]
+__all__ = ["_cancel_then", "EntryData", "UserData"]
 

--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -42,7 +42,7 @@ from .profile import profile_view
 from services.api.app.diabetes.gpt_command_parser import parse_command
 from .alert_handlers import check_alert
 from .reporting_handlers import history_view, report_request, send_report
-from . import UserData
+from . import EntryData, UserData
 
 logger = logging.getLogger(__name__)
 
@@ -123,11 +123,12 @@ async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     if xe < 0:
         await message.reply_text("Количество ХЕ не может быть отрицательным.")
         return DOSE_XE
-    user_data["pending_entry"] = {
+    entry: EntryData = {
         "telegram_id": user.id,
         "event_time": datetime.datetime.now(datetime.timezone.utc),
         "xe": xe,
     }
+    user_data["pending_entry"] = entry
     await message.reply_text("Введите текущий сахар (ммоль/л).")
     return DOSE_SUGAR
 
@@ -154,11 +155,12 @@ async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     if carbs < 0:
         await message.reply_text("Количество углеводов не может быть отрицательным.")
         return DOSE_CARBS
-    user_data["pending_entry"] = {
+    entry: EntryData = {
         "telegram_id": user.id,
         "event_time": datetime.datetime.now(datetime.timezone.utc),
         "carbs_g": carbs,
     }
+    user_data["pending_entry"] = entry
     await message.reply_text("Введите текущий сахар (ммоль/л).")
     return DOSE_SUGAR
 
@@ -186,7 +188,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         await message.reply_text("Сахар не может быть отрицательным.")
         return DOSE_SUGAR
 
-    entry = user_data.get("pending_entry", {})
+    entry = cast(EntryData, user_data.get("pending_entry", {}))
     entry["sugar_before"] = sugar
     xe = entry.get("xe")
     carbs_g = entry.get("carbs_g")

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -33,7 +33,7 @@ from services.api.app.diabetes.utils.ui import confirm_keyboard, menu_keyboard
 from .alert_handlers import check_alert
 from .dose_validation import _sanitize
 from .reporting_handlers import render_entry, send_report
-from . import UserData
+from . import EntryData, UserData
 
 T = TypeVar("T")
 
@@ -59,18 +59,6 @@ class EditMessageMeta(TypedDict):
 
     chat_id: int
     message_id: int
-
-
-class EntryData(TypedDict, total=False):
-    """Data required to create or update an :class:`Entry`."""
-
-    telegram_id: int
-    event_time: datetime.datetime
-    xe: float | None
-    carbs_g: float | None
-    dose: float | None
-    sugar_before: float | None
-    photo_path: str | None
 
 
 async def _handle_report_request(

--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -23,7 +23,7 @@ from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.functions import extract_nutrition_info
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
-from . import UserData
+from . import EntryData, UserData
 
 logger = logging.getLogger(__name__)
 
@@ -224,10 +224,14 @@ async def photo_handler(
             )
             return END
 
-        pending_entry = user_data.get("pending_entry") or {
-            "telegram_id": user_id,
-            "event_time": datetime.datetime.now(datetime.timezone.utc),
-        }
+        pending_entry = cast(
+            EntryData,
+            user_data.get("pending_entry")
+            or {
+                "telegram_id": user_id,
+                "event_time": datetime.datetime.now(datetime.timezone.utc),
+            },
+        )
         pending_entry.update({"carbs_g": carbs_g, "xe": xe, "photo_path": file_path})
         user_data["pending_entry"] = pending_entry
         if status_message and hasattr(status_message, "delete"):

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -15,7 +15,7 @@ from services.api.app.diabetes.services.db import Entry, SessionLocal
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
 from services.api.app.diabetes.services.repository import commit
-from . import UserData
+from . import EntryData, UserData
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ async def handle_confirm_entry(
     if user_data_raw is None:
         return
     user_data = cast(UserData, user_data_raw)
-    entry_data = user_data.pop("pending_entry", None)
+    entry_data = cast(EntryData | None, user_data.pop("pending_entry", None))
     if not entry_data:
         await query.edit_message_text("❗ Нет данных для сохранения.")
         return
@@ -67,7 +67,7 @@ async def handle_edit_entry(
     if user_data_raw is None:
         return
     user_data = cast(UserData, user_data_raw)
-    entry_data = user_data.get("pending_entry")
+    entry_data = cast(EntryData | None, user_data.get("pending_entry"))
     if not entry_data:
         await query.edit_message_text("❗ Нет данных для редактирования.")
         return


### PR DESCRIPTION
## Summary
- centralize entry payload shape in new `EntryData` TypedDict
- update `save_entry` and related helpers to use `EntryData`
- adjust handlers to construct and consume typed entry data

## Testing
- `pytest -q --cov` *(fails: async plugin required)*
- `mypy --strict services/api/app/diabetes/handlers/__init__.py services/api/app/diabetes/handlers/sugar_handlers.py services/api/app/diabetes/handlers/gpt_handlers.py services/api/app/diabetes/handlers/photo_handlers.py services/api/app/diabetes/handlers/dose_calc.py services/api/app/diabetes/handlers/router.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9dab1bd6c832ab56756f42c7b8d30