### PR TITLE
[handlers] handle missing webapp URL in reminders

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -178,17 +178,19 @@ def _render_reminders(
     header = f"Ваши напоминания  ({active_count} / {limit} 🔔)"
     if active_count > limit:
         header += " ⚠️"
-    add_button_row: list[InlineKeyboardButton] | None = None
-    if settings.webapp_url:
-        add_button_row = [
+    add_button_row: list[InlineKeyboardButton] | None = (
+        [
             InlineKeyboardButton(
                 "➕ Добавить",
                 web_app=WebAppInfo(build_webapp_url("/ui/reminders")),
             )
         ]
+        if settings.webapp_url
+        else None
+    )
     if not rems:
         text = header
-        if settings.webapp_url and add_button_row is not None:
+        if add_button_row is not None:
             text += (
                 "\nУ вас нет напоминаний. "
                 "Нажмите кнопку ниже или отправьте /addreminder."
@@ -363,10 +365,10 @@ async def reminders_list(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             text, keyboard = render_fn(session, user_id)
     else:
         text, keyboard = await run_db(render_fn, user_id, sessionmaker=SessionLocal)
+    kwargs = {"parse_mode": "HTML"}
     if keyboard is not None:
-        await message.reply_text(text, parse_mode="HTML", reply_markup=keyboard)
-    else:
-        await message.reply_text(text, parse_mode="HTML")
+        kwargs["reply_markup"] = keyboard
+    await message.reply_text(text, **kwargs)
 
 
 async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- Avoid building add-reminder button or keyboards when `WEBAPP_URL` isn't configured
- Only send reminder list keyboards if one was returned
- Test reminder list behavior with `webapp_url=None`

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aaafad3eb8832aa03d3b8bbf849047