### PR TITLE
[webapp] validate reminders list items

### DIFF
--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -106,6 +106,12 @@ describe('getReminders', () => {
     );
   });
 
+  it('throws on invalid API response', async () => {
+    mockRemindersGet.mockResolvedValueOnce([{} as any]);
+    mockInstanceOfReminder.mockReturnValueOnce(false);
+    await expect(getReminders(1)).rejects.toThrow('Некорректный ответ API');
+  });
+
   it('returns empty array on 404 response', async () => {
     mockRemindersGet.mockRejectedValueOnce(
       new ResponseError(new Response(null, { status: 404 })),

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -17,7 +17,19 @@ export async function getReminders(
 ): Promise<Reminder[]> {
   try {
     const data = await api.remindersGet({ telegramId }, { signal });
-    return data ?? [];
+
+    if (!data) {
+      return [];
+    }
+
+    for (const reminder of data) {
+      if (!instanceOfReminder(reminder)) {
+        console.error('Unexpected reminder API response:', reminder);
+        throw new Error('Некорректный ответ API');
+      }
+    }
+
+    return data;
   } catch (error) {
     if (error instanceof DOMException && error.name === 'AbortError') {
       throw error;


### PR DESCRIPTION
## Summary
- validate each reminder element from API response
- test getReminders error on invalid items

## Testing
- `pnpm --filter vite_react_shadcn_ts lint` *(fails: Unexpected any in existing tests)*
- `pnpm --filter vite_react_shadcn_ts typecheck`
- `pnpm --filter vite_react_shadcn_ts exec vitest run --environment jsdom` *(fails: react-test-renderer missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa18f317ac832aa42eaaed7aa61567