### PR TITLE
tests: use config settings for webapp url

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -179,15 +179,11 @@ def _render_reminders(
     add_button_row: list[InlineKeyboardButton] | None = None
     if config.settings.webapp_url:
         add_button_row = [
-
             InlineKeyboardButton(
                 "➕ Добавить",
                 web_app=WebAppInfo(build_webapp_url("/ui/reminders")),
             )
         ]
-        if settings.webapp_url
-        else None
-    )
     if not rems:
         text = header
 

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -276,7 +276,7 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     importlib.reload(config)
     importlib.reload(reminder_handlers)
     importlib.reload(handlers.reminder_handlers)
-    importlib.reload(handlers)
+    handlers.config = config
     monkeypatch.setattr(handlers, "get_api", lambda: (object(), Exception, None))
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: None)
 

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -11,7 +11,7 @@ from services.api.app.diabetes.handlers import profile as handlers
 from services.api.app.diabetes.services.repository import commit
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
-from services.api.app.config import settings
+from services.api.app import config
 
 
 class DummyMessage:
@@ -229,7 +229,8 @@ async def test_profile_security_add_delete_calls_handlers(
 
     monkeypatch.setattr(reminder_handlers, "delete_reminder", fake_del)
 
-    monkeypatch.setattr(settings, "webapp_url", "http://example")
+    monkeypatch.setattr(config.settings, "webapp_url", "http://example")
+    monkeypatch.setattr(reminder_handlers.config.settings, "webapp_url", "http://example")
     query_add = DummyQuery(DummyMessage(), "profile_security:add")
     update_add = cast(
         Any,

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -245,6 +245,14 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
+    monkeypatch.setenv("WEBAPP_URL", "https://example.org")
+    import importlib
+    import services.api.app.config as config_module
+
+    importlib.reload(config_module)
+    global config
+    config = config_module
+    importlib.reload(handlers)
     monkeypatch.setattr(handlers, "_limit_for", lambda u: 1)
     # Make _describe deterministic and include status icon to test strikethrough
     monkeypatch.setattr(
@@ -252,12 +260,6 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
         "_describe",
         lambda r, u=None: f"{'🔔' if r.is_enabled else '🔕'}title{r.id}",
     )
-
-    monkeypatch.setenv("WEBAPP_URL", "https://example.org")
-    import importlib
-
-    importlib.reload(config)
-    importlib.reload(handlers)
 
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
@@ -378,7 +380,7 @@ async def test_reminders_list_keyboard_no_webapp(
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.setattr(settings, "webapp_url", None)
+    monkeypatch.setattr(config.settings, "webapp_url", None)
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.add(


### PR DESCRIPTION
## Summary
- use `config.settings` to control `webapp_url` in reminder and profile tests
- fix `_render_reminders` button rendering
- align profile tests with new config reload logic

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac54e68b0832a9c774ab53f9abb5d