### PR TITLE
[ui] support tgWebAppStartParam from location

### DIFF
--- a/services/webapp/ui/src/hooks/use-telegram.test.tsx
+++ b/services/webapp/ui/src/hooks/use-telegram.test.tsx
@@ -16,6 +16,7 @@ describe("useTelegram start_param", () => {
   afterEach(() => {
     delete (window as any).Telegram;
     delete (window as any).tgWebAppStartParam;
+    window.history.pushState({}, "", "/");
     navigate.mockReset();
   });
 
@@ -55,6 +56,34 @@ describe("useTelegram start_param", () => {
       },
     };
     (window as any).tgWebAppStartParam = "reminders";
+
+    const TestComponent = () => {
+      useTelegram();
+      return null;
+    };
+
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith("/reminders");
+    });
+  });
+
+  it("navigates to reminders when query param tgWebAppStartParam is reminders", async () => {
+    (window as any).Telegram = {
+      WebApp: {
+        initDataUnsafe: { user: { id: 1 } },
+        initData: "",
+        expand: vi.fn(),
+        ready: vi.fn(),
+        onEvent: vi.fn(),
+        offEvent: vi.fn(),
+      },
+    };
+
+    const url = new URL(window.location.href);
+    url.search = "?tgWebAppStartParam=reminders";
+    window.history.pushState({}, "", url);
 
     const TestComponent = () => {
       useTelegram();

--- a/services/webapp/ui/src/hooks/useTelegram.ts
+++ b/services/webapp/ui/src/hooks/useTelegram.ts
@@ -85,9 +85,11 @@ export const useTelegram = (
     }
     let cancelled = false;
     const params = new URLSearchParams(tg?.initData ?? "");
+    const searchParams = new URLSearchParams(window.location.search);
     const startParam =
       tg?.initDataUnsafe?.start_param ??
       params.get("tgWebAppStartParam") ??
+      searchParams.get("tgWebAppStartParam") ??
       (window as TelegramWindow).tgWebAppStartParam;
     if (startParam === "reminders") {
       navigate("/reminders");

--- a/services/webapp/ui/src/main.tsx
+++ b/services/webapp/ui/src/main.tsx
@@ -10,6 +10,13 @@ import { TelegramProvider } from '@/contexts/TelegramProvider'
 import './styles/theme.css'
 import './index.css'
 
+const tgStartParam = new URLSearchParams(window.location.search).get(
+  'tgWebAppStartParam',
+)
+if (tgStartParam) {
+  (window as any).tgWebAppStartParam = tgStartParam
+}
+
 const rootElement = document.getElementById('root')
 
 if (rootElement === null) {


### PR DESCRIPTION
## Summary
- ensure Telegram hook reads `tgWebAppStartParam` from URL query before global fallback
- initialize `tgWebAppStartParam` during app bootstrap
- cover navigation by query param in `useTelegram` tests

## Testing
- `pnpm --filter "./services/webapp/ui" test -- src/hooks/use-telegram.test.tsx`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter "./services/webapp/ui" test` (fails: afterEach is not defined in CreateReminder.test.tsx)
- `pytest -q` (fails: async def functions are not natively supported)


------
https://chatgpt.com/codex/tasks/task_e_68aae1ce0728832a8e92cb0c895ebc46