### PR TITLE
[handlers] Fix add reminder webapp button block

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -176,18 +176,14 @@ def _render_reminders(
     if active_count > limit:
         header += " ⚠️"
 
-    add_button_row: list[InlineKeyboardButton] | None = None
+    add_button_row = None
     if config.settings.webapp_url:
         add_button_row = [
-
             InlineKeyboardButton(
                 "➕ Добавить",
                 web_app=WebAppInfo(build_webapp_url("/ui/reminders")),
             )
         ]
-        if settings.webapp_url
-        else None
-    )
     if not rems:
         text = header
 

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -378,14 +378,10 @@ async def test_reminders_list_keyboard_no_webapp(
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.setattr(settings, "webapp_url", None)
+    monkeypatch.setattr(config.settings, "webapp_url", None)
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
-        session.add(
-
-            Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0))
-
-        )
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0)))
         session.commit()
 
     captured: dict[str, Any] = {}
@@ -407,7 +403,6 @@ async def test_reminders_list_keyboard_no_webapp(
     assert len(markup.inline_keyboard) == 1
     texts = [btn.text for btn in markup.inline_keyboard[0]]
     assert texts == ["🗑️", "🔔"]
-
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- fix malformed add reminder button markup
- adjust reminder test for config settings

## Testing
- `pytest tests/test_reminders.py::test_reminders_list_keyboard_no_webapp -q --no-cov`
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aac70e3880832a9f04235a00838acd