### PR TITLE
[gpt] Support array-wrapped responses

### DIFF
--- a/tests/test_gpt_command_parser_errors.py
+++ b/tests/test_gpt_command_parser_errors.py
@@ -207,9 +207,12 @@ def test_sanitize_sensitive_data_masks_token() -> None:
     assert gpt_command_parser._sanitize_sensitive_data(text) == "key [REDACTED] end"
 
 
-def test_extract_first_json_ignores_array() -> None:
-    text = '[{"action":"add_entry"}]'
-    assert gpt_command_parser._extract_first_json(text) is None
+def test_extract_first_json_array_single_dict() -> None:
+    text = '[{"action":"add_entry","fields":{}}]'
+    assert gpt_command_parser._extract_first_json(text) == {
+        "action": "add_entry",
+        "fields": {},
+    }
 
 
 def test_extract_first_json_malformed_json() -> None:


### PR DESCRIPTION
## Summary
- parse single-element array responses in GPT command parser
- cover array-wrapped responses in gpt parser tests

## Testing
- `pytest -q --cov` *(fails: 26 failed, 577 passed, 10 warnings)*
- `mypy --strict .` *(fails: Found 35 errors in 11 files)*
- `ruff check .`
- `pytest -q tests/test_gpt_command_parser.py tests/test_gpt_command_parser_errors.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a9f4eda7ec832a90f89880f0b3b967