### PR TITLE
[onboarding] clean up unused imports

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from collections.abc import Awaitable, Callable
 from typing import cast
 
 from telegram import (
@@ -475,12 +474,8 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     from .dose_calc import photo_prompt
 
     message = update.message
-    user_data_raw = context.user_data
-    if user_data_raw is None:
+    if context.user_data is None:
         context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(UserData, user_data_raw)
     if message is None:
         return ConversationHandler.END
 


### PR DESCRIPTION
## Summary
- remove unused Awaitable and Callable imports
- drop redundant user_data cast in photo fallback

## Testing
- `ruff check services/api/app/diabetes/handlers/onboarding_handlers.py`
- `mypy --strict services/api/app/diabetes/handlers/onboarding_handlers.py` *(fails: Missing type parameters for generic type "sessionmaker" in alert_handlers and gpt_handlers)*
- `pytest tests/test_onboarding_demo_photo_missing.py tests/test_onboarding_flow.py tests/test_register_handlers.py tests/test_onboarding_start_command.py tests/test_onboarding_timezone_error.py tests/handlers/test_onboarding_handlers.py tests/test_onboarding_edge_cases.py tests/test_onboarding_handlers_errors.py tests/test_photo_fallbacks.py -q` *(fails: Coverage failure: total of 40 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f03f3440832aa4e168917563a82d