### PR TITLE
[gpt_command_parser] use async OpenAI client

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -126,12 +126,8 @@ async def parse_command(text: str, timeout: float = 10) -> dict[str, object] | N
     """
 
     try:
-        # ``asyncio.to_thread`` runs the blocking OpenAI client in the event
-        # loop's shared thread pool, so we reuse threads instead of spawning a
-        # fresh ``ThreadPoolExecutor`` for every invocation.
         response: ChatCompletion = await asyncio.wait_for(
-            asyncio.to_thread(
-                create_chat_completion,
+            create_chat_completion(
                 model="gpt-4o-mini",
                 messages=[
                     {"role": "system", "content": SYSTEM_PROMPT},

--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -1,8 +1,9 @@
+import asyncio
 import logging
 import threading
 
 import httpx
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 
 from services.api.app.config import settings
 
@@ -10,6 +11,9 @@ logger = logging.getLogger(__name__)
 
 _http_client: httpx.Client | None = None
 _http_client_lock = threading.Lock()
+
+_async_http_client: httpx.AsyncClient | None = None
+_async_http_client_lock = threading.Lock()
 
 
 def get_openai_client() -> OpenAI:
@@ -31,9 +35,7 @@ def get_openai_client() -> OpenAI:
         with _http_client_lock:
             if _http_client is None:
                 _http_client = httpx.Client(proxies=settings.openai_proxy)
-            client = OpenAI(
-                api_key=settings.openai_api_key, http_client=_http_client
-            )
+            client = OpenAI(api_key=settings.openai_api_key, http_client=_http_client)
     else:
         client = OpenAI(api_key=settings.openai_api_key, http_client=None)
 
@@ -42,10 +44,42 @@ def get_openai_client() -> OpenAI:
     return client
 
 
+def get_async_openai_client() -> AsyncOpenAI:
+    """Return a configured asynchronous OpenAI client."""
+
+    if not settings.openai_api_key:
+        message = "OPENAI_API_KEY is not set"
+        logger.error("[OpenAI] %s", message)
+        raise RuntimeError(message)
+
+    client: AsyncOpenAI
+    if settings.openai_proxy:
+        global _async_http_client
+        with _async_http_client_lock:
+            if _async_http_client is None:
+                _async_http_client = httpx.AsyncClient(proxies=settings.openai_proxy)
+            client = AsyncOpenAI(
+                api_key=settings.openai_api_key, http_client=_async_http_client
+            )
+    else:
+        client = AsyncOpenAI(api_key=settings.openai_api_key, http_client=None)
+
+    if settings.openai_assistant_id:
+        logger.info("[OpenAI] Using assistant: %s", settings.openai_assistant_id)
+    return client
+
+
 def dispose_http_client() -> None:
     """Close and reset the HTTP client used by OpenAI."""
-    global _http_client
+    global _http_client, _async_http_client
     with _http_client_lock:
         if _http_client is not None:
             _http_client.close()
             _http_client = None
+    with _async_http_client_lock:
+        if _async_http_client is not None:
+            try:
+                asyncio.run(_async_http_client.aclose())
+            except RuntimeError:
+                asyncio.get_event_loop().create_task(_async_http_client.aclose())
+            _async_http_client = None

--- a/tests/test_gpt_command_parser_errors.py
+++ b/tests/test_gpt_command_parser_errors.py
@@ -11,7 +11,7 @@ from services.api.app.diabetes import gpt_command_parser
 async def test_parse_command_handles_asyncio_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def raise_timeout(*args: object, **kwargs: object) -> None:
+    async def raise_timeout(*args: object, **kwargs: object) -> None:
         raise asyncio.TimeoutError
 
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", raise_timeout)
@@ -24,7 +24,7 @@ async def test_parse_command_handles_asyncio_timeout(
 async def test_parse_command_handles_openai_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def raise_openai(*args: object, **kwargs: object) -> None:
+    async def raise_openai(*args: object, **kwargs: object) -> None:
         raise OpenAIError("boom")
 
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", raise_openai)
@@ -38,7 +38,7 @@ async def test_parse_command_handles_openai_error(
 async def test_parse_command_handles_value_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def raise_value(*args: object, **kwargs: object) -> None:
+    async def raise_value(*args: object, **kwargs: object) -> None:
         raise ValueError
 
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", raise_value)
@@ -52,7 +52,7 @@ async def test_parse_command_handles_value_error(
 async def test_parse_command_handles_type_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def raise_type(*args: object, **kwargs: object) -> None:
+    async def raise_type(*args: object, **kwargs: object) -> None:
         raise TypeError
 
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", raise_type)
@@ -69,7 +69,7 @@ async def test_parse_command_returns_none_without_choices(
     class NoChoices:
         pass
 
-    def create(*args: object, **kwargs: object) -> NoChoices:
+    async def create(*args: object, **kwargs: object) -> NoChoices:
         return NoChoices()
 
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)
@@ -86,7 +86,7 @@ async def test_parse_command_returns_none_without_message(
     class NoMessageResponse:
         choices = [type("Choice", (), {})()]
 
-    def create(*args: object, **kwargs: object) -> NoMessageResponse:
+    async def create(*args: object, **kwargs: object) -> NoMessageResponse:
         return NoMessageResponse()
 
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)
@@ -103,7 +103,7 @@ async def test_parse_command_returns_none_without_content(
     class NoContentResponse:
         choices = [type("Choice", (), {"message": type("Msg", (), {})()})]
 
-    def create(*args: object, **kwargs: object) -> NoContentResponse:
+    async def create(*args: object, **kwargs: object) -> NoContentResponse:
         return NoContentResponse()
 
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)
@@ -120,7 +120,7 @@ async def test_parse_command_empty_content(
     class EmptyContentResponse:
         choices = [type("Choice", (), {"message": type("Msg", (), {"content": ""})()})]
 
-    def create(*args: object, **kwargs: object) -> EmptyContentResponse:
+    async def create(*args: object, **kwargs: object) -> EmptyContentResponse:
         return EmptyContentResponse()
 
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)
@@ -139,7 +139,7 @@ async def test_parse_command_non_string_content(
     class NonStringContentResponse:
         choices = [type("Choice", (), {"message": type("Msg", (), {"content": 123})()})]
 
-    def create(*args: object, **kwargs: object) -> NonStringContentResponse:
+    async def create(*args: object, **kwargs: object) -> NonStringContentResponse:
         return NonStringContentResponse()
 
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)
@@ -164,7 +164,7 @@ async def test_parse_command_string_without_json(
             )
         ]
 
-    def create(*args: object, **kwargs: object) -> NoJsonResponse:
+    async def create(*args: object, **kwargs: object) -> NoJsonResponse:
         return NoJsonResponse()
 
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)
@@ -189,7 +189,7 @@ async def test_parse_command_json_invalid_structure(
             )
         ]
 
-    def create(*args: object, **kwargs: object) -> BadStructureResponse:
+    async def create(*args: object, **kwargs: object) -> BadStructureResponse:
         return BadStructureResponse()
 
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)


### PR DESCRIPTION
## Summary
- replace blocking OpenAI calls with async client in `parse_command`
- add async OpenAI utilities and update GPT client
- strengthen timeout test to ensure request cancellation

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: Value of type variable "S" of "run_db" cannot be "SessionProtocol")*
- `mypy --strict services/api/app/diabetes/gpt_command_parser.py services/api/app/diabetes/services/gpt_client.py services/api/app/diabetes/utils/openai_utils.py tests/test_gpt_command_parser.py tests/test_gpt_command_parser_errors.py`
- `pytest -q` *(fails: freeform_handler() got an unexpected keyword argument 'menu_keyboard')*


------
https://chatgpt.com/codex/tasks/task_e_68a9fc1d3a30832a8b7354072c5905b9