### PR TITLE
[api] use lifespan for shutdown

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import time as dt_time
 import logging
 import os
@@ -48,12 +50,14 @@ except (ValueError, SQLAlchemyError) as exc:
         "Database initialization failed. Please check your configuration and try again."
     ) from exc
 
-app = FastAPI(title="Diabetes Assistant API", version="1.0.0")
 
-
-@app.on_event("shutdown")
-async def shutdown_openai_client() -> None:
+@asynccontextmanager
+async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    yield
     dispose_http_client()
+
+
+app = FastAPI(title="Diabetes Assistant API", version="1.0.0", lifespan=lifespan)
 
 
 # ────────── роуты статистики / legacy ──────────

--- a/tests/test_shutdown_openai_client.py
+++ b/tests/test_shutdown_openai_client.py
@@ -1,9 +1,12 @@
 from unittest.mock import patch
 
-from services.api.app.main import shutdown_openai_client
+from fastapi.testclient import TestClient
+
+from services.api.app.main import app
 
 
-async def test_shutdown_openai_client_disposes() -> None:
+def test_shutdown_openai_client_disposes() -> None:
     with patch("services.api.app.main.dispose_http_client") as dispose:
-        await shutdown_openai_client()
+        with TestClient(app):
+            pass
         dispose.assert_called_once()


### PR DESCRIPTION
## Summary
- replace deprecated shutdown event with FastAPI lifespan to dispose OpenAI HTTP client
- update tests for lifespan-based shutdown

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q` *(fails: tests/test_reminders.py::test_render_reminders_formatting)*
- `python -W default - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68aa276b5a18832ab78fafcfadb126f3