### PR TITLE
[tests] remove alembic type ignore comment

### DIFF
--- a/tests/test_alembic_env.py
+++ b/tests/test_alembic_env.py
@@ -9,7 +9,7 @@ import types
 from types import ModuleType
 from typing import Any, Iterator
 
-import alembic.context  # type: ignore[import-not-found]
+import alembic.context
 import pytest
 
 


### PR DESCRIPTION
## Summary
- remove `# type: ignore[import-not-found]` on alembic import in test

## Testing
- `pytest -q` *(fails: async plugin missing)*
- `mypy --strict .` *(fails: Module not found: diabetes_sdk)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9f4546d80832aaa22a2625e554dd7