### PR TITLE
[profile] Inject sessionmaker into profile API

### DIFF
--- a/services/api/app/diabetes/handlers/profile/__init__.py
+++ b/services/api/app/diabetes/handlers/profile/__init__.py
@@ -1,7 +1,7 @@
 """Expose profile conversation handlers and helpers."""
 
-from . import conversation as _conversation
-from .api import get_api, save_profile, set_timezone, fetch_profile, post_profile
+from . import conversation as _conversation, api as _api
+from .api import save_profile, set_timezone, fetch_profile, post_profile
 from services.api.app.diabetes.utils.ui import back_keyboard
 from .conversation import (
     profile_command,
@@ -24,6 +24,10 @@ from .conversation import (
     END,
 )
 from .validation import parse_profile_args
+
+
+def get_api() -> tuple[object, type[Exception], type]:
+    return _api.get_api(_conversation.SessionLocal)
 
 __all__ = [
     "profile_command",

--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -83,7 +83,9 @@ if TYPE_CHECKING:  # pragma: no cover - used only for type hints
     from diabetes_sdk.api.default_api import DefaultApi
 
 
-def get_api() -> tuple[object, type[Exception], type]:
+def get_api(
+    sessionmaker: Callable[[], Session] = SessionLocal,
+) -> tuple[object, type[Exception], type]:
     """Return API client, its exception type and profile model.
 
     The function attempts to import and configure the external
@@ -101,12 +103,12 @@ def get_api() -> tuple[object, type[Exception], type]:
         logger.warning(
             "diabetes_sdk is not installed. Falling back to local profile API.",
         )
-        return LocalProfileAPI(SessionLocal), Exception, LocalProfile
+        return LocalProfileAPI(sessionmaker), Exception, LocalProfile
     except RuntimeError:  # pragma: no cover - initialization issues
         logger.warning(
             "diabetes_sdk could not be initialized. Falling back to local profile API.",
         )
-        return LocalProfileAPI(SessionLocal), Exception, LocalProfile
+        return LocalProfileAPI(sessionmaker), Exception, LocalProfile
     api = DefaultApi(ApiClient(Configuration(host=settings.api_url)))
     return api, ApiException, ProfileModel
 


### PR DESCRIPTION
## Summary
- allow passing custom sessionmaker to profile API fallback
- expose profile.get_api wrapper using current SessionLocal

## Testing
- `pytest --no-cov tests/test_handlers_profile.py::test_profile_command_and_view -q`
- `pytest -q` *(fails: OPENAI_API_KEY is not set; Database engine is not initialized; WEBAPP_URL not configured)*
- `mypy --strict .` *(fails: No overload variant of "sessionmaker" matches argument types "Engine", "bool", "bool"; Missing type parameters for generic type "sessionmaker"; Returning Any from function declared to return "float")*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aa1380d0a0832ab03444169d664ede