### PR TITLE
[handlers] Check commit when resolving alerts

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -151,7 +151,11 @@ async def evaluate_sugar(
             if notify:
                 for a in alerts:
                     a.resolved = True
-                commit(session)
+                if not commit(session):
+                    logger.error(
+                        "Failed to commit resolved alerts for user %s", user_id
+                    )
+                    return False, None
             return True, {
                 "action": "schedule",
                 "notify": notify,


### PR DESCRIPTION
## Summary
- log commit failures when resolving repeat alerts
- test commit failure handling for alert resolution

## Testing
- `pytest -q --cov` *(fails: No module named 'matplotlib', 'alembic', 'uvicorn', etc.)*
- `mypy --strict .` *(fails: Module has no attribute 'BASE_DIR', incompatible types, missing type params)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9dfa81ba0832ab6ba43bdd064d8cc