### PR TITLE
[reminders] handle missing webapp

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -178,17 +178,19 @@ def _render_reminders(
     header = f"Ваши напоминания  ({active_count} / {limit} 🔔)"
     if active_count > limit:
         header += " ⚠️"
-    add_button_row: list[InlineKeyboardButton] | None = None
-    if settings.webapp_url:
-        add_button_row = [
+    add_button_row: list[InlineKeyboardButton] | None = (
+        [
             InlineKeyboardButton(
                 "➕ Добавить",
                 web_app=WebAppInfo(build_webapp_url("/ui/reminders")),
             )
         ]
+        if settings.webapp_url
+        else None
+    )
     if not rems:
         text = header
-        if settings.webapp_url and add_button_row is not None:
+        if add_button_row is not None:
             text += (
                 "\nУ вас нет напоминаний. "
                 "Нажмите кнопку ниже или отправьте /addreminder."
@@ -363,10 +365,10 @@ async def reminders_list(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             text, keyboard = render_fn(session, user_id)
     else:
         text, keyboard = await run_db(render_fn, user_id, sessionmaker=SessionLocal)
+    kwargs = {"parse_mode": "HTML"}
     if keyboard is not None:
-        await message.reply_text(text, parse_mode="HTML", reply_markup=keyboard)
-    else:
-        await message.reply_text(text, parse_mode="HTML")
+        kwargs["reply_markup"] = keyboard
+    await message.reply_text(text, **kwargs)
 
 
 async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -253,6 +253,7 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
         "_describe",
         lambda r, u=None: f"{'🔔' if r.is_enabled else '🔕'}title{r.id}",
     )
+    handlers.settings = settings
     monkeypatch.setattr(settings, "webapp_url", "https://example.org")
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
@@ -288,8 +289,11 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "📸 Триггер-фото" in text
     assert "2. <s>🔕title2</s>" in text
     assert markup.inline_keyboard
-    btn = markup.inline_keyboard[-1][0]
-    assert btn.web_app and btn.web_app.url.endswith("/ui/reminders")
+    assert any(
+        btn.web_app is not None and btn.web_app.url.endswith("/ui/reminders")
+        for row in markup.inline_keyboard
+        for btn in row
+    )
 
 
 def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -360,6 +364,43 @@ async def test_reminders_list_no_keyboard(monkeypatch: pytest.MonkeyPatch) -> No
     kwargs = captured.get("kwargs")
     assert kwargs is not None
     assert "reply_markup" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_reminders_list_keyboard_no_webapp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    handlers.SessionLocal = TestSession
+    monkeypatch.setattr(settings, "webapp_url", None)
+    with TestSession() as session:
+        session.add(DbUser(telegram_id=1, thread_id="t"))
+        session.add(
+            Reminder(
+                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
+            )
+        )
+        session.commit()
+
+    captured: dict[str, Any] = {}
+
+    async def fake_reply_text(text: str, **kwargs: Any) -> None:
+        captured["text"] = text
+        captured["kwargs"] = kwargs
+
+    message = MagicMock(spec=Message)
+    message.reply_text = fake_reply_text
+    update = make_update(effective_user=make_user(1), message=message)
+    context = make_context()
+    await handlers.reminders_list(update, context)
+    kwargs = captured.get("kwargs")
+    assert kwargs is not None
+    markup = kwargs.get("reply_markup")
+    assert markup is not None
+    first_row = markup.inline_keyboard[0]
+    assert [btn.text for btn in first_row] == ["🗑️", "🔔"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- handle absent WEBAPP_URL when rendering reminder lists
- send keyboard only when `_render_reminders` returns one
- add tests for reminder lists without webapp URLs

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aaad322724832a934c2fe41f04291e