### PR TITLE
[reminders] Preserve title when saving reminders

### DIFF
--- a/services/webapp/ui/src/reminders/CreateReminder.test.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.test.tsx
@@ -1,10 +1,12 @@
-import { render, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { render, waitFor, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+const mockNavigate = vi.fn();
+const mockUseParams = vi.fn();
 vi.mock("react-router-dom", () => ({
-  useNavigate: () => vi.fn(),
+  useNavigate: () => mockNavigate,
   useLocation: () => ({ state: undefined }),
-  useParams: () => ({ id: "1" }),
+  useParams: () => mockUseParams(),
 }));
 
 vi.mock("../contexts/telegram-context", () => ({
@@ -24,13 +26,43 @@ vi.mock("../api/reminders", () => ({
 }));
 
 import CreateReminder from "./CreateReminder";
-import { getReminder } from "../api/reminders";
+import { getReminder, createReminder } from "../api/reminders";
 
 describe("CreateReminder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
   it("requests reminder only once", async () => {
+    mockUseParams.mockReturnValue({ id: "1" });
     render(<CreateReminder />);
     await waitFor(() => expect(getReminder).toHaveBeenCalledTimes(1));
     const [, , signal] = vi.mocked(getReminder).mock.calls[0];
     expect(signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("sends title when saving", async () => {
+    mockUseParams.mockReturnValue({});
+    vi.mocked(createReminder).mockResolvedValue({ id: 1 });
+    render(<CreateReminder />);
+
+    fireEvent.change(screen.getByLabelText("Название"), {
+      target: { value: "My title" },
+    });
+    fireEvent.change(screen.getByLabelText("Время"), {
+      target: { value: "08:00" },
+    });
+    fireEvent.change(screen.getByLabelText("Интервал (мин)"), {
+      target: { value: "60" },
+    });
+    fireEvent.click(screen.getByText("Сохранить"));
+
+    await waitFor(() => expect(createReminder).toHaveBeenCalled());
+    expect(vi.mocked(createReminder).mock.calls[0][0]).toMatchObject({
+      title: "My title",
+    });
   });
 });

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -110,6 +110,7 @@ export default function CreateReminder() {
     const payload: ApiReminder = {
       telegramId: user.id,
       type,
+      title,
       time,
       intervalHours:
         intervalMinutes != null ? intervalMinutes / 60 : undefined,


### PR DESCRIPTION
## Summary
- include `title` in reminder payload before create/update
- ensure reminder creation sends the provided title

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Unexpected any in existing test files)*
- `pytest -q` *(fails: async plugin missing; many tests fail)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aad07b6314832aa26634e3348029ea