### PR TITLE
[api] handle DB init errors

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -16,6 +16,7 @@ if __name__ == "__main__" and __package__ is None:  # pragma: no cover
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import AliasChoices, BaseModel, Field
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 # ────────── local ──────────
@@ -38,7 +39,13 @@ from services.api.app.diabetes.utils.openai_utils import dispose_http_client
 
 # ────────── init ──────────
 logger = logging.getLogger(__name__)
-init_db()  # создаёт/инициализирует БД
+try:
+    init_db()  # создаёт/инициализирует БД
+except (ValueError, SQLAlchemyError) as exc:
+    logger.error("Failed to initialize the database: %s", exc)
+    raise RuntimeError(
+        "Database initialization failed. Please check your configuration and try again."
+    ) from exc
 
 app = FastAPI(title="Diabetes Assistant API", version="1.0.0")
 

--- a/tests/test_api_main_db_error.py
+++ b/tests/test_api_main_db_error.py
@@ -1,0 +1,29 @@
+import importlib
+import logging
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from services.api.app.diabetes.services import db
+
+
+def test_main_logs_db_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import services.api.app.main as main
+
+    def faulty_init_db() -> None:
+        raise SQLAlchemyError("boom")
+
+    monkeypatch.setattr(db, "init_db", faulty_init_db)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError, match="Database initialization failed"):
+            importlib.reload(main)
+    assert any(
+        "Failed to initialize the database" in record.getMessage()
+        for record in caplog.records
+    )
+
+    monkeypatch.setattr(db, "init_db", lambda: None)
+    importlib.reload(main)


### PR DESCRIPTION
## Summary
- catch misconfigured database errors during API startup and raise friendly message
- add regression test for DB init failure on API startup

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: tests/test_alembic_env.py:12: error: Unused "type: ignore" comment)*
- `mypy --strict services/api/app/main.py tests/test_api_main_db_error.py`
- `pytest -q` *(fails: 16 failed, 575 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e653acdc832a8cee4766dbe737ae