### PR TITLE
[py-sdk] Declare license metadata

### DIFF
--- a/libs/py-sdk/pyproject.toml
+++ b/libs/py-sdk/pyproject.toml
@@ -5,7 +5,7 @@ description = "Diabetes Assistant API"
 authors = [
   {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
 ]
-license = "NoLicense"
+license = { file = "LICENSE" }
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Diabetes Assistant API"]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- specify a proper license reference in the Python SDK's pyproject

## Testing
- `pip install -r requirements.txt`
- `pytest -q --cov` *(fails: 25 failed, 575 passed)*
- `mypy --strict .` *(fails: Found 35 errors)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9ecc25f8c832aaea0a086567f238f