### PR TITLE
[api] unify routes under /api prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ python services/api/app/main.py
    ```bash
    uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000
    ```
-   Приложение также подключает маршруты из `legacy.py`, предоставляя эндпоинты `/profiles` и `/api/reminders`, совместимые с SDK.
+   Приложение также подключает маршруты из `legacy.py`, предоставляя эндпоинты `/api/profiles` и `/api/reminders`, совместимые с SDK.
 
 ### Docker Compose
 

--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -3,13 +3,13 @@ info:
   title: Diabetes Assistant API
   version: 1.0.0
 servers:
-  - url: /api
+  - url: /
 tags:
 - name: Profiles
 - name: History
 - name: Reminders
 paths:
-  /health:
+  /api/health:
     get:
       summary: Health
       operationId: healthGet
@@ -24,7 +24,7 @@ paths:
                   type: string
                 title: Response Health Get
       security: []
-  /profiles:
+  /api/profiles:
     post:
       tags:
       - Profiles
@@ -78,7 +78,7 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
         '404':
           description: profile not found
-  /reminders:
+  /api/reminders:
     get:
       tags:
       - Reminders
@@ -201,7 +201,7 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
         '404':
           description: Reminder not found
-  /reminders/{id}:
+  /api/reminders/{id}:
     get:
       tags:
       - Reminders
@@ -235,7 +235,7 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
         '404':
           description: Reminder not found or telegramId mismatch
-  /timezone:
+  /api/timezone:
     get:
       summary: Get Timezone
       operationId: get_timezone_timezone_get
@@ -280,7 +280,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /profile/self:
+  /api/profile/self:
     get:
       summary: Profile Self
       operationId: profile_self_profile_self_get
@@ -297,7 +297,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /stats:
+  /api/stats:
     get:
       summary: Get Stats
       operationId: get_stats_stats_get
@@ -325,7 +325,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /analytics:
+  /api/analytics:
     get:
       summary: Get Analytics
       operationId: get_analytics_analytics_get
@@ -354,7 +354,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /user:
+  /api/user:
     post:
       summary: Create User
       description: Ensure a user exists in the database.
@@ -381,7 +381,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /user/{user_id}/role:
+  /api/user/{user_id}/role:
     get:
       summary: Get Role
       operationId: get_role_user_user_id_role_get
@@ -434,7 +434,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /history:
+  /api/history:
     post:
       tags:
       - History
@@ -485,7 +485,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /history/{id}:
+  /api/history/{id}:
     delete:
       tags:
       - History

--- a/tests/test_profile_self.py
+++ b/tests/test_profile_self.py
@@ -28,7 +28,7 @@ def test_profile_self_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     init_data = build_init_data(42)
     with TestClient(app) as client:
 
-        resp = client.get("/profile/self", headers={TG_INIT_DATA_HEADER: init_data})
+        resp = client.get("/api/profile/self", headers={TG_INIT_DATA_HEADER: init_data})
 
     assert resp.status_code == 200
     assert resp.json()["id"] == 42
@@ -36,7 +36,7 @@ def test_profile_self_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_profile_self_missing_header() -> None:
     with TestClient(app) as client:
-        resp = client.get("/profile/self")
+        resp = client.get("/api/profile/self")
     assert resp.status_code == 401
 
 
@@ -44,6 +44,6 @@ def test_profile_self_invalid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     with TestClient(app) as client:
 
-        resp = client.get("/profile/self", headers={TG_INIT_DATA_HEADER: "bad"})
+        resp = client.get("/api/profile/self", headers={TG_INIT_DATA_HEADER: "bad"})
 
     assert resp.status_code == 401

--- a/tests/test_user_roles.py
+++ b/tests/test_user_roles.py
@@ -23,17 +23,16 @@ def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker:
     return SessionLocal
 
 
-@pytest.mark.parametrize("prefix", ("", "/api"))
-def test_role_endpoints(monkeypatch: pytest.MonkeyPatch, prefix: str) -> None:
+def test_role_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
     SessionLocal = setup_db(monkeypatch)
     with TestClient(server.app) as client:
-        resp = client.get(f"{prefix}/user/1/role")
+        resp = client.get("/api/user/1/role")
         assert resp.status_code == 200
         assert resp.json() == {"role": "patient"}
-        resp = client.put(f"{prefix}/user/1/role", json={"role": "clinician"})
+        resp = client.put("/api/user/1/role", json={"role": "clinician"})
         assert resp.status_code == 200
         assert resp.json() == {"role": "clinician"}
-        resp = client.get(f"{prefix}/user/1/role")
+        resp = client.get("/api/user/1/role")
         assert resp.status_code == 200
         assert resp.json() == {"role": "clinician"}
 

--- a/tests/test_webapp_history.py
+++ b/tests/test_webapp_history.py
@@ -52,9 +52,9 @@ def test_history_auth_required(monkeypatch: pytest.MonkeyPatch) -> None:
     setup_db(monkeypatch)
     with TestClient(server.app) as client:
         rec = {"id": "1", "date": "2024-01-01", "time": "12:00", "type": "measurement"}
-        assert client.post("/history", json=rec).status_code == 401
-        assert client.get("/history").status_code == 401
-        assert client.delete("/history/1").status_code == 401
+        assert client.post("/api/history", json=rec).status_code == 401
+        assert client.get("/api/history").status_code == 401
+        assert client.delete("/api/history/1").status_code == 401
 
 
 def test_history_invalid_date_time(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -68,7 +68,7 @@ def test_history_invalid_date_time(monkeypatch: pytest.MonkeyPatch) -> None:
             "time": "12:00",
             "type": "measurement",
         }
-        resp = client.post("/history", json=bad_date, headers=headers)
+        resp = client.post("/api/history", json=bad_date, headers=headers)
         assert resp.status_code == 422
         bad_time = {
             "id": "1",
@@ -76,7 +76,7 @@ def test_history_invalid_date_time(monkeypatch: pytest.MonkeyPatch) -> None:
             "time": "24:00",
             "type": "measurement",
         }
-        resp = client.post("/history", json=bad_time, headers=headers)
+        resp = client.post("/api/history", json=bad_time, headers=headers)
         assert resp.status_code == 422
 
         bad_time_seconds = {
@@ -85,7 +85,7 @@ def test_history_invalid_date_time(monkeypatch: pytest.MonkeyPatch) -> None:
             "time": "12:00:00",
             "type": "measurement",
         }
-        resp = client.post("/history", json=bad_time_seconds, headers=headers)
+        resp = client.post("/api/history", json=bad_time_seconds, headers=headers)
         assert resp.status_code == 422
 
 
@@ -101,7 +101,7 @@ def test_history_persist_and_update(monkeypatch: pytest.MonkeyPatch) -> None:
             "time": "12:00",
             "type": "measurement",
         }
-        resp = client.post("/history", json=rec1, headers=headers1)
+        resp = client.post("/api/history", json=rec1, headers=headers1)
         assert resp.status_code == 200
 
         with cast(ContextManager[SASession], Session()) as session:
@@ -112,7 +112,7 @@ def test_history_persist_and_update(monkeypatch: pytest.MonkeyPatch) -> None:
             assert stored.telegram_id == 1
 
         rec1_update = {**rec1, "sugar": 5.5}
-        resp = client.post("/history", json=rec1_update, headers=headers1)
+        resp = client.post("/api/history", json=rec1_update, headers=headers1)
         assert resp.status_code == 200
 
         with cast(ContextManager[SASession], Session()) as session:
@@ -121,29 +121,29 @@ def test_history_persist_and_update(monkeypatch: pytest.MonkeyPatch) -> None:
             assert stored.sugar == 5.5
 
         rec2 = {"id": "2", "date": "2024-01-02", "time": "13:00", "type": "meal"}
-        resp = client.post("/history", json=rec2, headers=headers1)
+        resp = client.post("/api/history", json=rec2, headers=headers1)
         assert resp.status_code == 200
 
         rec3 = {"id": "3", "date": "2024-01-03", "time": "14:00", "type": "meal"}
-        resp = client.post("/history", json=rec3, headers=headers2)
+        resp = client.post("/api/history", json=rec3, headers=headers2)
         assert resp.status_code == 200
 
-        resp = client.get("/history", headers=headers1)
+        resp = client.get("/api/history", headers=headers1)
         body = resp.json()
         assert [r["id"] for r in body] == ["1", "2"]
         assert body[0]["time"] == "12:00"
         assert body[1]["time"] == "13:00"
 
-        resp = client.get("/history", headers=headers2)
+        resp = client.get("/api/history", headers=headers2)
         assert [r["id"] for r in resp.json()] == ["3"]
 
-        resp = client.delete("/history/1", headers=headers2)
+        resp = client.delete("/api/history/1", headers=headers2)
         assert resp.status_code == 403
 
-        resp = client.delete("/history/1", headers=headers1)
+        resp = client.delete("/api/history/1", headers=headers1)
         assert resp.status_code == 200
 
-        resp = client.get("/history", headers=headers1)
+        resp = client.get("/api/history", headers=headers1)
         assert [r["id"] for r in resp.json()] == ["2"]
 
 
@@ -173,7 +173,7 @@ def test_history_invalid_type(monkeypatch: pytest.MonkeyPatch) -> None:
         session.commit()
 
     with TestClient(server.app) as client:
-        resp = client.get("/history", headers=headers)
+        resp = client.get("/api/history", headers=headers)
         assert resp.status_code == 200
         body = resp.json()
         assert [r["id"] for r in body] == ["2"]
@@ -193,7 +193,7 @@ async def test_history_concurrent_writes(monkeypatch: pytest.MonkeyPatch) -> Non
         async with AsyncClient(
             transport=ASGITransport(app=cast(Any, server.app)), base_url="http://test"
         ) as ac:
-            resp = await ac.post("/history", json=rec, headers=headers)
+            resp = await ac.post("/api/history", json=rec, headers=headers)
             assert resp.status_code == 200
 
     await asyncio.gather(*(post_record(r) for r in records))

--- a/tests/test_webapp_server.py
+++ b/tests/test_webapp_server.py
@@ -1,13 +1,11 @@
 from fastapi.testclient import TestClient
-import pytest
 
 import services.api.app.main as server
 
 
-@pytest.mark.parametrize("prefix", ("", "/api"))
-def test_health(prefix: str) -> None:
+def test_health() -> None:
     with TestClient(server.app) as client:
-        resp = client.get(f"{prefix}/health")
+        resp = client.get("/api/health")
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
 

--- a/tests/test_webapp_user.py
+++ b/tests/test_webapp_user.py
@@ -45,14 +45,13 @@ def build_init_data(user_id: int = 1) -> str:
     return urllib.parse.urlencode(params)
 
 
-@pytest.mark.parametrize("prefix", ("", "/api"))
-def test_create_user_authorized(monkeypatch: pytest.MonkeyPatch, prefix: str) -> None:
+def test_create_user_authorized(monkeypatch: pytest.MonkeyPatch) -> None:
     Session = setup_db(monkeypatch)
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     init_data = build_init_data(42)
     with TestClient(server.app) as client:
         resp = client.post(
-            f"{prefix}/user",
+            "/api/user",
             json={"telegramId": 42},
             headers={TG_INIT_DATA_HEADER: init_data},
         )
@@ -64,14 +63,13 @@ def test_create_user_authorized(monkeypatch: pytest.MonkeyPatch, prefix: str) ->
         assert user.thread_id == "webapp"
 
 
-@pytest.mark.parametrize("prefix", ("", "/api"))
-def test_create_user_unauthorized(monkeypatch: pytest.MonkeyPatch, prefix: str) -> None:
+def test_create_user_unauthorized(monkeypatch: pytest.MonkeyPatch) -> None:
     setup_db(monkeypatch)
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     init_data = build_init_data(1)
     with TestClient(server.app) as client:
         resp = client.post(
-            f"{prefix}/user",
+            "/api/user",
             json={"telegramId": 42},
             headers={TG_INIT_DATA_HEADER: init_data},
         )


### PR DESCRIPTION
## Summary
- route all API endpoints through `/api` using FastAPI `APIRouter`
- drop alternative non-prefixed routes and update OpenAPI spec
- adjust documentation and tests for the new base path

## Testing
- `pytest -q` *(fails: freeform handler errors, profile endpoints not found, reminders service failure)*
- `mypy --strict .` *(fails: "Session" has no attribute `get`, other typing errors)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aa0d65d8d4832aac82ff265cecfb47