### PR TITLE
[api] add /api route aliases and regenerate sdk

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -2,6 +2,8 @@ openapi: 3.1.0
 info:
   title: Diabetes Assistant API
   version: 1.0.0
+servers:
+  - url: /api
 tags:
 - name: Profiles
 - name: History

--- a/libs/py-sdk/README.md
+++ b/libs/py-sdk/README.md
@@ -55,10 +55,10 @@ import diabetes_sdk
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -90,7 +90,7 @@ with diabetes_sdk.ApiClient(configuration) as api_client:
 
 ## Documentation for API Endpoints
 
-All URIs are relative to *http://localhost*
+All URIs are relative to */api*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------

--- a/libs/py-sdk/diabetes_sdk/configuration.py
+++ b/libs/py-sdk/diabetes_sdk/configuration.py
@@ -209,7 +209,7 @@ conf = diabetes_sdk.Configuration(
     ) -> None:
         """Constructor
         """
-        self._base_path = "http://localhost" if host is None else host
+        self._base_path = "/api" if host is None else host
         """Default Base url
         """
         self.server_index = 0 if server_index is None and host is None else server_index
@@ -541,7 +541,7 @@ conf = diabetes_sdk.Configuration(
         """
         return [
             {
-                'url': "",
+                'url': "/api",
                 'description': "No description provided",
             }
         ]

--- a/libs/py-sdk/docs/DefaultApi.md
+++ b/libs/py-sdk/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # diabetes_sdk.DefaultApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to */api*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -32,10 +32,10 @@ from diabetes_sdk.models.web_user import WebUser
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -110,10 +110,10 @@ from diabetes_sdk.models.analytics_point import AnalyticsPoint
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -189,10 +189,10 @@ from diabetes_sdk.models.role_schema import RoleSchema
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -267,10 +267,10 @@ from diabetes_sdk.models.day_stats import DayStats
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -346,10 +346,10 @@ import diabetes_sdk
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -418,10 +418,10 @@ import diabetes_sdk
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 
@@ -481,10 +481,10 @@ from diabetes_sdk.models.user_context import UserContext
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -555,10 +555,10 @@ from diabetes_sdk.models.role_schema import RoleSchema
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -635,10 +635,10 @@ from diabetes_sdk.models.timezone import Timezone
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters

--- a/libs/py-sdk/docs/HistoryApi.md
+++ b/libs/py-sdk/docs/HistoryApi.md
@@ -1,6 +1,6 @@
 # diabetes_sdk.HistoryApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to */api*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -26,10 +26,10 @@ from diabetes_sdk.models.history_record_schema_output import HistoryRecordSchema
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -101,10 +101,10 @@ import diabetes_sdk
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -181,10 +181,10 @@ from diabetes_sdk.models.history_record_schema_input import HistoryRecordSchemaI
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters

--- a/libs/py-sdk/docs/ProfilesApi.md
+++ b/libs/py-sdk/docs/ProfilesApi.md
@@ -1,6 +1,6 @@
 # diabetes_sdk.ProfilesApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to */api*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -23,10 +23,10 @@ from diabetes_sdk.models.profile_schema import ProfileSchema
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -102,10 +102,10 @@ from diabetes_sdk.models.profile_schema import ProfileSchema
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters

--- a/libs/py-sdk/docs/RemindersApi.md
+++ b/libs/py-sdk/docs/RemindersApi.md
@@ -1,6 +1,6 @@
 # diabetes_sdk.RemindersApi
 
-All URIs are relative to *http://localhost*
+All URIs are relative to */api*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -25,10 +25,10 @@ import diabetes_sdk
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -106,10 +106,10 @@ from diabetes_sdk.models.reminder_schema import ReminderSchema
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -185,10 +185,10 @@ from diabetes_sdk.models.reminder_schema import ReminderSchema
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -266,10 +266,10 @@ from diabetes_sdk.models.reminder_schema import ReminderSchema
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters
@@ -344,10 +344,10 @@ from diabetes_sdk.models.reminder_schema import ReminderSchema
 from diabetes_sdk.rest import ApiException
 from pprint import pprint
 
-# Defining the host is optional and defaults to http://localhost
+# Defining the host is optional and defaults to /api
 # See configuration.py for a list of all supported configuration parameters.
 configuration = diabetes_sdk.Configuration(
-    host = "http://localhost"
+    host = "/api"
 )
 
 # The client must configure the authentication and authorization parameters

--- a/libs/py-sdk/pyproject.toml
+++ b/libs/py-sdk/pyproject.toml
@@ -5,7 +5,7 @@ description = "Diabetes Assistant API"
 authors = [
   {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
 ]
-license = { file = "LICENSE" }
+license = "NoLicense"
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Diabetes Assistant API"]
 requires-python = ">=3.9"

--- a/libs/ts-sdk/runtime.ts
+++ b/libs/ts-sdk/runtime.ts
@@ -13,7 +13,7 @@
  */
 
 
-export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
+export const BASE_PATH = "/api".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -83,12 +83,14 @@ def _validate_history_type(value: str, status_code: int = 400) -> HistoryType:
 
 # ────────── health & misc ──────────
 @app.get("/health")
+@app.get("/api/health", include_in_schema=False)
 async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
 # ────────── timezone ──────────
 @app.get("/timezone")
+@app.get("/api/timezone", include_in_schema=False)
 async def get_timezone(_: UserContext = Depends(require_tg_user)) -> dict[str, str]:
     def _get_timezone(session: Session) -> TimezoneDB | None:
         return session.get(TimezoneDB, 1)
@@ -104,6 +106,7 @@ async def get_timezone(_: UserContext = Depends(require_tg_user)) -> dict[str, s
 
 
 @app.put("/timezone")
+@app.put("/api/timezone", include_in_schema=False)
 async def put_timezone(
     data: Timezone, _: UserContext = Depends(require_tg_user)
 ) -> dict[str, str]:
@@ -155,6 +158,7 @@ async def catch_root_ui() -> FileResponse:
 
 # ────────── user CRUD / roles ──────────
 @app.post("/user")
+@app.post("/api/user", include_in_schema=False)
 async def create_user(
     data: WebUser, user: UserContext = Depends(require_tg_user)
 ) -> dict[str, str]:
@@ -173,12 +177,14 @@ async def create_user(
 
 
 @app.get("/user/{user_id}/role")
+@app.get("/api/user/{user_id}/role", include_in_schema=False)
 async def get_role(user_id: int) -> RoleSchema:
     role = await get_user_role(user_id)
     return RoleSchema(role=role or "patient")
 
 
 @app.put("/user/{user_id}/role")
+@app.put("/api/user/{user_id}/role", include_in_schema=False)
 async def put_role(user_id: int, data: RoleSchema) -> RoleSchema:
     await set_user_role(user_id, data.role)
     return RoleSchema(role=data.role)

--- a/tests/test_user_roles.py
+++ b/tests/test_user_roles.py
@@ -23,16 +23,17 @@ def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker:
     return SessionLocal
 
 
-def test_role_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("prefix", ("", "/api"))
+def test_role_endpoints(monkeypatch: pytest.MonkeyPatch, prefix: str) -> None:
     SessionLocal = setup_db(monkeypatch)
     with TestClient(server.app) as client:
-        resp = client.get("/user/1/role")
+        resp = client.get(f"{prefix}/user/1/role")
         assert resp.status_code == 200
         assert resp.json() == {"role": "patient"}
-        resp = client.put("/user/1/role", json={"role": "clinician"})
+        resp = client.put(f"{prefix}/user/1/role", json={"role": "clinician"})
         assert resp.status_code == 200
         assert resp.json() == {"role": "clinician"}
-        resp = client.get("/user/1/role")
+        resp = client.get(f"{prefix}/user/1/role")
         assert resp.status_code == 200
         assert resp.json() == {"role": "clinician"}
 

--- a/tests/test_webapp_server.py
+++ b/tests/test_webapp_server.py
@@ -1,11 +1,13 @@
 from fastapi.testclient import TestClient
+import pytest
 
 import services.api.app.main as server
 
 
-def test_health() -> None:
+@pytest.mark.parametrize("prefix", ("", "/api"))
+def test_health(prefix: str) -> None:
     with TestClient(server.app) as client:
-        resp = client.get("/health")
+        resp = client.get(f"{prefix}/health")
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
 

--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -51,18 +51,19 @@ def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker:
     return SessionLocal
 
 
+@pytest.mark.parametrize("prefix", ("", "/api"))
 def test_timezone_persist_and_validate(
-    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
+    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str], prefix: str
 ) -> None:
     Session = setup_db(monkeypatch)
     with TestClient(server.app) as client:
         resp = client.put(
-            "/timezone", json={"tz": "Europe/Moscow"}, headers=auth_headers
+            f"{prefix}/timezone", json={"tz": "Europe/Moscow"}, headers=auth_headers
         )
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
 
-        resp = client.get("/timezone", headers=auth_headers)
+        resp = client.get(f"{prefix}/timezone", headers=auth_headers)
         assert resp.status_code == 200
         assert resp.json() == {"tz": "Europe/Moscow"}
 
@@ -71,24 +72,25 @@ def test_timezone_persist_and_validate(
             assert tz_row is not None
             assert tz_row.tz == "Europe/Moscow"
 
-        resp = client.put("/timezone", json={}, headers=auth_headers)
+        resp = client.put(f"{prefix}/timezone", json={}, headers=auth_headers)
         assert resp.status_code == 422
 
         resp = client.put(
-            "/timezone", json={"tz": "Invalid/Zone"}, headers=auth_headers
+            f"{prefix}/timezone", json={"tz": "Invalid/Zone"}, headers=auth_headers
         )
         assert resp.status_code == 400
 
         resp = client.put(
-            "/timezone",
+            f"{prefix}/timezone",
             content=b"not json",
             headers={**auth_headers, "Content-Type": "application/json"},
         )
         assert resp.status_code in {400, 422}
 
 
+@pytest.mark.parametrize("prefix", ("", "/api"))
 def test_timezone_partial_file(
-    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
+    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str], prefix: str
 ) -> None:
     Session = setup_db(monkeypatch)
     with Session() as session:
@@ -96,12 +98,13 @@ def test_timezone_partial_file(
         session.commit()
 
     with TestClient(server.app) as client:
-        resp = client.get("/timezone", headers=auth_headers)
+        resp = client.get(f"{prefix}/timezone", headers=auth_headers)
         assert resp.status_code == 500
 
 
+@pytest.mark.parametrize("prefix", ("", "/api"))
 def test_timezone_concurrent_writes(
-    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
+    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str], prefix: str
 ) -> None:
     Session = setup_db(monkeypatch)
     timezones = ["Europe/Moscow", "America/New_York", "Asia/Tokyo", "Europe/Paris"]
@@ -110,7 +113,7 @@ def test_timezone_concurrent_writes(
 
     def write_tz(tz: str) -> None:
         with TestClient(server.app) as c:
-            resp = c.put("/timezone", json={"tz": tz}, headers=headers.copy())
+            resp = c.put(f"{prefix}/timezone", json={"tz": tz}, headers=headers.copy())
             assert resp.status_code == 200
 
     with ThreadPoolExecutor(max_workers=len(timezones)) as exc:
@@ -123,14 +126,15 @@ def test_timezone_concurrent_writes(
         tz_value = tz_row.tz
 
     with TestClient(server.app) as client:
-        resp = client.get("/timezone", headers=headers)
+        resp = client.get(f"{prefix}/timezone", headers=headers)
         assert resp.status_code == 200
         assert resp.json() == {"tz": tz_value}
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", ("", "/api"))
 async def test_timezone_async_writes(
-    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
+    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str], prefix: str
 ) -> None:
     Session = setup_db(monkeypatch)
     timezones = ["Europe/Moscow", "America/New_York", "Asia/Tokyo", "Europe/Paris"]
@@ -141,7 +145,7 @@ async def test_timezone_async_writes(
         async with AsyncClient(
             transport=ASGITransport(app=cast(Any, server.app)), base_url="http://test"
         ) as ac:
-            resp = await ac.put("/timezone", json={"tz": tz}, headers=headers)
+            resp = await ac.put(f"{prefix}/timezone", json={"tz": tz}, headers=headers)
             assert resp.status_code == 200
 
     await asyncio.gather(*(write_tz(tz) for tz in timezones))
@@ -155,12 +159,16 @@ async def test_timezone_async_writes(
     async with AsyncClient(
         transport=ASGITransport(app=cast(Any, server.app)), base_url="http://test"
     ) as ac:
-        resp = await ac.get("/timezone", headers=headers)
+        resp = await ac.get(f"{prefix}/timezone", headers=headers)
         assert resp.status_code == 200
         assert resp.json() == {"tz": tz_value}
 
 
-def test_timezone_requires_header() -> None:
+@pytest.mark.parametrize("prefix", ("", "/api"))
+def test_timezone_requires_header(prefix: str) -> None:
     with TestClient(server.app) as client:
-        assert client.get("/timezone").status_code == 401
-        assert client.put("/timezone", json={"tz": "Europe/Moscow"}).status_code == 401
+        assert client.get(f"{prefix}/timezone").status_code == 401
+        assert (
+            client.put(f"{prefix}/timezone", json={"tz": "Europe/Moscow"}).status_code
+            == 401
+        )

--- a/tests/test_webapp_user.py
+++ b/tests/test_webapp_user.py
@@ -45,13 +45,14 @@ def build_init_data(user_id: int = 1) -> str:
     return urllib.parse.urlencode(params)
 
 
-def test_create_user_authorized(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("prefix", ("", "/api"))
+def test_create_user_authorized(monkeypatch: pytest.MonkeyPatch, prefix: str) -> None:
     Session = setup_db(monkeypatch)
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     init_data = build_init_data(42)
     with TestClient(server.app) as client:
         resp = client.post(
-            "/user",
+            f"{prefix}/user",
             json={"telegramId": 42},
             headers={TG_INIT_DATA_HEADER: init_data},
         )
@@ -63,13 +64,14 @@ def test_create_user_authorized(monkeypatch: pytest.MonkeyPatch) -> None:
         assert user.thread_id == "webapp"
 
 
-def test_create_user_unauthorized(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("prefix", ("", "/api"))
+def test_create_user_unauthorized(monkeypatch: pytest.MonkeyPatch, prefix: str) -> None:
     setup_db(monkeypatch)
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     init_data = build_init_data(1)
     with TestClient(server.app) as client:
         resp = client.post(
-            "/user",
+            f"{prefix}/user",
             json={"telegramId": 42},
             headers={TG_INIT_DATA_HEADER: init_data},
         )


### PR DESCRIPTION
## Summary
- add /api duplicates for core routes
- update OpenAPI server base and regenerate SDK
- cover both prefixed and root routes in tests

## Testing
- `pnpm generate:sdk`
- `pytest -q` *(fails: test_rest_multipart, test_alerts, test_dose_calc_reexports, test_gpt_handlers, test_handlers_freeform_pending, test_handlers_photo_sugar_save, test_handlers_profile, test_services_reminders, test_sugar_handlers)*
- `mypy --strict .` *(fails: tests/test_alembic_env.py:12: error: Unused "type: ignore" comment [unused-ignore], tests/test_ui_reminders_smoke.py:5: error: Unused "type: ignore" comment [unused-ignore], tests/test_reporting.py:10: error: Unused "type: ignore" comment [unused-ignore], tests/test_reporting.py:12: error: Unused "type: ignore" comment [unused-ignore])*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9e46bac24832abdc7131b92972721