### PR TITLE
tests: update freeform handler args

### DIFF
--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -118,7 +118,7 @@ async def test_photo_flow_saves_entry(
         update_start,
         context,
         parse_command=fake_parse_command,
-        menu_keyboard=None,
+        menu_keyboard_markup=None,
     )
 
     monkeypatch.chdir(tmp_path)
@@ -187,7 +187,7 @@ async def test_photo_flow_saves_entry(
         update_sugar,
         context,
         parse_command=fake_parse_command,
-        menu_keyboard=None,
+        menu_keyboard_markup=None,
     )
     assert user_data["pending_entry"]["sugar_before"] == 5.5
 


### PR DESCRIPTION
## Summary
- adjust tests for renamed `menu_keyboard_markup` parameter

## Testing
- `pytest tests/test_handlers_photo_sugar_save.py -q --cov=tests/test_handlers_photo_sugar_save.py --cov-fail-under=0` *(fails: Could not locate a bind configured on mapper Mapper[Profile(profiles)], SQL expression or this Session.)*
- `mypy --strict .` *(fails: Returning Any from function declared to return "Timezone | None")*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9f45dfce4832aaad42649484d5003