### PR TITLE
[utils] expand markdown bullet stripping

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def clean_markdown(text: str) -> str:
     """
     Удаляет простую Markdown-разметку: **жирный**, _курсив_, # заголовки,
-    * списки, 1. списки и т.д.
+    списки (*, -, +, 1. и т.д.).
     """
     replacements = [
         (r"\*\*([^*]+)\*\*", r"\1"),  # **жирный**
@@ -35,7 +35,7 @@ def clean_markdown(text: str) -> str:
         text = re.sub(pattern, repl, text)
     text = re.sub(r"^#+\s*", "", text, flags=re.MULTILINE)  # ### Заголовки
     text = re.sub(r"^\s*\d+\.\s*", "", text, flags=re.MULTILINE)  # 1. списки
-    text = re.sub(r"^\s*\*\s*", "", text, flags=re.MULTILINE)  # * списки
+    text = re.sub(r"^\s*[*+-]\s*", "", text, flags=re.MULTILINE)  # bullet lists
     return text
 
 
@@ -131,10 +131,7 @@ def split_text_by_width(
         part = ""
         for ch in word:
             test_part = part + ch
-            if (
-                stringWidth(test_part, font_name, font_size) / mm > max_width_mm
-                and part
-            ):
+            if stringWidth(test_part, font_name, font_size) / mm > max_width_mm and part:
                 parts.append(part)
                 part = ch
             else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,7 +26,7 @@ def test_clean_markdown() -> None:
     text = (
         "**Жирный** __подчёркнутый__ _курсив_ *italic* "
         "[ссылка](http://example.com) ![alt](img.png) `код` ~~зачёркнуто~~\n"
-        "# Заголовок\n* элемент\n1. Первый"
+        "# Заголовок\n* элемент\n- минус\n+ плюс\n1. Первый"
     )
     cleaned = clean_markdown(text)
     assert "Жирный" in cleaned
@@ -37,8 +37,12 @@ def test_clean_markdown() -> None:
     assert "alt" in cleaned
     assert "код" in cleaned
     assert "зачёркнуто" in cleaned
+    assert "минус" in cleaned
+    assert "плюс" in cleaned
     assert "#" not in cleaned
     assert "*" not in cleaned
+    assert "-" not in cleaned
+    assert "+" not in cleaned
     assert "1." not in cleaned
     assert "__" not in cleaned
     assert "_" not in cleaned
@@ -47,9 +51,7 @@ def test_clean_markdown() -> None:
 
 def test_split_text_by_width_simple() -> None:
     text = "Это короткая строка"
-    pdfmetrics.registerFont(
-        TTFont("DejaVuSans", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
-    )
+    pdfmetrics.registerFont(TTFont("DejaVuSans", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"))
     lines = split_text_by_width(text, "DejaVuSans", 12, 50)
     assert isinstance(lines, list)
     assert all(isinstance(line, str) for line in lines)
@@ -63,9 +65,7 @@ def test_split_text_by_width_simple() -> None:
     ],
 )
 def test_split_text_by_width_respects_limit(text: Any) -> None:
-    pdfmetrics.registerFont(
-        TTFont("DejaVuSans", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
-    )
+    pdfmetrics.registerFont(TTFont("DejaVuSans", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"))
     max_width = 20
     lines = split_text_by_width(text, "DejaVuSans", 12, max_width)
     for line in lines:
@@ -83,9 +83,7 @@ async def test_get_coords_and_link_non_blocking(
             def __enter__(self) -> io.StringIO:
                 return io.StringIO('{"loc": "1,2"}')
 
-            def __exit__(
-                self, exc_type: object, exc: object, tb: object
-            ) -> Literal[False]:
+            def __exit__(self, exc_type: object, exc: object, tb: object) -> Literal[False]:
                 return False
 
         return Resp()
@@ -125,9 +123,7 @@ async def test_get_coords_and_link_invalid_loc(
             def __enter__(self) -> io.StringIO:
                 return io.StringIO('{"loc": "invalid"}')
 
-            def __exit__(
-                self, exc_type: object, exc: object, tb: object
-            ) -> Literal[False]:
+            def __exit__(self, exc_type: object, exc: object, tb: object) -> Literal[False]:
                 return False
 
         return Resp()
@@ -152,9 +148,7 @@ async def test_get_coords_and_link_custom_source(
             def __enter__(self) -> io.StringIO:
                 return io.StringIO('{"loc": "1,2"}')
 
-            def __exit__(
-                self, exc_type: object, exc: object, tb: object
-            ) -> Literal[False]:
+            def __exit__(self, exc_type: object, exc: object, tb: object) -> Literal[False]:
                 return False
 
         return Resp()


### PR DESCRIPTION
## Summary
- handle `-` and `+` bullet markers in `clean_markdown`
- test removing `-` and `+` list items

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named 'diabetes_sdk')*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9f4ed233c832a93f1be610a249179