### PR TITLE
[utils] factor out http client builder

### DIFF
--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import threading
+from typing import Literal, overload
 
 import httpx
 from openai import AsyncOpenAI, OpenAI
@@ -16,6 +17,40 @@ _async_http_client: httpx.AsyncClient | None = None
 _async_http_client_lock = threading.Lock()
 
 
+@overload
+def _build_http_client(
+    proxy: str | None, async_: Literal[False]
+) -> httpx.Client | None: ...
+
+
+@overload
+def _build_http_client(
+    proxy: str | None, async_: Literal[True]
+) -> httpx.AsyncClient | None: ...
+
+
+def _build_http_client(
+    proxy: str | None, async_: bool
+) -> httpx.Client | httpx.AsyncClient | None:
+    """Return an httpx client configured with optional proxy."""
+
+    if proxy is None:
+        return None
+
+    if async_:
+        global _async_http_client
+        with _async_http_client_lock:
+            if _async_http_client is None:
+                _async_http_client = httpx.AsyncClient(proxies=proxy)
+            return _async_http_client
+
+    global _http_client
+    with _http_client_lock:
+        if _http_client is None:
+            _http_client = httpx.Client(proxies=proxy)
+        return _http_client
+
+
 def get_openai_client() -> OpenAI:
     """Return a configured OpenAI client.
 
@@ -29,15 +64,8 @@ def get_openai_client() -> OpenAI:
         logger.error("[OpenAI] %s", message)
         raise RuntimeError(message)
 
-    client: OpenAI
-    if settings.openai_proxy:
-        global _http_client
-        with _http_client_lock:
-            if _http_client is None:
-                _http_client = httpx.Client(proxies=settings.openai_proxy)
-            client = OpenAI(api_key=settings.openai_api_key, http_client=_http_client)
-    else:
-        client = OpenAI(api_key=settings.openai_api_key, http_client=None)
+    http_client = _build_http_client(settings.openai_proxy, False)
+    client = OpenAI(api_key=settings.openai_api_key, http_client=http_client)
 
     if settings.openai_assistant_id:
         logger.info("[OpenAI] Using assistant: %s", settings.openai_assistant_id)
@@ -52,17 +80,8 @@ def get_async_openai_client() -> AsyncOpenAI:
         logger.error("[OpenAI] %s", message)
         raise RuntimeError(message)
 
-    client: AsyncOpenAI
-    if settings.openai_proxy:
-        global _async_http_client
-        with _async_http_client_lock:
-            if _async_http_client is None:
-                _async_http_client = httpx.AsyncClient(proxies=settings.openai_proxy)
-            client = AsyncOpenAI(
-                api_key=settings.openai_api_key, http_client=_async_http_client
-            )
-    else:
-        client = AsyncOpenAI(api_key=settings.openai_api_key, http_client=None)
+    http_client = _build_http_client(settings.openai_proxy, True)
+    client = AsyncOpenAI(api_key=settings.openai_api_key, http_client=http_client)
 
     if settings.openai_assistant_id:
         logger.info("[OpenAI] Using assistant: %s", settings.openai_assistant_id)


### PR DESCRIPTION
## Summary
- extract `_build_http_client` helper to centralize proxy-aware httpx client creation
- reuse helper in OpenAI client constructors
- add tests for async client creation via proxy

## Testing
- `mypy --strict services/api/app/diabetes/utils/openai_utils.py tests/test_openai_utils.py`
- `ruff check services/api/app/diabetes/utils/openai_utils.py tests/test_openai_utils.py`
- `pytest -q --cov` *(fails: tests/test_reminders.py::test_render_reminders_formatting - AssertionError: assert (None))*

------
https://chatgpt.com/codex/tasks/task_e_68aa276e2948832a88379c656e24445d