### PR TITLE
[webapp] fix duplicated api prefix in TS SDK

### DIFF
--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -23,6 +23,7 @@ API_URL=http://localhost:8000
 VITE_BASE_URL=/ui/
 # Optional base API URL for webapp; defaults to '/api'.
 # Leave empty to use the '/api' prefix; for an external API set a full URL without a trailing '/'.
+VITE_API_URL=/api
 # VITE_API_URL=http://localhost:8000
 
 # OpenAI configuration

--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -3,13 +3,13 @@ info:
   title: Diabetes Assistant API
   version: 1.0.0
 servers:
-  - url: /
+  - url: /api
 tags:
 - name: Profiles
 - name: History
 - name: Reminders
 paths:
-  /api/health:
+  /health:
     get:
       summary: Health
       operationId: healthGet
@@ -24,7 +24,7 @@ paths:
                   type: string
                 title: Response Health Get
       security: []
-  /api/profiles:
+  /profiles:
     post:
       tags:
       - Profiles
@@ -78,7 +78,7 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
         '404':
           description: profile not found
-  /api/reminders:
+  /reminders:
     get:
       tags:
       - Reminders
@@ -201,7 +201,7 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
         '404':
           description: Reminder not found
-  /api/reminders/{id}:
+  /reminders/{id}:
     get:
       tags:
       - Reminders
@@ -235,7 +235,7 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
         '404':
           description: Reminder not found or telegramId mismatch
-  /api/timezone:
+  /timezone:
     get:
       summary: Get Timezone
       operationId: get_timezone_timezone_get
@@ -280,7 +280,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/profile/self:
+  /profile/self:
     get:
       summary: Profile Self
       operationId: profile_self_profile_self_get
@@ -297,7 +297,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/stats:
+  /stats:
     get:
       summary: Get Stats
       operationId: get_stats_stats_get
@@ -325,7 +325,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/analytics:
+  /analytics:
     get:
       summary: Get Analytics
       operationId: get_analytics_analytics_get
@@ -354,7 +354,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/user:
+  /user:
     post:
       summary: Create User
       description: Ensure a user exists in the database.
@@ -381,7 +381,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/user/{user_id}/role:
+  /user/{user_id}/role:
     get:
       summary: Get Role
       operationId: get_role_user_user_id_role_get
@@ -434,7 +434,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/history:
+  /history:
     post:
       tags:
       - History
@@ -485,7 +485,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/history/{id}:
+  /history/{id}:
     delete:
       tags:
       - History

--- a/libs/ts-sdk/apis/DefaultApi.ts
+++ b/libs/ts-sdk/apis/DefaultApi.ts
@@ -93,7 +93,7 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/user`;
+        let urlPath = `/user`;
 
         const response = await this.request({
             path: urlPath,
@@ -139,7 +139,7 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/analytics`;
+        let urlPath = `/analytics`;
 
         const response = await this.request({
             path: urlPath,
@@ -179,7 +179,7 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/user/{user_id}/role`;
+        let urlPath = `/user/{user_id}/role`;
         urlPath = urlPath.replace(`{${"user_id"}}`, encodeURIComponent(String(requestParameters['userId'])));
 
         const response = await this.request({
@@ -224,7 +224,7 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/stats`;
+        let urlPath = `/stats`;
 
         const response = await this.request({
             path: urlPath,
@@ -264,7 +264,7 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/timezone`;
+        let urlPath = `/timezone`;
 
         const response = await this.request({
             path: urlPath,
@@ -293,7 +293,7 @@ export class DefaultApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/api/health`;
+        let urlPath = `/health`;
 
         const response = await this.request({
             path: urlPath,
@@ -326,7 +326,7 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/profile/self`;
+        let urlPath = `/profile/self`;
 
         const response = await this.request({
             path: urlPath,
@@ -375,7 +375,7 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/user/{user_id}/role`;
+        let urlPath = `/user/{user_id}/role`;
         urlPath = urlPath.replace(`{${"user_id"}}`, encodeURIComponent(String(requestParameters['userId'])));
 
         const response = await this.request({
@@ -419,7 +419,7 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/timezone`;
+        let urlPath = `/timezone`;
 
         const response = await this.request({
             path: urlPath,

--- a/libs/ts-sdk/apis/HistoryApi.ts
+++ b/libs/ts-sdk/apis/HistoryApi.ts
@@ -55,7 +55,7 @@ export class HistoryApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/history`;
+        let urlPath = `/history`;
 
         const response = await this.request({
             path: urlPath,
@@ -97,7 +97,7 @@ export class HistoryApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/history/{id}`;
+        let urlPath = `/history/{id}`;
         urlPath = urlPath.replace(`{${"id"}}`, encodeURIComponent(String(requestParameters['id'])));
 
         const response = await this.request({
@@ -142,7 +142,7 @@ export class HistoryApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/history`;
+        let urlPath = `/history`;
 
         const response = await this.request({
             path: urlPath,

--- a/libs/ts-sdk/apis/ProfilesApi.ts
+++ b/libs/ts-sdk/apis/ProfilesApi.ts
@@ -62,7 +62,7 @@ export class ProfilesApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/profiles`;
+        let urlPath = `/profiles`;
 
         const response = await this.request({
             path: urlPath,
@@ -104,7 +104,7 @@ export class ProfilesApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/profiles`;
+        let urlPath = `/profiles`;
 
         const response = await this.request({
             path: urlPath,

--- a/libs/ts-sdk/apis/RemindersApi.ts
+++ b/libs/ts-sdk/apis/RemindersApi.ts
@@ -87,7 +87,7 @@ export class RemindersApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/reminders`;
+        let urlPath = `/reminders`;
 
         const response = await this.request({
             path: urlPath,
@@ -131,7 +131,7 @@ export class RemindersApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/reminders`;
+        let urlPath = `/reminders`;
 
         const response = await this.request({
             path: urlPath,
@@ -182,7 +182,7 @@ export class RemindersApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/reminders/{id}`;
+        let urlPath = `/reminders/{id}`;
         urlPath = urlPath.replace(`{${"id"}}`, encodeURIComponent(String(requestParameters['id'])));
 
         const response = await this.request({
@@ -225,7 +225,7 @@ export class RemindersApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/reminders`;
+        let urlPath = `/reminders`;
 
         const response = await this.request({
             path: urlPath,
@@ -268,7 +268,7 @@ export class RemindersApi extends runtime.BaseAPI {
         }
 
 
-        let urlPath = `/api/reminders`;
+        let urlPath = `/reminders`;
 
         const response = await this.request({
             path: urlPath,

--- a/libs/ts-sdk/runtime.ts
+++ b/libs/ts-sdk/runtime.ts
@@ -13,7 +13,7 @@
  */
 
 
-export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
+export const BASE_PATH = "/api".replace(/\/+$/, "");
 
 export interface ConfigurationParameters {
     basePath?: string; // override base path


### PR DESCRIPTION
## Summary
- define `/api` server in OpenAPI spec and remove duplicated path prefix
- regenerate TypeScript SDK without `/api/api` paths
- provide `VITE_API_URL=/api` in `.env.example`

## Testing
- `pytest -q --cov` *(fails: tests/test_reminders.py::test_render_reminders_formatting - AssertionError)*
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa0b57758832a967e4ea20ba00303