### PR TITLE
tests: remove type-ignore from optional imports

### DIFF
--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -7,9 +7,9 @@ from types import SimpleNamespace
 from typing import Any, BinaryIO
 
 import pytest
-import matplotlib.pyplot as plt  # type: ignore[import-not-found]
+import matplotlib.pyplot as plt
 from matplotlib.dates import date2num as _date2num
-from pypdf import PdfReader as _PdfReader  # type: ignore[import-not-found]
+from pypdf import PdfReader as _PdfReader
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import sessionmaker


### PR DESCRIPTION
## Summary
- remove type-ignore comments from matplotlib and pypdf imports in `tests/test_reporting.py`

## Testing
- `pytest -q --cov` *(fails: ValueError, TypeError, AssertionError, etc.)*
- `mypy --strict .` *(fails: 33 errors)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68a9f459df80832a84c745aad4c60084