### PR TITLE
[py-sdk] handle iterable post_params

### DIFF
--- a/libs/py-sdk/diabetes_sdk/rest.py
+++ b/libs/py-sdk/diabetes_sdk/rest.py
@@ -191,7 +191,9 @@ class RESTClientObject:
                     # serialize nested structures to JSON
                     if isinstance(post_params, dict):
                         items = post_params.items()
-                    elif isinstance(post_params, Iterable):
+                    elif isinstance(post_params, Iterable) and not isinstance(
+                        post_params, (str, bytes)
+                    ):
                         items = post_params
                     else:
                         raise ApiValueError(

--- a/libs/py-sdk/test/test_rest_multipart.py
+++ b/libs/py-sdk/test/test_rest_multipart.py
@@ -134,3 +134,14 @@ def test_multipart_invalid_post_params() -> None:
             headers={"Content-Type": "multipart/form-data"},
             post_params=[("foo",)],
         )
+
+
+def test_multipart_invalid_string() -> None:
+    client = _client()
+    with pytest.raises(ApiValueError):
+        client.request(  # type: ignore[no-untyped-call]
+            "POST",
+            "http://example.com",
+            headers={"Content-Type": "multipart/form-data"},
+            post_params="invalid",
+        )


### PR DESCRIPTION
## Summary
- refine multipart form handling to ignore string-like post_params
- test multipart request with dict, iterable, and invalid string params

## Testing
- `pytest libs/py-sdk/test/test_rest_multipart.py --no-cov`
- `mypy --strict libs/py-sdk/diabetes_sdk/rest.py`
- `ruff check libs/py-sdk/diabetes_sdk/rest.py`


------
https://chatgpt.com/codex/tasks/task_e_68aadd682cb0832a84f6d1d51d522f68