### PR TITLE
tests: fix sessionmaker typing in tests

### DIFF
--- a/tests/test_gpt_handlers_blocks.py
+++ b/tests/test_gpt_handlers_blocks.py
@@ -7,7 +7,7 @@ from telegram import Message, Update
 from telegram.ext import CallbackContext
 
 from services.api.app.diabetes.handlers import UserData, gpt_handlers
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 
 class DummyMessage:
@@ -43,8 +43,8 @@ class DummySession:
         pass
 
 
-def session_factory() -> DummySession:
-    return DummySession()
+def session_factory() -> Session:
+    return cast(Session, DummySession())
 
 
 SESSION_FACTORY = cast(sessionmaker, session_factory)

--- a/tests/test_gpt_handlers_db_errors.py
+++ b/tests/test_gpt_handlers_db_errors.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace, TracebackType
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 import pytest
 from telegram import Update
@@ -59,5 +59,5 @@ async def test_freeform_handler_db_error_propagates(
 
     with pytest.raises(AttributeError):
         await gpt_handlers.freeform_handler(
-            update, context, commit=failing_commit
+            update, context, commit=cast(Callable[[Session], bool], failing_commit)
         )


### PR DESCRIPTION
## Summary
- use `SessionMaker` and context-manager casts in tests
- adjust DB session factories to satisfy mypy

## Testing
- `pytest tests/test_stats_service.py tests/test_services_reminders.py tests/test_webapp_history.py tests/test_sugar_handlers.py tests/test_profile_ignores_sugar_conv.py tests/test_gpt_handlers_db_errors.py tests/test_gpt_handlers_blocks.py -q` *(fails: coverage < 85, assertion failure, TypeError)*
- `mypy --strict tests/test_stats_service.py tests/test_services_reminders.py tests/test_webapp_history.py tests/test_sugar_handlers.py tests/test_profile_ignores_sugar_conv.py tests/test_gpt_handlers_db_errors.py tests/test_gpt_handlers_blocks.py`
- `ruff check tests/test_stats_service.py tests/test_services_reminders.py tests/test_webapp_history.py tests/test_sugar_handlers.py tests/test_profile_ignores_sugar_conv.py tests/test_gpt_handlers_db_errors.py tests/test_gpt_handlers_blocks.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9e3990398832aa39d0ca8b6e73445