### PR TITLE
[utils] centralize run_db imports

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -16,21 +16,14 @@ from services.api.app.diabetes.services.db import (
     SessionLocal as _SessionLocal,
 )
 logger = logging.getLogger(__name__)
-
-try:
-    from services.api.app.diabetes.services.db import run_db as _run_db
-except ImportError:  # pragma: no cover - optional db runner
-    run_db: Callable[..., Awaitable[object]] | None = None
-except Exception:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db")
-    run_db = None
-else:
-    run_db = cast(Callable[..., Awaitable[object]], _run_db)
+from services.api.app.diabetes.utils.db_import import get_run_db
 from services.api.app.diabetes.services.repository import commit as _commit
 from services.api.app.diabetes.utils.helpers import get_coords_and_link
 
 SessionLocal: sessionmaker = _SessionLocal
 commit: Callable[[Session], bool] = _commit
+
+run_db: Callable[..., Awaitable[object]] | None = get_run_db()
 
 CustomContext = ContextTypes.DEFAULT_TYPE
 DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from services.api.app.diabetes.services.db import SessionLocal, Entry, Profile
 from services.api.app.diabetes.services.repository import commit
+from services.api.app.diabetes.utils.db_import import get_run_db
 from services.api.app.diabetes.utils.functions import (
     PatientProfile,
     calc_bolus,
@@ -46,16 +47,7 @@ class RunDB(Protocol):
 
 
 logger = logging.getLogger(__name__)
-
-try:
-    from services.api.app.diabetes.services.db import run_db as _run_db
-except ImportError:  # pragma: no cover - optional db runner
-    run_db: RunDB | None = None
-except Exception:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db")
-    run_db = None
-else:
-    run_db = cast(RunDB, _run_db)
+run_db: RunDB | None = cast(RunDB | None, get_run_db())
 
 
 class EditMessageMeta(TypedDict):

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -30,18 +30,7 @@ from services.api.app.diabetes.services.db import (
     Reminder,
     User,
 )
-logger = logging.getLogger(__name__)
-
-try:
-    from services.api.app.diabetes.services.db import run_db as _run_db
-except ImportError:  # pragma: no cover - optional db runner
-    run_db: Callable[..., Awaitable[object]] | None = None
-except Exception:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db")
-    run_db = None
-else:
-    run_db = cast(Callable[..., Awaitable[object]], _run_db)
-
+from services.api.app.diabetes.utils.db_import import get_run_db
 from services.api.app.diabetes.handlers.alert_handlers import (
     evaluate_sugar,
     DefaultJobQueue,
@@ -57,13 +46,13 @@ from services.api.app.diabetes.utils.ui import (
 from services.api.app.config import settings
 from services.api.app.diabetes.services.repository import commit
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
-
 from .api import get_api, save_profile, set_timezone, fetch_profile, post_profile
 from .validation import parse_profile_args
-
-back_keyboard: ReplyKeyboardMarkup = _back_keyboard
-
 from .. import UserData
+
+logger = logging.getLogger(__name__)
+back_keyboard: ReplyKeyboardMarkup = _back_keyboard
+run_db: Callable[..., Awaitable[object]] | None = get_run_db()
 
 
 MSG_ICR_GT0 = "ИКХ должен быть больше 0."

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -34,25 +34,16 @@ from services.api.app.diabetes.services.db import (
     SessionLocal as _SessionLocal,
     User,
 )
-
-logger = logging.getLogger(__name__)
-
-try:
-    from services.api.app.diabetes.services.db import run_db as _run_db
-except ImportError:  # pragma: no cover - optional db runner
-    run_db: Callable[..., Awaitable[object]] | None = None
-except Exception:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db")
-    run_db = None
-else:
-    run_db = cast(Callable[..., Awaitable[object]], _run_db)
+from services.api.app.diabetes.utils.db_import import get_run_db
 from services.api.app.diabetes.services.repository import commit as _commit
 from services.api.app.config import settings
 from services.api.app.diabetes.utils.helpers import (
     INVALID_TIME_MSG,
     parse_time_interval,
 )
+from . import UserData
 
+logger = logging.getLogger(__name__)
 SessionLocal: sessionmaker[Session] = _SessionLocal
 commit: Callable[[Session], bool] = _commit
 
@@ -60,7 +51,7 @@ DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]
 
 PLAN_LIMITS = {"free": 5, "pro": 10}
 
-from . import UserData
+run_db: Callable[..., Awaitable[object]] | None = get_run_db()
 
 
 def build_webapp_url(path: str) -> str:

--- a/services/api/app/diabetes/utils/db_import.py
+++ b/services/api/app/diabetes/utils/db_import.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import cast
+
+logger = logging.getLogger(__name__)
+
+
+def get_run_db() -> Callable[..., Awaitable[object]] | None:
+    """Safely import and return ``run_db``.
+
+    Returns ``None`` if the import is not available or fails with an
+    unexpected exception.
+    """
+    try:
+        from services.api.app.diabetes.services.db import run_db as _run_db
+    except ImportError:  # pragma: no cover - optional db runner
+        return None
+    except Exception:  # pragma: no cover - log unexpected errors
+        logger.exception("Unexpected error importing run_db")
+        return None
+    return cast(Callable[..., Awaitable[object]], _run_db)

--- a/tests/test_db_import.py
+++ b/tests/test_db_import.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import builtins
+from typing import Any
+
+import pytest
+
+from services.api.app.diabetes.utils.db_import import get_run_db
+
+
+def test_get_run_db_success() -> None:
+    run_db = get_run_db()
+    assert run_db is not None
+
+
+def test_get_run_db_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "services.api.app.diabetes.services.db":
+            raise ImportError
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert get_run_db() is None
+
+
+def test_get_run_db_other_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "services.api.app.diabetes.services.db":
+            raise RuntimeError("boom")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert get_run_db() is None


### PR DESCRIPTION
## Summary
- add utility to safely import `run_db`
- refactor handlers to use `get_run_db`
- test `get_run_db` import fallbacks

## Testing
- `pytest -q tests/test_db_import.py tests/test_dose_calc_reexports.py::test_reexported_names_available tests/test_dose_info_unit.py::test_entry_without_dose_has_no_unit tests/test_dose_info_unit.py::test_entry_without_sugar_has_placeholder tests/test_sugar_handlers.py::test_sugar_val_valid_saves_and_alerts`
- `mypy --strict services/api/app/diabetes/utils/db_import.py services/api/app/diabetes/handlers/gpt_handlers.py services/api/app/diabetes/handlers/sugar_handlers.py services/api/app/diabetes/handlers/dose_calc.py services/api/app/diabetes/handlers/profile/conversation.py services/api/app/diabetes/handlers/reminder_handlers.py services/api/app/diabetes/handlers/alert_handlers.py tests/test_db_import.py`
- `ruff check services/api/app/diabetes/utils/db_import.py services/api/app/diabetes/handlers/gpt_handlers.py services/api/app/diabetes/handlers/sugar_handlers.py services/api/app/diabetes/handlers/dose_calc.py services/api/app/diabetes/handlers/profile/conversation.py services/api/app/diabetes/handlers/reminder_handlers.py services/api/app/diabetes/handlers/alert_handlers.py tests/test_db_import.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9ed0b8738832a912681478a1e4a03