### PR TITLE
[handlers] delegate dose_calc freeform via gpt handlers

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -308,17 +308,11 @@ from . import gpt_handlers as _gpt_handlers  # noqa: E402
 
 
 async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    return await _gpt_handlers.freeform_handler(
-        update,
-        context,
-        SessionLocal=SessionLocal,
-        commit=commit,
-        check_alert=check_alert,
-        menu_keyboard=menu_keyboard,
-        smart_input=smart_input,
-        parse_command=parse_command,
-        send_report=send_report,
-    )
+    _gpt_handlers.commit = commit
+    _gpt_handlers.parse_command = parse_command
+    _gpt_handlers.smart_input = smart_input
+    _gpt_handlers.send_report = send_report
+    await _gpt_handlers.freeform_handler(update, context)
 
 
 chat_with_gpt = _gpt_handlers.chat_with_gpt


### PR DESCRIPTION
## Summary
- delegate `dose_calc.freeform_handler` directly to `_gpt_handlers` after binding commit, parse, smart input and report functions
- ensure re-exported helpers remain in `__all__`
- cover monkeypatch propagation of `dose_calc.commit` to `_gpt_handlers`

## Testing
- `pytest -q` *(fails: Could not locate DB bind / missing environment configuration)*
- `pytest tests/test_dose_calc_reexports.py -q -p no:cov -o addopts=""`
- `mypy --strict .` *(fails: Returning Any from function declared to return "int")*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aa0ea9895c832a836c6ea74279bad7