### PR TITLE
[ui] add vitest test script and docs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
+      react-test-renderer:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17
@@ -4424,7 +4427,6 @@ packages:
 
   /react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
-    dev: false
 
   /react-remove-scroll-bar@2.3.8(@types/react@18.3.24)(react@18.3.1):
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -4494,6 +4496,16 @@ packages:
       react: 18.3.1
     dev: false
 
+  /react-shallow-renderer@16.15.0(react@18.3.1):
+    resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
+    peerDependencies:
+      react: 18.3.1
+    dependencies:
+      object-assign: 4.1.1
+      react: 18.3.1
+      react-is: 18.3.1
+    dev: true
+
   /react-smooth@4.0.4(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
@@ -4522,6 +4534,17 @@ packages:
       react: 18.3.1
       tslib: 2.8.1
     dev: false
+
+  /react-test-renderer@18.3.1(react@18.3.1):
+    resolution: {integrity: sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==}
+    peerDependencies:
+      react: 18.3.1
+    dependencies:
+      react: 18.3.1
+      react-is: 18.3.1
+      react-shallow-renderer: 16.15.0(react@18.3.1)
+      scheduler: 0.23.2
+    dev: true
 
   /react-transition-group@4.4.5(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}

--- a/services/webapp/ui/README.md
+++ b/services/webapp/ui/README.md
@@ -36,6 +36,20 @@ pnpm install
 pnpm run dev
 ```
 
+## Testing
+
+Run the Vitest suite to verify the UI behavior:
+
+```sh
+pnpm test
+```
+
+You can also invoke the runner directly:
+
+```sh
+pnpm vitest run --config ../../../vitest.config.ts
+```
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/services/webapp/ui/package.json
+++ b/services/webapp/ui/package.json
@@ -9,7 +9,8 @@
     "watch": "vite build --watch",
     "lint": "eslint .",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --config ../../../vitest.config.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -80,6 +81,7 @@
     "jsdom": "^26.1.0",
     "lovable-tagger": "^1.1.9",
     "postcss": "^8.5.6",
+    "react-test-renderer": "18.3.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",


### PR DESCRIPTION
## Summary
- add vitest `test` script and `react-test-renderer` dev dependency in web UI package
- document how to run the Vitest suite

## Testing
- `pnpm test`
- `ruff check .`
- `pytest -q` *(fails: Unknown config option: asyncio_mode & KeyboardInterrupt)*
- `mypy --strict .` *(terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68aacc226724832ab66effd74fd9b394