### PR TITLE
[ci] add mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,8 @@ repos:
     rev: v0.6.2
     hooks:
       - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.1
+    hooks:
+      - id: mypy
+        args: [--strict]


### PR DESCRIPTION
## Summary
- run mypy --strict in pre-commit

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: unused "type: ignore" comments)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9e6cb4a1c832ab4a08b91f2959bf7