### PR TITLE
tests: simplify reminders smoke test

### DIFF
--- a/tests/test_ui_reminders_smoke.py
+++ b/tests/test_ui_reminders_smoke.py
@@ -1,29 +1,9 @@
-import threading
-import time
-
-import httpx
-from uvicorn import Config, Server
-
-import services.api.app.main as server
-
-
-def _run_server() -> Server:
-    config = Config(
-        server.app, host="127.0.0.1", port=8001, log_level="info", ws="wsproto"
-    )
-    srv = Server(config)
-    thread = threading.Thread(target=srv.run, daemon=True)
-    thread.start()
-    while not srv.started:
-        time.sleep(0.05)
-    return srv
+from fastapi.testclient import TestClient
+from services.api.app.main import app
 
 
 def test_reminders_page_smoke() -> None:
-    srv = _run_server()
-    try:
-        resp = httpx.get("http://127.0.0.1:8001/ui/reminders", timeout=5.0)
+    with TestClient(app) as client:
+        resp = client.get("/ui/reminders")
         assert resp.status_code == 200
         assert "<html" in resp.text.lower()
-    finally:
-        srv.should_exit = True


### PR DESCRIPTION
## Summary
- replace custom server thread in reminders smoke test with FastAPI `TestClient`

## Testing
- `ruff check tests/test_ui_reminders_smoke.py`
- `mypy --strict tests/test_ui_reminders_smoke.py`
- `pytest tests/test_ui_reminders_smoke.py -q` *(fails: Required test coverage of 85% not reached. Total coverage: 7.48%)*
- `pytest -q` *(fails: tests/test_reminders.py::test_render_reminders_formatting - AssertionError: assert (None))*

------
https://chatgpt.com/codex/tasks/task_e_68aa9901dadc832aa440e4ef151cef69