### PR TITLE
[gpt] Harden JSON extraction in command parser

### DIFF
--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -213,6 +213,41 @@ async def test_parse_command_with_nested_json(
 
 
 @pytest.mark.asyncio
+async def test_parse_command_with_braces_in_explanatory_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        choices = [
+            type(
+                "Choice",
+                (),
+                {
+                    "message": type(
+                        "Msg",
+                        (),
+                        {
+                            "content": (
+                                '"пример {текста}" '
+                                '{"action":"add_entry","fields":{}}'
+                                " trailing"
+                            )
+                        },
+                    )()
+                },
+            )
+        ]
+
+    def create(*args: Any, **kwargs: Any) -> Any:
+        return FakeResponse()
+
+    monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)
+
+    result = await gpt_command_parser.parse_command("test")
+
+    assert result == {"action": "add_entry", "fields": {}}
+
+
+@pytest.mark.asyncio
 async def test_parse_command_with_scalar_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -363,14 +398,29 @@ def test_extract_first_json_array_single_object() -> None:
 
 def test_extract_first_json_array_multiple_objects() -> None:
     text = (
-        '[{"action":"add_entry","fields":{}},'
-        '{"action":"delete_entry","fields":{}}]'
+        '[{"action":"add_entry","fields":{}},' '{"action":"delete_entry","fields":{}}]'
     )
     assert gpt_command_parser._extract_first_json(text) is None
 
 
 def test_extract_first_json_multiple_objects() -> None:
     text = '{"action":"add_entry","fields":{}} ' '{"action":"delete_entry","fields":{}}'
+    assert gpt_command_parser._extract_first_json(text) == {
+        "action": "add_entry",
+        "fields": {},
+    }
+
+
+def test_extract_first_json_braces_in_string_before_object() -> None:
+    text = 'prefix "not json { }" {"action":"add_entry","fields":{}}'
+    assert gpt_command_parser._extract_first_json(text) == {
+        "action": "add_entry",
+        "fields": {},
+    }
+
+
+def test_extract_first_json_multiple_objects_no_space() -> None:
+    text = '{"action":"add_entry","fields":{}}' '{"action":"delete_entry","fields":{}}'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {},


### PR DESCRIPTION
## Summary
- use bracket-aware scan to locate first JSON object in GPT responses
- extend parser tests for braces in strings and back-to-back objects

## Testing
- `pytest tests/test_gpt_command_parser.py -q` *(fails: Required test coverage of 85% not reached. Total coverage: 11.94%)*
- `mypy --strict .` *(fails: Found 9 errors in 2 files)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9fc25c7f0832aac14551a96659331