### PR TITLE
[api] Use Session for DB helpers

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -5,7 +5,7 @@ import logging
 import os
 from pathlib import Path
 import sys
-from typing import Callable, cast
+from typing import cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 # ────────── Path-хаки, когда файл запускают напрямую ──────────
@@ -21,7 +21,6 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 # ────────── local ──────────
-from services.api.app.types import SessionProtocol
 from .diabetes.services.db import (
     HistoryRecord as HistoryRecordDB,
     Timezone as TimezoneDB,
@@ -101,12 +100,10 @@ async def health() -> dict[str, str]:
 # ────────── timezone ──────────
 @api_router.get("/timezone")
 async def get_timezone(_: UserContext = Depends(require_tg_user)) -> dict[str, str]:
-    def _get_timezone(session: SessionProtocol) -> TimezoneDB | None:
-        return cast(TimezoneDB | None, session.get(TimezoneDB, 1))
+    def _get_timezone(session: Session) -> TimezoneDB | None:
+        return session.get(TimezoneDB, 1)
 
-    tz_row = await run_db(
-        cast(Callable[[Session], TimezoneDB | None], _get_timezone)
-    )
+    tz_row = await run_db(_get_timezone)
     if not tz_row:
         raise HTTPException(status_code=404, detail="timezone not set")
     try:
@@ -125,17 +122,17 @@ async def put_timezone(
     except ZoneInfoNotFoundError as exc:
         raise HTTPException(status_code=400, detail="invalid timezone") from exc
 
-    def _save_timezone(session: SessionProtocol) -> None:
-        obj = cast(TimezoneDB | None, session.get(TimezoneDB, 1))
+    def _save_timezone(session: Session) -> None:
+        obj = session.get(TimezoneDB, 1)
         if obj is None:
             obj = TimezoneDB(id=1, tz=data.tz)
-            cast(Session, session).add(obj)
+            session.add(obj)
         else:
             obj.tz = data.tz
-        if not commit(cast(Session, session)):
+        if not commit(session):
             raise HTTPException(status_code=500, detail="db commit failed")
 
-    await run_db(cast(Callable[[Session], None], _save_timezone))
+    await run_db(_save_timezone)
     return {"status": "ok"}
 
 
@@ -173,16 +170,14 @@ async def create_user(
     if data.telegramId != user["id"]:
         raise HTTPException(status_code=403, detail="telegram id mismatch")
 
-    def _create_user(session: SessionProtocol) -> None:
-        db_user = cast(UserDB | None, session.get(UserDB, data.telegramId))
+    def _create_user(session: Session) -> None:
+        db_user = session.get(UserDB, data.telegramId)
         if db_user is None:
-            cast(Session, session).add(
-                UserDB(telegram_id=data.telegramId, thread_id="webapp")
-            )
-        if not commit(cast(Session, session)):
+            session.add(UserDB(telegram_id=data.telegramId, thread_id="webapp"))
+        if not commit(session):
             raise HTTPException(status_code=500, detail="db commit failed")
 
-    await run_db(cast(Callable[[Session], None], _create_user))
+    await run_db(_create_user)
     return {"status": "ok"}
 
 
@@ -205,13 +200,13 @@ async def post_history(
 ) -> dict[str, str]:
     validated_type = _validate_history_type(data.type)
 
-    def _save(session: SessionProtocol) -> None:
-        obj = cast(HistoryRecordDB | None, session.get(HistoryRecordDB, data.id))
+    def _save(session: Session) -> None:
+        obj = session.get(HistoryRecordDB, data.id)
         if obj and obj.telegram_id != user["id"]:
             raise HTTPException(status_code=403, detail="forbidden")
         if obj is None:
             obj = HistoryRecordDB(id=data.id, telegram_id=user["id"])
-            cast(Session, session).add(obj)
+            session.add(obj)
         obj.date = data.date
         obj.time = dt_time.fromisoformat(data.time)
         obj.sugar = data.sugar
@@ -220,10 +215,10 @@ async def post_history(
         obj.insulin = data.insulin
         obj.notes = data.notes
         obj.type = validated_type
-        if not commit(cast(Session, session)):
+        if not commit(session):
             raise HTTPException(status_code=500, detail="db commit failed")
 
-    await run_db(cast(Callable[[Session], None], _save))
+    await run_db(_save)
     return {"status": "ok"}
 
 
@@ -239,7 +234,7 @@ async def get_history(
             .all()
         )
 
-    records = await run_db(cast(Callable[[Session], list[HistoryRecordDB]], _query))
+    records = await run_db(_query)
 
     result: list[HistoryRecordSchema] = []
     for r in records:
@@ -264,21 +259,21 @@ async def get_history(
 async def delete_history(
     id: str, user: UserContext = Depends(require_tg_user)
 ) -> dict[str, str]:
-    def _get(session: SessionProtocol) -> HistoryRecordDB | None:
-        return cast(HistoryRecordDB | None, session.get(HistoryRecordDB, id))
+    def _get(session: Session) -> HistoryRecordDB | None:
+        return session.get(HistoryRecordDB, id)
 
-    record = await run_db(cast(Callable[[Session], HistoryRecordDB | None], _get))
+    record = await run_db(_get)
     if record is None:
         raise HTTPException(status_code=404, detail="not found")
     if record.telegram_id != user["id"]:
         raise HTTPException(status_code=403, detail="forbidden")
 
-    def _delete(session: SessionProtocol) -> None:
+    def _delete(session: Session) -> None:
         session.delete(record)
-        if not commit(cast(Session, session)):
+        if not commit(session):
             raise HTTPException(status_code=500, detail="db commit failed")
 
-    await run_db(cast(Callable[[Session], None], _delete))
+    await run_db(_delete)
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Summary
- type database helper functions with `sqlalchemy.orm.Session`
- drop unused `SessionProtocol` and `Callable` casts

## Testing
- `pytest tests/test_webapp_timezone.py::test_timezone_async_writes -q` *(fails: coverage < 85%)*
- `mypy --strict --follow-imports=skip services/api/app/main.py` *(fails: untyped decorators)*
- `ruff check services/api/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa19c882c4832aba826e956ceec707