### PR TITLE
[utils] centralize run_db import

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -17,17 +17,9 @@ from services.api.app.diabetes.services.db import (
 )
 
 logger = logging.getLogger(__name__)
+from services.api.app.diabetes.utils.db_import import get_run_db
 
-run_db: Callable[..., Awaitable[object]] | None
-try:
-    from services.api.app.diabetes.services.db import run_db as _run_db
-except ImportError:  # pragma: no cover - optional db runner
-    run_db = None
-except Exception as exc:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db", exc_info=exc)
-    raise
-else:
-    run_db = cast(Callable[..., Awaitable[object]], _run_db)
+run_db: Callable[..., Awaitable[object]] | None = get_run_db()
 from services.api.app.diabetes.services.repository import commit as _commit
 from services.api.app.diabetes.utils.helpers import get_coords_and_link
 

--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -18,17 +18,9 @@ from services.api.app.diabetes.services.db import (
 )
 
 logger = logging.getLogger(__name__)
+from services.api.app.diabetes.utils.db_import import get_run_db
 
-run_db: Callable[..., Awaitable[object]] | None
-try:
-    from services.api.app.diabetes.services.db import run_db as _run_db
-except ImportError:  # pragma: no cover - optional db runner
-    run_db = None
-except Exception as exc:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db", exc_info=exc)
-    raise
-else:
-    run_db = cast(Callable[..., Awaitable[object]], _run_db)
+run_db: Callable[..., Awaitable[object]] | None = get_run_db()
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.functions import (
     PatientProfile,

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -46,17 +46,9 @@ class RunDB(Protocol):
 
 
 logger = logging.getLogger(__name__)
+from services.api.app.diabetes.utils.db_import import get_run_db
 
-run_db: RunDB | None
-try:
-    from services.api.app.diabetes.services.db import run_db as _run_db
-except ImportError:  # pragma: no cover - optional db runner
-    run_db = None
-except Exception as exc:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db", exc_info=exc)
-    raise
-else:
-    run_db = cast(RunDB, _run_db)
+run_db: RunDB | None = cast(RunDB | None, get_run_db())
 
 
 class EditMessageMeta(TypedDict):

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -32,17 +32,9 @@ from services.api.app.diabetes.services.db import (
 )
 
 logger = logging.getLogger(__name__)
+from services.api.app.diabetes.utils.db_import import get_run_db
 
-run_db: Callable[..., Awaitable[object]] | None
-try:
-    from services.api.app.diabetes.services.db import run_db as _run_db
-except ImportError:  # pragma: no cover - optional db runner
-    run_db = None
-except Exception as exc:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db", exc_info=exc)
-    raise
-else:
-    run_db = cast(Callable[..., Awaitable[object]], _run_db)
+run_db: Callable[..., Awaitable[object]] | None = get_run_db()
 
 from services.api.app.diabetes.handlers.alert_handlers import (
     evaluate_sugar,

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -36,17 +36,9 @@ from services.api.app.diabetes.services.db import (
 )
 
 logger = logging.getLogger(__name__)
+from services.api.app.diabetes.utils.db_import import get_run_db
 
-run_db: Callable[..., Awaitable[object]] | None
-try:
-    from services.api.app.diabetes.services.db import run_db as _run_db
-except ImportError:  # pragma: no cover - optional db runner
-    run_db = None
-except Exception as exc:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db", exc_info=exc)
-    raise
-else:
-    run_db = cast(Callable[..., Awaitable[object]], _run_db)
+run_db: Callable[..., Awaitable[object]] | None = get_run_db()
 from services.api.app.diabetes.services.repository import commit as _commit
 from services.api.app.config import settings
 from services.api.app.diabetes.utils.helpers import (

--- a/services/api/app/diabetes/handlers/sugar_handlers.py
+++ b/services/api/app/diabetes/handlers/sugar_handlers.py
@@ -16,17 +16,9 @@ from sqlalchemy.orm import Session
 from services.api.app.diabetes.services.db import Entry, SessionLocal
 
 logger = logging.getLogger(__name__)
+from services.api.app.diabetes.utils.db_import import get_run_db
 
-run_db: Callable[..., Awaitable[object]] | None
-try:
-    from services.api.app.diabetes.services.db import run_db as _run_db
-except ImportError:  # pragma: no cover - optional db runner
-    run_db = None
-except Exception as exc:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db", exc_info=exc)
-    raise
-else:
-    run_db = cast(Callable[..., Awaitable[object]], _run_db)
+run_db: Callable[..., Awaitable[object]] | None = get_run_db()
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.functions import _safe_float
 from services.api.app.diabetes.utils.ui import menu_keyboard, sugar_keyboard

--- a/services/api/app/diabetes/utils/db_import.py
+++ b/services/api/app/diabetes/utils/db_import.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import cast
+
+logger = logging.getLogger(__name__)
+
+RunDB = Callable[..., Awaitable[object]]
+
+
+def get_run_db() -> RunDB | None:
+    """Safely import ``run_db`` from the services layer.
+
+    Returns
+    -------
+    ``RunDB`` | ``None``
+        ``run_db`` callable when the import succeeds, otherwise ``None``.
+    """
+    try:
+        from services.api.app.diabetes.services.db import run_db as _run_db
+    except Exception as exc:  # pragma: no cover - log unexpected errors
+        logger.exception("Unexpected error importing run_db", exc_info=exc)
+        return None
+    return cast(RunDB, _run_db)

--- a/tests/test_db_import.py
+++ b/tests/test_db_import.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+import sys
+import types
+
+import pytest
+
+from services.api.app.diabetes.utils.db_import import get_run_db
+
+
+def test_get_run_db_success() -> None:
+    assert get_run_db() is not None
+
+
+def test_get_run_db_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    dummy = types.ModuleType("services.api.app.diabetes.services.db")
+    monkeypatch.setitem(sys.modules, "services.api.app.diabetes.services.db", dummy)
+    with caplog.at_level(logging.ERROR):
+        assert get_run_db() is None
+    assert "Unexpected error importing run_db" in caplog.text


### PR DESCRIPTION
## Summary
- add helper `get_run_db` for safe database runner import
- replace ad-hoc `run_db` imports in handlers with `get_run_db`
- add tests for `get_run_db`

## Testing
- `pytest -q --cov` *(fails: libs/py-sdk/test/test_rest_multipart.py::test_multipart_dict - ValueError: too many values to unpack (expected 2))*
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named "diabetes_sdk")*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9f238bd90832a8697c2396cf6c50c