### PR TITLE
tests: remove type ignore comment

### DIFF
--- a/tests/test_ui_reminders_smoke.py
+++ b/tests/test_ui_reminders_smoke.py
@@ -2,7 +2,7 @@ import threading
 import time
 
 import httpx
-from uvicorn import Config, Server  # type: ignore[import-not-found]
+from uvicorn import Config, Server
 
 import services.api.app.main as server
 


### PR DESCRIPTION
## Summary
- remove outdated type ignore from uvicorn import in UI reminders smoke test

## Testing
- `pytest -q` (fails: async plugin missing and coverage below threshold)
- `mypy --strict .` (fails: 34 errors)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9f458ab00832ab4c7bcf2631f0d53