### PR TITLE
[webapp] Allow custom webapp base path in buttons

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -81,9 +81,7 @@ MSG_LOW_GT0 = "Нижний порог должен быть больше 0."
 MSG_HIGH_GT_LOW = "Верхний порог должен быть больше нижнего и больше 0."
 
 
-PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(
-    6
-)
+PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(6)
 END: int = ConversationHandler.END
 
 
@@ -112,21 +110,9 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         if callable(end_conv):
             end_conv(update, context, END)
         else:
-            chat_id = (
-                getattr(update.effective_chat, "id", None)
-                if sugar_conv.per_chat
-                else None
-            )
-            user_id = (
-                getattr(update.effective_user, "id", None)
-                if sugar_conv.per_user
-                else None
-            )
-            msg_id = (
-                getattr(update.effective_message, "message_id", None)
-                if sugar_conv.per_message
-                else None
-            )
+            chat_id = getattr(update.effective_chat, "id", None) if sugar_conv.per_chat else None
+            user_id = getattr(update.effective_user, "id", None) if sugar_conv.per_user else None
+            msg_id = getattr(update.effective_message, "message_id", None) if sugar_conv.per_message else None
             key = cast(
                 tuple[int | str, ...],
                 tuple(i for i in (chat_id, user_id, msg_id) if i is not None),
@@ -166,9 +152,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         low = float(values["low"].replace(",", "."))
         high = float(values["high"].replace(",", "."))
     except ValueError:
-        await message.reply_text(
-            "❗ Пожалуйста, введите корректные числа. Справка: /profile help"
-        )
+        await message.reply_text("❗ Пожалуйста, введите корректные числа. Справка: /profile help")
         return END
 
     if icr <= 0:
@@ -244,16 +228,12 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                     [
                         InlineKeyboardButton(
                             "📝 Заполнить форму",
-                            web_app=WebAppInfo(
-                                reminder_handlers.build_webapp_url("/ui/profile")
-                            ),
+                            web_app=WebAppInfo(reminder_handlers.build_webapp_url("/profile")),
                         )
                     ]
                 ]
             )
-            await message.reply_text(
-                "Ваш профиль пока не настроен.", reply_markup=keyboard
-            )
+            await message.reply_text("Ваш профиль пока не настроен.", reply_markup=keyboard)
         else:
             await message.reply_text(
                 "Ваш профиль пока не настроен.\n\n"
@@ -285,9 +265,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             [
                 InlineKeyboardButton(
                     "📝 Заполнить форму",
-                    web_app=WebAppInfo(
-                        reminder_handlers.build_webapp_url("/ui/profile")
-                    ),
+                    web_app=WebAppInfo(reminder_handlers.build_webapp_url("/profile")),
                 )
             ],
         )
@@ -397,15 +375,11 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     button = build_timezone_webapp_button()
     if button:
         keyboard = InlineKeyboardMarkup([[button]])
-        await query.message.reply_text(
-            "Можно определить автоматически:", reply_markup=keyboard
-        )
+        await query.message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
     return PROFILE_TZ
 
 
-async def profile_timezone_save(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Save user timezone from input."""
     message = update.message
     if message is None:
@@ -430,9 +404,7 @@ async def profile_timezone_save(
         button = build_timezone_webapp_button()
         if button:
             keyboard = InlineKeyboardMarkup([[button]])
-            await message.reply_text(
-                "Можно определить автоматически:", reply_markup=keyboard
-            )
+            await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
         return PROFILE_TZ
     user = update.effective_user
     if user is None:
@@ -460,9 +432,7 @@ async def profile_timezone_save(
     return END
 
 
-def _security_db(
-    session: Session, user_id: int, action: str | None
-) -> dict[str, object]:
+def _security_db(session: Session, user_id: int, action: str | None) -> dict[str, object]:
     profile = session.get(Profile, user_id)
     user = session.get(User, user_id)
     if not profile:
@@ -496,20 +466,11 @@ def _security_db(
     if changed:
         commit_ok = commit(session)
         if commit_ok:
-            alert = (
-                session.query(Alert)
-                .filter_by(user_id=user_id)
-                .order_by(Alert.ts.desc())
-                .first()
-            )
+            alert = session.query(Alert).filter_by(user_id=user_id).order_by(Alert.ts.desc()).first()
             alert_sugar = alert.sugar if alert else None
 
     rems = session.query(Reminder).filter_by(telegram_id=user_id).all()
-    rem_text = (
-        "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems)
-        if rems
-        else "нет"
-    )
+    rem_text = "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems) if rems else "нет"
     return {
         "found": True,
         "commit_ok": commit_ok,
@@ -544,7 +505,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if action == "add" and config.settings.webapp_url:
         button = InlineKeyboardButton(
             "📝 Новое",
-            web_app=WebAppInfo(reminder_handlers.build_webapp_url("/ui/reminders")),
+            web_app=WebAppInfo(reminder_handlers.build_webapp_url("/reminders")),
         )
         keyboard = InlineKeyboardMarkup([[button]])
         await q_message.reply_text("Создать напоминание:", reply_markup=keyboard)
@@ -587,20 +548,12 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton(
-                    "Низкий -0.5", callback_data="profile_security:low_dec"
-                ),
-                InlineKeyboardButton(
-                    "Низкий +0.5", callback_data="profile_security:low_inc"
-                ),
+                InlineKeyboardButton("Низкий -0.5", callback_data="profile_security:low_dec"),
+                InlineKeyboardButton("Низкий +0.5", callback_data="profile_security:low_inc"),
             ],
             [
-                InlineKeyboardButton(
-                    "Высокий -0.5", callback_data="profile_security:high_dec"
-                ),
-                InlineKeyboardButton(
-                    "Высокий +0.5", callback_data="profile_security:high_inc"
-                ),
+                InlineKeyboardButton("Высокий -0.5", callback_data="profile_security:high_dec"),
+                InlineKeyboardButton("Высокий +0.5", callback_data="profile_security:high_inc"),
             ],
             [
                 InlineKeyboardButton(
@@ -608,15 +561,9 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     callback_data="profile_security:toggle_sos",
                 )
             ],
+            [InlineKeyboardButton("SOS контакт", callback_data="profile_security:sos_contact")],
             [
-                InlineKeyboardButton(
-                    "SOS контакт", callback_data="profile_security:sos_contact"
-                )
-            ],
-            [
-                InlineKeyboardButton(
-                    "➕ Добавить", callback_data="profile_security:add"
-                ),
+                InlineKeyboardButton("➕ Добавить", callback_data="profile_security:add"),
                 InlineKeyboardButton("🗑 Удалить", callback_data="profile_security:del"),
             ],
             [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
@@ -730,9 +677,7 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     try:
         target = float(text)
     except ValueError:
-        await message.reply_text(
-            "Введите целевой сахар числом.", reply_markup=back_keyboard
-        )
+        await message.reply_text("Введите целевой сахар числом.", reply_markup=back_keyboard)
         return PROFILE_TARGET
     if target <= 0:
         await message.reply_text(MSG_TARGET_GT0, reply_markup=back_keyboard)
@@ -768,9 +713,7 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     try:
         low = float(text)
     except ValueError:
-        await message.reply_text(
-            "Введите нижний порог числом.", reply_markup=back_keyboard
-        )
+        await message.reply_text("Введите нижний порог числом.", reply_markup=back_keyboard)
         return PROFILE_LOW
     if low <= 0:
         await message.reply_text(MSG_LOW_GT0, reply_markup=back_keyboard)
@@ -806,9 +749,7 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     try:
         high = float(text)
     except ValueError:
-        await message.reply_text(
-            "Введите верхний порог числом.", reply_markup=back_keyboard
-        )
+        await message.reply_text("Введите верхний порог числом.", reply_markup=back_keyboard)
         return PROFILE_HIGH
     low = user_data.get("profile_low")
     if high <= 0 or low is None or high <= low:
@@ -822,9 +763,7 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     target = user_data.pop("profile_target", None)
     user_data.pop("profile_low", None)
     if icr is None or cf is None or target is None:
-        await message.reply_text(
-            "⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново."
-        )
+        await message.reply_text("⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново.")
         return END
     user = update.effective_user
     if user is None:
@@ -887,15 +826,11 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return END
 
 
-async def _profile_edit_entry(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def _profile_edit_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     return await profile_edit(update, context)
 
 
-async def _profile_timezone_entry(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def _profile_timezone_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     return await profile_timezone(update, context)
 
 
@@ -903,16 +838,12 @@ profile_conv = ConversationHandler(
     entry_points=[
         CommandHandler("profile", profile_command),
         CallbackQueryNoWarnHandler(_profile_edit_entry, pattern="^profile_edit$"),
-        CallbackQueryNoWarnHandler(
-            _profile_timezone_entry, pattern="^profile_timezone$"
-        ),
+        CallbackQueryNoWarnHandler(_profile_timezone_entry, pattern="^profile_timezone$"),
     ],
     states={
         PROFILE_ICR: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_icr)],
         PROFILE_CF: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_cf)],
-        PROFILE_TARGET: [
-            MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)
-        ],
+        PROFILE_TARGET: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)],
         PROFILE_LOW: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_low)],
         PROFILE_HIGH: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_high)],
         PROFILE_TZ: [
@@ -934,9 +865,7 @@ profile_conv = ConversationHandler(
 )
 
 
-profile_webapp_handler = MessageHandler(
-    filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save
-)
+profile_webapp_handler = MessageHandler(filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save)
 
 
 __all__ = [

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -26,20 +26,16 @@ __all__ = (
 )
 
 # ─────────────── Reply-клавиатуры (отображаются на экране чата) ───────────────
-_WEBAPP_URL = (
-    config.settings.webapp_url.rstrip("/").removesuffix("/ui")
-    if config.settings.webapp_url
-    else None
-)
+_WEBAPP_URL = config.settings.webapp_url.rstrip("/") if config.settings.webapp_url else None
 
 # Create WebApp buttons when WebApp is configured, fall back to text buttons otherwise
 profile_button = (
-    KeyboardButton("📄 Мой профиль", web_app=WebAppInfo(f"{_WEBAPP_URL}/ui/profile"))
+    KeyboardButton("📄 Мой профиль", web_app=WebAppInfo(f"{_WEBAPP_URL}/profile"))
     if _WEBAPP_URL
     else KeyboardButton("📄 Мой профиль")
 )
 reminders_button = (
-    KeyboardButton("⏰ Напоминания", web_app=WebAppInfo(f"{_WEBAPP_URL}/ui/reminders"))
+    KeyboardButton("⏰ Напоминания", web_app=WebAppInfo(f"{_WEBAPP_URL}/reminders"))
     if _WEBAPP_URL
     else KeyboardButton("⏰ Напоминания")
 )
@@ -122,5 +118,5 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
 
     return InlineKeyboardButton(
         "Определить автоматически",
-        web_app=WebAppInfo(f"{_WEBAPP_URL}/ui/timezone"),
+        web_app=WebAppInfo(f"{_WEBAPP_URL}/timezone"),
     )

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -89,9 +89,7 @@ async def test_profile_command_and_view(
         session.commit()
 
     message = DummyMessage()
-    update = cast(
-        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=123))
-    )
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=123)))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=args, user_data={}),
@@ -148,9 +146,7 @@ async def test_profile_command_and_view(
     ],
 )
 @pytest.mark.asyncio
-async def test_profile_command_invalid_values(
-    monkeypatch: pytest.MonkeyPatch, args: Any, expected_attr: str
-) -> None:
+async def test_profile_command_invalid_values(monkeypatch: pytest.MonkeyPatch, args: Any, expected_attr: str) -> None:
     import os
 
     os.environ["OPENAI_API_KEY"] = "test"
@@ -166,9 +162,7 @@ async def test_profile_command_invalid_values(
     monkeypatch.setattr(handlers, "post_profile", post_profile_mock)
 
     message = DummyMessage()
-    update = cast(
-        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    )
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=args, user_data={}),
@@ -194,9 +188,7 @@ async def test_profile_command_help_and_dialog(monkeypatch: pytest.MonkeyPatch) 
 
     # Test /profile help
     help_msg = DummyMessage()
-    update = cast(
-        Update, SimpleNamespace(message=help_msg, effective_user=SimpleNamespace(id=1))
-    )
+    update = cast(Update, SimpleNamespace(message=help_msg, effective_user=SimpleNamespace(id=1)))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=["help"], user_data={}),
@@ -244,9 +236,7 @@ async def test_profile_view_preserves_user_data(
         session.commit()
 
     message = DummyMessage()
-    update = cast(
-        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    )
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"thread_id": "tid", "foo": "bar"}),
@@ -281,9 +271,7 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: None)
 
     msg = DummyMessage()
-    update = cast(
-        Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
-    )
+    update = cast(Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1)))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
@@ -296,4 +284,4 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     button = markup.inline_keyboard[0][0]
     assert button.text == "📝 Заполнить форму"
     assert button.web_app is not None
-    assert urlparse(button.web_app.url).path == "/ui/profile"
+    assert urlparse(button.web_app.url).path == "/profile"

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -8,9 +8,7 @@ import pytest
     "base_url",
     ["https://example.com", "https://example.com/"],
 )
-def test_menu_keyboard_webapp_urls(
-    monkeypatch: pytest.MonkeyPatch, base_url: str
-) -> None:
+def test_menu_keyboard_webapp_urls(monkeypatch: pytest.MonkeyPatch, base_url: str) -> None:
     """Menu buttons should open webapp paths for profile and reminders."""
     monkeypatch.setenv("WEBAPP_URL", base_url)
 
@@ -25,11 +23,10 @@ def test_menu_keyboard_webapp_urls(
     reminders_btn = next(b for b in buttons if b.text == "⏰ Напоминания")
 
     assert profile_btn.web_app is not None
-    assert urlparse(profile_btn.web_app.url).path == "/ui/profile"
+    assert urlparse(profile_btn.web_app.url).path == "/profile"
     assert reminders_btn.web_app is not None
-    assert urlparse(reminders_btn.web_app.url).path == "/ui/reminders"
+    assert urlparse(reminders_btn.web_app.url).path == "/reminders"
 
     monkeypatch.delenv("WEBAPP_URL", raising=False)
     importlib.reload(config)
     importlib.reload(ui)
-

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -71,9 +71,7 @@ class DummyBot:
     async def send_message(self, chat_id: int | str, text: str, **kwargs: Any) -> None:
         self.messages.append((chat_id, text, kwargs))
 
-    async def answer_callback_query(
-        self, callback_query_id: str, text: str | None = None, **kwargs: Any
-    ) -> None:
+    async def answer_callback_query(self, callback_query_id: str, text: str | None = None, **kwargs: Any) -> None:
         self.cb_answers.append((callback_query_id, text))
 
 
@@ -163,11 +161,7 @@ def test_schedule_reminder_replaces_existing_job() -> None:
     handlers.SessionLocal = TestSession
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="Europe/Moscow"))
-        session.add(
-            Reminder(
-                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
-            )
-        )
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
         session.commit()
     job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
     with TestSession() as session:
@@ -199,9 +193,7 @@ def test_schedule_with_next_interval(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(handlers, "datetime", DummyDatetime)
     user = DbUser(telegram_id=1, thread_id="t", timezone="Europe/Moscow")
-    rem = Reminder(
-        telegram_id=1, type="sugar", interval_hours=2, is_enabled=True, user=user
-    )
+    rem = Reminder(telegram_id=1, type="sugar", interval_hours=2, is_enabled=True, user=user)
     icon, schedule = handlers._schedule_with_next(rem)
     assert icon == "⏱"
     assert schedule == "каждые 2 ч (next 12:00)"
@@ -211,9 +203,7 @@ def test_schedule_with_next_invalid_timezone_logs_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     user = DbUser(telegram_id=1, thread_id="t", timezone="Invalid/Zone")
-    rem = Reminder(
-        telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user
-    )
+    rem = Reminder(telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user)
     with caplog.at_level(logging.WARNING):
         icon, schedule = handlers._schedule_with_next(rem)
     assert icon == "⏰"
@@ -224,9 +214,7 @@ def test_schedule_reminder_invalid_timezone_logs_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     user = DbUser(telegram_id=1, thread_id="t", timezone="Bad/Zone")
-    rem = Reminder(
-        id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user
-    )
+    rem = Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user)
     job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
     with caplog.at_level(logging.WARNING):
         handlers.schedule_reminder(rem, job_queue)
@@ -265,9 +253,7 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.add_all(
             [
-                Reminder(
-                    id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
-                ),
+                Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True),
                 Reminder(
                     id=2,
                     telegram_id=1,
@@ -296,7 +282,7 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "2. <s>🔕title2</s>" in text
     assert markup.inline_keyboard
     assert any(
-        btn.web_app is not None and btn.web_app.url.endswith("/ui/reminders")
+        btn.web_app is not None and btn.web_app.url.endswith("/reminders")
         for row in markup.inline_keyboard
         for btn in row
     )
@@ -310,11 +296,7 @@ def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(config.settings, "webapp_url", None)
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
-        session.add(
-            Reminder(
-                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
-            )
-        )
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
         session.commit()
     with TestSession() as session:
         text, markup = handlers._render_reminders(session, 1)
@@ -389,7 +371,6 @@ async def test_reminders_list_keyboard_no_webapp(
     captured: dict[str, Any] = {}
 
     async def fake_reply_text(text: str, **kwargs: Any) -> None:
-
         captured["kwargs"] = kwargs
 
     message = MagicMock(spec=Message)
@@ -417,11 +398,7 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
-        session.add(
-            Reminder(
-                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
-            )
-        )
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
         session.commit()
 
     job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
@@ -653,9 +630,7 @@ def client(
         yield test_client
 
 
-def test_empty_returns_200(
-    client: TestClient, session_factory: sessionmaker[Session]
-) -> None:
+def test_empty_returns_200(client: TestClient, session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -664,9 +639,7 @@ def test_empty_returns_200(
     assert resp.json() == []
 
 
-def test_nonempty_returns_list(
-    client: TestClient, session_factory: sessionmaker[Session]
-) -> None:
+def test_nonempty_returns_list(client: TestClient, session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(
@@ -697,9 +670,7 @@ def test_nonempty_returns_list(
     ]
 
 
-def test_get_single_reminder(
-    client: TestClient, session_factory: sessionmaker[Session]
-) -> None:
+def test_get_single_reminder(client: TestClient, session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(
@@ -736,9 +707,7 @@ def test_real_404(client: TestClient) -> None:
     assert resp.json() == []
 
 
-def test_get_single_reminder_not_found(
-    client: TestClient, session_factory: sessionmaker[Session]
-) -> None:
+def test_get_single_reminder_not_found(client: TestClient, session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -747,9 +716,7 @@ def test_get_single_reminder_not_found(
     assert resp.json() == {"detail": "reminder not found"}
 
 
-def test_post_reminder_forbidden(
-    client: TestClient, session_factory: sessionmaker[Session]
-) -> None:
+def test_post_reminder_forbidden(client: TestClient, session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -764,9 +731,7 @@ def test_post_reminder_forbidden(
     fastapi_app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
 
 
-def test_patch_reminder_forbidden(
-    client: TestClient, session_factory: sessionmaker[Session]
-) -> None:
+def test_patch_reminder_forbidden(client: TestClient, session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -18,7 +18,7 @@ def test_timezone_button_webapp_url(monkeypatch: pytest.MonkeyPatch) -> None:
     assert button is not None
     web_app = button.web_app
     assert web_app is not None
-    assert urlparse(web_app.url).path == "/ui/timezone"
+    assert urlparse(web_app.url).path == "/timezone"
 
     monkeypatch.delenv("WEBAPP_URL", raising=False)
     importlib.reload(config)


### PR DESCRIPTION
## Summary
- build WebApp URLs using configurable base path
- update profile, reminder and timezone buttons to match new paths
- adjust tests for new WebApp link structure

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae0f026b8832a9fc3adfd928f05e4