### PR TITLE
[bot] export bot components

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -28,6 +28,7 @@ async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> N
         "Exception while handling update %s", update, exc_info=context.error
     )
 
+
 def main() -> None:
     """Configure and run the bot."""
     logging.basicConfig(
@@ -75,7 +76,7 @@ def main() -> None:
             dict[str, Any],
             dict[str, Any],
             DefaultJobQueue,
-        ]
+        ],
     ) -> None:
         await app.bot.set_my_commands(commands)
 
@@ -98,6 +99,10 @@ def main() -> None:
 
     register_handlers(application)
     application.run_polling()
+
+
+__all__ = ["main", "error_handler", "settings", "TELEGRAM_TOKEN"]
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_bot_db_error.py
+++ b/tests/test_bot_db_error.py
@@ -12,7 +12,7 @@ def test_main_logs_db_error(
         bot.settings,
         "telegram_token",
         "token",
-    )  # type: ignore[attr-defined]
+    )
     monkeypatch.setattr(bot, "TELEGRAM_TOKEN", "token")
 
     def faulty_init_db() -> None:


### PR DESCRIPTION
## Summary
- export key bot symbols via `__all__` in `services/bot/main.py`
- drop obsolete `type: ignore` in `test_bot_db_error`

## Testing
- `pytest -q` *(fails: freeform_handler unexpected keyword argument, db errors)*
- `mypy --strict .` *(fails: "Session" has no attribute "get" and more)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9f4600640832abc46aabc8be434ee