### PR TITLE
tests: improve error handler typing

### DIFF
--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import importlib
 import logging
 import sys
+from typing import Awaitable, Callable
 
 import pytest
+from telegram.ext import ContextTypes
 
 
 def test_log_level_debug(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -34,7 +36,12 @@ def test_log_level_debug(monkeypatch: pytest.MonkeyPatch) -> None:
         bot = DummyBot()
         job_queue = None
 
-        def add_error_handler(self, _: object) -> None:
+        def add_error_handler(
+            self,
+            handler: Callable[
+                [object, ContextTypes.DEFAULT_TYPE], Awaitable[None]
+            ],
+        ) -> None:
             return None
 
         def add_handler(self, _: object) -> None:


### PR DESCRIPTION
## Summary
- refine dummy app error handler typing in debug logging test
- import missing typing and telegram types

## Testing
- `pytest tests/test_bot_debug_logging.py -q --cov-fail-under=0`
- `mypy --strict tests/test_bot_debug_logging.py`
- `ruff check tests/test_bot_debug_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9e6c997f4832a9fa0c9475bdbc655