### PR TITLE
[ci] Use pnpm/action-setup before setup-node

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: pnpm
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - run: pnpm install
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- run pnpm/action-setup@v2 with version 8 before actions/setup-node@v4 in tests workflow

## Testing
- `pytest --cov=services.api.app.diabetes --cov-report=term-missing --cov-report=xml --cov-fail-under=85` *(fails: tests/test_dose_calc_reexports.py::test_reexported_names_available, tests/test_gpt_handlers.py::test_freeform_handler_pending_entry_numeric_add_carbs, tests/test_handlers_freeform_pending.py::test_freeform_handler_edits_pending_entry_keeps_state, tests/test_handlers_freeform_pending.py::test_freeform_handler_adds_sugar_to_photo_entry, tests/test_handlers_photo_sugar_save.py::test_photo_flow_saves_entry, tests/test_handlers_profile.py::test_profile_command_and_view[args0-8.0-3.0-6.0-4.0-9.0], tests/test_handlers_profile.py::test_profile_command_and_view[args1-8.5-3.1-6.7-3.2-8.2], tests/test_handlers_profile.py::test_profile_command_and_view[args2-8.0-3.0-6.0-4.0-9.0], tests/test_handlers_profile.py::test_profile_command_and_view[args3-8.0-3.0-6.0-4.0-9.0], tests/test_handlers_profile.py::test_profile_command_and_view[args4-8.0-3.0-6.0-4.0-9.0], tests/test_handlers_profile.py::test_profile_view_missing_profile_shows_webapp_button, tests/test_sugar_handlers.py::test_sugar_val_valid_saves_and_alerts)*
- `mypy --strict .` *(fails: tests/test_stats_service.py:13: error: "sessionmaker" expects no type arguments, but 1 given  [type-arg], tests/test_stats_service.py:20: error: "sessionmaker" expects no type arguments, but 1 given  [type-arg], tests/test_stats_service.py:31: error: "sessionmaker" expects no type arguments, but 1 given  [type-arg], tests/test_services_reminders.py:34: error: Argument "time" to "ReminderSchema" has incompatible type "str"; expected "time | None"  [arg-type], tests/test_services_reminders.py:49: error: Argument "time" to "ReminderSchema" has incompatible type "str"; expected "time | None"  [arg-type], tests/test_webapp_history.py:34: error: "sessionmaker" expects no type arguments, but 1 given  [type-arg], tests/test_webapp_history.py:40: error: "sessionmaker" expects no type arguments, but 1 given  [type-arg], tests/test_sugar_handlers.py:14: error: Module has no attribute "parse_command"  [attr-defined], tests/test_sugar_handlers.py:21: error: Module has no attribute "ParserTimeoutError"  [attr-defined], tests/test_sugar_handlers.py:25: error: Module has no attribute "BASE_DIR"  [attr-defined], tests/test_sugar_handlers.py:26: error: Module has no attribute "UI_DIR"  [attr-defined], tests/test_profile_ignores_sugar_conv.py:21: error: Module has no attribute "parse_command"  [attr-defined], tests/test_profile_ignores_sugar_conv.py:28: error: Module has no attribute "ParserTimeoutError"  [attr-defined], tests/test_profile_ignores_sugar_conv.py:32: error: Module has no attribute "BASE_DIR"  [attr-defined], tests/test_profile_ignores_sugar_conv.py:33: error: Module has no attribute "UI_DIR"  [attr-defined], tests/test_gpt_handlers_db_errors.py:61: error: Argument "commit" to "freeform_handler" has incompatible type "Callable[[DummySession], bool]"; expected "Callable[[Session], bool]"  [arg-type], tests/test_gpt_handlers_blocks.py:163: error: Argument "SessionLocal" to "_handle_pending_entry" has incompatible type "Callable[[], DummySession]"; expected "sessionmaker"  [arg-type], tests/test_gpt_handlers_blocks.py:188: error: Argument "SessionLocal" to "_handle_pending_entry" has incompatible type "Callable[[], DummySession]"; expected "sessionmaker"  [arg-type], tests/test_gpt_handlers_blocks.py:213: error: Argument "SessionLocal" to "_handle_pending_entry" has incompatible type "Callable[[], DummySession]"; expected "sessionmaker"  [arg-type], tests/test_gpt_handlers_blocks.py:252: error: Argument "SessionLocal" to "_handle_pending_entry" has incompatible type "Callable[[], DummySession]"; expected "sessionmaker"  [arg-type]*)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9dc3eaf00832aaa18f8de4b589e63