### PR TITLE
[api] use Session directly for db helpers

### DIFF
--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -44,7 +44,7 @@ async def save_reminder(data: ReminderSchema) -> int:
         rem.is_enabled = data.isEnabled
         commit(cast(Session, session))
         cast(Session, session).refresh(rem)
-        return cast(int, rem.id)
+        return rem.id
 
     return await run_db(_save, sessionmaker=SessionLocal)
 


### PR DESCRIPTION
## Summary
- refactor API main DB helper functions to accept `sqlalchemy.orm.Session`
- remove casts when invoking `run_db` and drop redundant `cast` calls
- clean up reminder saving routine by removing an unnecessary `cast`

## Testing
- `python -m black services/api/app/main.py services/api/app/services/reminders.py`
- `ruff check services/api/app/main.py services/api/app/services/reminders.py`
- `pytest -q -c /dev/null` *(fails: async def functions are not natively supported)*
- `mypy --strict services/api/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa0640dd58832a96d3be3c15ba29e7