### PR TITLE
[handlers] Drop explicit sessionmaker from sugar_val

### DIFF
--- a/services/api/app/diabetes/handlers/sugar_handlers.py
+++ b/services/api/app/diabetes/handlers/sugar_handlers.py
@@ -114,7 +114,7 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         with SessionLocal() as session:
             success = save_entry(session, entry_data)
     else:
-        success = await run_db(save_entry, entry_data, sessionmaker=SessionLocal)
+        success = await run_db(save_entry, entry_data)
     if not success:
         await message.reply_text("⚠️ Не удалось сохранить запись.")
         return END

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -58,6 +58,7 @@ async def test_profile_input_not_logged_as_sugar(
     monkeypatch.setattr(profile_handlers, "SessionLocal", TestSession)
 
     async def run_db_wrapper(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        assert "sessionmaker" not in kwargs
         return await db.run_db(fn, *args, sessionmaker=TestSession, **kwargs)
 
     monkeypatch.setattr(sugar_handlers, "run_db", run_db_wrapper)

--- a/tests/test_sugar_handlers.py
+++ b/tests/test_sugar_handlers.py
@@ -153,6 +153,7 @@ async def test_sugar_val_valid_saves_and_alerts(
     session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
     async def run_db_wrapper(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        assert "sessionmaker" not in kwargs
         return await db.run_db(fn, *args, sessionmaker=session_factory, **kwargs)
 
     monkeypatch.setattr(sugar_handlers, "run_db", run_db_wrapper)


### PR DESCRIPTION
## Summary
- rely on default `SessionLocal` when saving sugar entry
- ensure tests verify no custom sessionmaker is passed to sugar handlers

## Testing
- `pytest -q --cov` *(fails: 25 failed, 585 passed)*
- `pytest tests/test_sugar_handlers.py::test_sugar_val_valid_saves_and_alerts -q --no-cov`
- `pytest tests/test_profile_ignores_sugar_conv.py::test_profile_input_not_logged_as_sugar -q --no-cov`
- `mypy --strict .` *(fails: 7 errors)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aa0ead3dd0832a898ab07305ba21d1