### PR TITLE
[py-sdk] Normalize multipart post params

### DIFF
--- a/libs/py-sdk/diabetes_sdk/rest.py
+++ b/libs/py-sdk/diabetes_sdk/rest.py
@@ -194,15 +194,16 @@ class RESTClientObject:
                         else post_params
                     )
                     fields = []
-                    try:
-                        for key, value in items:
-                            if isinstance(value, (dict, list, tuple)):
-                                value = json.dumps(value)
-                            fields.append((key, value))
-                    except ValueError as exc:
-                        raise ApiValueError(
-                            "Invalid number of elements in post_params",
-                        ) from exc
+                    for item in items:
+                        try:
+                            key, value = item
+                        except (TypeError, ValueError) as exc:
+                            raise ApiValueError(
+                                "Invalid number of elements in post_params",
+                            ) from exc
+                        if isinstance(value, (dict, list, tuple)):
+                            value = json.dumps(value)
+                        fields.append((key, value))
                     r = self.pool_manager.request(
                         method,
                         url,


### PR DESCRIPTION
## Summary
- Ensure `multipart/form-data` post params are normalized and JSON-encoded when needed
- Validate each multipart item has exactly two elements

## Testing
- `pytest libs/py-sdk/test/test_rest_multipart.py --cov=libs/py-sdk/diabetes_sdk --cov-fail-under=0 -q`
- `mypy --strict libs/py-sdk/diabetes_sdk/rest.py libs/py-sdk/test/test_rest_multipart.py`
- `ruff check libs/py-sdk/diabetes_sdk/rest.py libs/py-sdk/test/test_rest_multipart.py`


------
https://chatgpt.com/codex/tasks/task_e_68aad05e5ce0832a98b593c8f4a6a2aa