### PR TITLE
services: simplify list reminders

### DIFF
--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -12,15 +12,10 @@ from ..types import SessionProtocol
 
 
 async def list_reminders(telegram_id: int) -> list[Reminder]:
-    def _list(session: SessionProtocol) -> list[Reminder]:
-        if cast(User | None, session.get(User, telegram_id)) is None:
+    def _list(session: Session) -> list[Reminder]:
+        if cast(User | None, session.get(User, telegram_id)) is None:  # type: ignore[attr-defined]
             return []
-        return (
-            cast(Session, session)
-            .query(Reminder)
-            .filter_by(telegram_id=telegram_id)
-            .all()
-        )
+        return session.query(Reminder).filter_by(telegram_id=telegram_id).all()
 
     return await run_db(_list, sessionmaker=SessionLocal)
 


### PR DESCRIPTION
## Summary
- use SQLAlchemy Session directly in list_reminders
- drop redundant cast when fetching reminders

## Testing
- `ruff check services/api/app/services/reminders.py`
- `mypy --strict services/api/app/services/reminders.py`
- `pytest tests/test_services_reminders.py::test_save_and_list_reminder -q` *(fails: AssertionError; coverage < 85%)*

------
https://chatgpt.com/codex/tasks/task_e_68aa064584ac832a82bebf197e38d2b3