### PR TITLE
[utils] remove redundant mm cast

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -3,7 +3,6 @@ import os
 import re
 from datetime import datetime, time, timedelta
 from json import JSONDecodeError
-from typing import cast
 
 import httpx
 
@@ -123,7 +122,8 @@ def split_text_by_width(
         try:
 
             raw: float = float(stringWidth(chunk, font_name, font_size))
-            return raw / cast(float, mm)
+            mm_value: float = mm
+            return raw / mm_value
 
         except KeyError as exc:
             raise ValueError(f"Unknown font '{font_name}'") from exc


### PR DESCRIPTION
## Summary
- clean up redundant mm cast when computing PDF text width

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aa27c8b34c832a9f9a2b6cd28089f4