### PR TITLE
[handlers] answer edit query on success and failure

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -40,9 +40,7 @@ T = TypeVar("T")
 
 
 class RunDB(Protocol):
-    def __call__(
-        self, fn: Callable[[Session], T], *args: object, **kwargs: object
-    ) -> Awaitable[T]: ...
+    def __call__(self, fn: Callable[[Session], T], *args: object, **kwargs: object) -> Awaitable[T]: ...
 
 
 logger = logging.getLogger(__name__)
@@ -88,9 +86,7 @@ async def _handle_report_request(
         await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
         return True
     try:
-        date_from = datetime.datetime.strptime(raw_text, "%Y-%m-%d").replace(
-            tzinfo=datetime.timezone.utc
-        )
+        date_from = datetime.datetime.strptime(raw_text, "%Y-%m-%d").replace(tzinfo=datetime.timezone.utc)
     except ValueError:
         await message.reply_text("❗ Некорректная дата. Используйте формат YYYY-MM-DD.")
         return True
@@ -128,9 +124,7 @@ async def _handle_pending_entry(
     *,
     SessionLocal: sessionmaker,
     commit: Callable[[Session], bool],
-    check_alert: Callable[
-        [Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]
-    ],
+    check_alert: Callable[[Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]],
     menu_keyboard: ReplyKeyboardMarkup | None,
 ) -> bool:
     """Process numeric input for a pending entry."""
@@ -201,10 +195,7 @@ async def _handle_pending_entry(
         return True
 
     text = raw_text.lower()
-    if (
-        re.fullmatch(r"-?\d+(?:[.,]\d+)?", text)
-        and pending_entry.get("sugar_before") is None
-    ):
+    if re.fullmatch(r"-?\d+(?:[.,]\d+)?", text) and pending_entry.get("sugar_before") is None:
         try:
             sugar = float(text.replace(",", "."))
         except ValueError:
@@ -214,10 +205,7 @@ async def _handle_pending_entry(
             await message.reply_text("Сахар не может быть отрицательным.")
             return True
         pending_entry["sugar_before"] = sugar
-        if (
-            pending_entry.get("carbs_g") is not None
-            or pending_entry.get("xe") is not None
-        ):
+        if pending_entry.get("carbs_g") is not None or pending_entry.get("xe") is not None:
             xe_val = pending_entry.get("xe")
             carbs_g = pending_entry.get("carbs_g")
             if carbs_g is None and xe_val is not None:
@@ -247,9 +235,7 @@ async def _handle_pending_entry(
                 and profile.cf is not None
                 and profile.target_bg is not None
             ):
-                patient = PatientProfile(
-                    icr=profile.icr, cf=profile.cf, target_bg=profile.target_bg
-                )
+                patient = PatientProfile(icr=profile.icr, cf=profile.cf, target_bg=profile.target_bg)
                 dose = calc_bolus(carbs_g, sugar, patient)
                 pending_entry["dose"] = dose
                 await message.reply_text(
@@ -257,9 +243,7 @@ async def _handle_pending_entry(
                     reply_markup=confirm_keyboard(),
                 )
                 return True
-        await message.reply_text(
-            "Введите количество углеводов или ХЕ.", reply_markup=menu_keyboard
-        )
+        await message.reply_text("Введите количество углеводов или ХЕ.", reply_markup=menu_keyboard)
         return True
 
     # not handled here
@@ -279,6 +263,8 @@ async def _handle_edit_entry(
     edit_id = user_data.get("edit_id")
     if edit_id is None:
         return False
+    edit_query_obj = user_data.get("edit_query")
+    edit_query: CallbackQuery | None = edit_query_obj if isinstance(edit_query_obj, CallbackQuery) else None
     text = raw_text.replace(",", ".")
     try:
         value = float(text)
@@ -313,6 +299,8 @@ async def _handle_edit_entry(
         entry = await run_db(db_edit, sessionmaker=SessionLocal)
     if entry is None:
         await message.reply_text("⚠️ Не удалось сохранить запись.")
+        if edit_query is not None:
+            await edit_query.answer("Не удалось")
         return True
     edit_info_raw = user_data.get("edit_entry")
     if not isinstance(edit_info_raw, dict):
@@ -338,10 +326,6 @@ async def _handle_edit_entry(
         reply_markup=markup,
         parse_mode="HTML",
     )
-    edit_query_obj = user_data.get("edit_query")
-    edit_query: CallbackQuery | None = (
-        edit_query_obj if isinstance(edit_query_obj, CallbackQuery) else None
-    )
     if edit_query is not None:
         await edit_query.answer("Изменено")
     for key in ("edit_id", "edit_field", "edit_entry", "edit_query"):
@@ -359,9 +343,7 @@ async def _handle_smart_input(
     *,
     SessionLocal: sessionmaker,
     commit: Callable[[Session], bool],
-    check_alert: Callable[
-        [Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]
-    ],
+    check_alert: Callable[[Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]],
     menu_keyboard: ReplyKeyboardMarkup | None,
     smart_input: Callable[[str], dict[str, float | None]],
     parse_command: Callable[[str], Awaitable[dict[str, object] | None]],
@@ -383,9 +365,7 @@ async def _handle_smart_input(
             )
         return
 
-    carbs_match = re.search(
-        r"(?:carbs|углеводов)\s*=\s*(-?\d+(?:[.,]\d+)?)", raw_text, re.I
-    )
+    carbs_match = re.search(r"(?:carbs|углеводов)\s*=\s*(-?\d+(?:[.,]\d+)?)", raw_text, re.I)
     pending_raw = user_data.get("pending_entry")
     edit_id = user_data.get("edit_id")
     if (
@@ -402,9 +382,7 @@ async def _handle_smart_input(
         elif carbs_match:
             carbs_match_val = float(carbs_match.group(1).replace(",", "."))
             if carbs_match_val < 0:
-                await message.reply_text(
-                    "Количество углеводов не может быть отрицательным."
-                )
+                await message.reply_text("Количество углеводов не может быть отрицательным.")
                 return
             pending_entry["carbs_g"] = carbs_match_val
         if quick["dose"] is not None:
@@ -533,13 +511,9 @@ async def _handle_smart_input(
         try:
             hh, mm = map(int, time_obj.split(":"))
             today = datetime.datetime.now(datetime.timezone.utc).date()
-            event_dt = datetime.datetime.combine(
-                today, datetime.time(hh, mm), tzinfo=datetime.timezone.utc
-            )
+            event_dt = datetime.datetime.combine(today, datetime.time(hh, mm), tzinfo=datetime.timezone.utc)
         except (ValueError, TypeError):
-            await message.reply_text(
-                "⏰ Неверный формат времени. Использую текущее время."
-            )
+            await message.reply_text("⏰ Неверный формат времени. Использую текущее время.")
             event_dt = datetime.datetime.now(datetime.timezone.utc)
     else:
         event_dt = datetime.datetime.now(datetime.timezone.utc)
@@ -566,9 +540,7 @@ async def _handle_smart_input(
     sugar_part = f"Сахар: {sugar_val}\u202fммоль/л" if sugar_val is not None else ""
     lines = "  \n- ".join(filter(None, [xe_part or carb_part, dose_part, sugar_part]))
 
-    reply = (
-        f"💉 Расчёт завершён:\n\n{date_str}  \n- {lines}\n\nСохранить это в дневник?"
-    )
+    reply = f"💉 Расчёт завершён:\n\n{date_str}  \n- {lines}\n\nСохранить это в дневник?"
     await message.reply_text(text=reply, reply_markup=confirm_keyboard())
 
 
@@ -578,9 +550,7 @@ async def freeform_handler(
     *,
     SessionLocal: sessionmaker = SessionLocal,
     commit: Callable[[Session], bool] = commit,
-    check_alert: Callable[
-        [Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]
-    ] = check_alert,
+    check_alert: Callable[[Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]] = check_alert,
     menu_keyboard_markup: ReplyKeyboardMarkup | None = menu_keyboard,
     smart_input: Callable[[str], dict[str, float | None]] = smart_input,
     parse_command: Callable[[str], Awaitable[dict[str, object] | None]] = parse_command,

--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from typing import Callable, cast
 
 
+from datetime import time as time_
+
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
@@ -65,9 +67,7 @@ async def save_reminder(data: ReminderSchema) -> int:
 
     return cast(
         int,
-        await run_db(
-            cast(Callable[[Session], int], _save), sessionmaker=SessionLocal
-        ),
+        await run_db(cast(Callable[[Session], int], _save), sessionmaker=SessionLocal),
     )
 
 
@@ -79,6 +79,4 @@ async def delete_reminder(telegram_id: int, reminder_id: int) -> None:
         session.delete(rem)
         commit(cast(Session, session))
 
-    await run_db(
-        cast(Callable[[Session], None], _delete), sessionmaker=SessionLocal
-    )
+    await run_db(cast(Callable[[Session], None], _delete), sessionmaker=SessionLocal)


### PR DESCRIPTION
## Summary
- ensure edit callbacks are answered with explicit success or failure messages
- cover failure path in entry edit tests
- fix missing `time_` import in reminders service

## Testing
- `ruff check tests/test_edit_record.py services/api/app/diabetes/handlers/gpt_handlers.py services/api/app/services/reminders.py`
- `mypy --strict .` *(fails: SQLAlchemy plugin conflict)*
- `pytest -q --cov` *(fails: UnboundExecutionError, missing WEBAPP_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68aa191eb264832ab0a0ffdaa2c4e4ff