### PR TITLE
[handlers] Remove unused variable in router edit handler

### DIFF
--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -73,7 +73,6 @@ async def handle_edit_entry(
         await query.edit_message_text("❗ Нет данных для редактирования.")
         return
     user_data["edit_id"] = None
-    entry_data: EntryData = entry_data_raw
     await query.edit_message_text(
         "Отправьте новое сообщение в формате:\n"
         "`сахар=<ммоль/л>  xe=<ХЕ>  carbs=<г>  dose=<ед>`\n"


### PR DESCRIPTION
## Summary
- clean up `handle_edit_entry` by removing unused `entry_data` variable

## Testing
- `ruff check services/api/app/diabetes/handlers/router.py`
- `mypy --strict --follow-imports=skip services/api/app/diabetes/handlers/router.py`
- `pytest tests/test_router_mapping.py tests/test_handlers_cancel_entry.py -q -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68a9f03fae1c832a8a7f5b0f8be85826