### PR TITLE
[utils] Simplify PDF width calculation

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -4,11 +4,6 @@ import re
 from datetime import datetime, time, timedelta
 from json import JSONDecodeError
 
-from urllib.error import URLError
-from urllib.request import urlopen
-
-
-
 import httpx
 
 from reportlab.pdfbase.pdfmetrics import stringWidth
@@ -125,8 +120,8 @@ def split_text_by_width(
 
     def _width(chunk: str) -> float:
         try:
-            raw = float(stringWidth(chunk, font_name, font_size))
-            return raw / float(mm)
+            raw = stringWidth(chunk, font_name, font_size)
+            return raw / mm
         except KeyError as exc:
             raise ValueError(f"Unknown font '{font_name}'") from exc
 


### PR DESCRIPTION
## Summary
- avoid unnecessary float conversions when measuring text width
- drop unused urllib imports

## Testing
- `ruff check services/api/app/diabetes/utils/helpers.py`
- `mypy --strict services/api/app/diabetes/utils/helpers.py`
- `pytest -q` *(fails: async functions are not natively supported, 210 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa06430028832ab495d7b0f4eadff4