### PR TITLE
[main] Type delete_history session

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -273,9 +273,9 @@ async def delete_history(
     if record.telegram_id != user["id"]:
         raise HTTPException(status_code=403, detail="forbidden")
 
-    def _delete(session: SessionProtocol) -> None:
+    def _delete(session: Session) -> None:
         session.delete(record)
-        if not commit(cast(Session, session)):
+        if not commit(session):
             raise HTTPException(status_code=500, detail="db commit failed")
 
     await run_db(cast(Callable[[Session], None], _delete))


### PR DESCRIPTION
## Summary
- use `Session` type in `delete_history` helper and delete records directly

## Testing
- `mypy --strict services/api/app/main.py` *(fails: Name `time_` is not defined)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: Missing type parameters for generic type `sessionmaker`)*
- `ruff check .` *(fails: Undefined name `time_`)*

------
https://chatgpt.com/codex/tasks/task_e_68aa19cb3fb8832a9ad84a05f0304ac0