### PR TITLE
[py-sdk] Set repository URL and license

### DIFF
--- a/libs/py-sdk/pyproject.toml
+++ b/libs/py-sdk/pyproject.toml
@@ -5,7 +5,7 @@ description = "Diabetes Assistant API"
 authors = [
   {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
 ]
-license = "NoLicense"
+license = "MIT"
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Diabetes Assistant API"]
 requires-python = ">=3.9"
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.urls]
-Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
+Repository = "https://github.com/Offonika/saharlight-ux"
 
 [tool.poetry]
 requires-poetry = ">=2.0"


### PR DESCRIPTION
## Summary
- replace placeholder repository URL with project repo
- set package license to MIT

## Testing
- `pip install -e libs/py-sdk`
- `pytest -q --cov` *(fails: 10 failed)*
- `mypy --strict .` *(fails: 15 errors)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9da29a584832a8335cdb26311ef3c