### PR TITLE
[handlers] narrow run_db import error handling

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -15,11 +15,15 @@ from services.api.app.diabetes.services.db import (
     Profile,
     SessionLocal as _SessionLocal,
 )
+logger = logging.getLogger(__name__)
 
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
-except Exception:  # pragma: no cover - optional db runner
+except ImportError:  # pragma: no cover - optional db runner
     run_db: Callable[..., Awaitable[object]] | None = None
+except Exception:  # pragma: no cover - log unexpected errors
+    logger.exception("Unexpected error importing run_db")
+    run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 from services.api.app.diabetes.services.repository import commit as _commit
@@ -38,9 +42,6 @@ class AlertJobData(TypedDict, total=False):
     sugar: float
     profile: dict[str, object]
     first_name: str
-
-
-logger = logging.getLogger(__name__)
 
 MAX_REPEATS = 3
 ALERT_REPEAT_DELAY = datetime.timedelta(minutes=5)

--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -16,11 +16,15 @@ from services.api.app.diabetes.services.db import (
     Profile,
     SessionLocal,
 )
+logger = logging.getLogger(__name__)
 
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
-except Exception:  # pragma: no cover - optional db runner
+except ImportError:  # pragma: no cover - optional db runner
     run_db: Callable[..., Awaitable[object]] | None = None
+except Exception:  # pragma: no cover - log unexpected errors
+    logger.exception("Unexpected error importing run_db")
+    run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 from services.api.app.diabetes.services.repository import commit
@@ -43,8 +47,6 @@ from services.api.app.diabetes.gpt_command_parser import parse_command
 from .alert_handlers import check_alert
 from .reporting_handlers import history_view, report_request, send_report
 from . import EntryData, UserData
-
-logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -44,14 +44,17 @@ class RunDB(Protocol):
     ) -> Awaitable[T]: ...
 
 
+logger = logging.getLogger(__name__)
+
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
-except Exception:  # pragma: no cover - fallback for optional db runner
+except ImportError:  # pragma: no cover - optional db runner
     run_db: RunDB | None = None
+except Exception:  # pragma: no cover - log unexpected errors
+    logger.exception("Unexpected error importing run_db")
+    run_db = None
 else:
     run_db = cast(RunDB, _run_db)
-
-logger = logging.getLogger(__name__)
 
 
 class EditMessageMeta(TypedDict):

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -30,11 +30,15 @@ from services.api.app.diabetes.services.db import (
     Reminder,
     User,
 )
+logger = logging.getLogger(__name__)
 
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
-except Exception:  # pragma: no cover - optional db runner
+except ImportError:  # pragma: no cover - optional db runner
     run_db: Callable[..., Awaitable[object]] | None = None
+except Exception:  # pragma: no cover - log unexpected errors
+    logger.exception("Unexpected error importing run_db")
+    run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 
@@ -58,8 +62,6 @@ from .api import get_api, save_profile, set_timezone, fetch_profile, post_profil
 from .validation import parse_profile_args
 
 back_keyboard: ReplyKeyboardMarkup = _back_keyboard
-
-logger = logging.getLogger(__name__)
 
 from .. import UserData
 

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -34,11 +34,15 @@ from services.api.app.diabetes.services.db import (
     SessionLocal as _SessionLocal,
     User,
 )
+logger = logging.getLogger(__name__)
 
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
-except Exception:  # pragma: no cover - optional db runner
+except ImportError:  # pragma: no cover - optional db runner
     run_db: Callable[..., Awaitable[object]] | None = None
+except Exception:  # pragma: no cover - log unexpected errors
+    logger.exception("Unexpected error importing run_db")
+    run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 from services.api.app.diabetes.services.repository import commit as _commit
@@ -50,8 +54,6 @@ from services.api.app.diabetes.utils.helpers import (
 
 SessionLocal: sessionmaker[Session] = _SessionLocal
 commit: Callable[[Session], bool] = _commit
-
-logger = logging.getLogger(__name__)
 
 DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]
 

--- a/services/api/app/diabetes/handlers/sugar_handlers.py
+++ b/services/api/app/diabetes/handlers/sugar_handlers.py
@@ -14,11 +14,15 @@ from telegram.ext import (
 from sqlalchemy.orm import Session
 
 from services.api.app.diabetes.services.db import Entry, SessionLocal
+logger = logging.getLogger(__name__)
 
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
-except Exception:  # pragma: no cover - optional db runner
+except ImportError:  # pragma: no cover - optional db runner
     run_db: Callable[..., Awaitable[object]] | None = None
+except Exception:  # pragma: no cover - log unexpected errors
+    logger.exception("Unexpected error importing run_db")
+    run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 from services.api.app.diabetes.services.repository import commit
@@ -30,8 +34,6 @@ from .common_handlers import menu_command
 from .photo_handlers import photo_prompt
 from .dose_calc import dose_cancel, _cancel_then
 from . import EntryData, UserData
-
-logger = logging.getLogger(__name__)
 
 SUGAR_VAL = 8
 END = ConversationHandler.END


### PR DESCRIPTION
## Summary
- avoid broad `Exception` when importing `run_db` in handlers
- log unexpected import errors instead of suppressing them

## Testing
- `pytest -q --cov` *(fails: ImportError/other collection errors)*
- `mypy --strict .` *(fails: missing stubs and type errors)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9dfa094ac832a95b717f1b5e06ff2