### PR TITLE
[handlers] load settings dynamically from config

### DIFF
--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Session
 
-from services.api.app.config import settings
+from services.api.app import config
 from services.api.app.diabetes.services.db import Profile, User, SessionLocal
 from services.api.app.diabetes.services.repository import commit
 
@@ -109,7 +109,7 @@ def get_api(
             "diabetes_sdk could not be initialized. Falling back to local profile API.",
         )
         return LocalProfileAPI(sessionmaker), Exception, LocalProfile
-    api = DefaultApi(ApiClient(Configuration(host=settings.api_url)))
+    api = DefaultApi(ApiClient(Configuration(host=config.settings.api_url)))
     return api, ApiException, ProfileModel
 
 

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -56,7 +56,7 @@ from services.api.app.diabetes.utils.ui import (  # noqa: E402
     back_keyboard as _back_keyboard,
     menu_keyboard,
 )
-from services.api.app.config import settings  # noqa: E402
+from services.api.app import config  # noqa: E402
 from services.api.app.diabetes.services.repository import commit  # noqa: E402
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers  # noqa: E402
 
@@ -238,7 +238,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     profile = fetch_profile(api, ApiException, user_id)
 
     if not profile:
-        if settings.webapp_url:
+        if config.settings.webapp_url:
             keyboard = InlineKeyboardMarkup(
                 [
                     [
@@ -279,7 +279,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         [InlineKeyboardButton("🌐 Часовой пояс", callback_data="profile_timezone")],
         [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
     ]
-    if settings.webapp_url:
+    if config.settings.webapp_url:
         rows.insert(
             1,
             [
@@ -541,7 +541,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
         await sos_handlers.sos_contact_start(update, context)
         return
-    if action == "add" and settings.webapp_url:
+    if action == "add" and config.settings.webapp_url:
         button = InlineKeyboardButton(
             "📝 Новое",
             web_app=WebAppInfo(reminder_handlers.build_webapp_url("/ui/reminders")),

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -29,9 +29,6 @@ from telegram.ext import (
 from telegram.error import BadRequest, TelegramError
 
 from services.api.app import config
-
-# Aliased settings for easier monkeypatching in tests
-settings = config.settings
 from services.api.app.diabetes.services.db import (
     Reminder,
     ReminderLog,
@@ -71,9 +68,9 @@ PLAN_LIMITS = {"free": 5, "pro": 10}
 def build_webapp_url(path: str) -> str:
     """Build an absolute webapp URL from ``path``.
 
-    Raises ``RuntimeError`` if ``settings.webapp_url`` is not configured.
+    Raises ``RuntimeError`` if ``WEBAPP_URL`` is not configured.
     """
-    base_url = settings.webapp_url
+    base_url = config.settings.webapp_url
     if not base_url:
         raise RuntimeError("WEBAPP_URL not configured")
     base = base_url.rstrip("/") + "/"
@@ -179,7 +176,7 @@ def _render_reminders(
     if active_count > limit:
         header += " ⚠️"
     add_button_row: list[InlineKeyboardButton] | None = None
-    if settings.webapp_url:
+    if config.settings.webapp_url:
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
@@ -188,7 +185,7 @@ def _render_reminders(
         ]
     if not rems:
         text = header
-        if settings.webapp_url and add_button_row is not None:
+        if config.settings.webapp_url and add_button_row is not None:
             text += (
                 "\nУ вас нет напоминаний. "
                 "Нажмите кнопку ниже или отправьте /addreminder."
@@ -208,7 +205,7 @@ def _render_reminders(
         line = f"{r.id}. {title}"
         status_icon = "🔔" if r.is_enabled else "🔕"
         row: list[InlineKeyboardButton] = []
-        if settings.webapp_url:
+        if config.settings.webapp_url:
             row.append(
                 InlineKeyboardButton(
                     "✏️",

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -267,14 +267,12 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from urllib.parse import urlparse
-    from services.api.app.config import settings as config_settings
+    import services.api.app.config as config
     from services.api.app.diabetes.handlers import profile as handlers
 
-    monkeypatch.setattr(config_settings, "webapp_url", "https://example.com")
-    monkeypatch.setattr(handlers, "settings", config_settings, raising=False)
-    monkeypatch.setattr(
-        handlers.reminder_handlers, "settings", config_settings, raising=False
-    )
+    monkeypatch.setattr(config.settings, "webapp_url", "https://example.com")
+    monkeypatch.setattr(handlers, "config", config, raising=False)
+    monkeypatch.setattr(handlers.reminder_handlers, "config", config, raising=False)
     monkeypatch.setattr(handlers, "get_api", lambda: (object(), Exception, None))
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: None)
 


### PR DESCRIPTION
## Summary
- reference `config.settings` directly in reminder and profile handlers
- drop manual settings aliasing in tests
- update reminder/profile tests to patch `config` module

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`

------
https://chatgpt.com/codex/tasks/task_e_68aaad337d98832a9ae5dcdd6f97734a