### PR TITLE
[ci] fix pr auto assign workflow

### DIFF
--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -12,10 +12,14 @@ jobs:
   assign:
     runs-on: ubuntu-latest
     steps:
-      - name: Add reviewers and labels
+      - name: Add reviewers
         uses: wow-actions/auto-assign@v2
         with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           reviewers: |
             offonar
-          labels: |
-            webapp-sync
+      - name: Add webapp-sync label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: webapp-sync


### PR DESCRIPTION
## Summary
- add GITHUB_TOKEN to auto-assign action
- move labeling to dedicated action

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aae194237c832ab71c4f7954791642