### PR TITLE
tests: remove unused asyncio import

### DIFF
--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from unittest.mock import AsyncMock, Mock
 


### PR DESCRIPTION
## Summary
- remove unused asyncio import from test suite

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: tests/test_reminders.py::test_render_reminders_formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68aa97b90138832a948dbe5e3dd6956c