### PR TITLE
[py-sdk] handle invalid multipart post params

### DIFF
--- a/libs/py-sdk/diabetes_sdk/rest.py
+++ b/libs/py-sdk/diabetes_sdk/rest.py
@@ -193,19 +193,15 @@ class RESTClientObject:
                     else:
                         items = post_params
                     fields = []
-                    for item in items:
-                        if isinstance(item, (list, tuple)):
-                            if len(item) >= 2:
-                                key, value = item[0], item[1]
-                            else:
-                                raise ApiValueError(
-                                    "Invalid number of elements in post_params"
-                                )
-                        else:
-                            key, value = item  # type: ignore[misc]
-                        if isinstance(value, (dict, list, tuple)):
-                            value = json.dumps(value)
-                        fields.append((key, value))
+                    try:
+                        for key, value in items:
+                            if isinstance(value, (dict, list, tuple)):
+                                value = json.dumps(value)
+                            fields.append((key, value))
+                    except ValueError as exc:
+                        raise ApiValueError(
+                            "Invalid number of elements in post_params",
+                        ) from exc
                     r = self.pool_manager.request(
                         method,
                         url,

--- a/libs/py-sdk/test/test_rest_multipart.py
+++ b/libs/py-sdk/test/test_rest_multipart.py
@@ -1,9 +1,11 @@
 import json
 from unittest.mock import MagicMock
 
+import pytest
 import urllib3
 
 from diabetes_sdk.configuration import Configuration
+from diabetes_sdk.exceptions import ApiValueError
 from diabetes_sdk.rest import RESTClientObject
 
 
@@ -68,3 +70,14 @@ def test_multipart_nested_dict() -> None:
     assert kwargs["encode_multipart"] is True
     assert all(len(item) == 2 for item in kwargs["fields"])
     assert kwargs["fields"] == [("nested", json.dumps(nested))]
+
+
+def test_multipart_invalid_post_params() -> None:
+    client = _client()
+    with pytest.raises(ApiValueError):
+        client.request(  # type: ignore[no-untyped-call]
+            "POST",
+            "http://example.com",
+            headers={"Content-Type": "multipart/form-data"},
+            post_params=[("foo",)],
+        )


### PR DESCRIPTION
## Summary
- make multipart form iteration safer and JSON-serialize nested structures
- add regression tests for multipart dictionary handling

## Testing
- `ruff check .`
- `mypy --strict libs/py-sdk/diabetes_sdk/rest.py libs/py-sdk/test/test_rest_multipart.py`
- `pytest -q libs/py-sdk/test/test_rest_multipart.py -c /tmp/pytest_empty.ini --cov=diabetes_sdk.rest`


------
https://chatgpt.com/codex/tasks/task_e_68aaad2f936c832a945bdfe6b24093df