### PR TITLE
[handlers] narrow exception handling for run_db imports

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -15,15 +15,17 @@ from services.api.app.diabetes.services.db import (
     Profile,
     SessionLocal as _SessionLocal,
 )
+
 logger = logging.getLogger(__name__)
 
+run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    run_db: Callable[..., Awaitable[object]] | None = None
-except Exception:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db")
     run_db = None
+except Exception as exc:  # pragma: no cover - log unexpected errors
+    logger.exception("Unexpected error importing run_db", exc_info=exc)
+    raise
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 from services.api.app.diabetes.services.repository import commit as _commit
@@ -42,6 +44,7 @@ class AlertJobData(TypedDict, total=False):
     sugar: float
     profile: dict[str, object]
     first_name: str
+
 
 MAX_REPEATS = 3
 ALERT_REPEAT_DELAY = datetime.timedelta(minutes=5)

--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -16,15 +16,17 @@ from services.api.app.diabetes.services.db import (
     Profile,
     SessionLocal,
 )
+
 logger = logging.getLogger(__name__)
 
+run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    run_db: Callable[..., Awaitable[object]] | None = None
-except Exception:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db")
     run_db = None
+except Exception as exc:  # pragma: no cover - log unexpected errors
+    logger.exception("Unexpected error importing run_db", exc_info=exc)
+    raise
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 from services.api.app.diabetes.services.repository import commit

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -47,13 +47,14 @@ class RunDB(Protocol):
 
 logger = logging.getLogger(__name__)
 
+run_db: RunDB | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    run_db: RunDB | None = None
-except Exception:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db")
     run_db = None
+except Exception as exc:  # pragma: no cover - log unexpected errors
+    logger.exception("Unexpected error importing run_db", exc_info=exc)
+    raise
 else:
     run_db = cast(RunDB, _run_db)
 

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -30,15 +30,17 @@ from services.api.app.diabetes.services.db import (
     Reminder,
     User,
 )
+
 logger = logging.getLogger(__name__)
 
+run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    run_db: Callable[..., Awaitable[object]] | None = None
-except Exception:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db")
     run_db = None
+except Exception as exc:  # pragma: no cover - log unexpected errors
+    logger.exception("Unexpected error importing run_db", exc_info=exc)
+    raise
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -37,13 +37,14 @@ from services.api.app.diabetes.services.db import (
 
 logger = logging.getLogger(__name__)
 
+run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    run_db: Callable[..., Awaitable[object]] | None = None
-except Exception:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db")
     run_db = None
+except Exception as exc:  # pragma: no cover - log unexpected errors
+    logger.exception("Unexpected error importing run_db", exc_info=exc)
+    raise
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 from services.api.app.diabetes.services.repository import commit as _commit

--- a/services/api/app/diabetes/handlers/sugar_handlers.py
+++ b/services/api/app/diabetes/handlers/sugar_handlers.py
@@ -14,15 +14,17 @@ from telegram.ext import (
 from sqlalchemy.orm import Session
 
 from services.api.app.diabetes.services.db import Entry, SessionLocal
+
 logger = logging.getLogger(__name__)
 
+run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    run_db: Callable[..., Awaitable[object]] | None = None
-except Exception:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db")
     run_db = None
+except Exception as exc:  # pragma: no cover - log unexpected errors
+    logger.exception("Unexpected error importing run_db", exc_info=exc)
+    raise
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 from services.api.app.diabetes.services.repository import commit


### PR DESCRIPTION
## Summary
- replace broad `except Exception` blocks when importing `run_db` in diabetes handlers
- log and re-raise unexpected errors during `run_db` import

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'reportlab')*
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named 'alembic')*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9ed09f8f4832a8cb7059338a0b285