### PR TITLE
[docs] Document running backend tests from repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ pip install -r services/api/app/requirements-dev.txt
 Тесты используют переменные `OPENAI_API_KEY`, `DB_PASSWORD` и другие из `.env`.
 Отсутствие обязательных пакетов (например, SQLAlchemy, `python-telegram-bot`, `openai`) приведёт к `ModuleNotFoundError`.
 
-Запустите тесты:
+Тесты необходимо запускать из корня репозитория:
 
 ```bash
 pytest tests/

--- a/services/webapp/ui/README.md
+++ b/services/webapp/ui/README.md
@@ -79,3 +79,13 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Testing
+
+> **Warning:** `pytest` is intended for backend tests and should be run from the project root or a backend subdirectory, for example:
+
+```bash
+pytest tests/
+```
+
+Running `pytest` inside this front-end directory is not supported.


### PR DESCRIPTION
## Summary
- clarify that backend tests must be run from the repository root via `pytest tests/`
- warn frontend developers not to run `pytest` inside `services/webapp/ui`

## Testing
- `pytest tests/` *(fails: async functions not supported, several failing tests)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68aacc228610832ab12dc797f2ae173b