### PR TITLE
[py-sdk] Declare MIT license

### DIFF
--- a/libs/py-sdk/pyproject.toml
+++ b/libs/py-sdk/pyproject.toml
@@ -5,7 +5,7 @@ description = "Diabetes Assistant API"
 authors = [
   {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
 ]
-license = { file = "LICENSE" }
+license = {text = "MIT"}
 readme = "README.md"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Diabetes Assistant API"]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- declare MIT license for Python SDK

## Testing
- `pip install -r requirements.txt`
- `pytest -q --cov` *(fails: freeform_handler unexpected keyword arguments, etc.)*
- `mypy --strict .` *(fails: attribute errors and unused ignore comments)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9ef6970e4832a937b4a2c6a78e80c