### PR TITLE
[handlers] Make session factory injectable

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -576,7 +576,7 @@ async def freeform_handler(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
     *,
-    SessionLocal: sessionmaker = SessionLocal,
+    SessionLocal: sessionmaker | None = None,
     commit: Callable[[Session], bool] = commit,
     check_alert: Callable[
         [Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]
@@ -590,6 +590,8 @@ async def freeform_handler(
     ] = send_report,
 ) -> None:
     """Handle freeform text commands for adding diary entries."""
+    SessionLocal = SessionLocal or globals()["SessionLocal"]
+    assert SessionLocal is not None
     user_data_raw = context.user_data
     if user_data_raw is None:
         return


### PR DESCRIPTION
## Summary
- allow injecting custom SessionLocal factory in `freeform_handler`
- resolve default SessionLocal inside handler when not provided

## Testing
- `pytest tests -q` *(fails: test_edit_dose, test_freeform_handler_edits_pending_entry_keeps_state, test_profile_view_missing_profile_shows_webapp_button)*
- `mypy --strict .` *(fails: Missing type parameters for generic type "sessionmaker" and others)*
- `ruff check .` *(fails: Undefined name `time_` in services/api/app/services/reminders.py:16)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1919ff80832ab84a6a1e937862e9