### PR TITLE
[services] add session protocol and casts

### DIFF
--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, cast
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
@@ -8,26 +8,33 @@ from sqlalchemy.orm import Session
 from ..diabetes.services.db import Reminder, SessionLocal, User, run_db
 from ..diabetes.services.repository import commit
 from ..schemas.reminders import ReminderSchema
+from ..types import SessionProtocol
 
 
 async def list_reminders(telegram_id: int) -> List[Reminder]:
-    def _list(session: Session) -> List[Reminder]:
-        if session.get(User, telegram_id) is None:
+    def _list(session: SessionProtocol) -> List[Reminder]:
+        if cast(User | None, session.get(User, telegram_id)) is None:
             return []
-        return session.query(Reminder).filter_by(telegram_id=telegram_id).all()
+        return cast(
+            List[Reminder],
+            cast(Session, session)
+            .query(Reminder)
+            .filter_by(telegram_id=telegram_id)
+            .all(),
+        )
 
     return await run_db(_list, sessionmaker=SessionLocal)
 
 
 async def save_reminder(data: ReminderSchema) -> int:
-    def _save(session: Session) -> int:
+    def _save(session: SessionProtocol) -> int:
         if data.id is not None:
-            rem = session.get(Reminder, data.id)
+            rem = cast(Reminder | None, session.get(Reminder, data.id))
             if rem is None or rem.telegram_id != data.telegramId:
                 raise HTTPException(status_code=404, detail="reminder not found")
         else:
             rem = Reminder(telegram_id=data.telegramId)
-            session.add(rem)
+            cast(Session, session).add(rem)
         if data.orgId is not None:
             rem.org_id = data.orgId
         rem.type = data.type
@@ -36,19 +43,19 @@ async def save_reminder(data: ReminderSchema) -> int:
         rem.interval_hours = data.intervalHours
         rem.minutes_after = data.minutesAfter
         rem.is_enabled = data.isEnabled
-        commit(session)
-        session.refresh(rem)
-        return rem.id
+        commit(cast(Session, session))
+        cast(Session, session).refresh(rem)
+        return cast(int, rem.id)
 
     return await run_db(_save, sessionmaker=SessionLocal)
 
 
 async def delete_reminder(telegram_id: int, reminder_id: int) -> None:
-    def _delete(session: Session) -> None:
-        rem = session.get(Reminder, reminder_id)
+    def _delete(session: SessionProtocol) -> None:
+        rem = cast(Reminder | None, session.get(Reminder, reminder_id))
         if rem is None or rem.telegram_id != telegram_id:
             raise HTTPException(status_code=404, detail="reminder not found")
         session.delete(rem)
-        commit(session)
+        commit(cast(Session, session))
 
     await run_db(_delete, sessionmaker=SessionLocal)

--- a/services/api/app/services/user_roles.py
+++ b/services/api/app/services/user_roles.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
+from typing import cast
+
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from ..diabetes.services.db import SessionLocal, UserRole, run_db
 from ..diabetes.services.repository import commit
+from ..types import SessionProtocol
 
 ALLOWED_ROLES = {"patient", "clinician", "org_admin", "superadmin"}
 
 
 async def get_user_role(user_id: int) -> str | None:
-    def _get(session: Session) -> str | None:
-        obj = session.get(UserRole, user_id)
+    def _get(session: SessionProtocol) -> str | None:
+        obj = cast(UserRole | None, session.get(UserRole, user_id))
         return obj.role if obj else None
 
     return await run_db(_get, sessionmaker=SessionLocal)
@@ -21,14 +24,14 @@ async def set_user_role(user_id: int, role: str) -> None:
     if role not in ALLOWED_ROLES:
         raise HTTPException(status_code=400, detail="invalid role")
 
-    def _save(session: Session) -> None:
-        obj = session.get(UserRole, user_id)
+    def _save(session: SessionProtocol) -> None:
+        obj = cast(UserRole | None, session.get(UserRole, user_id))
         if obj is None:
             obj = UserRole(user_id=user_id, role=role)
-            session.add(obj)
+            cast(Session, session).add(obj)
         else:
             obj.role = role
-        if not commit(session):
+        if not commit(cast(Session, session)):
             raise HTTPException(status_code=500, detail="db commit failed")
 
     await run_db(_save, sessionmaker=SessionLocal)

--- a/services/api/app/types.py
+++ b/services/api/app/types.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any, Protocol, TypeVar
+
+T = TypeVar("T")
+
+
+class SessionProtocol(Protocol):
+    """Minimal protocol for DB sessions used by services."""
+
+    def get(self, entity: type[T], ident: Any) -> T | None:
+        """Retrieve an entity by primary key."""
+        ...
+
+    def delete(self, instance: Any) -> None:
+        """Mark an object for deletion."""
+        ...


### PR DESCRIPTION
## Summary
- define minimal `SessionProtocol` with typed `get` and `delete`
- update services and main API to accept the protocol and cast ORM calls
- cast IDs returned from reminders

## Testing
- `pytest -q` (fails: freeform_handler unexpected keyword, etc.)
- `mypy --strict .` (fails: SessionProtocol type-var, unused ignore, etc.)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9f4571b14832ab2e82a36c4d92905