### PR TITLE
[services] Ensure reminder ID is int

### DIFF
--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -39,7 +39,7 @@ async def save_reminder(data: ReminderSchema) -> int:
         rem.is_enabled = data.isEnabled
         commit(cast(Session, session))
         cast(Session, session).refresh(rem)
-        return rem.id
+        return cast(int, rem.id)
 
     return await run_db(_save, sessionmaker=SessionLocal)
 


### PR DESCRIPTION
## Summary
- cast reminder ID to int in `save_reminder`

## Testing
- `ruff check .`
- `mypy --strict services/api/app/services/reminders.py`
- `pytest -q --cov` *(fails: KeyboardInterrupt during test collection with pypdf)*

------
https://chatgpt.com/codex/tasks/task_e_68aa10684934832a83d469ad18a1697f