### PR TITLE
test(repository): add unit tests

### DIFF
--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from services.api.app.diabetes.services import repository
+
+
+class DummyError(SQLAlchemyError):
+    """Custom SQLAlchemy error for testing."""
+
+
+def test_commit_success() -> None:
+    session = MagicMock()
+    assert repository.commit(session) is True
+    session.commit.assert_called_once()
+    session.rollback.assert_not_called()
+
+
+def test_commit_failure() -> None:
+    session = MagicMock()
+    session.commit.side_effect = DummyError("boom")
+    assert repository.commit(session) is False
+    session.rollback.assert_called_once()
+
+
+def test_transactional_success() -> None:
+    session = MagicMock()
+    with repository.transactional(session) as sess:
+        assert sess is session
+    session.commit.assert_called_once()
+    session.rollback.assert_not_called()
+
+
+def test_transactional_failure() -> None:
+    session = MagicMock()
+    with pytest.raises(DummyError):
+        with repository.transactional(session):
+            raise DummyError("boom")
+    session.rollback.assert_called_once()
+    session.commit.assert_not_called()


### PR DESCRIPTION
## Summary
- add unit tests for database commit and transactional helpers

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest --maxfail=1 --disable-warnings -q`
- `pytest --cov=services.api.app --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68aad760b71c832a8de2500ff9577d51