### PR TITLE
chore: upgrade websockets

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -28,7 +28,10 @@ from telegram.ext import (
 )
 from telegram.error import BadRequest, TelegramError
 
-from services.api.app.config import settings
+from services.api.app import config
+
+# Aliased settings for easier monkeypatching in tests
+settings = config.settings
 from services.api.app.diabetes.services.db import (
     Reminder,
     ReminderLog,

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -284,4 +284,6 @@ app.include_router(api_router, prefix="/api")
 if __name__ == "__main__":  # pragma: no cover
     import uvicorn
 
-    uvicorn.run("services.api.app.main:app", host="0.0.0.0", port=8000)
+    uvicorn.run(
+        "services.api.app.main:app", host="0.0.0.0", port=8000, ws="wsproto"
+    )

--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -36,7 +36,9 @@ tqdm==4.67.1
 typing-inspection==0.4.0
 typing_extensions==4.13.2
 fastapi==0.115.0
-uvicorn[standard]==0.30.1
+uvicorn[standard]==0.35.0
+websockets==15.0.1
+wsproto==1.2.0
 
 # 📦 Дополнения для SPA/FastAPI
 aiofiles==23.2.1

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -30,6 +30,8 @@ from services.api.app.routers.reminders import router as reminders_router
 from services.api.app.services import reminders
 from services.api.app.telegram_auth import require_tg_user
 
+# Ensure handlers use current settings after config reloads
+handlers.settings = settings
 
 class DummyMessage:
     def __init__(self, text: str | None = None) -> None:

--- a/tests/test_ui_reminders_smoke.py
+++ b/tests/test_ui_reminders_smoke.py
@@ -8,7 +8,9 @@ import services.api.app.main as server
 
 
 def _run_server() -> Server:
-    config = Config(server.app, host="127.0.0.1", port=8001, log_level="info")
+    config = Config(
+        server.app, host="127.0.0.1", port=8001, log_level="info", ws="wsproto"
+    )
     srv = Server(config)
     thread = threading.Thread(target=srv.run, daemon=True)
     thread.start()


### PR DESCRIPTION
## Summary
- bump uvicorn and websockets versions
- switch FastAPI server and smoke test to wsproto websocket protocol
- align reminder handler settings usage with config

## Testing
- `pytest tests/test_reminders.py::test_render_reminders_formatting tests/test_handlers_profile.py::test_profile_view_missing_profile_shows_webapp_button -q`
- `mypy --strict .` *(fails: SQLAlchemy mypy plugin conflict)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aa27721348832a9e2cbb9c85392495