### PR TITLE
[stats] return empty object when no stats

### DIFF
--- a/services/api/app/routers/stats.py
+++ b/services/api/app/routers/stats.py
@@ -1,6 +1,7 @@
 import logging
+from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from ..schemas.stats import AnalyticsPoint, DayStats
 from ..schemas.user import UserContext
@@ -12,16 +13,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/stats", response_model=DayStats, responses={204: {"description": "No Content"}})
+@router.get("/stats", response_model=DayStats | dict[str, Any])
 async def get_stats(
     telegram_id: int = Query(alias="telegramId"),
     user: UserContext = Depends(require_tg_user),
-) -> DayStats | Response:
+) -> DayStats | dict[str, Any]:
     if telegram_id != user["id"]:
         raise HTTPException(status_code=403, detail="telegram id mismatch")
     stats = await get_day_stats(telegram_id)
     if stats is None:
-        return Response(status_code=204)
+        return {}
     return stats
 
 

--- a/tests/test_stats_api.py
+++ b/tests/test_stats_api.py
@@ -122,4 +122,5 @@ def test_stats_no_data(monkeypatch: pytest.MonkeyPatch) -> None:
             params={"telegramId": 5},
             headers={TG_INIT_DATA_HEADER: init_data},
         )
-    assert resp.status_code == 204
+    assert resp.status_code == 200
+    assert resp.json() == {}


### PR DESCRIPTION
## Summary
- return empty object for missing stats instead of 204
- adjust tests for new stats behavior

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aacc047acc832a9f6dbad68bbe5db3