### PR TITLE
[ui] Ensure reminder title passed to API

### DIFF
--- a/services/webapp/ui/src/reminders/CreateReminder.test.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.test.tsx
@@ -1,5 +1,5 @@
-import { render, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { render, waitFor, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("react-router-dom", () => ({
   useNavigate: () => vi.fn(),
@@ -24,7 +24,11 @@ vi.mock("../api/reminders", () => ({
 }));
 
 import CreateReminder from "./CreateReminder";
-import { getReminder } from "../api/reminders";
+import { getReminder, updateReminder } from "../api/reminders";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("CreateReminder", () => {
   it("requests reminder only once", async () => {
@@ -32,5 +36,17 @@ describe("CreateReminder", () => {
     await waitFor(() => expect(getReminder).toHaveBeenCalledTimes(1));
     const [, , signal] = vi.mocked(getReminder).mock.calls[0];
     expect(signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("submits custom title", async () => {
+    render(<CreateReminder />);
+    await waitFor(() => expect(getReminder).toHaveBeenCalled());
+    const input = screen.getByLabelText("Название");
+    fireEvent.change(input, { target: { value: "Custom" } });
+    fireEvent.click(screen.getAllByText("Сохранить")[0]);
+    await waitFor(() => expect(updateReminder).toHaveBeenCalled());
+    expect(updateReminder).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Custom" }),
+    );
   });
 });

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -111,6 +111,7 @@ export default function CreateReminder() {
       telegramId: user.id,
       type,
       time,
+      title,
       intervalHours:
         intervalMinutes != null ? intervalMinutes / 60 : undefined,
       isEnabled: true,


### PR DESCRIPTION
## Summary
- send custom title when creating or updating a reminder
- test reminder form submits with custom title

## Testing
- `pnpm --filter ./services/webapp/ui test -- src/reminders/CreateReminder.test.tsx`
- `pytest -q --cov` *(fails: unrecognized arguments: --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=85 --cov)*
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68aad082358c832aba80b888b68422f0