### PR TITLE
ci: use pnpm setup action

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -17,13 +17,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: pnpm
-      - name: Enable pnpm
-        run: corepack enable pnpm
       - run: pnpm install
       - name: Generate SDKs
         run: pnpm run generate:sdk


### PR DESCRIPTION
## Summary
- initialize pnpm with pnpm/action-setup and remove corepack step

## Testing
- `pytest -q` (fails: 12 failed, 575 passed, 6 warnings)
- `mypy --strict .` (fails: Found 20 errors in 7 files)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9dc35e68c832a800722a26b511c70