### PR TITLE
[py-sdk] Clarify post_params handling

### DIFF
--- a/libs/py-sdk/diabetes_sdk/rest.py
+++ b/libs/py-sdk/diabetes_sdk/rest.py
@@ -126,9 +126,16 @@ class RESTClientObject:
         :param url: http request url
         :param headers: http request headers
         :param body: request json body, for `application/json`
-        :param post_params: request post parameters,
-                            `application/x-www-form-urlencoded`
-                            and `multipart/form-data`
+        :param post_params: request post parameters for
+                            `application/x-www-form-urlencoded` or
+                            `multipart/form-data`. Accepts either a
+                            ``dict`` or any iterable of ``(key, value)``
+                            pairs. Values that are ``dict``, ``list`` or
+                            ``tuple`` are JSON serialized.
+
+                            Examples:
+                                post_params = {"a": 1, "meta": {"b": 2}}
+                                post_params = [("a", 1), ("meta", {"b": 2})]
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of

--- a/libs/py-sdk/docs/RESTClientObject.html
+++ b/libs/py-sdk/docs/RESTClientObject.html
@@ -1,0 +1,1145 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="generator" content="pdoc 15.0.4"/>
+    <title>diabetes_sdk.rest API documentation</title>
+
+    <style>/*! * Bootstrap Reboot v5.0.0 (https://getbootstrap.com/) * Copyright 2011-2021 The Bootstrap Authors * Copyright 2011-2021 Twitter, Inc. * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE) * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md) */*,::after,::before{box-sizing:border-box}@media (prefers-reduced-motion:no-preference){:root{scroll-behavior:smooth}}body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";font-size:1rem;font-weight:400;line-height:1.5;color:#212529;background-color:#fff;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:transparent}hr{margin:1rem 0;color:inherit;background-color:currentColor;border:0;opacity:.25}hr:not([size]){height:1px}h1,h2,h3,h4,h5,h6{margin-top:0;margin-bottom:.5rem;font-weight:500;line-height:1.2}h1{font-size:calc(1.375rem + 1.5vw)}@media (min-width:1200px){h1{font-size:2.5rem}}h2{font-size:calc(1.325rem + .9vw)}@media (min-width:1200px){h2{font-size:2rem}}h3{font-size:calc(1.3rem + .6vw)}@media (min-width:1200px){h3{font-size:1.75rem}}h4{font-size:calc(1.275rem + .3vw)}@media (min-width:1200px){h4{font-size:1.5rem}}h5{font-size:1.25rem}h6{font-size:1rem}p{margin-top:0;margin-bottom:1rem}abbr[data-bs-original-title],abbr[title]{-webkit-text-decoration:underline dotted;text-decoration:underline dotted;cursor:help;-webkit-text-decoration-skip-ink:none;text-decoration-skip-ink:none}address{margin-bottom:1rem;font-style:normal;line-height:inherit}ol,ul{padding-left:2rem}dl,ol,ul{margin-top:0;margin-bottom:1rem}ol ol,ol ul,ul ol,ul ul{margin-bottom:0}dt{font-weight:700}dd{margin-bottom:.5rem;margin-left:0}blockquote{margin:0 0 1rem}b,strong{font-weight:bolder}small{font-size:.875em}mark{padding:.2em;background-color:#fcf8e3}sub,sup{position:relative;font-size:.75em;line-height:0;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}a{color:#0d6efd;text-decoration:underline}a:hover{color:#0a58ca}a:not([href]):not([class]),a:not([href]):not([class]):hover{color:inherit;text-decoration:none}code,kbd,pre,samp{font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:1em;direction:ltr;unicode-bidi:bidi-override}pre{display:block;margin-top:0;margin-bottom:1rem;overflow:auto;font-size:.875em}pre code{font-size:inherit;color:inherit;word-break:normal}code{font-size:.875em;color:#d63384;word-wrap:break-word}a>code{color:inherit}kbd{padding:.2rem .4rem;font-size:.875em;color:#fff;background-color:#212529;border-radius:.2rem}kbd kbd{padding:0;font-size:1em;font-weight:700}figure{margin:0 0 1rem}img,svg{vertical-align:middle}table{caption-side:bottom;border-collapse:collapse}caption{padding-top:.5rem;padding-bottom:.5rem;color:#6c757d;text-align:left}th{text-align:inherit;text-align:-webkit-match-parent}tbody,td,tfoot,th,thead,tr{border-color:inherit;border-style:solid;border-width:0}label{display:inline-block}button{border-radius:0}button:focus:not(:focus-visible){outline:0}button,input,optgroup,select,textarea{margin:0;font-family:inherit;font-size:inherit;line-height:inherit}button,select{text-transform:none}[role=button]{cursor:pointer}select{word-wrap:normal}select:disabled{opacity:1}[list]::-webkit-calendar-picker-indicator{display:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]:not(:disabled),[type=reset]:not(:disabled),[type=submit]:not(:disabled),button:not(:disabled){cursor:pointer}::-moz-focus-inner{padding:0;border-style:none}textarea{resize:vertical}fieldset{min-width:0;padding:0;margin:0;border:0}legend{float:left;width:100%;padding:0;margin-bottom:.5rem;font-size:calc(1.275rem + .3vw);line-height:inherit}@media (min-width:1200px){legend{font-size:1.5rem}}legend+*{clear:left}::-webkit-datetime-edit-day-field,::-webkit-datetime-edit-fields-wrapper,::-webkit-datetime-edit-hour-field,::-webkit-datetime-edit-minute,::-webkit-datetime-edit-month-field,::-webkit-datetime-edit-text,::-webkit-datetime-edit-year-field{padding:0}::-webkit-inner-spin-button{height:auto}[type=search]{outline-offset:-2px;-webkit-appearance:textfield}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-color-swatch-wrapper{padding:0}::file-selector-button{font:inherit}::-webkit-file-upload-button{font:inherit;-webkit-appearance:button}output{display:inline-block}iframe{border:0}summary{display:list-item;cursor:pointer}progress{vertical-align:baseline}[hidden]{display:none!important}</style>
+    <style>/*! syntax-highlighting.css */pre{line-height:125%;}span.linenos{color:inherit; background-color:transparent; padding-left:5px; padding-right:20px;}.pdoc-code .hll{background-color:#ffffcc}.pdoc-code{background:#f8f8f8;}.pdoc-code .c{color:#3D7B7B; font-style:italic}.pdoc-code .err{border:1px solid #FF0000}.pdoc-code .k{color:#008000; font-weight:bold}.pdoc-code .o{color:#666666}.pdoc-code .ch{color:#3D7B7B; font-style:italic}.pdoc-code .cm{color:#3D7B7B; font-style:italic}.pdoc-code .cp{color:#9C6500}.pdoc-code .cpf{color:#3D7B7B; font-style:italic}.pdoc-code .c1{color:#3D7B7B; font-style:italic}.pdoc-code .cs{color:#3D7B7B; font-style:italic}.pdoc-code .gd{color:#A00000}.pdoc-code .ge{font-style:italic}.pdoc-code .gr{color:#E40000}.pdoc-code .gh{color:#000080; font-weight:bold}.pdoc-code .gi{color:#008400}.pdoc-code .go{color:#717171}.pdoc-code .gp{color:#000080; font-weight:bold}.pdoc-code .gs{font-weight:bold}.pdoc-code .gu{color:#800080; font-weight:bold}.pdoc-code .gt{color:#0044DD}.pdoc-code .kc{color:#008000; font-weight:bold}.pdoc-code .kd{color:#008000; font-weight:bold}.pdoc-code .kn{color:#008000; font-weight:bold}.pdoc-code .kp{color:#008000}.pdoc-code .kr{color:#008000; font-weight:bold}.pdoc-code .kt{color:#B00040}.pdoc-code .m{color:#666666}.pdoc-code .s{color:#BA2121}.pdoc-code .na{color:#687822}.pdoc-code .nb{color:#008000}.pdoc-code .nc{color:#0000FF; font-weight:bold}.pdoc-code .no{color:#880000}.pdoc-code .nd{color:#AA22FF}.pdoc-code .ni{color:#717171; font-weight:bold}.pdoc-code .ne{color:#CB3F38; font-weight:bold}.pdoc-code .nf{color:#0000FF}.pdoc-code .nl{color:#767600}.pdoc-code .nn{color:#0000FF; font-weight:bold}.pdoc-code .nt{color:#008000; font-weight:bold}.pdoc-code .nv{color:#19177C}.pdoc-code .ow{color:#AA22FF; font-weight:bold}.pdoc-code .w{color:#bbbbbb}.pdoc-code .mb{color:#666666}.pdoc-code .mf{color:#666666}.pdoc-code .mh{color:#666666}.pdoc-code .mi{color:#666666}.pdoc-code .mo{color:#666666}.pdoc-code .sa{color:#BA2121}.pdoc-code .sb{color:#BA2121}.pdoc-code .sc{color:#BA2121}.pdoc-code .dl{color:#BA2121}.pdoc-code .sd{color:#BA2121; font-style:italic}.pdoc-code .s2{color:#BA2121}.pdoc-code .se{color:#AA5D1F; font-weight:bold}.pdoc-code .sh{color:#BA2121}.pdoc-code .si{color:#A45A77; font-weight:bold}.pdoc-code .sx{color:#008000}.pdoc-code .sr{color:#A45A77}.pdoc-code .s1{color:#BA2121}.pdoc-code .ss{color:#19177C}.pdoc-code .bp{color:#008000}.pdoc-code .fm{color:#0000FF}.pdoc-code .vc{color:#19177C}.pdoc-code .vg{color:#19177C}.pdoc-code .vi{color:#19177C}.pdoc-code .vm{color:#19177C}.pdoc-code .il{color:#666666}</style>
+    <style>/*! theme.css */:root{--pdoc-background:#fff;}.pdoc{--text:#212529;--muted:#6c757d;--link:#3660a5;--link-hover:#1659c5;--code:#f8f8f8;--active:#fff598;--accent:#eee;--accent2:#c1c1c1;--nav-hover:rgba(255, 255, 255, 0.5);--name:#0066BB;--def:#008800;--annotation:#007020;}</style>
+    <style>/*! layout.css */html, body{width:100%;height:100%;}html, main{scroll-behavior:smooth;}body{background-color:var(--pdoc-background);}@media (max-width:769px){#navtoggle{cursor:pointer;position:absolute;width:50px;height:40px;top:1rem;right:1rem;border-color:var(--text);color:var(--text);display:flex;opacity:0.8;z-index:999;}#navtoggle:hover{opacity:1;}#togglestate + div{display:none;}#togglestate:checked + div{display:inherit;}main, header{padding:2rem 3vw;}header + main{margin-top:-3rem;}.git-button{display:none !important;}nav input[type="search"]{max-width:77%;}nav input[type="search"]:first-child{margin-top:-6px;}nav input[type="search"]:valid ~ *{display:none !important;}}@media (min-width:770px){:root{--sidebar-width:clamp(12.5rem, 28vw, 22rem);}nav{position:fixed;overflow:auto;height:100vh;width:var(--sidebar-width);}main, header{padding:3rem 2rem 3rem calc(var(--sidebar-width) + 3rem);width:calc(54rem + var(--sidebar-width));max-width:100%;}header + main{margin-top:-4rem;}#navtoggle{display:none;}}#togglestate{position:absolute;height:0;opacity:0;}nav.pdoc{--pad:clamp(0.5rem, 2vw, 1.75rem);--indent:1.5rem;background-color:var(--accent);border-right:1px solid var(--accent2);box-shadow:0 0 20px rgba(50, 50, 50, .2) inset;padding:0 0 0 var(--pad);overflow-wrap:anywhere;scrollbar-width:thin; scrollbar-color:var(--accent2) transparent; z-index:1}nav.pdoc::-webkit-scrollbar{width:.4rem; }nav.pdoc::-webkit-scrollbar-thumb{background-color:var(--accent2); }nav.pdoc > div{padding:var(--pad) 0;}nav.pdoc .module-list-button{display:inline-flex;align-items:center;color:var(--text);border-color:var(--muted);margin-bottom:1rem;}nav.pdoc .module-list-button:hover{border-color:var(--text);}nav.pdoc input[type=search]{display:block;outline-offset:0;width:calc(100% - var(--pad));}nav.pdoc .logo{max-width:calc(100% - var(--pad));max-height:35vh;display:block;margin:0 auto 1rem;transform:translate(calc(-.5 * var(--pad)), 0);}nav.pdoc ul{list-style:none;padding-left:0;}nav.pdoc > div > ul{margin-left:calc(0px - var(--pad));}nav.pdoc li a{padding:.2rem 0 .2rem calc(var(--pad) + var(--indent));}nav.pdoc > div > ul > li > a{padding-left:var(--pad);}nav.pdoc li{transition:all 100ms;}nav.pdoc li:hover{background-color:var(--nav-hover);}nav.pdoc a, nav.pdoc a:hover{color:var(--text);}nav.pdoc a{display:block;}nav.pdoc > h2:first-of-type{margin-top:1.5rem;}nav.pdoc .class:before{content:"class ";color:var(--muted);}nav.pdoc .function:after{content:"()";color:var(--muted);}nav.pdoc footer:before{content:"";display:block;width:calc(100% - var(--pad));border-top:solid var(--accent2) 1px;margin-top:1.5rem;padding-top:.5rem;}nav.pdoc footer{font-size:small;}</style>
+    <style>/*! content.css */.pdoc{color:var(--text);box-sizing:border-box;line-height:1.5;background:none;}.pdoc .pdoc-button{cursor:pointer;display:inline-block;border:solid black 1px;border-radius:2px;font-size:.75rem;padding:calc(0.5em - 1px) 1em;transition:100ms all;}.pdoc .alert{padding:1rem 1rem 1rem calc(1.5rem + 24px);border:1px solid transparent;border-radius:.25rem;background-repeat:no-repeat;background-position:.75rem center;margin-bottom:1rem;}.pdoc .alert > em{display:none;}.pdoc .alert > *:last-child{margin-bottom:0;}.pdoc .alert.note{color:#084298;background-color:#cfe2ff;border-color:#b6d4fe;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23084298%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M8%2016A8%208%200%201%200%208%200a8%208%200%200%200%200%2016zm.93-9.412-1%204.705c-.07.34.029.533.304.533.194%200%20.487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703%200-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381%202.29-.287zM8%205.5a1%201%200%201%201%200-2%201%201%200%200%201%200%202z%22/%3E%3C/svg%3E");}.pdoc .alert.tip{color:#0a3622;background-color:#d1e7dd;border-color:#a3cfbb;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%230a3622%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M2%206a6%206%200%201%201%2010.174%204.31c-.203.196-.359.4-.453.619l-.762%201.769A.5.5%200%200%201%2010.5%2013a.5.5%200%200%201%200%201%20.5.5%200%200%201%200%201l-.224.447a1%201%200%200%201-.894.553H6.618a1%201%200%200%201-.894-.553L5.5%2015a.5.5%200%200%201%200-1%20.5.5%200%200%201%200-1%20.5.5%200%200%201-.46-.302l-.761-1.77a2%202%200%200%200-.453-.618A5.98%205.98%200%200%201%202%206m6-5a5%205%200%200%200-3.479%208.592c.263.254.514.564.676.941L5.83%2012h4.342l.632-1.467c.162-.377.413-.687.676-.941A5%205%200%200%200%208%201%22/%3E%3C/svg%3E");}.pdoc .alert.important{color:#055160;background-color:#cff4fc;border-color:#9eeaf9;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23055160%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M2%200a2%202%200%200%200-2%202v12a2%202%200%200%200%202%202h12a2%202%200%200%200%202-2V2a2%202%200%200%200-2-2zm6%204c.535%200%20.954.462.9.995l-.35%203.507a.552.552%200%200%201-1.1%200L7.1%204.995A.905.905%200%200%201%208%204m.002%206a1%201%200%201%201%200%202%201%201%200%200%201%200-2%22/%3E%3C/svg%3E");}.pdoc .alert.warning{color:#664d03;background-color:#fff3cd;border-color:#ffecb5;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23664d03%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M8.982%201.566a1.13%201.13%200%200%200-1.96%200L.165%2013.233c-.457.778.091%201.767.98%201.767h13.713c.889%200%201.438-.99.98-1.767L8.982%201.566zM8%205c.535%200%20.954.462.9.995l-.35%203.507a.552.552%200%200%201-1.1%200L7.1%205.995A.905.905%200%200%201%208%205zm.002%206a1%201%200%201%201%200%202%201%201%200%200%201%200-2z%22/%3E%3C/svg%3E");}.pdoc .alert.caution{color:#842029;background-color:#f8d7da;border-color:#f5c2c7;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23842029%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M11.46.146A.5.5%200%200%200%2011.107%200H4.893a.5.5%200%200%200-.353.146L.146%204.54A.5.5%200%200%200%200%204.893v6.214a.5.5%200%200%200%20.146.353l4.394%204.394a.5.5%200%200%200%20.353.146h6.214a.5.5%200%200%200%20.353-.146l4.394-4.394a.5.5%200%200%200%20.146-.353V4.893a.5.5%200%200%200-.146-.353zM8%204c.535%200%20.954.462.9.995l-.35%203.507a.552.552%200%200%201-1.1%200L7.1%204.995A.905.905%200%200%201%208%204m.002%206a1%201%200%201%201%200%202%201%201%200%200%201%200-2%22/%3E%3C/svg%3E");}.pdoc .alert.danger{color:#842029;background-color:#f8d7da;border-color:#f5c2c7;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23842029%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M5.52.359A.5.5%200%200%201%206%200h4a.5.5%200%200%201%20.474.658L8.694%206H12.5a.5.5%200%200%201%20.395.807l-7%209a.5.5%200%200%201-.873-.454L6.823%209.5H3.5a.5.5%200%200%201-.48-.641l2.5-8.5z%22/%3E%3C/svg%3E");}.pdoc .visually-hidden{position:absolute !important;width:1px !important;height:1px !important;padding:0 !important;margin:-1px !important;overflow:hidden !important;clip:rect(0, 0, 0, 0) !important;white-space:nowrap !important;border:0 !important;}.pdoc h1, .pdoc h2, .pdoc h3{font-weight:300;margin:.3em 0;padding:.2em 0;}.pdoc > section:not(.module-info) h1{font-size:1.5rem;font-weight:500;}.pdoc > section:not(.module-info) h2{font-size:1.4rem;font-weight:500;}.pdoc > section:not(.module-info) h3{font-size:1.3rem;font-weight:500;}.pdoc > section:not(.module-info) h4{font-size:1.2rem;}.pdoc > section:not(.module-info) h5{font-size:1.1rem;}.pdoc a{text-decoration:none;color:var(--link);}.pdoc a:hover{color:var(--link-hover);}.pdoc blockquote{margin-left:2rem;}.pdoc pre{border-top:1px solid var(--accent2);border-bottom:1px solid var(--accent2);margin-top:0;margin-bottom:1em;padding:.5rem 0 .5rem .5rem;overflow-x:auto;background-color:var(--code);}.pdoc code{color:var(--text);padding:.2em .4em;margin:0;font-size:85%;background-color:var(--accent);border-radius:6px;}.pdoc a > code{color:inherit;}.pdoc pre > code{display:inline-block;font-size:inherit;background:none;border:none;padding:0;}.pdoc > section:not(.module-info){margin-bottom:1.5rem;}.pdoc .modulename{margin-top:0;font-weight:bold;}.pdoc .modulename a{color:var(--link);transition:100ms all;}.pdoc .git-button{float:right;border:solid var(--link) 1px;}.pdoc .git-button:hover{background-color:var(--link);color:var(--pdoc-background);}.view-source-toggle-state,.view-source-toggle-state ~ .pdoc-code{display:none;}.view-source-toggle-state:checked ~ .pdoc-code{display:block;}.view-source-button{display:inline-block;float:right;font-size:.75rem;line-height:1.5rem;color:var(--muted);padding:0 .4rem 0 1.3rem;cursor:pointer;text-indent:-2px;}.view-source-button > span{visibility:hidden;}.module-info .view-source-button{float:none;display:flex;justify-content:flex-end;margin:-1.2rem .4rem -.2rem 0;}.view-source-button::before{position:absolute;content:"View Source";display:list-item;list-style-type:disclosure-closed;}.view-source-toggle-state:checked ~ .attr .view-source-button::before,.view-source-toggle-state:checked ~ .view-source-button::before{list-style-type:disclosure-open;}.pdoc .docstring{margin-bottom:1.5rem;}.pdoc section:not(.module-info) .docstring{margin-left:clamp(0rem, 5vw - 2rem, 1rem);}.pdoc .docstring .pdoc-code{margin-left:1em;margin-right:1em;}.pdoc h1:target,.pdoc h2:target,.pdoc h3:target,.pdoc h4:target,.pdoc h5:target,.pdoc h6:target,.pdoc .pdoc-code > pre > span:target{background-color:var(--active);box-shadow:-1rem 0 0 0 var(--active);}.pdoc .pdoc-code > pre > span:target{display:block;}.pdoc div:target > .attr,.pdoc section:target > .attr,.pdoc dd:target > a{background-color:var(--active);}.pdoc *{scroll-margin:2rem;}.pdoc .pdoc-code .linenos{user-select:none;}.pdoc .attr:hover{filter:contrast(0.95);}.pdoc section, .pdoc .classattr{position:relative;}.pdoc .headerlink{--width:clamp(1rem, 3vw, 2rem);position:absolute;top:0;left:calc(0rem - var(--width));transition:all 100ms ease-in-out;opacity:0;}.pdoc .headerlink::before{content:"#";display:block;text-align:center;width:var(--width);height:2.3rem;line-height:2.3rem;font-size:1.5rem;}.pdoc .attr:hover ~ .headerlink,.pdoc *:target > .headerlink,.pdoc .headerlink:hover{opacity:1;}.pdoc .attr{display:block;margin:.5rem 0 .5rem;padding:.4rem .4rem .4rem 1rem;background-color:var(--accent);overflow-x:auto;}.pdoc .classattr{margin-left:2rem;}.pdoc .decorator-deprecated{color:#842029;}.pdoc .decorator-deprecated ~ span{filter:grayscale(1) opacity(0.8);}.pdoc .name{color:var(--name);font-weight:bold;}.pdoc .def{color:var(--def);font-weight:bold;}.pdoc .signature{background-color:transparent;}.pdoc .param, .pdoc .return-annotation{white-space:pre;}.pdoc .signature.multiline .param{display:block;}.pdoc .signature.condensed .param{display:inline-block;}.pdoc .annotation{color:var(--annotation);}.pdoc .view-value-toggle-state,.pdoc .view-value-toggle-state ~ .default_value{display:none;}.pdoc .view-value-toggle-state:checked ~ .default_value{display:inherit;}.pdoc .view-value-button{font-size:.5rem;vertical-align:middle;border-style:dashed;margin-top:-0.1rem;}.pdoc .view-value-button:hover{background:white;}.pdoc .view-value-button::before{content:"show";text-align:center;width:2.2em;display:inline-block;}.pdoc .view-value-toggle-state:checked ~ .view-value-button::before{content:"hide";}.pdoc .inherited{margin-left:2rem;}.pdoc .inherited dt{font-weight:700;}.pdoc .inherited dt, .pdoc .inherited dd{display:inline;margin-left:0;margin-bottom:.5rem;}.pdoc .inherited dd:not(:last-child):after{content:", ";}.pdoc .inherited .class:before{content:"class ";}.pdoc .inherited .function a:after{content:"()";}.pdoc .search-result .docstring{overflow:auto;max-height:25vh;}.pdoc .search-result.focused > .attr{background-color:var(--active);}.pdoc .attribution{margin-top:2rem;display:block;opacity:0.5;transition:all 200ms;filter:grayscale(100%);}.pdoc .attribution:hover{opacity:1;filter:grayscale(0%);}.pdoc .attribution img{margin-left:5px;height:35px;vertical-align:middle;width:70px;transition:all 200ms;}.pdoc table{display:block;width:max-content;max-width:100%;overflow:auto;margin-bottom:1rem;}.pdoc table th{font-weight:600;}.pdoc table th, .pdoc table td{padding:6px 13px;border:1px solid var(--accent2);}</style>
+    <style>/*! custom.css */</style></head>
+<body>
+    <nav class="pdoc">
+        <label id="navtoggle" for="togglestate" class="pdoc-button"><svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke-linecap='round' stroke="currentColor" stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg></label>
+        <input id="togglestate" type="checkbox" aria-hidden="true" tabindex="-1">
+        <div>
+
+
+
+
+            <h2>API Documentation</h2>
+                <ul class="memberlist">
+            <li>
+                    <a class="variable" href="#SUPPORTED_SOCKS_PROXIES">SUPPORTED_SOCKS_PROXIES</a>
+            </li>
+            <li>
+                    <a class="variable" href="#RESTResponseType">RESTResponseType</a>
+            </li>
+            <li>
+                    <a class="function" href="#is_socks_proxy_url">is_socks_proxy_url</a>
+            </li>
+            <li>
+                    <a class="class" href="#RESTResponse">RESTResponse</a>
+                            <ul class="memberlist">
+                        <li>
+                                <a class="function" href="#RESTResponse.__init__">RESTResponse</a>
+                        </li>
+                        <li>
+                                <a class="variable" href="#RESTResponse.response">response</a>
+                        </li>
+                        <li>
+                                <a class="variable" href="#RESTResponse.status">status</a>
+                        </li>
+                        <li>
+                                <a class="variable" href="#RESTResponse.reason">reason</a>
+                        </li>
+                        <li>
+                                <a class="variable" href="#RESTResponse.data">data</a>
+                        </li>
+                        <li>
+                                <a class="function" href="#RESTResponse.read">read</a>
+                        </li>
+                        <li>
+                                <a class="function" href="#RESTResponse.getheaders">getheaders</a>
+                        </li>
+                        <li>
+                                <a class="function" href="#RESTResponse.getheader">getheader</a>
+                        </li>
+                </ul>
+
+            </li>
+            <li>
+                    <a class="class" href="#RESTClientObject">RESTClientObject</a>
+                            <ul class="memberlist">
+                        <li>
+                                <a class="function" href="#RESTClientObject.__init__">RESTClientObject</a>
+                        </li>
+                        <li>
+                                <a class="variable" href="#RESTClientObject.pool_manager">pool_manager</a>
+                        </li>
+                        <li>
+                                <a class="function" href="#RESTClientObject.request">request</a>
+                        </li>
+                </ul>
+
+            </li>
+    </ul>
+
+
+
+        <a class="attribution" title="pdoc: Python API documentation generator" href="https://pdoc.dev" target="_blank">
+            built with <span class="visually-hidden">pdoc</span><img
+                alt="pdoc logo"
+                src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20role%3D%22img%22%20aria-label%3D%22pdoc%20logo%22%20width%3D%22300%22%20height%3D%22150%22%20viewBox%3D%22-1%200%2060%2030%22%3E%3Ctitle%3Epdoc%3C/title%3E%3Cpath%20d%3D%22M29.621%2021.293c-.011-.273-.214-.475-.511-.481a.5.5%200%200%200-.489.503l-.044%201.393c-.097.551-.695%201.215-1.566%201.704-.577.428-1.306.486-2.193.182-1.426-.617-2.467-1.654-3.304-2.487l-.173-.172a3.43%203.43%200%200%200-.365-.306.49.49%200%200%200-.286-.196c-1.718-1.06-4.931-1.47-7.353.191l-.219.15c-1.707%201.187-3.413%202.131-4.328%201.03-.02-.027-.49-.685-.141-1.763.233-.721.546-2.408.772-4.076.042-.09.067-.187.046-.288.166-1.347.277-2.625.241-3.351%201.378-1.008%202.271-2.586%202.271-4.362%200-.976-.272-1.935-.788-2.774-.057-.094-.122-.18-.184-.268.033-.167.052-.339.052-.516%200-1.477-1.202-2.679-2.679-2.679-.791%200-1.496.352-1.987.9a6.3%206.3%200%200%200-1.001.029c-.492-.564-1.207-.929-2.012-.929-1.477%200-2.679%201.202-2.679%202.679A2.65%202.65%200%200%200%20.97%206.554c-.383.747-.595%201.572-.595%202.41%200%202.311%201.507%204.29%203.635%205.107-.037.699-.147%202.27-.423%203.294l-.137.461c-.622%202.042-2.515%208.257%201.727%2010.643%201.614.908%203.06%201.248%204.317%201.248%202.665%200%204.492-1.524%205.322-2.401%201.476-1.559%202.886-1.854%206.491.82%201.877%201.393%203.514%201.753%204.861%201.068%202.223-1.713%202.811-3.867%203.399-6.374.077-.846.056-1.469.054-1.537zm-4.835%204.313c-.054.305-.156.586-.242.629-.034-.007-.131-.022-.307-.157-.145-.111-.314-.478-.456-.908.221.121.432.25.675.355.115.039.219.051.33.081zm-2.251-1.238c-.05.33-.158.648-.252.694-.022.001-.125-.018-.307-.157-.217-.166-.488-.906-.639-1.573.358.344.754.693%201.198%201.036zm-3.887-2.337c-.006-.116-.018-.231-.041-.342.635.145%201.189.368%201.599.625.097.231.166.481.174.642-.03.049-.055.101-.067.158-.046.013-.128.026-.298.004-.278-.037-.901-.57-1.367-1.087zm-1.127-.497c.116.306.176.625.12.71-.019.014-.117.045-.345.016-.206-.027-.604-.332-.986-.695.41-.051.816-.056%201.211-.031zm-4.535%201.535c.209.22.379.47.358.598-.006.041-.088.138-.351.234-.144.055-.539-.063-.979-.259a11.66%2011.66%200%200%200%20.972-.573zm.983-.664c.359-.237.738-.418%201.126-.554.25.237.479.548.457.694-.006.042-.087.138-.351.235-.174.064-.694-.105-1.232-.375zm-3.381%201.794c-.022.145-.061.29-.149.401-.133.166-.358.248-.69.251h-.002c-.133%200-.306-.26-.45-.621.417.091.854.07%201.291-.031zm-2.066-8.077a4.78%204.78%200%200%201-.775-.584c.172-.115.505-.254.88-.378l-.105.962zm-.331%202.302a10.32%2010.32%200%200%201-.828-.502c.202-.143.576-.328.984-.49l-.156.992zm-.45%202.157l-.701-.403c.214-.115.536-.249.891-.376a11.57%2011.57%200%200%201-.19.779zm-.181%201.716c.064.398.194.702.298.893-.194-.051-.435-.162-.736-.398.061-.119.224-.3.438-.495zM8.87%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zm-.735-.389a1.15%201.15%200%200%200-.314.783%201.16%201.16%200%200%200%201.162%201.162c.457%200%20.842-.27%201.032-.653.026.117.042.238.042.362a1.68%201.68%200%200%201-1.679%201.679%201.68%201.68%200%200%201-1.679-1.679c0-.843.626-1.535%201.436-1.654zM5.059%205.406A1.68%201.68%200%200%201%203.38%207.085a1.68%201.68%200%200%201-1.679-1.679c0-.037.009-.072.011-.109.21.3.541.508.935.508a1.16%201.16%200%200%200%201.162-1.162%201.14%201.14%200%200%200-.474-.912c.015%200%20.03-.005.045-.005.926.001%201.679.754%201.679%201.68zM3.198%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zM1.375%208.964c0-.52.103-1.035.288-1.52.466.394%201.06.64%201.717.64%201.144%200%202.116-.725%202.499-1.738.383%201.012%201.355%201.738%202.499%201.738.867%200%201.631-.421%202.121-1.062.307.605.478%201.267.478%201.942%200%202.486-2.153%204.51-4.801%204.51s-4.801-2.023-4.801-4.51zm24.342%2019.349c-.985.498-2.267.168-3.813-.979-3.073-2.281-5.453-3.199-7.813-.705-1.315%201.391-4.163%203.365-8.423.97-3.174-1.786-2.239-6.266-1.261-9.479l.146-.492c.276-1.02.395-2.457.444-3.268a6.11%206.11%200%200%200%201.18.115%206.01%206.01%200%200%200%202.536-.562l-.006.175c-.802.215-1.848.612-2.021%201.25-.079.295.021.601.274.837.219.203.415.364.598.501-.667.304-1.243.698-1.311%201.179-.02.144-.022.507.393.787.213.144.395.26.564.365-1.285.521-1.361.96-1.381%201.126-.018.142-.011.496.427.746l.854.489c-.473.389-.971.914-.999%201.429-.018.278.095.532.316.713.675.556%201.231.721%201.653.721.059%200%20.104-.014.158-.02.207.707.641%201.64%201.513%201.64h.013c.8-.008%201.236-.345%201.462-.626.173-.216.268-.457.325-.692.424.195.93.374%201.372.374.151%200%20.294-.021.423-.068.732-.27.944-.704.993-1.021.009-.061.003-.119.002-.179.266.086.538.147.789.147.15%200%20.294-.021.423-.069.542-.2.797-.489.914-.754.237.147.478.258.704.288.106.014.205.021.296.021.356%200%20.595-.101.767-.229.438.435%201.094.992%201.656%201.067.106.014.205.021.296.021a1.56%201.56%200%200%200%20.323-.035c.17.575.453%201.289.866%201.605.358.273.665.362.914.362a.99.99%200%200%200%20.421-.093%201.03%201.03%200%200%200%20.245-.164c.168.428.39.846.68%201.068.358.273.665.362.913.362a.99.99%200%200%200%20.421-.093c.317-.148.512-.448.639-.762.251.157.495.257.726.257.127%200%20.25-.024.37-.071.427-.17.706-.617.841-1.314.022-.015.047-.022.068-.038.067-.051.133-.104.196-.159-.443%201.486-1.107%202.761-2.086%203.257zM8.66%209.925a.5.5%200%201%200-1%200c0%20.653-.818%201.205-1.787%201.205s-1.787-.552-1.787-1.205a.5.5%200%201%200-1%200c0%201.216%201.25%202.205%202.787%202.205s2.787-.989%202.787-2.205zm4.4%2015.965l-.208.097c-2.661%201.258-4.708%201.436-6.086.527-1.542-1.017-1.88-3.19-1.844-4.198a.4.4%200%200%200-.385-.414c-.242-.029-.406.164-.414.385-.046%201.249.367%203.686%202.202%204.896.708.467%201.547.7%202.51.7%201.248%200%202.706-.392%204.362-1.174l.185-.086a.4.4%200%200%200%20.205-.527c-.089-.204-.326-.291-.527-.206zM9.547%202.292c.093.077.205.114.317.114a.5.5%200%200%200%20.318-.886L8.817.397a.5.5%200%200%200-.703.068.5.5%200%200%200%20.069.703l1.364%201.124zm-7.661-.065c.086%200%20.173-.022.253-.068l1.523-.893a.5.5%200%200%200-.506-.863l-1.523.892a.5.5%200%200%200-.179.685c.094.158.261.247.432.247z%22%20transform%3D%22matrix%28-1%200%200%201%2058%200%29%22%20fill%3D%22%233bb300%22/%3E%3Cpath%20d%3D%22M.3%2021.86V10.18q0-.46.02-.68.04-.22.18-.5.28-.54%201.34-.54%201.06%200%201.42.28.38.26.44.78.76-1.04%202.38-1.04%201.64%200%203.1%201.54%201.46%201.54%201.46%203.58%200%202.04-1.46%203.58-1.44%201.54-3.08%201.54-1.64%200-2.38-.92v4.04q0%20.46-.04.68-.02.22-.18.5-.14.3-.5.42-.36.12-.98.12-.62%200-1-.12-.36-.12-.52-.4-.14-.28-.18-.5-.02-.22-.02-.68zm3.96-9.42q-.46.54-.46%201.18%200%20.64.46%201.18.48.52%201.2.52.74%200%201.24-.52.52-.52.52-1.18%200-.66-.48-1.18-.48-.54-1.26-.54-.76%200-1.22.54zm14.741-8.36q.16-.3.54-.42.38-.12%201-.12.64%200%201.02.12.38.12.52.42.16.3.18.54.04.22.04.68v11.94q0%20.46-.04.7-.02.22-.18.5-.3.54-1.7.54-1.38%200-1.54-.98-.84.96-2.34.96-1.8%200-3.28-1.56-1.48-1.58-1.48-3.66%200-2.1%201.48-3.68%201.5-1.58%203.28-1.58%201.48%200%202.3%201v-4.2q0-.46.02-.68.04-.24.18-.52zm-3.24%2010.86q.52.54%201.26.54.74%200%201.22-.54.5-.54.5-1.18%200-.66-.48-1.22-.46-.56-1.26-.56-.8%200-1.28.56-.48.54-.48%201.2%200%20.66.52%201.2zm7.833-1.2q0-2.4%201.68-3.96%201.68-1.56%203.84-1.56%202.16%200%203.82%201.56%201.66%201.54%201.66%203.94%200%201.66-.86%202.96-.86%201.28-2.1%201.9-1.22.6-2.54.6-1.32%200-2.56-.64-1.24-.66-2.1-1.92-.84-1.28-.84-2.88zm4.18%201.44q.64.48%201.3.48.66%200%201.32-.5.66-.5.66-1.48%200-.98-.62-1.46-.62-.48-1.34-.48-.72%200-1.34.5-.62.5-.62%201.48%200%20.96.64%201.46zm11.412-1.44q0%20.84.56%201.32.56.46%201.18.46.64%200%201.18-.36.56-.38.9-.38.6%200%201.46%201.06.46.58.46%201.04%200%20.76-1.1%201.42-1.14.8-2.8.8-1.86%200-3.58-1.34-.82-.64-1.34-1.7-.52-1.08-.52-2.36%200-1.3.52-2.34.52-1.06%201.34-1.7%201.66-1.32%203.54-1.32.76%200%201.48.22.72.2%201.06.4l.32.2q.36.24.56.38.52.4.52.92%200%20.5-.42%201.14-.72%201.1-1.38%201.1-.38%200-1.08-.44-.36-.34-1.04-.34-.66%200-1.24.48-.58.48-.58%201.34z%22%20fill%3D%22green%22/%3E%3C/svg%3E"/>
+        </a>
+</div>
+    </nav>
+    <main class="pdoc">
+            <section class="module-info">
+                    <h1 class="modulename">
+diabetes_sdk<wbr>.rest    </h1>
+
+                        <div class="docstring"><p>Diabetes Assistant API</p>
+
+<p>No description provided (generated by Openapi Generator <a href="https://github.com/openapitools/openapi-generator">https://github.com/openapitools/openapi-generator</a>)</p>
+
+<p>The version of the OpenAPI document: 1.0.0
+Generated by OpenAPI Generator (<a href="https://openapi-generator.tech">https://openapi-generator.tech</a>)</p>
+
+<p>Do not edit the class manually.</p>
+</div>
+
+                        <input id="mod-rest-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+
+                        <label class="view-source-button" for="mod-rest-view-source"><span>View Source</span></label>
+
+                        <div class="pdoc-code codehilite"><pre><span></span><span id="L-1"><a href="#L-1"><span class="linenos">  1</span></a><span class="c1"># coding: utf-8</span>
+</span><span id="L-2"><a href="#L-2"><span class="linenos">  2</span></a>
+</span><span id="L-3"><a href="#L-3"><span class="linenos">  3</span></a><span class="sd">&quot;&quot;&quot;</span>
+</span><span id="L-4"><a href="#L-4"><span class="linenos">  4</span></a><span class="sd">Diabetes Assistant API</span>
+</span><span id="L-5"><a href="#L-5"><span class="linenos">  5</span></a>
+</span><span id="L-6"><a href="#L-6"><span class="linenos">  6</span></a><span class="sd">No description provided (generated by Openapi Generator https://github.com/openapitools/openapi-generator)</span>
+</span><span id="L-7"><a href="#L-7"><span class="linenos">  7</span></a>
+</span><span id="L-8"><a href="#L-8"><span class="linenos">  8</span></a><span class="sd">The version of the OpenAPI document: 1.0.0</span>
+</span><span id="L-9"><a href="#L-9"><span class="linenos">  9</span></a><span class="sd">Generated by OpenAPI Generator (https://openapi-generator.tech)</span>
+</span><span id="L-10"><a href="#L-10"><span class="linenos"> 10</span></a>
+</span><span id="L-11"><a href="#L-11"><span class="linenos"> 11</span></a><span class="sd">Do not edit the class manually.</span>
+</span><span id="L-12"><a href="#L-12"><span class="linenos"> 12</span></a><span class="sd">&quot;&quot;&quot;</span>  <span class="c1"># noqa: E501</span>
+</span><span id="L-13"><a href="#L-13"><span class="linenos"> 13</span></a>
+</span><span id="L-14"><a href="#L-14"><span class="linenos"> 14</span></a>
+</span><span id="L-15"><a href="#L-15"><span class="linenos"> 15</span></a><span class="kn">import</span><span class="w"> </span><span class="nn">io</span>
+</span><span id="L-16"><a href="#L-16"><span class="linenos"> 16</span></a><span class="kn">import</span><span class="w"> </span><span class="nn">json</span>
+</span><span id="L-17"><a href="#L-17"><span class="linenos"> 17</span></a><span class="kn">import</span><span class="w"> </span><span class="nn">re</span>
+</span><span id="L-18"><a href="#L-18"><span class="linenos"> 18</span></a><span class="kn">import</span><span class="w"> </span><span class="nn">ssl</span>
+</span><span id="L-19"><a href="#L-19"><span class="linenos"> 19</span></a><span class="kn">from</span><span class="w"> </span><span class="nn">collections.abc</span><span class="w"> </span><span class="kn">import</span> <span class="n">Iterable</span>
+</span><span id="L-20"><a href="#L-20"><span class="linenos"> 20</span></a>
+</span><span id="L-21"><a href="#L-21"><span class="linenos"> 21</span></a><span class="kn">import</span><span class="w"> </span><span class="nn">urllib3</span>
+</span><span id="L-22"><a href="#L-22"><span class="linenos"> 22</span></a>
+</span><span id="L-23"><a href="#L-23"><span class="linenos"> 23</span></a><span class="kn">from</span><span class="w"> </span><span class="nn">diabetes_sdk.exceptions</span><span class="w"> </span><span class="kn">import</span> <span class="n">ApiException</span><span class="p">,</span> <span class="n">ApiValueError</span>
+</span><span id="L-24"><a href="#L-24"><span class="linenos"> 24</span></a>
+</span><span id="L-25"><a href="#L-25"><span class="linenos"> 25</span></a><span class="n">SUPPORTED_SOCKS_PROXIES</span> <span class="o">=</span> <span class="p">{</span><span class="s2">&quot;socks5&quot;</span><span class="p">,</span> <span class="s2">&quot;socks5h&quot;</span><span class="p">,</span> <span class="s2">&quot;socks4&quot;</span><span class="p">,</span> <span class="s2">&quot;socks4a&quot;</span><span class="p">}</span>
+</span><span id="L-26"><a href="#L-26"><span class="linenos"> 26</span></a><span class="n">RESTResponseType</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">HTTPResponse</span>
+</span><span id="L-27"><a href="#L-27"><span class="linenos"> 27</span></a>
+</span><span id="L-28"><a href="#L-28"><span class="linenos"> 28</span></a>
+</span><span id="L-29"><a href="#L-29"><span class="linenos"> 29</span></a><span class="k">def</span><span class="w"> </span><span class="nf">is_socks_proxy_url</span><span class="p">(</span><span class="n">url</span><span class="p">):</span>
+</span><span id="L-30"><a href="#L-30"><span class="linenos"> 30</span></a>    <span class="k">if</span> <span class="n">url</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="L-31"><a href="#L-31"><span class="linenos"> 31</span></a>        <span class="k">return</span> <span class="kc">False</span>
+</span><span id="L-32"><a href="#L-32"><span class="linenos"> 32</span></a>    <span class="n">split_section</span> <span class="o">=</span> <span class="n">url</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s2">&quot;://&quot;</span><span class="p">)</span>
+</span><span id="L-33"><a href="#L-33"><span class="linenos"> 33</span></a>    <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">split_section</span><span class="p">)</span> <span class="o">&lt;</span> <span class="mi">2</span><span class="p">:</span>
+</span><span id="L-34"><a href="#L-34"><span class="linenos"> 34</span></a>        <span class="k">return</span> <span class="kc">False</span>
+</span><span id="L-35"><a href="#L-35"><span class="linenos"> 35</span></a>    <span class="k">else</span><span class="p">:</span>
+</span><span id="L-36"><a href="#L-36"><span class="linenos"> 36</span></a>        <span class="k">return</span> <span class="n">split_section</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">lower</span><span class="p">()</span> <span class="ow">in</span> <span class="n">SUPPORTED_SOCKS_PROXIES</span>
+</span><span id="L-37"><a href="#L-37"><span class="linenos"> 37</span></a>
+</span><span id="L-38"><a href="#L-38"><span class="linenos"> 38</span></a>
+</span><span id="L-39"><a href="#L-39"><span class="linenos"> 39</span></a><span class="k">class</span><span class="w"> </span><span class="nc">RESTResponse</span><span class="p">(</span><span class="n">io</span><span class="o">.</span><span class="n">IOBase</span><span class="p">):</span>
+</span><span id="L-40"><a href="#L-40"><span class="linenos"> 40</span></a>
+</span><span id="L-41"><a href="#L-41"><span class="linenos"> 41</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">resp</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="L-42"><a href="#L-42"><span class="linenos"> 42</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">response</span> <span class="o">=</span> <span class="n">resp</span>
+</span><span id="L-43"><a href="#L-43"><span class="linenos"> 43</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">status</span> <span class="o">=</span> <span class="n">resp</span><span class="o">.</span><span class="n">status</span>
+</span><span id="L-44"><a href="#L-44"><span class="linenos"> 44</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">reason</span> <span class="o">=</span> <span class="n">resp</span><span class="o">.</span><span class="n">reason</span>
+</span><span id="L-45"><a href="#L-45"><span class="linenos"> 45</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">data</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="L-46"><a href="#L-46"><span class="linenos"> 46</span></a>
+</span><span id="L-47"><a href="#L-47"><span class="linenos"> 47</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">read</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+</span><span id="L-48"><a href="#L-48"><span class="linenos"> 48</span></a>        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">data</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="L-49"><a href="#L-49"><span class="linenos"> 49</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">data</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">response</span><span class="o">.</span><span class="n">data</span>
+</span><span id="L-50"><a href="#L-50"><span class="linenos"> 50</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">data</span>
+</span><span id="L-51"><a href="#L-51"><span class="linenos"> 51</span></a>
+</span><span id="L-52"><a href="#L-52"><span class="linenos"> 52</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">getheaders</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+</span><span id="L-53"><a href="#L-53"><span class="linenos"> 53</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Returns a dictionary of the response headers.&quot;&quot;&quot;</span>
+</span><span id="L-54"><a href="#L-54"><span class="linenos"> 54</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">response</span><span class="o">.</span><span class="n">headers</span>
+</span><span id="L-55"><a href="#L-55"><span class="linenos"> 55</span></a>
+</span><span id="L-56"><a href="#L-56"><span class="linenos"> 56</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">getheader</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">,</span> <span class="n">default</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
+</span><span id="L-57"><a href="#L-57"><span class="linenos"> 57</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Returns a given response header.&quot;&quot;&quot;</span>
+</span><span id="L-58"><a href="#L-58"><span class="linenos"> 58</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">response</span><span class="o">.</span><span class="n">headers</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="n">name</span><span class="p">,</span> <span class="n">default</span><span class="p">)</span>
+</span><span id="L-59"><a href="#L-59"><span class="linenos"> 59</span></a>
+</span><span id="L-60"><a href="#L-60"><span class="linenos"> 60</span></a>
+</span><span id="L-61"><a href="#L-61"><span class="linenos"> 61</span></a><span class="k">class</span><span class="w"> </span><span class="nc">RESTClientObject</span><span class="p">:</span>
+</span><span id="L-62"><a href="#L-62"><span class="linenos"> 62</span></a>
+</span><span id="L-63"><a href="#L-63"><span class="linenos"> 63</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">configuration</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="L-64"><a href="#L-64"><span class="linenos"> 64</span></a>        <span class="c1"># urllib3.PoolManager will pass all kw parameters to connectionpool</span>
+</span><span id="L-65"><a href="#L-65"><span class="linenos"> 65</span></a>        <span class="c1"># https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75  # noqa: E501</span>
+</span><span id="L-66"><a href="#L-66"><span class="linenos"> 66</span></a>        <span class="c1"># https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680  # noqa: E501</span>
+</span><span id="L-67"><a href="#L-67"><span class="linenos"> 67</span></a>        <span class="c1"># Custom SSL certificates and client certificates: http://urllib3.readthedocs.io/en/latest/advanced-usage.html  # noqa: E501</span>
+</span><span id="L-68"><a href="#L-68"><span class="linenos"> 68</span></a>
+</span><span id="L-69"><a href="#L-69"><span class="linenos"> 69</span></a>        <span class="c1"># cert_reqs</span>
+</span><span id="L-70"><a href="#L-70"><span class="linenos"> 70</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">verify_ssl</span><span class="p">:</span>
+</span><span id="L-71"><a href="#L-71"><span class="linenos"> 71</span></a>            <span class="n">cert_reqs</span> <span class="o">=</span> <span class="n">ssl</span><span class="o">.</span><span class="n">CERT_REQUIRED</span>
+</span><span id="L-72"><a href="#L-72"><span class="linenos"> 72</span></a>        <span class="k">else</span><span class="p">:</span>
+</span><span id="L-73"><a href="#L-73"><span class="linenos"> 73</span></a>            <span class="n">cert_reqs</span> <span class="o">=</span> <span class="n">ssl</span><span class="o">.</span><span class="n">CERT_NONE</span>
+</span><span id="L-74"><a href="#L-74"><span class="linenos"> 74</span></a>
+</span><span id="L-75"><a href="#L-75"><span class="linenos"> 75</span></a>        <span class="n">pool_args</span> <span class="o">=</span> <span class="p">{</span>
+</span><span id="L-76"><a href="#L-76"><span class="linenos"> 76</span></a>            <span class="s2">&quot;cert_reqs&quot;</span><span class="p">:</span> <span class="n">cert_reqs</span><span class="p">,</span>
+</span><span id="L-77"><a href="#L-77"><span class="linenos"> 77</span></a>            <span class="s2">&quot;ca_certs&quot;</span><span class="p">:</span> <span class="n">configuration</span><span class="o">.</span><span class="n">ssl_ca_cert</span><span class="p">,</span>
+</span><span id="L-78"><a href="#L-78"><span class="linenos"> 78</span></a>            <span class="s2">&quot;cert_file&quot;</span><span class="p">:</span> <span class="n">configuration</span><span class="o">.</span><span class="n">cert_file</span><span class="p">,</span>
+</span><span id="L-79"><a href="#L-79"><span class="linenos"> 79</span></a>            <span class="s2">&quot;key_file&quot;</span><span class="p">:</span> <span class="n">configuration</span><span class="o">.</span><span class="n">key_file</span><span class="p">,</span>
+</span><span id="L-80"><a href="#L-80"><span class="linenos"> 80</span></a>            <span class="s2">&quot;ca_cert_data&quot;</span><span class="p">:</span> <span class="n">configuration</span><span class="o">.</span><span class="n">ca_cert_data</span><span class="p">,</span>
+</span><span id="L-81"><a href="#L-81"><span class="linenos"> 81</span></a>        <span class="p">}</span>
+</span><span id="L-82"><a href="#L-82"><span class="linenos"> 82</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">assert_hostname</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="L-83"><a href="#L-83"><span class="linenos"> 83</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;assert_hostname&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">assert_hostname</span>
+</span><span id="L-84"><a href="#L-84"><span class="linenos"> 84</span></a>
+</span><span id="L-85"><a href="#L-85"><span class="linenos"> 85</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">retries</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="L-86"><a href="#L-86"><span class="linenos"> 86</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;retries&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">retries</span>
+</span><span id="L-87"><a href="#L-87"><span class="linenos"> 87</span></a>
+</span><span id="L-88"><a href="#L-88"><span class="linenos"> 88</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">tls_server_name</span><span class="p">:</span>
+</span><span id="L-89"><a href="#L-89"><span class="linenos"> 89</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;server_hostname&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">tls_server_name</span>
+</span><span id="L-90"><a href="#L-90"><span class="linenos"> 90</span></a>
+</span><span id="L-91"><a href="#L-91"><span class="linenos"> 91</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">socket_options</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="L-92"><a href="#L-92"><span class="linenos"> 92</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;socket_options&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">socket_options</span>
+</span><span id="L-93"><a href="#L-93"><span class="linenos"> 93</span></a>
+</span><span id="L-94"><a href="#L-94"><span class="linenos"> 94</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">connection_pool_maxsize</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="L-95"><a href="#L-95"><span class="linenos"> 95</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;maxsize&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">connection_pool_maxsize</span>
+</span><span id="L-96"><a href="#L-96"><span class="linenos"> 96</span></a>
+</span><span id="L-97"><a href="#L-97"><span class="linenos"> 97</span></a>        <span class="c1"># https pool manager</span>
+</span><span id="L-98"><a href="#L-98"><span class="linenos"> 98</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="p">:</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">PoolManager</span>
+</span><span id="L-99"><a href="#L-99"><span class="linenos"> 99</span></a>
+</span><span id="L-100"><a href="#L-100"><span class="linenos">100</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy</span><span class="p">:</span>
+</span><span id="L-101"><a href="#L-101"><span class="linenos">101</span></a>            <span class="k">if</span> <span class="n">is_socks_proxy_url</span><span class="p">(</span><span class="n">configuration</span><span class="o">.</span><span class="n">proxy</span><span class="p">):</span>
+</span><span id="L-102"><a href="#L-102"><span class="linenos">102</span></a>                <span class="kn">from</span><span class="w"> </span><span class="nn">urllib3.contrib.socks</span><span class="w"> </span><span class="kn">import</span> <span class="n">SOCKSProxyManager</span>
+</span><span id="L-103"><a href="#L-103"><span class="linenos">103</span></a>
+</span><span id="L-104"><a href="#L-104"><span class="linenos">104</span></a>                <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;proxy_url&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy</span>
+</span><span id="L-105"><a href="#L-105"><span class="linenos">105</span></a>                <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;headers&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy_headers</span>
+</span><span id="L-106"><a href="#L-106"><span class="linenos">106</span></a>                <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span> <span class="o">=</span> <span class="n">SOCKSProxyManager</span><span class="p">(</span><span class="o">**</span><span class="n">pool_args</span><span class="p">)</span>
+</span><span id="L-107"><a href="#L-107"><span class="linenos">107</span></a>            <span class="k">else</span><span class="p">:</span>
+</span><span id="L-108"><a href="#L-108"><span class="linenos">108</span></a>                <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;proxy_url&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy</span>
+</span><span id="L-109"><a href="#L-109"><span class="linenos">109</span></a>                <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;proxy_headers&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy_headers</span>
+</span><span id="L-110"><a href="#L-110"><span class="linenos">110</span></a>                <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">ProxyManager</span><span class="p">(</span><span class="o">**</span><span class="n">pool_args</span><span class="p">)</span>
+</span><span id="L-111"><a href="#L-111"><span class="linenos">111</span></a>        <span class="k">else</span><span class="p">:</span>
+</span><span id="L-112"><a href="#L-112"><span class="linenos">112</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">PoolManager</span><span class="p">(</span><span class="o">**</span><span class="n">pool_args</span><span class="p">)</span>
+</span><span id="L-113"><a href="#L-113"><span class="linenos">113</span></a>
+</span><span id="L-114"><a href="#L-114"><span class="linenos">114</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">request</span><span class="p">(</span>
+</span><span id="L-115"><a href="#L-115"><span class="linenos">115</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="L-116"><a href="#L-116"><span class="linenos">116</span></a>        <span class="n">method</span><span class="p">,</span>
+</span><span id="L-117"><a href="#L-117"><span class="linenos">117</span></a>        <span class="n">url</span><span class="p">,</span>
+</span><span id="L-118"><a href="#L-118"><span class="linenos">118</span></a>        <span class="n">headers</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+</span><span id="L-119"><a href="#L-119"><span class="linenos">119</span></a>        <span class="n">body</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+</span><span id="L-120"><a href="#L-120"><span class="linenos">120</span></a>        <span class="n">post_params</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+</span><span id="L-121"><a href="#L-121"><span class="linenos">121</span></a>        <span class="n">_request_timeout</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+</span><span id="L-122"><a href="#L-122"><span class="linenos">122</span></a>    <span class="p">):</span>
+</span><span id="L-123"><a href="#L-123"><span class="linenos">123</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Perform requests.</span>
+</span><span id="L-124"><a href="#L-124"><span class="linenos">124</span></a>
+</span><span id="L-125"><a href="#L-125"><span class="linenos">125</span></a><span class="sd">        :param method: http request method</span>
+</span><span id="L-126"><a href="#L-126"><span class="linenos">126</span></a><span class="sd">        :param url: http request url</span>
+</span><span id="L-127"><a href="#L-127"><span class="linenos">127</span></a><span class="sd">        :param headers: http request headers</span>
+</span><span id="L-128"><a href="#L-128"><span class="linenos">128</span></a><span class="sd">        :param body: request json body, for `application/json`</span>
+</span><span id="L-129"><a href="#L-129"><span class="linenos">129</span></a><span class="sd">        :param post_params: request post parameters for</span>
+</span><span id="L-130"><a href="#L-130"><span class="linenos">130</span></a><span class="sd">                            `application/x-www-form-urlencoded` or</span>
+</span><span id="L-131"><a href="#L-131"><span class="linenos">131</span></a><span class="sd">                            `multipart/form-data`. Accepts either a</span>
+</span><span id="L-132"><a href="#L-132"><span class="linenos">132</span></a><span class="sd">                            ``dict`` or any iterable of ``(key, value)``</span>
+</span><span id="L-133"><a href="#L-133"><span class="linenos">133</span></a><span class="sd">                            pairs. Values that are ``dict``, ``list`` or</span>
+</span><span id="L-134"><a href="#L-134"><span class="linenos">134</span></a><span class="sd">                            ``tuple`` are JSON serialized.</span>
+</span><span id="L-135"><a href="#L-135"><span class="linenos">135</span></a>
+</span><span id="L-136"><a href="#L-136"><span class="linenos">136</span></a><span class="sd">                            Examples:</span>
+</span><span id="L-137"><a href="#L-137"><span class="linenos">137</span></a><span class="sd">                                post_params = {&quot;a&quot;: 1, &quot;meta&quot;: {&quot;b&quot;: 2}}</span>
+</span><span id="L-138"><a href="#L-138"><span class="linenos">138</span></a><span class="sd">                                post_params = [(&quot;a&quot;, 1), (&quot;meta&quot;, {&quot;b&quot;: 2})]</span>
+</span><span id="L-139"><a href="#L-139"><span class="linenos">139</span></a><span class="sd">        :param _request_timeout: timeout setting for this request. If one</span>
+</span><span id="L-140"><a href="#L-140"><span class="linenos">140</span></a><span class="sd">                                 number provided, it will be total request</span>
+</span><span id="L-141"><a href="#L-141"><span class="linenos">141</span></a><span class="sd">                                 timeout. It can also be a pair (tuple) of</span>
+</span><span id="L-142"><a href="#L-142"><span class="linenos">142</span></a><span class="sd">                                 (connection, read) timeouts.</span>
+</span><span id="L-143"><a href="#L-143"><span class="linenos">143</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="L-144"><a href="#L-144"><span class="linenos">144</span></a>        <span class="n">method</span> <span class="o">=</span> <span class="n">method</span><span class="o">.</span><span class="n">upper</span><span class="p">()</span>
+</span><span id="L-145"><a href="#L-145"><span class="linenos">145</span></a>        <span class="k">assert</span> <span class="n">method</span> <span class="ow">in</span> <span class="p">[</span><span class="s2">&quot;GET&quot;</span><span class="p">,</span> <span class="s2">&quot;HEAD&quot;</span><span class="p">,</span> <span class="s2">&quot;DELETE&quot;</span><span class="p">,</span> <span class="s2">&quot;POST&quot;</span><span class="p">,</span> <span class="s2">&quot;PUT&quot;</span><span class="p">,</span> <span class="s2">&quot;PATCH&quot;</span><span class="p">,</span> <span class="s2">&quot;OPTIONS&quot;</span><span class="p">]</span>
+</span><span id="L-146"><a href="#L-146"><span class="linenos">146</span></a>
+</span><span id="L-147"><a href="#L-147"><span class="linenos">147</span></a>        <span class="k">if</span> <span class="n">post_params</span> <span class="ow">and</span> <span class="n">body</span><span class="p">:</span>
+</span><span id="L-148"><a href="#L-148"><span class="linenos">148</span></a>            <span class="k">raise</span> <span class="n">ApiValueError</span><span class="p">(</span>
+</span><span id="L-149"><a href="#L-149"><span class="linenos">149</span></a>                <span class="s2">&quot;body parameter cannot be used with post_params parameter.&quot;</span>
+</span><span id="L-150"><a href="#L-150"><span class="linenos">150</span></a>            <span class="p">)</span>
+</span><span id="L-151"><a href="#L-151"><span class="linenos">151</span></a>
+</span><span id="L-152"><a href="#L-152"><span class="linenos">152</span></a>        <span class="n">post_params</span> <span class="o">=</span> <span class="n">post_params</span> <span class="ow">or</span> <span class="p">{}</span>
+</span><span id="L-153"><a href="#L-153"><span class="linenos">153</span></a>        <span class="n">headers</span> <span class="o">=</span> <span class="n">headers</span> <span class="ow">or</span> <span class="p">{}</span>
+</span><span id="L-154"><a href="#L-154"><span class="linenos">154</span></a>
+</span><span id="L-155"><a href="#L-155"><span class="linenos">155</span></a>        <span class="n">timeout</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="L-156"><a href="#L-156"><span class="linenos">156</span></a>        <span class="k">if</span> <span class="n">_request_timeout</span><span class="p">:</span>
+</span><span id="L-157"><a href="#L-157"><span class="linenos">157</span></a>            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">_request_timeout</span><span class="p">,</span> <span class="p">(</span><span class="nb">int</span><span class="p">,</span> <span class="nb">float</span><span class="p">)):</span>
+</span><span id="L-158"><a href="#L-158"><span class="linenos">158</span></a>                <span class="n">timeout</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">Timeout</span><span class="p">(</span><span class="n">total</span><span class="o">=</span><span class="n">_request_timeout</span><span class="p">)</span>
+</span><span id="L-159"><a href="#L-159"><span class="linenos">159</span></a>            <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">_request_timeout</span><span class="p">,</span> <span class="nb">tuple</span><span class="p">)</span> <span class="ow">and</span> <span class="nb">len</span><span class="p">(</span><span class="n">_request_timeout</span><span class="p">)</span> <span class="o">==</span> <span class="mi">2</span><span class="p">:</span>
+</span><span id="L-160"><a href="#L-160"><span class="linenos">160</span></a>                <span class="n">timeout</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">Timeout</span><span class="p">(</span>
+</span><span id="L-161"><a href="#L-161"><span class="linenos">161</span></a>                    <span class="n">connect</span><span class="o">=</span><span class="n">_request_timeout</span><span class="p">[</span><span class="mi">0</span><span class="p">],</span> <span class="n">read</span><span class="o">=</span><span class="n">_request_timeout</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span>
+</span><span id="L-162"><a href="#L-162"><span class="linenos">162</span></a>                <span class="p">)</span>
+</span><span id="L-163"><a href="#L-163"><span class="linenos">163</span></a>
+</span><span id="L-164"><a href="#L-164"><span class="linenos">164</span></a>        <span class="k">try</span><span class="p">:</span>
+</span><span id="L-165"><a href="#L-165"><span class="linenos">165</span></a>            <span class="c1"># For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`</span>
+</span><span id="L-166"><a href="#L-166"><span class="linenos">166</span></a>            <span class="k">if</span> <span class="n">method</span> <span class="ow">in</span> <span class="p">[</span><span class="s2">&quot;POST&quot;</span><span class="p">,</span> <span class="s2">&quot;PUT&quot;</span><span class="p">,</span> <span class="s2">&quot;PATCH&quot;</span><span class="p">,</span> <span class="s2">&quot;OPTIONS&quot;</span><span class="p">,</span> <span class="s2">&quot;DELETE&quot;</span><span class="p">]:</span>
+</span><span id="L-167"><a href="#L-167"><span class="linenos">167</span></a>
+</span><span id="L-168"><a href="#L-168"><span class="linenos">168</span></a>                <span class="c1"># no content type provided or payload is json</span>
+</span><span id="L-169"><a href="#L-169"><span class="linenos">169</span></a>                <span class="n">content_type</span> <span class="o">=</span> <span class="n">headers</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s2">&quot;Content-Type&quot;</span><span class="p">)</span>
+</span><span id="L-170"><a href="#L-170"><span class="linenos">170</span></a>                <span class="k">if</span> <span class="ow">not</span> <span class="n">content_type</span> <span class="ow">or</span> <span class="n">re</span><span class="o">.</span><span class="n">search</span><span class="p">(</span><span class="s2">&quot;json&quot;</span><span class="p">,</span> <span class="n">content_type</span><span class="p">,</span> <span class="n">re</span><span class="o">.</span><span class="n">IGNORECASE</span><span class="p">):</span>
+</span><span id="L-171"><a href="#L-171"><span class="linenos">171</span></a>                    <span class="n">request_body</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="L-172"><a href="#L-172"><span class="linenos">172</span></a>                    <span class="k">if</span> <span class="n">body</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="L-173"><a href="#L-173"><span class="linenos">173</span></a>                        <span class="n">request_body</span> <span class="o">=</span> <span class="n">json</span><span class="o">.</span><span class="n">dumps</span><span class="p">(</span><span class="n">body</span><span class="p">)</span>
+</span><span id="L-174"><a href="#L-174"><span class="linenos">174</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="L-175"><a href="#L-175"><span class="linenos">175</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="L-176"><a href="#L-176"><span class="linenos">176</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="L-177"><a href="#L-177"><span class="linenos">177</span></a>                        <span class="n">body</span><span class="o">=</span><span class="n">request_body</span><span class="p">,</span>
+</span><span id="L-178"><a href="#L-178"><span class="linenos">178</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="L-179"><a href="#L-179"><span class="linenos">179</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="L-180"><a href="#L-180"><span class="linenos">180</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="L-181"><a href="#L-181"><span class="linenos">181</span></a>                    <span class="p">)</span>
+</span><span id="L-182"><a href="#L-182"><span class="linenos">182</span></a>                <span class="k">elif</span> <span class="n">content_type</span> <span class="o">==</span> <span class="s2">&quot;application/x-www-form-urlencoded&quot;</span><span class="p">:</span>
+</span><span id="L-183"><a href="#L-183"><span class="linenos">183</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="L-184"><a href="#L-184"><span class="linenos">184</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="L-185"><a href="#L-185"><span class="linenos">185</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="L-186"><a href="#L-186"><span class="linenos">186</span></a>                        <span class="n">fields</span><span class="o">=</span><span class="n">post_params</span><span class="p">,</span>
+</span><span id="L-187"><a href="#L-187"><span class="linenos">187</span></a>                        <span class="n">encode_multipart</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="L-188"><a href="#L-188"><span class="linenos">188</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="L-189"><a href="#L-189"><span class="linenos">189</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="L-190"><a href="#L-190"><span class="linenos">190</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="L-191"><a href="#L-191"><span class="linenos">191</span></a>                    <span class="p">)</span>
+</span><span id="L-192"><a href="#L-192"><span class="linenos">192</span></a>                <span class="k">elif</span> <span class="n">content_type</span> <span class="o">==</span> <span class="s2">&quot;multipart/form-data&quot;</span><span class="p">:</span>
+</span><span id="L-193"><a href="#L-193"><span class="linenos">193</span></a>                    <span class="c1"># must del headers[&#39;Content-Type&#39;], or the correct</span>
+</span><span id="L-194"><a href="#L-194"><span class="linenos">194</span></a>                    <span class="c1"># Content-Type which generated by urllib3 will be</span>
+</span><span id="L-195"><a href="#L-195"><span class="linenos">195</span></a>                    <span class="c1"># overwritten.</span>
+</span><span id="L-196"><a href="#L-196"><span class="linenos">196</span></a>                    <span class="k">del</span> <span class="n">headers</span><span class="p">[</span><span class="s2">&quot;Content-Type&quot;</span><span class="p">]</span>
+</span><span id="L-197"><a href="#L-197"><span class="linenos">197</span></a>                    <span class="c1"># Ensure ``fields`` only contains (key, value) tuples and</span>
+</span><span id="L-198"><a href="#L-198"><span class="linenos">198</span></a>                    <span class="c1"># serialize nested structures to JSON</span>
+</span><span id="L-199"><a href="#L-199"><span class="linenos">199</span></a>                    <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">post_params</span><span class="p">,</span> <span class="nb">dict</span><span class="p">):</span>
+</span><span id="L-200"><a href="#L-200"><span class="linenos">200</span></a>                        <span class="n">items</span> <span class="o">=</span> <span class="n">post_params</span><span class="o">.</span><span class="n">items</span><span class="p">()</span>
+</span><span id="L-201"><a href="#L-201"><span class="linenos">201</span></a>                    <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">post_params</span><span class="p">,</span> <span class="n">Iterable</span><span class="p">)</span> <span class="ow">and</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span>
+</span><span id="L-202"><a href="#L-202"><span class="linenos">202</span></a>                        <span class="n">post_params</span><span class="p">,</span> <span class="p">(</span><span class="nb">str</span><span class="p">,</span> <span class="nb">bytes</span><span class="p">)</span>
+</span><span id="L-203"><a href="#L-203"><span class="linenos">203</span></a>                    <span class="p">):</span>
+</span><span id="L-204"><a href="#L-204"><span class="linenos">204</span></a>                        <span class="n">items</span> <span class="o">=</span> <span class="n">post_params</span>
+</span><span id="L-205"><a href="#L-205"><span class="linenos">205</span></a>                    <span class="k">else</span><span class="p">:</span>
+</span><span id="L-206"><a href="#L-206"><span class="linenos">206</span></a>                        <span class="k">raise</span> <span class="n">ApiValueError</span><span class="p">(</span>
+</span><span id="L-207"><a href="#L-207"><span class="linenos">207</span></a>                            <span class="s2">&quot;post_params must be a dict or iterable&quot;</span><span class="p">,</span>
+</span><span id="L-208"><a href="#L-208"><span class="linenos">208</span></a>                        <span class="p">)</span>
+</span><span id="L-209"><a href="#L-209"><span class="linenos">209</span></a>                    <span class="n">fields</span> <span class="o">=</span> <span class="p">[]</span>
+</span><span id="L-210"><a href="#L-210"><span class="linenos">210</span></a>                    <span class="k">for</span> <span class="n">item</span> <span class="ow">in</span> <span class="n">items</span><span class="p">:</span>
+</span><span id="L-211"><a href="#L-211"><span class="linenos">211</span></a>                        <span class="k">try</span><span class="p">:</span>
+</span><span id="L-212"><a href="#L-212"><span class="linenos">212</span></a>                            <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="o">=</span> <span class="n">item</span>
+</span><span id="L-213"><a href="#L-213"><span class="linenos">213</span></a>                        <span class="k">except</span> <span class="p">(</span><span class="ne">TypeError</span><span class="p">,</span> <span class="ne">ValueError</span><span class="p">)</span> <span class="k">as</span> <span class="n">exc</span><span class="p">:</span>
+</span><span id="L-214"><a href="#L-214"><span class="linenos">214</span></a>                            <span class="k">raise</span> <span class="n">ApiValueError</span><span class="p">(</span>
+</span><span id="L-215"><a href="#L-215"><span class="linenos">215</span></a>                                <span class="s2">&quot;Invalid number of elements in post_params&quot;</span><span class="p">,</span>
+</span><span id="L-216"><a href="#L-216"><span class="linenos">216</span></a>                            <span class="p">)</span> <span class="kn">from</span><span class="w"> </span><span class="nn">exc</span>
+</span><span id="L-217"><a href="#L-217"><span class="linenos">217</span></a>                        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">value</span><span class="p">,</span> <span class="p">(</span><span class="nb">dict</span><span class="p">,</span> <span class="nb">list</span><span class="p">,</span> <span class="nb">tuple</span><span class="p">)):</span>
+</span><span id="L-218"><a href="#L-218"><span class="linenos">218</span></a>                            <span class="n">value</span> <span class="o">=</span> <span class="n">json</span><span class="o">.</span><span class="n">dumps</span><span class="p">(</span><span class="n">value</span><span class="p">)</span>
+</span><span id="L-219"><a href="#L-219"><span class="linenos">219</span></a>                        <span class="n">fields</span><span class="o">.</span><span class="n">append</span><span class="p">((</span><span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">))</span>
+</span><span id="L-220"><a href="#L-220"><span class="linenos">220</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="L-221"><a href="#L-221"><span class="linenos">221</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="L-222"><a href="#L-222"><span class="linenos">222</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="L-223"><a href="#L-223"><span class="linenos">223</span></a>                        <span class="n">fields</span><span class="o">=</span><span class="n">fields</span><span class="p">,</span>
+</span><span id="L-224"><a href="#L-224"><span class="linenos">224</span></a>                        <span class="n">encode_multipart</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
+</span><span id="L-225"><a href="#L-225"><span class="linenos">225</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="L-226"><a href="#L-226"><span class="linenos">226</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="L-227"><a href="#L-227"><span class="linenos">227</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="L-228"><a href="#L-228"><span class="linenos">228</span></a>                    <span class="p">)</span>
+</span><span id="L-229"><a href="#L-229"><span class="linenos">229</span></a>                <span class="c1"># Pass a `string` parameter directly in the body to support</span>
+</span><span id="L-230"><a href="#L-230"><span class="linenos">230</span></a>                <span class="c1"># other content types than JSON when `body` argument is</span>
+</span><span id="L-231"><a href="#L-231"><span class="linenos">231</span></a>                <span class="c1"># provided in serialized form.</span>
+</span><span id="L-232"><a href="#L-232"><span class="linenos">232</span></a>                <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">body</span><span class="p">,</span> <span class="nb">str</span><span class="p">)</span> <span class="ow">or</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">body</span><span class="p">,</span> <span class="nb">bytes</span><span class="p">):</span>
+</span><span id="L-233"><a href="#L-233"><span class="linenos">233</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="L-234"><a href="#L-234"><span class="linenos">234</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="L-235"><a href="#L-235"><span class="linenos">235</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="L-236"><a href="#L-236"><span class="linenos">236</span></a>                        <span class="n">body</span><span class="o">=</span><span class="n">body</span><span class="p">,</span>
+</span><span id="L-237"><a href="#L-237"><span class="linenos">237</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="L-238"><a href="#L-238"><span class="linenos">238</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="L-239"><a href="#L-239"><span class="linenos">239</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="L-240"><a href="#L-240"><span class="linenos">240</span></a>                    <span class="p">)</span>
+</span><span id="L-241"><a href="#L-241"><span class="linenos">241</span></a>                <span class="k">elif</span> <span class="n">headers</span><span class="p">[</span><span class="s2">&quot;Content-Type&quot;</span><span class="p">]</span><span class="o">.</span><span class="n">startswith</span><span class="p">(</span><span class="s2">&quot;text/&quot;</span><span class="p">)</span> <span class="ow">and</span> <span class="nb">isinstance</span><span class="p">(</span>
+</span><span id="L-242"><a href="#L-242"><span class="linenos">242</span></a>                    <span class="n">body</span><span class="p">,</span> <span class="nb">bool</span>
+</span><span id="L-243"><a href="#L-243"><span class="linenos">243</span></a>                <span class="p">):</span>
+</span><span id="L-244"><a href="#L-244"><span class="linenos">244</span></a>                    <span class="n">request_body</span> <span class="o">=</span> <span class="s2">&quot;true&quot;</span> <span class="k">if</span> <span class="n">body</span> <span class="k">else</span> <span class="s2">&quot;false&quot;</span>
+</span><span id="L-245"><a href="#L-245"><span class="linenos">245</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="L-246"><a href="#L-246"><span class="linenos">246</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="L-247"><a href="#L-247"><span class="linenos">247</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="L-248"><a href="#L-248"><span class="linenos">248</span></a>                        <span class="n">body</span><span class="o">=</span><span class="n">request_body</span><span class="p">,</span>
+</span><span id="L-249"><a href="#L-249"><span class="linenos">249</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="L-250"><a href="#L-250"><span class="linenos">250</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="L-251"><a href="#L-251"><span class="linenos">251</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="L-252"><a href="#L-252"><span class="linenos">252</span></a>                    <span class="p">)</span>
+</span><span id="L-253"><a href="#L-253"><span class="linenos">253</span></a>                <span class="k">else</span><span class="p">:</span>
+</span><span id="L-254"><a href="#L-254"><span class="linenos">254</span></a>                    <span class="c1"># Cannot generate the request from given parameters</span>
+</span><span id="L-255"><a href="#L-255"><span class="linenos">255</span></a>                    <span class="n">msg</span> <span class="o">=</span> <span class="s2">&quot;&quot;&quot;Cannot prepare a request message for provided</span>
+</span><span id="L-256"><a href="#L-256"><span class="linenos">256</span></a><span class="s2">                             arguments. Please check that your arguments match</span>
+</span><span id="L-257"><a href="#L-257"><span class="linenos">257</span></a><span class="s2">                             declared content type.&quot;&quot;&quot;</span>
+</span><span id="L-258"><a href="#L-258"><span class="linenos">258</span></a>                    <span class="k">raise</span> <span class="n">ApiException</span><span class="p">(</span><span class="n">status</span><span class="o">=</span><span class="mi">0</span><span class="p">,</span> <span class="n">reason</span><span class="o">=</span><span class="n">msg</span><span class="p">)</span>
+</span><span id="L-259"><a href="#L-259"><span class="linenos">259</span></a>            <span class="c1"># For `GET`, `HEAD`</span>
+</span><span id="L-260"><a href="#L-260"><span class="linenos">260</span></a>            <span class="k">else</span><span class="p">:</span>
+</span><span id="L-261"><a href="#L-261"><span class="linenos">261</span></a>                <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="L-262"><a href="#L-262"><span class="linenos">262</span></a>                    <span class="n">method</span><span class="p">,</span>
+</span><span id="L-263"><a href="#L-263"><span class="linenos">263</span></a>                    <span class="n">url</span><span class="p">,</span>
+</span><span id="L-264"><a href="#L-264"><span class="linenos">264</span></a>                    <span class="n">fields</span><span class="o">=</span><span class="p">{},</span>
+</span><span id="L-265"><a href="#L-265"><span class="linenos">265</span></a>                    <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="L-266"><a href="#L-266"><span class="linenos">266</span></a>                    <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="L-267"><a href="#L-267"><span class="linenos">267</span></a>                    <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="L-268"><a href="#L-268"><span class="linenos">268</span></a>                <span class="p">)</span>
+</span><span id="L-269"><a href="#L-269"><span class="linenos">269</span></a>        <span class="k">except</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">exceptions</span><span class="o">.</span><span class="n">SSLError</span> <span class="k">as</span> <span class="n">e</span><span class="p">:</span>
+</span><span id="L-270"><a href="#L-270"><span class="linenos">270</span></a>            <span class="n">msg</span> <span class="o">=</span> <span class="s2">&quot;</span><span class="se">\n</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">join</span><span class="p">([</span><span class="nb">type</span><span class="p">(</span><span class="n">e</span><span class="p">)</span><span class="o">.</span><span class="vm">__name__</span><span class="p">,</span> <span class="nb">str</span><span class="p">(</span><span class="n">e</span><span class="p">)])</span>
+</span><span id="L-271"><a href="#L-271"><span class="linenos">271</span></a>            <span class="k">raise</span> <span class="n">ApiException</span><span class="p">(</span><span class="n">status</span><span class="o">=</span><span class="mi">0</span><span class="p">,</span> <span class="n">reason</span><span class="o">=</span><span class="n">msg</span><span class="p">)</span>
+</span><span id="L-272"><a href="#L-272"><span class="linenos">272</span></a>
+</span><span id="L-273"><a href="#L-273"><span class="linenos">273</span></a>        <span class="k">return</span> <span class="n">RESTResponse</span><span class="p">(</span><span class="n">r</span><span class="p">)</span>
+</span></pre></div>
+
+
+            </section>
+                <section id="SUPPORTED_SOCKS_PROXIES">
+                    <div class="attr variable">
+            <span class="name">SUPPORTED_SOCKS_PROXIES</span>        =
+<span class="default_value">{&#39;socks5h&#39;, &#39;socks4&#39;, &#39;socks4a&#39;, &#39;socks5&#39;}</span>
+
+        
+    </div>
+    <a class="headerlink" href="#SUPPORTED_SOCKS_PROXIES"></a>
+    
+    
+
+                </section>
+                <section id="RESTResponseType">
+                    <div class="attr variable">
+            <span class="name">RESTResponseType</span>        =
+<span class="default_value">&lt;class &#39;urllib3.response.HTTPResponse&#39;&gt;</span>
+
+        
+    </div>
+    <a class="headerlink" href="#RESTResponseType"></a>
+    
+    
+
+                </section>
+                <section id="is_socks_proxy_url">
+                            <input id="is_socks_proxy_url-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">is_socks_proxy_url</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">url</span></span><span class="return-annotation">):</span></span>
+
+                <label class="view-source-button" for="is_socks_proxy_url-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#is_socks_proxy_url"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="is_socks_proxy_url-30"><a href="#is_socks_proxy_url-30"><span class="linenos">30</span></a><span class="k">def</span><span class="w"> </span><span class="nf">is_socks_proxy_url</span><span class="p">(</span><span class="n">url</span><span class="p">):</span>
+</span><span id="is_socks_proxy_url-31"><a href="#is_socks_proxy_url-31"><span class="linenos">31</span></a>    <span class="k">if</span> <span class="n">url</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="is_socks_proxy_url-32"><a href="#is_socks_proxy_url-32"><span class="linenos">32</span></a>        <span class="k">return</span> <span class="kc">False</span>
+</span><span id="is_socks_proxy_url-33"><a href="#is_socks_proxy_url-33"><span class="linenos">33</span></a>    <span class="n">split_section</span> <span class="o">=</span> <span class="n">url</span><span class="o">.</span><span class="n">split</span><span class="p">(</span><span class="s2">&quot;://&quot;</span><span class="p">)</span>
+</span><span id="is_socks_proxy_url-34"><a href="#is_socks_proxy_url-34"><span class="linenos">34</span></a>    <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">split_section</span><span class="p">)</span> <span class="o">&lt;</span> <span class="mi">2</span><span class="p">:</span>
+</span><span id="is_socks_proxy_url-35"><a href="#is_socks_proxy_url-35"><span class="linenos">35</span></a>        <span class="k">return</span> <span class="kc">False</span>
+</span><span id="is_socks_proxy_url-36"><a href="#is_socks_proxy_url-36"><span class="linenos">36</span></a>    <span class="k">else</span><span class="p">:</span>
+</span><span id="is_socks_proxy_url-37"><a href="#is_socks_proxy_url-37"><span class="linenos">37</span></a>        <span class="k">return</span> <span class="n">split_section</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">lower</span><span class="p">()</span> <span class="ow">in</span> <span class="n">SUPPORTED_SOCKS_PROXIES</span>
+</span></pre></div>
+
+
+    
+
+                </section>
+                <section id="RESTResponse">
+                            <input id="RESTResponse-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">RESTResponse</span><wbr>(<span class="base">io.IOBase</span>):
+
+                <label class="view-source-button" for="RESTResponse-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#RESTResponse"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="RESTResponse-40"><a href="#RESTResponse-40"><span class="linenos">40</span></a><span class="k">class</span><span class="w"> </span><span class="nc">RESTResponse</span><span class="p">(</span><span class="n">io</span><span class="o">.</span><span class="n">IOBase</span><span class="p">):</span>
+</span><span id="RESTResponse-41"><a href="#RESTResponse-41"><span class="linenos">41</span></a>
+</span><span id="RESTResponse-42"><a href="#RESTResponse-42"><span class="linenos">42</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">resp</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTResponse-43"><a href="#RESTResponse-43"><span class="linenos">43</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">response</span> <span class="o">=</span> <span class="n">resp</span>
+</span><span id="RESTResponse-44"><a href="#RESTResponse-44"><span class="linenos">44</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">status</span> <span class="o">=</span> <span class="n">resp</span><span class="o">.</span><span class="n">status</span>
+</span><span id="RESTResponse-45"><a href="#RESTResponse-45"><span class="linenos">45</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">reason</span> <span class="o">=</span> <span class="n">resp</span><span class="o">.</span><span class="n">reason</span>
+</span><span id="RESTResponse-46"><a href="#RESTResponse-46"><span class="linenos">46</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">data</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="RESTResponse-47"><a href="#RESTResponse-47"><span class="linenos">47</span></a>
+</span><span id="RESTResponse-48"><a href="#RESTResponse-48"><span class="linenos">48</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">read</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+</span><span id="RESTResponse-49"><a href="#RESTResponse-49"><span class="linenos">49</span></a>        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">data</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTResponse-50"><a href="#RESTResponse-50"><span class="linenos">50</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">data</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">response</span><span class="o">.</span><span class="n">data</span>
+</span><span id="RESTResponse-51"><a href="#RESTResponse-51"><span class="linenos">51</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">data</span>
+</span><span id="RESTResponse-52"><a href="#RESTResponse-52"><span class="linenos">52</span></a>
+</span><span id="RESTResponse-53"><a href="#RESTResponse-53"><span class="linenos">53</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">getheaders</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+</span><span id="RESTResponse-54"><a href="#RESTResponse-54"><span class="linenos">54</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Returns a dictionary of the response headers.&quot;&quot;&quot;</span>
+</span><span id="RESTResponse-55"><a href="#RESTResponse-55"><span class="linenos">55</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">response</span><span class="o">.</span><span class="n">headers</span>
+</span><span id="RESTResponse-56"><a href="#RESTResponse-56"><span class="linenos">56</span></a>
+</span><span id="RESTResponse-57"><a href="#RESTResponse-57"><span class="linenos">57</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">getheader</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">,</span> <span class="n">default</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
+</span><span id="RESTResponse-58"><a href="#RESTResponse-58"><span class="linenos">58</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Returns a given response header.&quot;&quot;&quot;</span>
+</span><span id="RESTResponse-59"><a href="#RESTResponse-59"><span class="linenos">59</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">response</span><span class="o">.</span><span class="n">headers</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="n">name</span><span class="p">,</span> <span class="n">default</span><span class="p">)</span>
+</span></pre></div>
+
+
+            <div class="docstring"><p>The abstract base class for all I/O classes.</p>
+
+<p>This class provides dummy implementations for many methods that
+derived classes can override selectively; the default implementations
+represent a file that cannot be read, written or seeked.</p>
+
+<p>Even though IOBase does not declare read, readinto, or write because
+their signatures will vary, implementations and clients should
+consider those methods part of the interface. Also, implementations
+may raise UnsupportedOperation when operations they do not support are
+called.</p>
+
+<p>The basic type used for binary data read from or written to a file is
+bytes. Other bytes-like objects are accepted as method arguments too.
+In some cases (such as readinto), a writable object is required. Text
+I/O classes work with str data.</p>
+
+<p>Note that calling any method (except additional calls to close(),
+which are ignored) on a closed stream should raise a ValueError.</p>
+
+<p>IOBase (and its subclasses) support the iterator protocol, meaning
+that an IOBase object can be iterated over yielding the lines in a
+stream.</p>
+
+<p>IOBase also supports the :keyword:<code>with</code> statement. In this example,
+fp is closed after the suite of the with statement is complete:</p>
+
+<p>with open('spam.txt', 'r') as fp:
+    fp.write('Spam and eggs!')</p>
+</div>
+
+
+                            <div id="RESTResponse.__init__" class="classattr">
+                                        <input id="RESTResponse.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="name">RESTResponse</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">resp</span></span>)</span>
+
+                <label class="view-source-button" for="RESTResponse.__init__-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#RESTResponse.__init__"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="RESTResponse.__init__-42"><a href="#RESTResponse.__init__-42"><span class="linenos">42</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">resp</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTResponse.__init__-43"><a href="#RESTResponse.__init__-43"><span class="linenos">43</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">response</span> <span class="o">=</span> <span class="n">resp</span>
+</span><span id="RESTResponse.__init__-44"><a href="#RESTResponse.__init__-44"><span class="linenos">44</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">status</span> <span class="o">=</span> <span class="n">resp</span><span class="o">.</span><span class="n">status</span>
+</span><span id="RESTResponse.__init__-45"><a href="#RESTResponse.__init__-45"><span class="linenos">45</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">reason</span> <span class="o">=</span> <span class="n">resp</span><span class="o">.</span><span class="n">reason</span>
+</span><span id="RESTResponse.__init__-46"><a href="#RESTResponse.__init__-46"><span class="linenos">46</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">data</span> <span class="o">=</span> <span class="kc">None</span>
+</span></pre></div>
+
+
+    
+
+                            </div>
+                            <div id="RESTResponse.response" class="classattr">
+                                <div class="attr variable">
+            <span class="name">response</span>
+
+        
+    </div>
+    <a class="headerlink" href="#RESTResponse.response"></a>
+    
+    
+
+                            </div>
+                            <div id="RESTResponse.status" class="classattr">
+                                <div class="attr variable">
+            <span class="name">status</span>
+
+        
+    </div>
+    <a class="headerlink" href="#RESTResponse.status"></a>
+    
+    
+
+                            </div>
+                            <div id="RESTResponse.reason" class="classattr">
+                                <div class="attr variable">
+            <span class="name">reason</span>
+
+        
+    </div>
+    <a class="headerlink" href="#RESTResponse.reason"></a>
+    
+    
+
+                            </div>
+                            <div id="RESTResponse.data" class="classattr">
+                                <div class="attr variable">
+            <span class="name">data</span>
+
+        
+    </div>
+    <a class="headerlink" href="#RESTResponse.data"></a>
+    
+    
+
+                            </div>
+                            <div id="RESTResponse.read" class="classattr">
+                                        <input id="RESTResponse.read-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">read</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span></span><span class="return-annotation">):</span></span>
+
+                <label class="view-source-button" for="RESTResponse.read-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#RESTResponse.read"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="RESTResponse.read-48"><a href="#RESTResponse.read-48"><span class="linenos">48</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">read</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+</span><span id="RESTResponse.read-49"><a href="#RESTResponse.read-49"><span class="linenos">49</span></a>        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">data</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTResponse.read-50"><a href="#RESTResponse.read-50"><span class="linenos">50</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">data</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">response</span><span class="o">.</span><span class="n">data</span>
+</span><span id="RESTResponse.read-51"><a href="#RESTResponse.read-51"><span class="linenos">51</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">data</span>
+</span></pre></div>
+
+
+    
+
+                            </div>
+                            <div id="RESTResponse.getheaders" class="classattr">
+                                        <input id="RESTResponse.getheaders-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">getheaders</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span></span><span class="return-annotation">):</span></span>
+
+                <label class="view-source-button" for="RESTResponse.getheaders-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#RESTResponse.getheaders"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="RESTResponse.getheaders-53"><a href="#RESTResponse.getheaders-53"><span class="linenos">53</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">getheaders</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
+</span><span id="RESTResponse.getheaders-54"><a href="#RESTResponse.getheaders-54"><span class="linenos">54</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Returns a dictionary of the response headers.&quot;&quot;&quot;</span>
+</span><span id="RESTResponse.getheaders-55"><a href="#RESTResponse.getheaders-55"><span class="linenos">55</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">response</span><span class="o">.</span><span class="n">headers</span>
+</span></pre></div>
+
+
+            <div class="docstring"><p>Returns a dictionary of the response headers.</p>
+</div>
+
+
+                            </div>
+                            <div id="RESTResponse.getheader" class="classattr">
+                                        <input id="RESTResponse.getheader-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">getheader</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span>, </span><span class="param"><span class="n">name</span>, </span><span class="param"><span class="n">default</span><span class="o">=</span><span class="kc">None</span></span><span class="return-annotation">):</span></span>
+
+                <label class="view-source-button" for="RESTResponse.getheader-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#RESTResponse.getheader"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="RESTResponse.getheader-57"><a href="#RESTResponse.getheader-57"><span class="linenos">57</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">getheader</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">name</span><span class="p">,</span> <span class="n">default</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
+</span><span id="RESTResponse.getheader-58"><a href="#RESTResponse.getheader-58"><span class="linenos">58</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Returns a given response header.&quot;&quot;&quot;</span>
+</span><span id="RESTResponse.getheader-59"><a href="#RESTResponse.getheader-59"><span class="linenos">59</span></a>        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">response</span><span class="o">.</span><span class="n">headers</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="n">name</span><span class="p">,</span> <span class="n">default</span><span class="p">)</span>
+</span></pre></div>
+
+
+            <div class="docstring"><p>Returns a given response header.</p>
+</div>
+
+
+                            </div>
+                </section>
+                <section id="RESTClientObject">
+                            <input id="RESTClientObject-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">RESTClientObject</span>:
+
+                <label class="view-source-button" for="RESTClientObject-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#RESTClientObject"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="RESTClientObject-62"><a href="#RESTClientObject-62"><span class="linenos"> 62</span></a><span class="k">class</span><span class="w"> </span><span class="nc">RESTClientObject</span><span class="p">:</span>
+</span><span id="RESTClientObject-63"><a href="#RESTClientObject-63"><span class="linenos"> 63</span></a>
+</span><span id="RESTClientObject-64"><a href="#RESTClientObject-64"><span class="linenos"> 64</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">configuration</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTClientObject-65"><a href="#RESTClientObject-65"><span class="linenos"> 65</span></a>        <span class="c1"># urllib3.PoolManager will pass all kw parameters to connectionpool</span>
+</span><span id="RESTClientObject-66"><a href="#RESTClientObject-66"><span class="linenos"> 66</span></a>        <span class="c1"># https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75  # noqa: E501</span>
+</span><span id="RESTClientObject-67"><a href="#RESTClientObject-67"><span class="linenos"> 67</span></a>        <span class="c1"># https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680  # noqa: E501</span>
+</span><span id="RESTClientObject-68"><a href="#RESTClientObject-68"><span class="linenos"> 68</span></a>        <span class="c1"># Custom SSL certificates and client certificates: http://urllib3.readthedocs.io/en/latest/advanced-usage.html  # noqa: E501</span>
+</span><span id="RESTClientObject-69"><a href="#RESTClientObject-69"><span class="linenos"> 69</span></a>
+</span><span id="RESTClientObject-70"><a href="#RESTClientObject-70"><span class="linenos"> 70</span></a>        <span class="c1"># cert_reqs</span>
+</span><span id="RESTClientObject-71"><a href="#RESTClientObject-71"><span class="linenos"> 71</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">verify_ssl</span><span class="p">:</span>
+</span><span id="RESTClientObject-72"><a href="#RESTClientObject-72"><span class="linenos"> 72</span></a>            <span class="n">cert_reqs</span> <span class="o">=</span> <span class="n">ssl</span><span class="o">.</span><span class="n">CERT_REQUIRED</span>
+</span><span id="RESTClientObject-73"><a href="#RESTClientObject-73"><span class="linenos"> 73</span></a>        <span class="k">else</span><span class="p">:</span>
+</span><span id="RESTClientObject-74"><a href="#RESTClientObject-74"><span class="linenos"> 74</span></a>            <span class="n">cert_reqs</span> <span class="o">=</span> <span class="n">ssl</span><span class="o">.</span><span class="n">CERT_NONE</span>
+</span><span id="RESTClientObject-75"><a href="#RESTClientObject-75"><span class="linenos"> 75</span></a>
+</span><span id="RESTClientObject-76"><a href="#RESTClientObject-76"><span class="linenos"> 76</span></a>        <span class="n">pool_args</span> <span class="o">=</span> <span class="p">{</span>
+</span><span id="RESTClientObject-77"><a href="#RESTClientObject-77"><span class="linenos"> 77</span></a>            <span class="s2">&quot;cert_reqs&quot;</span><span class="p">:</span> <span class="n">cert_reqs</span><span class="p">,</span>
+</span><span id="RESTClientObject-78"><a href="#RESTClientObject-78"><span class="linenos"> 78</span></a>            <span class="s2">&quot;ca_certs&quot;</span><span class="p">:</span> <span class="n">configuration</span><span class="o">.</span><span class="n">ssl_ca_cert</span><span class="p">,</span>
+</span><span id="RESTClientObject-79"><a href="#RESTClientObject-79"><span class="linenos"> 79</span></a>            <span class="s2">&quot;cert_file&quot;</span><span class="p">:</span> <span class="n">configuration</span><span class="o">.</span><span class="n">cert_file</span><span class="p">,</span>
+</span><span id="RESTClientObject-80"><a href="#RESTClientObject-80"><span class="linenos"> 80</span></a>            <span class="s2">&quot;key_file&quot;</span><span class="p">:</span> <span class="n">configuration</span><span class="o">.</span><span class="n">key_file</span><span class="p">,</span>
+</span><span id="RESTClientObject-81"><a href="#RESTClientObject-81"><span class="linenos"> 81</span></a>            <span class="s2">&quot;ca_cert_data&quot;</span><span class="p">:</span> <span class="n">configuration</span><span class="o">.</span><span class="n">ca_cert_data</span><span class="p">,</span>
+</span><span id="RESTClientObject-82"><a href="#RESTClientObject-82"><span class="linenos"> 82</span></a>        <span class="p">}</span>
+</span><span id="RESTClientObject-83"><a href="#RESTClientObject-83"><span class="linenos"> 83</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">assert_hostname</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTClientObject-84"><a href="#RESTClientObject-84"><span class="linenos"> 84</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;assert_hostname&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">assert_hostname</span>
+</span><span id="RESTClientObject-85"><a href="#RESTClientObject-85"><span class="linenos"> 85</span></a>
+</span><span id="RESTClientObject-86"><a href="#RESTClientObject-86"><span class="linenos"> 86</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">retries</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTClientObject-87"><a href="#RESTClientObject-87"><span class="linenos"> 87</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;retries&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">retries</span>
+</span><span id="RESTClientObject-88"><a href="#RESTClientObject-88"><span class="linenos"> 88</span></a>
+</span><span id="RESTClientObject-89"><a href="#RESTClientObject-89"><span class="linenos"> 89</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">tls_server_name</span><span class="p">:</span>
+</span><span id="RESTClientObject-90"><a href="#RESTClientObject-90"><span class="linenos"> 90</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;server_hostname&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">tls_server_name</span>
+</span><span id="RESTClientObject-91"><a href="#RESTClientObject-91"><span class="linenos"> 91</span></a>
+</span><span id="RESTClientObject-92"><a href="#RESTClientObject-92"><span class="linenos"> 92</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">socket_options</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTClientObject-93"><a href="#RESTClientObject-93"><span class="linenos"> 93</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;socket_options&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">socket_options</span>
+</span><span id="RESTClientObject-94"><a href="#RESTClientObject-94"><span class="linenos"> 94</span></a>
+</span><span id="RESTClientObject-95"><a href="#RESTClientObject-95"><span class="linenos"> 95</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">connection_pool_maxsize</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTClientObject-96"><a href="#RESTClientObject-96"><span class="linenos"> 96</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;maxsize&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">connection_pool_maxsize</span>
+</span><span id="RESTClientObject-97"><a href="#RESTClientObject-97"><span class="linenos"> 97</span></a>
+</span><span id="RESTClientObject-98"><a href="#RESTClientObject-98"><span class="linenos"> 98</span></a>        <span class="c1"># https pool manager</span>
+</span><span id="RESTClientObject-99"><a href="#RESTClientObject-99"><span class="linenos"> 99</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="p">:</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">PoolManager</span>
+</span><span id="RESTClientObject-100"><a href="#RESTClientObject-100"><span class="linenos">100</span></a>
+</span><span id="RESTClientObject-101"><a href="#RESTClientObject-101"><span class="linenos">101</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy</span><span class="p">:</span>
+</span><span id="RESTClientObject-102"><a href="#RESTClientObject-102"><span class="linenos">102</span></a>            <span class="k">if</span> <span class="n">is_socks_proxy_url</span><span class="p">(</span><span class="n">configuration</span><span class="o">.</span><span class="n">proxy</span><span class="p">):</span>
+</span><span id="RESTClientObject-103"><a href="#RESTClientObject-103"><span class="linenos">103</span></a>                <span class="kn">from</span><span class="w"> </span><span class="nn">urllib3.contrib.socks</span><span class="w"> </span><span class="kn">import</span> <span class="n">SOCKSProxyManager</span>
+</span><span id="RESTClientObject-104"><a href="#RESTClientObject-104"><span class="linenos">104</span></a>
+</span><span id="RESTClientObject-105"><a href="#RESTClientObject-105"><span class="linenos">105</span></a>                <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;proxy_url&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy</span>
+</span><span id="RESTClientObject-106"><a href="#RESTClientObject-106"><span class="linenos">106</span></a>                <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;headers&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy_headers</span>
+</span><span id="RESTClientObject-107"><a href="#RESTClientObject-107"><span class="linenos">107</span></a>                <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span> <span class="o">=</span> <span class="n">SOCKSProxyManager</span><span class="p">(</span><span class="o">**</span><span class="n">pool_args</span><span class="p">)</span>
+</span><span id="RESTClientObject-108"><a href="#RESTClientObject-108"><span class="linenos">108</span></a>            <span class="k">else</span><span class="p">:</span>
+</span><span id="RESTClientObject-109"><a href="#RESTClientObject-109"><span class="linenos">109</span></a>                <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;proxy_url&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy</span>
+</span><span id="RESTClientObject-110"><a href="#RESTClientObject-110"><span class="linenos">110</span></a>                <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;proxy_headers&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy_headers</span>
+</span><span id="RESTClientObject-111"><a href="#RESTClientObject-111"><span class="linenos">111</span></a>                <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">ProxyManager</span><span class="p">(</span><span class="o">**</span><span class="n">pool_args</span><span class="p">)</span>
+</span><span id="RESTClientObject-112"><a href="#RESTClientObject-112"><span class="linenos">112</span></a>        <span class="k">else</span><span class="p">:</span>
+</span><span id="RESTClientObject-113"><a href="#RESTClientObject-113"><span class="linenos">113</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">PoolManager</span><span class="p">(</span><span class="o">**</span><span class="n">pool_args</span><span class="p">)</span>
+</span><span id="RESTClientObject-114"><a href="#RESTClientObject-114"><span class="linenos">114</span></a>
+</span><span id="RESTClientObject-115"><a href="#RESTClientObject-115"><span class="linenos">115</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">request</span><span class="p">(</span>
+</span><span id="RESTClientObject-116"><a href="#RESTClientObject-116"><span class="linenos">116</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="RESTClientObject-117"><a href="#RESTClientObject-117"><span class="linenos">117</span></a>        <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject-118"><a href="#RESTClientObject-118"><span class="linenos">118</span></a>        <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject-119"><a href="#RESTClientObject-119"><span class="linenos">119</span></a>        <span class="n">headers</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+</span><span id="RESTClientObject-120"><a href="#RESTClientObject-120"><span class="linenos">120</span></a>        <span class="n">body</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+</span><span id="RESTClientObject-121"><a href="#RESTClientObject-121"><span class="linenos">121</span></a>        <span class="n">post_params</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+</span><span id="RESTClientObject-122"><a href="#RESTClientObject-122"><span class="linenos">122</span></a>        <span class="n">_request_timeout</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+</span><span id="RESTClientObject-123"><a href="#RESTClientObject-123"><span class="linenos">123</span></a>    <span class="p">):</span>
+</span><span id="RESTClientObject-124"><a href="#RESTClientObject-124"><span class="linenos">124</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Perform requests.</span>
+</span><span id="RESTClientObject-125"><a href="#RESTClientObject-125"><span class="linenos">125</span></a>
+</span><span id="RESTClientObject-126"><a href="#RESTClientObject-126"><span class="linenos">126</span></a><span class="sd">        :param method: http request method</span>
+</span><span id="RESTClientObject-127"><a href="#RESTClientObject-127"><span class="linenos">127</span></a><span class="sd">        :param url: http request url</span>
+</span><span id="RESTClientObject-128"><a href="#RESTClientObject-128"><span class="linenos">128</span></a><span class="sd">        :param headers: http request headers</span>
+</span><span id="RESTClientObject-129"><a href="#RESTClientObject-129"><span class="linenos">129</span></a><span class="sd">        :param body: request json body, for `application/json`</span>
+</span><span id="RESTClientObject-130"><a href="#RESTClientObject-130"><span class="linenos">130</span></a><span class="sd">        :param post_params: request post parameters for</span>
+</span><span id="RESTClientObject-131"><a href="#RESTClientObject-131"><span class="linenos">131</span></a><span class="sd">                            `application/x-www-form-urlencoded` or</span>
+</span><span id="RESTClientObject-132"><a href="#RESTClientObject-132"><span class="linenos">132</span></a><span class="sd">                            `multipart/form-data`. Accepts either a</span>
+</span><span id="RESTClientObject-133"><a href="#RESTClientObject-133"><span class="linenos">133</span></a><span class="sd">                            ``dict`` or any iterable of ``(key, value)``</span>
+</span><span id="RESTClientObject-134"><a href="#RESTClientObject-134"><span class="linenos">134</span></a><span class="sd">                            pairs. Values that are ``dict``, ``list`` or</span>
+</span><span id="RESTClientObject-135"><a href="#RESTClientObject-135"><span class="linenos">135</span></a><span class="sd">                            ``tuple`` are JSON serialized.</span>
+</span><span id="RESTClientObject-136"><a href="#RESTClientObject-136"><span class="linenos">136</span></a>
+</span><span id="RESTClientObject-137"><a href="#RESTClientObject-137"><span class="linenos">137</span></a><span class="sd">                            Examples:</span>
+</span><span id="RESTClientObject-138"><a href="#RESTClientObject-138"><span class="linenos">138</span></a><span class="sd">                                post_params = {&quot;a&quot;: 1, &quot;meta&quot;: {&quot;b&quot;: 2}}</span>
+</span><span id="RESTClientObject-139"><a href="#RESTClientObject-139"><span class="linenos">139</span></a><span class="sd">                                post_params = [(&quot;a&quot;, 1), (&quot;meta&quot;, {&quot;b&quot;: 2})]</span>
+</span><span id="RESTClientObject-140"><a href="#RESTClientObject-140"><span class="linenos">140</span></a><span class="sd">        :param _request_timeout: timeout setting for this request. If one</span>
+</span><span id="RESTClientObject-141"><a href="#RESTClientObject-141"><span class="linenos">141</span></a><span class="sd">                                 number provided, it will be total request</span>
+</span><span id="RESTClientObject-142"><a href="#RESTClientObject-142"><span class="linenos">142</span></a><span class="sd">                                 timeout. It can also be a pair (tuple) of</span>
+</span><span id="RESTClientObject-143"><a href="#RESTClientObject-143"><span class="linenos">143</span></a><span class="sd">                                 (connection, read) timeouts.</span>
+</span><span id="RESTClientObject-144"><a href="#RESTClientObject-144"><span class="linenos">144</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="RESTClientObject-145"><a href="#RESTClientObject-145"><span class="linenos">145</span></a>        <span class="n">method</span> <span class="o">=</span> <span class="n">method</span><span class="o">.</span><span class="n">upper</span><span class="p">()</span>
+</span><span id="RESTClientObject-146"><a href="#RESTClientObject-146"><span class="linenos">146</span></a>        <span class="k">assert</span> <span class="n">method</span> <span class="ow">in</span> <span class="p">[</span><span class="s2">&quot;GET&quot;</span><span class="p">,</span> <span class="s2">&quot;HEAD&quot;</span><span class="p">,</span> <span class="s2">&quot;DELETE&quot;</span><span class="p">,</span> <span class="s2">&quot;POST&quot;</span><span class="p">,</span> <span class="s2">&quot;PUT&quot;</span><span class="p">,</span> <span class="s2">&quot;PATCH&quot;</span><span class="p">,</span> <span class="s2">&quot;OPTIONS&quot;</span><span class="p">]</span>
+</span><span id="RESTClientObject-147"><a href="#RESTClientObject-147"><span class="linenos">147</span></a>
+</span><span id="RESTClientObject-148"><a href="#RESTClientObject-148"><span class="linenos">148</span></a>        <span class="k">if</span> <span class="n">post_params</span> <span class="ow">and</span> <span class="n">body</span><span class="p">:</span>
+</span><span id="RESTClientObject-149"><a href="#RESTClientObject-149"><span class="linenos">149</span></a>            <span class="k">raise</span> <span class="n">ApiValueError</span><span class="p">(</span>
+</span><span id="RESTClientObject-150"><a href="#RESTClientObject-150"><span class="linenos">150</span></a>                <span class="s2">&quot;body parameter cannot be used with post_params parameter.&quot;</span>
+</span><span id="RESTClientObject-151"><a href="#RESTClientObject-151"><span class="linenos">151</span></a>            <span class="p">)</span>
+</span><span id="RESTClientObject-152"><a href="#RESTClientObject-152"><span class="linenos">152</span></a>
+</span><span id="RESTClientObject-153"><a href="#RESTClientObject-153"><span class="linenos">153</span></a>        <span class="n">post_params</span> <span class="o">=</span> <span class="n">post_params</span> <span class="ow">or</span> <span class="p">{}</span>
+</span><span id="RESTClientObject-154"><a href="#RESTClientObject-154"><span class="linenos">154</span></a>        <span class="n">headers</span> <span class="o">=</span> <span class="n">headers</span> <span class="ow">or</span> <span class="p">{}</span>
+</span><span id="RESTClientObject-155"><a href="#RESTClientObject-155"><span class="linenos">155</span></a>
+</span><span id="RESTClientObject-156"><a href="#RESTClientObject-156"><span class="linenos">156</span></a>        <span class="n">timeout</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="RESTClientObject-157"><a href="#RESTClientObject-157"><span class="linenos">157</span></a>        <span class="k">if</span> <span class="n">_request_timeout</span><span class="p">:</span>
+</span><span id="RESTClientObject-158"><a href="#RESTClientObject-158"><span class="linenos">158</span></a>            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">_request_timeout</span><span class="p">,</span> <span class="p">(</span><span class="nb">int</span><span class="p">,</span> <span class="nb">float</span><span class="p">)):</span>
+</span><span id="RESTClientObject-159"><a href="#RESTClientObject-159"><span class="linenos">159</span></a>                <span class="n">timeout</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">Timeout</span><span class="p">(</span><span class="n">total</span><span class="o">=</span><span class="n">_request_timeout</span><span class="p">)</span>
+</span><span id="RESTClientObject-160"><a href="#RESTClientObject-160"><span class="linenos">160</span></a>            <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">_request_timeout</span><span class="p">,</span> <span class="nb">tuple</span><span class="p">)</span> <span class="ow">and</span> <span class="nb">len</span><span class="p">(</span><span class="n">_request_timeout</span><span class="p">)</span> <span class="o">==</span> <span class="mi">2</span><span class="p">:</span>
+</span><span id="RESTClientObject-161"><a href="#RESTClientObject-161"><span class="linenos">161</span></a>                <span class="n">timeout</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">Timeout</span><span class="p">(</span>
+</span><span id="RESTClientObject-162"><a href="#RESTClientObject-162"><span class="linenos">162</span></a>                    <span class="n">connect</span><span class="o">=</span><span class="n">_request_timeout</span><span class="p">[</span><span class="mi">0</span><span class="p">],</span> <span class="n">read</span><span class="o">=</span><span class="n">_request_timeout</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span>
+</span><span id="RESTClientObject-163"><a href="#RESTClientObject-163"><span class="linenos">163</span></a>                <span class="p">)</span>
+</span><span id="RESTClientObject-164"><a href="#RESTClientObject-164"><span class="linenos">164</span></a>
+</span><span id="RESTClientObject-165"><a href="#RESTClientObject-165"><span class="linenos">165</span></a>        <span class="k">try</span><span class="p">:</span>
+</span><span id="RESTClientObject-166"><a href="#RESTClientObject-166"><span class="linenos">166</span></a>            <span class="c1"># For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`</span>
+</span><span id="RESTClientObject-167"><a href="#RESTClientObject-167"><span class="linenos">167</span></a>            <span class="k">if</span> <span class="n">method</span> <span class="ow">in</span> <span class="p">[</span><span class="s2">&quot;POST&quot;</span><span class="p">,</span> <span class="s2">&quot;PUT&quot;</span><span class="p">,</span> <span class="s2">&quot;PATCH&quot;</span><span class="p">,</span> <span class="s2">&quot;OPTIONS&quot;</span><span class="p">,</span> <span class="s2">&quot;DELETE&quot;</span><span class="p">]:</span>
+</span><span id="RESTClientObject-168"><a href="#RESTClientObject-168"><span class="linenos">168</span></a>
+</span><span id="RESTClientObject-169"><a href="#RESTClientObject-169"><span class="linenos">169</span></a>                <span class="c1"># no content type provided or payload is json</span>
+</span><span id="RESTClientObject-170"><a href="#RESTClientObject-170"><span class="linenos">170</span></a>                <span class="n">content_type</span> <span class="o">=</span> <span class="n">headers</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s2">&quot;Content-Type&quot;</span><span class="p">)</span>
+</span><span id="RESTClientObject-171"><a href="#RESTClientObject-171"><span class="linenos">171</span></a>                <span class="k">if</span> <span class="ow">not</span> <span class="n">content_type</span> <span class="ow">or</span> <span class="n">re</span><span class="o">.</span><span class="n">search</span><span class="p">(</span><span class="s2">&quot;json&quot;</span><span class="p">,</span> <span class="n">content_type</span><span class="p">,</span> <span class="n">re</span><span class="o">.</span><span class="n">IGNORECASE</span><span class="p">):</span>
+</span><span id="RESTClientObject-172"><a href="#RESTClientObject-172"><span class="linenos">172</span></a>                    <span class="n">request_body</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="RESTClientObject-173"><a href="#RESTClientObject-173"><span class="linenos">173</span></a>                    <span class="k">if</span> <span class="n">body</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTClientObject-174"><a href="#RESTClientObject-174"><span class="linenos">174</span></a>                        <span class="n">request_body</span> <span class="o">=</span> <span class="n">json</span><span class="o">.</span><span class="n">dumps</span><span class="p">(</span><span class="n">body</span><span class="p">)</span>
+</span><span id="RESTClientObject-175"><a href="#RESTClientObject-175"><span class="linenos">175</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="RESTClientObject-176"><a href="#RESTClientObject-176"><span class="linenos">176</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject-177"><a href="#RESTClientObject-177"><span class="linenos">177</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject-178"><a href="#RESTClientObject-178"><span class="linenos">178</span></a>                        <span class="n">body</span><span class="o">=</span><span class="n">request_body</span><span class="p">,</span>
+</span><span id="RESTClientObject-179"><a href="#RESTClientObject-179"><span class="linenos">179</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="RESTClientObject-180"><a href="#RESTClientObject-180"><span class="linenos">180</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="RESTClientObject-181"><a href="#RESTClientObject-181"><span class="linenos">181</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject-182"><a href="#RESTClientObject-182"><span class="linenos">182</span></a>                    <span class="p">)</span>
+</span><span id="RESTClientObject-183"><a href="#RESTClientObject-183"><span class="linenos">183</span></a>                <span class="k">elif</span> <span class="n">content_type</span> <span class="o">==</span> <span class="s2">&quot;application/x-www-form-urlencoded&quot;</span><span class="p">:</span>
+</span><span id="RESTClientObject-184"><a href="#RESTClientObject-184"><span class="linenos">184</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="RESTClientObject-185"><a href="#RESTClientObject-185"><span class="linenos">185</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject-186"><a href="#RESTClientObject-186"><span class="linenos">186</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject-187"><a href="#RESTClientObject-187"><span class="linenos">187</span></a>                        <span class="n">fields</span><span class="o">=</span><span class="n">post_params</span><span class="p">,</span>
+</span><span id="RESTClientObject-188"><a href="#RESTClientObject-188"><span class="linenos">188</span></a>                        <span class="n">encode_multipart</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject-189"><a href="#RESTClientObject-189"><span class="linenos">189</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="RESTClientObject-190"><a href="#RESTClientObject-190"><span class="linenos">190</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="RESTClientObject-191"><a href="#RESTClientObject-191"><span class="linenos">191</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject-192"><a href="#RESTClientObject-192"><span class="linenos">192</span></a>                    <span class="p">)</span>
+</span><span id="RESTClientObject-193"><a href="#RESTClientObject-193"><span class="linenos">193</span></a>                <span class="k">elif</span> <span class="n">content_type</span> <span class="o">==</span> <span class="s2">&quot;multipart/form-data&quot;</span><span class="p">:</span>
+</span><span id="RESTClientObject-194"><a href="#RESTClientObject-194"><span class="linenos">194</span></a>                    <span class="c1"># must del headers[&#39;Content-Type&#39;], or the correct</span>
+</span><span id="RESTClientObject-195"><a href="#RESTClientObject-195"><span class="linenos">195</span></a>                    <span class="c1"># Content-Type which generated by urllib3 will be</span>
+</span><span id="RESTClientObject-196"><a href="#RESTClientObject-196"><span class="linenos">196</span></a>                    <span class="c1"># overwritten.</span>
+</span><span id="RESTClientObject-197"><a href="#RESTClientObject-197"><span class="linenos">197</span></a>                    <span class="k">del</span> <span class="n">headers</span><span class="p">[</span><span class="s2">&quot;Content-Type&quot;</span><span class="p">]</span>
+</span><span id="RESTClientObject-198"><a href="#RESTClientObject-198"><span class="linenos">198</span></a>                    <span class="c1"># Ensure ``fields`` only contains (key, value) tuples and</span>
+</span><span id="RESTClientObject-199"><a href="#RESTClientObject-199"><span class="linenos">199</span></a>                    <span class="c1"># serialize nested structures to JSON</span>
+</span><span id="RESTClientObject-200"><a href="#RESTClientObject-200"><span class="linenos">200</span></a>                    <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">post_params</span><span class="p">,</span> <span class="nb">dict</span><span class="p">):</span>
+</span><span id="RESTClientObject-201"><a href="#RESTClientObject-201"><span class="linenos">201</span></a>                        <span class="n">items</span> <span class="o">=</span> <span class="n">post_params</span><span class="o">.</span><span class="n">items</span><span class="p">()</span>
+</span><span id="RESTClientObject-202"><a href="#RESTClientObject-202"><span class="linenos">202</span></a>                    <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">post_params</span><span class="p">,</span> <span class="n">Iterable</span><span class="p">)</span> <span class="ow">and</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span>
+</span><span id="RESTClientObject-203"><a href="#RESTClientObject-203"><span class="linenos">203</span></a>                        <span class="n">post_params</span><span class="p">,</span> <span class="p">(</span><span class="nb">str</span><span class="p">,</span> <span class="nb">bytes</span><span class="p">)</span>
+</span><span id="RESTClientObject-204"><a href="#RESTClientObject-204"><span class="linenos">204</span></a>                    <span class="p">):</span>
+</span><span id="RESTClientObject-205"><a href="#RESTClientObject-205"><span class="linenos">205</span></a>                        <span class="n">items</span> <span class="o">=</span> <span class="n">post_params</span>
+</span><span id="RESTClientObject-206"><a href="#RESTClientObject-206"><span class="linenos">206</span></a>                    <span class="k">else</span><span class="p">:</span>
+</span><span id="RESTClientObject-207"><a href="#RESTClientObject-207"><span class="linenos">207</span></a>                        <span class="k">raise</span> <span class="n">ApiValueError</span><span class="p">(</span>
+</span><span id="RESTClientObject-208"><a href="#RESTClientObject-208"><span class="linenos">208</span></a>                            <span class="s2">&quot;post_params must be a dict or iterable&quot;</span><span class="p">,</span>
+</span><span id="RESTClientObject-209"><a href="#RESTClientObject-209"><span class="linenos">209</span></a>                        <span class="p">)</span>
+</span><span id="RESTClientObject-210"><a href="#RESTClientObject-210"><span class="linenos">210</span></a>                    <span class="n">fields</span> <span class="o">=</span> <span class="p">[]</span>
+</span><span id="RESTClientObject-211"><a href="#RESTClientObject-211"><span class="linenos">211</span></a>                    <span class="k">for</span> <span class="n">item</span> <span class="ow">in</span> <span class="n">items</span><span class="p">:</span>
+</span><span id="RESTClientObject-212"><a href="#RESTClientObject-212"><span class="linenos">212</span></a>                        <span class="k">try</span><span class="p">:</span>
+</span><span id="RESTClientObject-213"><a href="#RESTClientObject-213"><span class="linenos">213</span></a>                            <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="o">=</span> <span class="n">item</span>
+</span><span id="RESTClientObject-214"><a href="#RESTClientObject-214"><span class="linenos">214</span></a>                        <span class="k">except</span> <span class="p">(</span><span class="ne">TypeError</span><span class="p">,</span> <span class="ne">ValueError</span><span class="p">)</span> <span class="k">as</span> <span class="n">exc</span><span class="p">:</span>
+</span><span id="RESTClientObject-215"><a href="#RESTClientObject-215"><span class="linenos">215</span></a>                            <span class="k">raise</span> <span class="n">ApiValueError</span><span class="p">(</span>
+</span><span id="RESTClientObject-216"><a href="#RESTClientObject-216"><span class="linenos">216</span></a>                                <span class="s2">&quot;Invalid number of elements in post_params&quot;</span><span class="p">,</span>
+</span><span id="RESTClientObject-217"><a href="#RESTClientObject-217"><span class="linenos">217</span></a>                            <span class="p">)</span> <span class="kn">from</span><span class="w"> </span><span class="nn">exc</span>
+</span><span id="RESTClientObject-218"><a href="#RESTClientObject-218"><span class="linenos">218</span></a>                        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">value</span><span class="p">,</span> <span class="p">(</span><span class="nb">dict</span><span class="p">,</span> <span class="nb">list</span><span class="p">,</span> <span class="nb">tuple</span><span class="p">)):</span>
+</span><span id="RESTClientObject-219"><a href="#RESTClientObject-219"><span class="linenos">219</span></a>                            <span class="n">value</span> <span class="o">=</span> <span class="n">json</span><span class="o">.</span><span class="n">dumps</span><span class="p">(</span><span class="n">value</span><span class="p">)</span>
+</span><span id="RESTClientObject-220"><a href="#RESTClientObject-220"><span class="linenos">220</span></a>                        <span class="n">fields</span><span class="o">.</span><span class="n">append</span><span class="p">((</span><span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">))</span>
+</span><span id="RESTClientObject-221"><a href="#RESTClientObject-221"><span class="linenos">221</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="RESTClientObject-222"><a href="#RESTClientObject-222"><span class="linenos">222</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject-223"><a href="#RESTClientObject-223"><span class="linenos">223</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject-224"><a href="#RESTClientObject-224"><span class="linenos">224</span></a>                        <span class="n">fields</span><span class="o">=</span><span class="n">fields</span><span class="p">,</span>
+</span><span id="RESTClientObject-225"><a href="#RESTClientObject-225"><span class="linenos">225</span></a>                        <span class="n">encode_multipart</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
+</span><span id="RESTClientObject-226"><a href="#RESTClientObject-226"><span class="linenos">226</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="RESTClientObject-227"><a href="#RESTClientObject-227"><span class="linenos">227</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="RESTClientObject-228"><a href="#RESTClientObject-228"><span class="linenos">228</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject-229"><a href="#RESTClientObject-229"><span class="linenos">229</span></a>                    <span class="p">)</span>
+</span><span id="RESTClientObject-230"><a href="#RESTClientObject-230"><span class="linenos">230</span></a>                <span class="c1"># Pass a `string` parameter directly in the body to support</span>
+</span><span id="RESTClientObject-231"><a href="#RESTClientObject-231"><span class="linenos">231</span></a>                <span class="c1"># other content types than JSON when `body` argument is</span>
+</span><span id="RESTClientObject-232"><a href="#RESTClientObject-232"><span class="linenos">232</span></a>                <span class="c1"># provided in serialized form.</span>
+</span><span id="RESTClientObject-233"><a href="#RESTClientObject-233"><span class="linenos">233</span></a>                <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">body</span><span class="p">,</span> <span class="nb">str</span><span class="p">)</span> <span class="ow">or</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">body</span><span class="p">,</span> <span class="nb">bytes</span><span class="p">):</span>
+</span><span id="RESTClientObject-234"><a href="#RESTClientObject-234"><span class="linenos">234</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="RESTClientObject-235"><a href="#RESTClientObject-235"><span class="linenos">235</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject-236"><a href="#RESTClientObject-236"><span class="linenos">236</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject-237"><a href="#RESTClientObject-237"><span class="linenos">237</span></a>                        <span class="n">body</span><span class="o">=</span><span class="n">body</span><span class="p">,</span>
+</span><span id="RESTClientObject-238"><a href="#RESTClientObject-238"><span class="linenos">238</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="RESTClientObject-239"><a href="#RESTClientObject-239"><span class="linenos">239</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="RESTClientObject-240"><a href="#RESTClientObject-240"><span class="linenos">240</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject-241"><a href="#RESTClientObject-241"><span class="linenos">241</span></a>                    <span class="p">)</span>
+</span><span id="RESTClientObject-242"><a href="#RESTClientObject-242"><span class="linenos">242</span></a>                <span class="k">elif</span> <span class="n">headers</span><span class="p">[</span><span class="s2">&quot;Content-Type&quot;</span><span class="p">]</span><span class="o">.</span><span class="n">startswith</span><span class="p">(</span><span class="s2">&quot;text/&quot;</span><span class="p">)</span> <span class="ow">and</span> <span class="nb">isinstance</span><span class="p">(</span>
+</span><span id="RESTClientObject-243"><a href="#RESTClientObject-243"><span class="linenos">243</span></a>                    <span class="n">body</span><span class="p">,</span> <span class="nb">bool</span>
+</span><span id="RESTClientObject-244"><a href="#RESTClientObject-244"><span class="linenos">244</span></a>                <span class="p">):</span>
+</span><span id="RESTClientObject-245"><a href="#RESTClientObject-245"><span class="linenos">245</span></a>                    <span class="n">request_body</span> <span class="o">=</span> <span class="s2">&quot;true&quot;</span> <span class="k">if</span> <span class="n">body</span> <span class="k">else</span> <span class="s2">&quot;false&quot;</span>
+</span><span id="RESTClientObject-246"><a href="#RESTClientObject-246"><span class="linenos">246</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="RESTClientObject-247"><a href="#RESTClientObject-247"><span class="linenos">247</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject-248"><a href="#RESTClientObject-248"><span class="linenos">248</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject-249"><a href="#RESTClientObject-249"><span class="linenos">249</span></a>                        <span class="n">body</span><span class="o">=</span><span class="n">request_body</span><span class="p">,</span>
+</span><span id="RESTClientObject-250"><a href="#RESTClientObject-250"><span class="linenos">250</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject-251"><a href="#RESTClientObject-251"><span class="linenos">251</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="RESTClientObject-252"><a href="#RESTClientObject-252"><span class="linenos">252</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="RESTClientObject-253"><a href="#RESTClientObject-253"><span class="linenos">253</span></a>                    <span class="p">)</span>
+</span><span id="RESTClientObject-254"><a href="#RESTClientObject-254"><span class="linenos">254</span></a>                <span class="k">else</span><span class="p">:</span>
+</span><span id="RESTClientObject-255"><a href="#RESTClientObject-255"><span class="linenos">255</span></a>                    <span class="c1"># Cannot generate the request from given parameters</span>
+</span><span id="RESTClientObject-256"><a href="#RESTClientObject-256"><span class="linenos">256</span></a>                    <span class="n">msg</span> <span class="o">=</span> <span class="s2">&quot;&quot;&quot;Cannot prepare a request message for provided</span>
+</span><span id="RESTClientObject-257"><a href="#RESTClientObject-257"><span class="linenos">257</span></a><span class="s2">                             arguments. Please check that your arguments match</span>
+</span><span id="RESTClientObject-258"><a href="#RESTClientObject-258"><span class="linenos">258</span></a><span class="s2">                             declared content type.&quot;&quot;&quot;</span>
+</span><span id="RESTClientObject-259"><a href="#RESTClientObject-259"><span class="linenos">259</span></a>                    <span class="k">raise</span> <span class="n">ApiException</span><span class="p">(</span><span class="n">status</span><span class="o">=</span><span class="mi">0</span><span class="p">,</span> <span class="n">reason</span><span class="o">=</span><span class="n">msg</span><span class="p">)</span>
+</span><span id="RESTClientObject-260"><a href="#RESTClientObject-260"><span class="linenos">260</span></a>            <span class="c1"># For `GET`, `HEAD`</span>
+</span><span id="RESTClientObject-261"><a href="#RESTClientObject-261"><span class="linenos">261</span></a>            <span class="k">else</span><span class="p">:</span>
+</span><span id="RESTClientObject-262"><a href="#RESTClientObject-262"><span class="linenos">262</span></a>                <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="RESTClientObject-263"><a href="#RESTClientObject-263"><span class="linenos">263</span></a>                    <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject-264"><a href="#RESTClientObject-264"><span class="linenos">264</span></a>                    <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject-265"><a href="#RESTClientObject-265"><span class="linenos">265</span></a>                    <span class="n">fields</span><span class="o">=</span><span class="p">{},</span>
+</span><span id="RESTClientObject-266"><a href="#RESTClientObject-266"><span class="linenos">266</span></a>                    <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="RESTClientObject-267"><a href="#RESTClientObject-267"><span class="linenos">267</span></a>                    <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="RESTClientObject-268"><a href="#RESTClientObject-268"><span class="linenos">268</span></a>                    <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject-269"><a href="#RESTClientObject-269"><span class="linenos">269</span></a>                <span class="p">)</span>
+</span><span id="RESTClientObject-270"><a href="#RESTClientObject-270"><span class="linenos">270</span></a>        <span class="k">except</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">exceptions</span><span class="o">.</span><span class="n">SSLError</span> <span class="k">as</span> <span class="n">e</span><span class="p">:</span>
+</span><span id="RESTClientObject-271"><a href="#RESTClientObject-271"><span class="linenos">271</span></a>            <span class="n">msg</span> <span class="o">=</span> <span class="s2">&quot;</span><span class="se">\n</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">join</span><span class="p">([</span><span class="nb">type</span><span class="p">(</span><span class="n">e</span><span class="p">)</span><span class="o">.</span><span class="vm">__name__</span><span class="p">,</span> <span class="nb">str</span><span class="p">(</span><span class="n">e</span><span class="p">)])</span>
+</span><span id="RESTClientObject-272"><a href="#RESTClientObject-272"><span class="linenos">272</span></a>            <span class="k">raise</span> <span class="n">ApiException</span><span class="p">(</span><span class="n">status</span><span class="o">=</span><span class="mi">0</span><span class="p">,</span> <span class="n">reason</span><span class="o">=</span><span class="n">msg</span><span class="p">)</span>
+</span><span id="RESTClientObject-273"><a href="#RESTClientObject-273"><span class="linenos">273</span></a>
+</span><span id="RESTClientObject-274"><a href="#RESTClientObject-274"><span class="linenos">274</span></a>        <span class="k">return</span> <span class="n">RESTResponse</span><span class="p">(</span><span class="n">r</span><span class="p">)</span>
+</span></pre></div>
+
+
+    
+
+                            <div id="RESTClientObject.__init__" class="classattr">
+                                        <input id="RESTClientObject.__init__-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="name">RESTClientObject</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">configuration</span></span>)</span>
+
+                <label class="view-source-button" for="RESTClientObject.__init__-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#RESTClientObject.__init__"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="RESTClientObject.__init__-64"><a href="#RESTClientObject.__init__-64"><span class="linenos"> 64</span></a>    <span class="k">def</span><span class="w"> </span><span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">configuration</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTClientObject.__init__-65"><a href="#RESTClientObject.__init__-65"><span class="linenos"> 65</span></a>        <span class="c1"># urllib3.PoolManager will pass all kw parameters to connectionpool</span>
+</span><span id="RESTClientObject.__init__-66"><a href="#RESTClientObject.__init__-66"><span class="linenos"> 66</span></a>        <span class="c1"># https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75  # noqa: E501</span>
+</span><span id="RESTClientObject.__init__-67"><a href="#RESTClientObject.__init__-67"><span class="linenos"> 67</span></a>        <span class="c1"># https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680  # noqa: E501</span>
+</span><span id="RESTClientObject.__init__-68"><a href="#RESTClientObject.__init__-68"><span class="linenos"> 68</span></a>        <span class="c1"># Custom SSL certificates and client certificates: http://urllib3.readthedocs.io/en/latest/advanced-usage.html  # noqa: E501</span>
+</span><span id="RESTClientObject.__init__-69"><a href="#RESTClientObject.__init__-69"><span class="linenos"> 69</span></a>
+</span><span id="RESTClientObject.__init__-70"><a href="#RESTClientObject.__init__-70"><span class="linenos"> 70</span></a>        <span class="c1"># cert_reqs</span>
+</span><span id="RESTClientObject.__init__-71"><a href="#RESTClientObject.__init__-71"><span class="linenos"> 71</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">verify_ssl</span><span class="p">:</span>
+</span><span id="RESTClientObject.__init__-72"><a href="#RESTClientObject.__init__-72"><span class="linenos"> 72</span></a>            <span class="n">cert_reqs</span> <span class="o">=</span> <span class="n">ssl</span><span class="o">.</span><span class="n">CERT_REQUIRED</span>
+</span><span id="RESTClientObject.__init__-73"><a href="#RESTClientObject.__init__-73"><span class="linenos"> 73</span></a>        <span class="k">else</span><span class="p">:</span>
+</span><span id="RESTClientObject.__init__-74"><a href="#RESTClientObject.__init__-74"><span class="linenos"> 74</span></a>            <span class="n">cert_reqs</span> <span class="o">=</span> <span class="n">ssl</span><span class="o">.</span><span class="n">CERT_NONE</span>
+</span><span id="RESTClientObject.__init__-75"><a href="#RESTClientObject.__init__-75"><span class="linenos"> 75</span></a>
+</span><span id="RESTClientObject.__init__-76"><a href="#RESTClientObject.__init__-76"><span class="linenos"> 76</span></a>        <span class="n">pool_args</span> <span class="o">=</span> <span class="p">{</span>
+</span><span id="RESTClientObject.__init__-77"><a href="#RESTClientObject.__init__-77"><span class="linenos"> 77</span></a>            <span class="s2">&quot;cert_reqs&quot;</span><span class="p">:</span> <span class="n">cert_reqs</span><span class="p">,</span>
+</span><span id="RESTClientObject.__init__-78"><a href="#RESTClientObject.__init__-78"><span class="linenos"> 78</span></a>            <span class="s2">&quot;ca_certs&quot;</span><span class="p">:</span> <span class="n">configuration</span><span class="o">.</span><span class="n">ssl_ca_cert</span><span class="p">,</span>
+</span><span id="RESTClientObject.__init__-79"><a href="#RESTClientObject.__init__-79"><span class="linenos"> 79</span></a>            <span class="s2">&quot;cert_file&quot;</span><span class="p">:</span> <span class="n">configuration</span><span class="o">.</span><span class="n">cert_file</span><span class="p">,</span>
+</span><span id="RESTClientObject.__init__-80"><a href="#RESTClientObject.__init__-80"><span class="linenos"> 80</span></a>            <span class="s2">&quot;key_file&quot;</span><span class="p">:</span> <span class="n">configuration</span><span class="o">.</span><span class="n">key_file</span><span class="p">,</span>
+</span><span id="RESTClientObject.__init__-81"><a href="#RESTClientObject.__init__-81"><span class="linenos"> 81</span></a>            <span class="s2">&quot;ca_cert_data&quot;</span><span class="p">:</span> <span class="n">configuration</span><span class="o">.</span><span class="n">ca_cert_data</span><span class="p">,</span>
+</span><span id="RESTClientObject.__init__-82"><a href="#RESTClientObject.__init__-82"><span class="linenos"> 82</span></a>        <span class="p">}</span>
+</span><span id="RESTClientObject.__init__-83"><a href="#RESTClientObject.__init__-83"><span class="linenos"> 83</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">assert_hostname</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTClientObject.__init__-84"><a href="#RESTClientObject.__init__-84"><span class="linenos"> 84</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;assert_hostname&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">assert_hostname</span>
+</span><span id="RESTClientObject.__init__-85"><a href="#RESTClientObject.__init__-85"><span class="linenos"> 85</span></a>
+</span><span id="RESTClientObject.__init__-86"><a href="#RESTClientObject.__init__-86"><span class="linenos"> 86</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">retries</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTClientObject.__init__-87"><a href="#RESTClientObject.__init__-87"><span class="linenos"> 87</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;retries&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">retries</span>
+</span><span id="RESTClientObject.__init__-88"><a href="#RESTClientObject.__init__-88"><span class="linenos"> 88</span></a>
+</span><span id="RESTClientObject.__init__-89"><a href="#RESTClientObject.__init__-89"><span class="linenos"> 89</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">tls_server_name</span><span class="p">:</span>
+</span><span id="RESTClientObject.__init__-90"><a href="#RESTClientObject.__init__-90"><span class="linenos"> 90</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;server_hostname&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">tls_server_name</span>
+</span><span id="RESTClientObject.__init__-91"><a href="#RESTClientObject.__init__-91"><span class="linenos"> 91</span></a>
+</span><span id="RESTClientObject.__init__-92"><a href="#RESTClientObject.__init__-92"><span class="linenos"> 92</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">socket_options</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTClientObject.__init__-93"><a href="#RESTClientObject.__init__-93"><span class="linenos"> 93</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;socket_options&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">socket_options</span>
+</span><span id="RESTClientObject.__init__-94"><a href="#RESTClientObject.__init__-94"><span class="linenos"> 94</span></a>
+</span><span id="RESTClientObject.__init__-95"><a href="#RESTClientObject.__init__-95"><span class="linenos"> 95</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">connection_pool_maxsize</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTClientObject.__init__-96"><a href="#RESTClientObject.__init__-96"><span class="linenos"> 96</span></a>            <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;maxsize&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">connection_pool_maxsize</span>
+</span><span id="RESTClientObject.__init__-97"><a href="#RESTClientObject.__init__-97"><span class="linenos"> 97</span></a>
+</span><span id="RESTClientObject.__init__-98"><a href="#RESTClientObject.__init__-98"><span class="linenos"> 98</span></a>        <span class="c1"># https pool manager</span>
+</span><span id="RESTClientObject.__init__-99"><a href="#RESTClientObject.__init__-99"><span class="linenos"> 99</span></a>        <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="p">:</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">PoolManager</span>
+</span><span id="RESTClientObject.__init__-100"><a href="#RESTClientObject.__init__-100"><span class="linenos">100</span></a>
+</span><span id="RESTClientObject.__init__-101"><a href="#RESTClientObject.__init__-101"><span class="linenos">101</span></a>        <span class="k">if</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy</span><span class="p">:</span>
+</span><span id="RESTClientObject.__init__-102"><a href="#RESTClientObject.__init__-102"><span class="linenos">102</span></a>            <span class="k">if</span> <span class="n">is_socks_proxy_url</span><span class="p">(</span><span class="n">configuration</span><span class="o">.</span><span class="n">proxy</span><span class="p">):</span>
+</span><span id="RESTClientObject.__init__-103"><a href="#RESTClientObject.__init__-103"><span class="linenos">103</span></a>                <span class="kn">from</span><span class="w"> </span><span class="nn">urllib3.contrib.socks</span><span class="w"> </span><span class="kn">import</span> <span class="n">SOCKSProxyManager</span>
+</span><span id="RESTClientObject.__init__-104"><a href="#RESTClientObject.__init__-104"><span class="linenos">104</span></a>
+</span><span id="RESTClientObject.__init__-105"><a href="#RESTClientObject.__init__-105"><span class="linenos">105</span></a>                <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;proxy_url&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy</span>
+</span><span id="RESTClientObject.__init__-106"><a href="#RESTClientObject.__init__-106"><span class="linenos">106</span></a>                <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;headers&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy_headers</span>
+</span><span id="RESTClientObject.__init__-107"><a href="#RESTClientObject.__init__-107"><span class="linenos">107</span></a>                <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span> <span class="o">=</span> <span class="n">SOCKSProxyManager</span><span class="p">(</span><span class="o">**</span><span class="n">pool_args</span><span class="p">)</span>
+</span><span id="RESTClientObject.__init__-108"><a href="#RESTClientObject.__init__-108"><span class="linenos">108</span></a>            <span class="k">else</span><span class="p">:</span>
+</span><span id="RESTClientObject.__init__-109"><a href="#RESTClientObject.__init__-109"><span class="linenos">109</span></a>                <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;proxy_url&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy</span>
+</span><span id="RESTClientObject.__init__-110"><a href="#RESTClientObject.__init__-110"><span class="linenos">110</span></a>                <span class="n">pool_args</span><span class="p">[</span><span class="s2">&quot;proxy_headers&quot;</span><span class="p">]</span> <span class="o">=</span> <span class="n">configuration</span><span class="o">.</span><span class="n">proxy_headers</span>
+</span><span id="RESTClientObject.__init__-111"><a href="#RESTClientObject.__init__-111"><span class="linenos">111</span></a>                <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">ProxyManager</span><span class="p">(</span><span class="o">**</span><span class="n">pool_args</span><span class="p">)</span>
+</span><span id="RESTClientObject.__init__-112"><a href="#RESTClientObject.__init__-112"><span class="linenos">112</span></a>        <span class="k">else</span><span class="p">:</span>
+</span><span id="RESTClientObject.__init__-113"><a href="#RESTClientObject.__init__-113"><span class="linenos">113</span></a>            <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">PoolManager</span><span class="p">(</span><span class="o">**</span><span class="n">pool_args</span><span class="p">)</span>
+</span></pre></div>
+
+
+    
+
+                            </div>
+                            <div id="RESTClientObject.pool_manager" class="classattr">
+                                <div class="attr variable">
+            <span class="name">pool_manager</span><span class="annotation">: urllib3.poolmanager.PoolManager</span>
+
+        
+    </div>
+    <a class="headerlink" href="#RESTClientObject.pool_manager"></a>
+    
+    
+
+                            </div>
+                            <div id="RESTClientObject.request" class="classattr">
+                                        <input id="RESTClientObject.request-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">request</span><span class="signature pdoc-code multiline">(<span class="param">	<span class="bp">self</span>,</span><span class="param">	<span class="n">method</span>,</span><span class="param">	<span class="n">url</span>,</span><span class="param">	<span class="n">headers</span><span class="o">=</span><span class="kc">None</span>,</span><span class="param">	<span class="n">body</span><span class="o">=</span><span class="kc">None</span>,</span><span class="param">	<span class="n">post_params</span><span class="o">=</span><span class="kc">None</span>,</span><span class="param">	<span class="n">_request_timeout</span><span class="o">=</span><span class="kc">None</span></span><span class="return-annotation">):</span></span>
+
+                <label class="view-source-button" for="RESTClientObject.request-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#RESTClientObject.request"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="RESTClientObject.request-115"><a href="#RESTClientObject.request-115"><span class="linenos">115</span></a>    <span class="k">def</span><span class="w"> </span><span class="nf">request</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-116"><a href="#RESTClientObject.request-116"><span class="linenos">116</span></a>        <span class="bp">self</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-117"><a href="#RESTClientObject.request-117"><span class="linenos">117</span></a>        <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-118"><a href="#RESTClientObject.request-118"><span class="linenos">118</span></a>        <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-119"><a href="#RESTClientObject.request-119"><span class="linenos">119</span></a>        <span class="n">headers</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-120"><a href="#RESTClientObject.request-120"><span class="linenos">120</span></a>        <span class="n">body</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-121"><a href="#RESTClientObject.request-121"><span class="linenos">121</span></a>        <span class="n">post_params</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-122"><a href="#RESTClientObject.request-122"><span class="linenos">122</span></a>        <span class="n">_request_timeout</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-123"><a href="#RESTClientObject.request-123"><span class="linenos">123</span></a>    <span class="p">):</span>
+</span><span id="RESTClientObject.request-124"><a href="#RESTClientObject.request-124"><span class="linenos">124</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;Perform requests.</span>
+</span><span id="RESTClientObject.request-125"><a href="#RESTClientObject.request-125"><span class="linenos">125</span></a>
+</span><span id="RESTClientObject.request-126"><a href="#RESTClientObject.request-126"><span class="linenos">126</span></a><span class="sd">        :param method: http request method</span>
+</span><span id="RESTClientObject.request-127"><a href="#RESTClientObject.request-127"><span class="linenos">127</span></a><span class="sd">        :param url: http request url</span>
+</span><span id="RESTClientObject.request-128"><a href="#RESTClientObject.request-128"><span class="linenos">128</span></a><span class="sd">        :param headers: http request headers</span>
+</span><span id="RESTClientObject.request-129"><a href="#RESTClientObject.request-129"><span class="linenos">129</span></a><span class="sd">        :param body: request json body, for `application/json`</span>
+</span><span id="RESTClientObject.request-130"><a href="#RESTClientObject.request-130"><span class="linenos">130</span></a><span class="sd">        :param post_params: request post parameters for</span>
+</span><span id="RESTClientObject.request-131"><a href="#RESTClientObject.request-131"><span class="linenos">131</span></a><span class="sd">                            `application/x-www-form-urlencoded` or</span>
+</span><span id="RESTClientObject.request-132"><a href="#RESTClientObject.request-132"><span class="linenos">132</span></a><span class="sd">                            `multipart/form-data`. Accepts either a</span>
+</span><span id="RESTClientObject.request-133"><a href="#RESTClientObject.request-133"><span class="linenos">133</span></a><span class="sd">                            ``dict`` or any iterable of ``(key, value)``</span>
+</span><span id="RESTClientObject.request-134"><a href="#RESTClientObject.request-134"><span class="linenos">134</span></a><span class="sd">                            pairs. Values that are ``dict``, ``list`` or</span>
+</span><span id="RESTClientObject.request-135"><a href="#RESTClientObject.request-135"><span class="linenos">135</span></a><span class="sd">                            ``tuple`` are JSON serialized.</span>
+</span><span id="RESTClientObject.request-136"><a href="#RESTClientObject.request-136"><span class="linenos">136</span></a>
+</span><span id="RESTClientObject.request-137"><a href="#RESTClientObject.request-137"><span class="linenos">137</span></a><span class="sd">                            Examples:</span>
+</span><span id="RESTClientObject.request-138"><a href="#RESTClientObject.request-138"><span class="linenos">138</span></a><span class="sd">                                post_params = {&quot;a&quot;: 1, &quot;meta&quot;: {&quot;b&quot;: 2}}</span>
+</span><span id="RESTClientObject.request-139"><a href="#RESTClientObject.request-139"><span class="linenos">139</span></a><span class="sd">                                post_params = [(&quot;a&quot;, 1), (&quot;meta&quot;, {&quot;b&quot;: 2})]</span>
+</span><span id="RESTClientObject.request-140"><a href="#RESTClientObject.request-140"><span class="linenos">140</span></a><span class="sd">        :param _request_timeout: timeout setting for this request. If one</span>
+</span><span id="RESTClientObject.request-141"><a href="#RESTClientObject.request-141"><span class="linenos">141</span></a><span class="sd">                                 number provided, it will be total request</span>
+</span><span id="RESTClientObject.request-142"><a href="#RESTClientObject.request-142"><span class="linenos">142</span></a><span class="sd">                                 timeout. It can also be a pair (tuple) of</span>
+</span><span id="RESTClientObject.request-143"><a href="#RESTClientObject.request-143"><span class="linenos">143</span></a><span class="sd">                                 (connection, read) timeouts.</span>
+</span><span id="RESTClientObject.request-144"><a href="#RESTClientObject.request-144"><span class="linenos">144</span></a><span class="sd">        &quot;&quot;&quot;</span>
+</span><span id="RESTClientObject.request-145"><a href="#RESTClientObject.request-145"><span class="linenos">145</span></a>        <span class="n">method</span> <span class="o">=</span> <span class="n">method</span><span class="o">.</span><span class="n">upper</span><span class="p">()</span>
+</span><span id="RESTClientObject.request-146"><a href="#RESTClientObject.request-146"><span class="linenos">146</span></a>        <span class="k">assert</span> <span class="n">method</span> <span class="ow">in</span> <span class="p">[</span><span class="s2">&quot;GET&quot;</span><span class="p">,</span> <span class="s2">&quot;HEAD&quot;</span><span class="p">,</span> <span class="s2">&quot;DELETE&quot;</span><span class="p">,</span> <span class="s2">&quot;POST&quot;</span><span class="p">,</span> <span class="s2">&quot;PUT&quot;</span><span class="p">,</span> <span class="s2">&quot;PATCH&quot;</span><span class="p">,</span> <span class="s2">&quot;OPTIONS&quot;</span><span class="p">]</span>
+</span><span id="RESTClientObject.request-147"><a href="#RESTClientObject.request-147"><span class="linenos">147</span></a>
+</span><span id="RESTClientObject.request-148"><a href="#RESTClientObject.request-148"><span class="linenos">148</span></a>        <span class="k">if</span> <span class="n">post_params</span> <span class="ow">and</span> <span class="n">body</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-149"><a href="#RESTClientObject.request-149"><span class="linenos">149</span></a>            <span class="k">raise</span> <span class="n">ApiValueError</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-150"><a href="#RESTClientObject.request-150"><span class="linenos">150</span></a>                <span class="s2">&quot;body parameter cannot be used with post_params parameter.&quot;</span>
+</span><span id="RESTClientObject.request-151"><a href="#RESTClientObject.request-151"><span class="linenos">151</span></a>            <span class="p">)</span>
+</span><span id="RESTClientObject.request-152"><a href="#RESTClientObject.request-152"><span class="linenos">152</span></a>
+</span><span id="RESTClientObject.request-153"><a href="#RESTClientObject.request-153"><span class="linenos">153</span></a>        <span class="n">post_params</span> <span class="o">=</span> <span class="n">post_params</span> <span class="ow">or</span> <span class="p">{}</span>
+</span><span id="RESTClientObject.request-154"><a href="#RESTClientObject.request-154"><span class="linenos">154</span></a>        <span class="n">headers</span> <span class="o">=</span> <span class="n">headers</span> <span class="ow">or</span> <span class="p">{}</span>
+</span><span id="RESTClientObject.request-155"><a href="#RESTClientObject.request-155"><span class="linenos">155</span></a>
+</span><span id="RESTClientObject.request-156"><a href="#RESTClientObject.request-156"><span class="linenos">156</span></a>        <span class="n">timeout</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="RESTClientObject.request-157"><a href="#RESTClientObject.request-157"><span class="linenos">157</span></a>        <span class="k">if</span> <span class="n">_request_timeout</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-158"><a href="#RESTClientObject.request-158"><span class="linenos">158</span></a>            <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">_request_timeout</span><span class="p">,</span> <span class="p">(</span><span class="nb">int</span><span class="p">,</span> <span class="nb">float</span><span class="p">)):</span>
+</span><span id="RESTClientObject.request-159"><a href="#RESTClientObject.request-159"><span class="linenos">159</span></a>                <span class="n">timeout</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">Timeout</span><span class="p">(</span><span class="n">total</span><span class="o">=</span><span class="n">_request_timeout</span><span class="p">)</span>
+</span><span id="RESTClientObject.request-160"><a href="#RESTClientObject.request-160"><span class="linenos">160</span></a>            <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">_request_timeout</span><span class="p">,</span> <span class="nb">tuple</span><span class="p">)</span> <span class="ow">and</span> <span class="nb">len</span><span class="p">(</span><span class="n">_request_timeout</span><span class="p">)</span> <span class="o">==</span> <span class="mi">2</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-161"><a href="#RESTClientObject.request-161"><span class="linenos">161</span></a>                <span class="n">timeout</span> <span class="o">=</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">Timeout</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-162"><a href="#RESTClientObject.request-162"><span class="linenos">162</span></a>                    <span class="n">connect</span><span class="o">=</span><span class="n">_request_timeout</span><span class="p">[</span><span class="mi">0</span><span class="p">],</span> <span class="n">read</span><span class="o">=</span><span class="n">_request_timeout</span><span class="p">[</span><span class="mi">1</span><span class="p">]</span>
+</span><span id="RESTClientObject.request-163"><a href="#RESTClientObject.request-163"><span class="linenos">163</span></a>                <span class="p">)</span>
+</span><span id="RESTClientObject.request-164"><a href="#RESTClientObject.request-164"><span class="linenos">164</span></a>
+</span><span id="RESTClientObject.request-165"><a href="#RESTClientObject.request-165"><span class="linenos">165</span></a>        <span class="k">try</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-166"><a href="#RESTClientObject.request-166"><span class="linenos">166</span></a>            <span class="c1"># For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`</span>
+</span><span id="RESTClientObject.request-167"><a href="#RESTClientObject.request-167"><span class="linenos">167</span></a>            <span class="k">if</span> <span class="n">method</span> <span class="ow">in</span> <span class="p">[</span><span class="s2">&quot;POST&quot;</span><span class="p">,</span> <span class="s2">&quot;PUT&quot;</span><span class="p">,</span> <span class="s2">&quot;PATCH&quot;</span><span class="p">,</span> <span class="s2">&quot;OPTIONS&quot;</span><span class="p">,</span> <span class="s2">&quot;DELETE&quot;</span><span class="p">]:</span>
+</span><span id="RESTClientObject.request-168"><a href="#RESTClientObject.request-168"><span class="linenos">168</span></a>
+</span><span id="RESTClientObject.request-169"><a href="#RESTClientObject.request-169"><span class="linenos">169</span></a>                <span class="c1"># no content type provided or payload is json</span>
+</span><span id="RESTClientObject.request-170"><a href="#RESTClientObject.request-170"><span class="linenos">170</span></a>                <span class="n">content_type</span> <span class="o">=</span> <span class="n">headers</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s2">&quot;Content-Type&quot;</span><span class="p">)</span>
+</span><span id="RESTClientObject.request-171"><a href="#RESTClientObject.request-171"><span class="linenos">171</span></a>                <span class="k">if</span> <span class="ow">not</span> <span class="n">content_type</span> <span class="ow">or</span> <span class="n">re</span><span class="o">.</span><span class="n">search</span><span class="p">(</span><span class="s2">&quot;json&quot;</span><span class="p">,</span> <span class="n">content_type</span><span class="p">,</span> <span class="n">re</span><span class="o">.</span><span class="n">IGNORECASE</span><span class="p">):</span>
+</span><span id="RESTClientObject.request-172"><a href="#RESTClientObject.request-172"><span class="linenos">172</span></a>                    <span class="n">request_body</span> <span class="o">=</span> <span class="kc">None</span>
+</span><span id="RESTClientObject.request-173"><a href="#RESTClientObject.request-173"><span class="linenos">173</span></a>                    <span class="k">if</span> <span class="n">body</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-174"><a href="#RESTClientObject.request-174"><span class="linenos">174</span></a>                        <span class="n">request_body</span> <span class="o">=</span> <span class="n">json</span><span class="o">.</span><span class="n">dumps</span><span class="p">(</span><span class="n">body</span><span class="p">)</span>
+</span><span id="RESTClientObject.request-175"><a href="#RESTClientObject.request-175"><span class="linenos">175</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-176"><a href="#RESTClientObject.request-176"><span class="linenos">176</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-177"><a href="#RESTClientObject.request-177"><span class="linenos">177</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-178"><a href="#RESTClientObject.request-178"><span class="linenos">178</span></a>                        <span class="n">body</span><span class="o">=</span><span class="n">request_body</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-179"><a href="#RESTClientObject.request-179"><span class="linenos">179</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-180"><a href="#RESTClientObject.request-180"><span class="linenos">180</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-181"><a href="#RESTClientObject.request-181"><span class="linenos">181</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-182"><a href="#RESTClientObject.request-182"><span class="linenos">182</span></a>                    <span class="p">)</span>
+</span><span id="RESTClientObject.request-183"><a href="#RESTClientObject.request-183"><span class="linenos">183</span></a>                <span class="k">elif</span> <span class="n">content_type</span> <span class="o">==</span> <span class="s2">&quot;application/x-www-form-urlencoded&quot;</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-184"><a href="#RESTClientObject.request-184"><span class="linenos">184</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-185"><a href="#RESTClientObject.request-185"><span class="linenos">185</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-186"><a href="#RESTClientObject.request-186"><span class="linenos">186</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-187"><a href="#RESTClientObject.request-187"><span class="linenos">187</span></a>                        <span class="n">fields</span><span class="o">=</span><span class="n">post_params</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-188"><a href="#RESTClientObject.request-188"><span class="linenos">188</span></a>                        <span class="n">encode_multipart</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-189"><a href="#RESTClientObject.request-189"><span class="linenos">189</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-190"><a href="#RESTClientObject.request-190"><span class="linenos">190</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-191"><a href="#RESTClientObject.request-191"><span class="linenos">191</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-192"><a href="#RESTClientObject.request-192"><span class="linenos">192</span></a>                    <span class="p">)</span>
+</span><span id="RESTClientObject.request-193"><a href="#RESTClientObject.request-193"><span class="linenos">193</span></a>                <span class="k">elif</span> <span class="n">content_type</span> <span class="o">==</span> <span class="s2">&quot;multipart/form-data&quot;</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-194"><a href="#RESTClientObject.request-194"><span class="linenos">194</span></a>                    <span class="c1"># must del headers[&#39;Content-Type&#39;], or the correct</span>
+</span><span id="RESTClientObject.request-195"><a href="#RESTClientObject.request-195"><span class="linenos">195</span></a>                    <span class="c1"># Content-Type which generated by urllib3 will be</span>
+</span><span id="RESTClientObject.request-196"><a href="#RESTClientObject.request-196"><span class="linenos">196</span></a>                    <span class="c1"># overwritten.</span>
+</span><span id="RESTClientObject.request-197"><a href="#RESTClientObject.request-197"><span class="linenos">197</span></a>                    <span class="k">del</span> <span class="n">headers</span><span class="p">[</span><span class="s2">&quot;Content-Type&quot;</span><span class="p">]</span>
+</span><span id="RESTClientObject.request-198"><a href="#RESTClientObject.request-198"><span class="linenos">198</span></a>                    <span class="c1"># Ensure ``fields`` only contains (key, value) tuples and</span>
+</span><span id="RESTClientObject.request-199"><a href="#RESTClientObject.request-199"><span class="linenos">199</span></a>                    <span class="c1"># serialize nested structures to JSON</span>
+</span><span id="RESTClientObject.request-200"><a href="#RESTClientObject.request-200"><span class="linenos">200</span></a>                    <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">post_params</span><span class="p">,</span> <span class="nb">dict</span><span class="p">):</span>
+</span><span id="RESTClientObject.request-201"><a href="#RESTClientObject.request-201"><span class="linenos">201</span></a>                        <span class="n">items</span> <span class="o">=</span> <span class="n">post_params</span><span class="o">.</span><span class="n">items</span><span class="p">()</span>
+</span><span id="RESTClientObject.request-202"><a href="#RESTClientObject.request-202"><span class="linenos">202</span></a>                    <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">post_params</span><span class="p">,</span> <span class="n">Iterable</span><span class="p">)</span> <span class="ow">and</span> <span class="ow">not</span> <span class="nb">isinstance</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-203"><a href="#RESTClientObject.request-203"><span class="linenos">203</span></a>                        <span class="n">post_params</span><span class="p">,</span> <span class="p">(</span><span class="nb">str</span><span class="p">,</span> <span class="nb">bytes</span><span class="p">)</span>
+</span><span id="RESTClientObject.request-204"><a href="#RESTClientObject.request-204"><span class="linenos">204</span></a>                    <span class="p">):</span>
+</span><span id="RESTClientObject.request-205"><a href="#RESTClientObject.request-205"><span class="linenos">205</span></a>                        <span class="n">items</span> <span class="o">=</span> <span class="n">post_params</span>
+</span><span id="RESTClientObject.request-206"><a href="#RESTClientObject.request-206"><span class="linenos">206</span></a>                    <span class="k">else</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-207"><a href="#RESTClientObject.request-207"><span class="linenos">207</span></a>                        <span class="k">raise</span> <span class="n">ApiValueError</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-208"><a href="#RESTClientObject.request-208"><span class="linenos">208</span></a>                            <span class="s2">&quot;post_params must be a dict or iterable&quot;</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-209"><a href="#RESTClientObject.request-209"><span class="linenos">209</span></a>                        <span class="p">)</span>
+</span><span id="RESTClientObject.request-210"><a href="#RESTClientObject.request-210"><span class="linenos">210</span></a>                    <span class="n">fields</span> <span class="o">=</span> <span class="p">[]</span>
+</span><span id="RESTClientObject.request-211"><a href="#RESTClientObject.request-211"><span class="linenos">211</span></a>                    <span class="k">for</span> <span class="n">item</span> <span class="ow">in</span> <span class="n">items</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-212"><a href="#RESTClientObject.request-212"><span class="linenos">212</span></a>                        <span class="k">try</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-213"><a href="#RESTClientObject.request-213"><span class="linenos">213</span></a>                            <span class="n">key</span><span class="p">,</span> <span class="n">value</span> <span class="o">=</span> <span class="n">item</span>
+</span><span id="RESTClientObject.request-214"><a href="#RESTClientObject.request-214"><span class="linenos">214</span></a>                        <span class="k">except</span> <span class="p">(</span><span class="ne">TypeError</span><span class="p">,</span> <span class="ne">ValueError</span><span class="p">)</span> <span class="k">as</span> <span class="n">exc</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-215"><a href="#RESTClientObject.request-215"><span class="linenos">215</span></a>                            <span class="k">raise</span> <span class="n">ApiValueError</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-216"><a href="#RESTClientObject.request-216"><span class="linenos">216</span></a>                                <span class="s2">&quot;Invalid number of elements in post_params&quot;</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-217"><a href="#RESTClientObject.request-217"><span class="linenos">217</span></a>                            <span class="p">)</span> <span class="kn">from</span><span class="w"> </span><span class="nn">exc</span>
+</span><span id="RESTClientObject.request-218"><a href="#RESTClientObject.request-218"><span class="linenos">218</span></a>                        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">value</span><span class="p">,</span> <span class="p">(</span><span class="nb">dict</span><span class="p">,</span> <span class="nb">list</span><span class="p">,</span> <span class="nb">tuple</span><span class="p">)):</span>
+</span><span id="RESTClientObject.request-219"><a href="#RESTClientObject.request-219"><span class="linenos">219</span></a>                            <span class="n">value</span> <span class="o">=</span> <span class="n">json</span><span class="o">.</span><span class="n">dumps</span><span class="p">(</span><span class="n">value</span><span class="p">)</span>
+</span><span id="RESTClientObject.request-220"><a href="#RESTClientObject.request-220"><span class="linenos">220</span></a>                        <span class="n">fields</span><span class="o">.</span><span class="n">append</span><span class="p">((</span><span class="n">key</span><span class="p">,</span> <span class="n">value</span><span class="p">))</span>
+</span><span id="RESTClientObject.request-221"><a href="#RESTClientObject.request-221"><span class="linenos">221</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-222"><a href="#RESTClientObject.request-222"><span class="linenos">222</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-223"><a href="#RESTClientObject.request-223"><span class="linenos">223</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-224"><a href="#RESTClientObject.request-224"><span class="linenos">224</span></a>                        <span class="n">fields</span><span class="o">=</span><span class="n">fields</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-225"><a href="#RESTClientObject.request-225"><span class="linenos">225</span></a>                        <span class="n">encode_multipart</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-226"><a href="#RESTClientObject.request-226"><span class="linenos">226</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-227"><a href="#RESTClientObject.request-227"><span class="linenos">227</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-228"><a href="#RESTClientObject.request-228"><span class="linenos">228</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-229"><a href="#RESTClientObject.request-229"><span class="linenos">229</span></a>                    <span class="p">)</span>
+</span><span id="RESTClientObject.request-230"><a href="#RESTClientObject.request-230"><span class="linenos">230</span></a>                <span class="c1"># Pass a `string` parameter directly in the body to support</span>
+</span><span id="RESTClientObject.request-231"><a href="#RESTClientObject.request-231"><span class="linenos">231</span></a>                <span class="c1"># other content types than JSON when `body` argument is</span>
+</span><span id="RESTClientObject.request-232"><a href="#RESTClientObject.request-232"><span class="linenos">232</span></a>                <span class="c1"># provided in serialized form.</span>
+</span><span id="RESTClientObject.request-233"><a href="#RESTClientObject.request-233"><span class="linenos">233</span></a>                <span class="k">elif</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">body</span><span class="p">,</span> <span class="nb">str</span><span class="p">)</span> <span class="ow">or</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">body</span><span class="p">,</span> <span class="nb">bytes</span><span class="p">):</span>
+</span><span id="RESTClientObject.request-234"><a href="#RESTClientObject.request-234"><span class="linenos">234</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-235"><a href="#RESTClientObject.request-235"><span class="linenos">235</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-236"><a href="#RESTClientObject.request-236"><span class="linenos">236</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-237"><a href="#RESTClientObject.request-237"><span class="linenos">237</span></a>                        <span class="n">body</span><span class="o">=</span><span class="n">body</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-238"><a href="#RESTClientObject.request-238"><span class="linenos">238</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-239"><a href="#RESTClientObject.request-239"><span class="linenos">239</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-240"><a href="#RESTClientObject.request-240"><span class="linenos">240</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-241"><a href="#RESTClientObject.request-241"><span class="linenos">241</span></a>                    <span class="p">)</span>
+</span><span id="RESTClientObject.request-242"><a href="#RESTClientObject.request-242"><span class="linenos">242</span></a>                <span class="k">elif</span> <span class="n">headers</span><span class="p">[</span><span class="s2">&quot;Content-Type&quot;</span><span class="p">]</span><span class="o">.</span><span class="n">startswith</span><span class="p">(</span><span class="s2">&quot;text/&quot;</span><span class="p">)</span> <span class="ow">and</span> <span class="nb">isinstance</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-243"><a href="#RESTClientObject.request-243"><span class="linenos">243</span></a>                    <span class="n">body</span><span class="p">,</span> <span class="nb">bool</span>
+</span><span id="RESTClientObject.request-244"><a href="#RESTClientObject.request-244"><span class="linenos">244</span></a>                <span class="p">):</span>
+</span><span id="RESTClientObject.request-245"><a href="#RESTClientObject.request-245"><span class="linenos">245</span></a>                    <span class="n">request_body</span> <span class="o">=</span> <span class="s2">&quot;true&quot;</span> <span class="k">if</span> <span class="n">body</span> <span class="k">else</span> <span class="s2">&quot;false&quot;</span>
+</span><span id="RESTClientObject.request-246"><a href="#RESTClientObject.request-246"><span class="linenos">246</span></a>                    <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-247"><a href="#RESTClientObject.request-247"><span class="linenos">247</span></a>                        <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-248"><a href="#RESTClientObject.request-248"><span class="linenos">248</span></a>                        <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-249"><a href="#RESTClientObject.request-249"><span class="linenos">249</span></a>                        <span class="n">body</span><span class="o">=</span><span class="n">request_body</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-250"><a href="#RESTClientObject.request-250"><span class="linenos">250</span></a>                        <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-251"><a href="#RESTClientObject.request-251"><span class="linenos">251</span></a>                        <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-252"><a href="#RESTClientObject.request-252"><span class="linenos">252</span></a>                        <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-253"><a href="#RESTClientObject.request-253"><span class="linenos">253</span></a>                    <span class="p">)</span>
+</span><span id="RESTClientObject.request-254"><a href="#RESTClientObject.request-254"><span class="linenos">254</span></a>                <span class="k">else</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-255"><a href="#RESTClientObject.request-255"><span class="linenos">255</span></a>                    <span class="c1"># Cannot generate the request from given parameters</span>
+</span><span id="RESTClientObject.request-256"><a href="#RESTClientObject.request-256"><span class="linenos">256</span></a>                    <span class="n">msg</span> <span class="o">=</span> <span class="s2">&quot;&quot;&quot;Cannot prepare a request message for provided</span>
+</span><span id="RESTClientObject.request-257"><a href="#RESTClientObject.request-257"><span class="linenos">257</span></a><span class="s2">                             arguments. Please check that your arguments match</span>
+</span><span id="RESTClientObject.request-258"><a href="#RESTClientObject.request-258"><span class="linenos">258</span></a><span class="s2">                             declared content type.&quot;&quot;&quot;</span>
+</span><span id="RESTClientObject.request-259"><a href="#RESTClientObject.request-259"><span class="linenos">259</span></a>                    <span class="k">raise</span> <span class="n">ApiException</span><span class="p">(</span><span class="n">status</span><span class="o">=</span><span class="mi">0</span><span class="p">,</span> <span class="n">reason</span><span class="o">=</span><span class="n">msg</span><span class="p">)</span>
+</span><span id="RESTClientObject.request-260"><a href="#RESTClientObject.request-260"><span class="linenos">260</span></a>            <span class="c1"># For `GET`, `HEAD`</span>
+</span><span id="RESTClientObject.request-261"><a href="#RESTClientObject.request-261"><span class="linenos">261</span></a>            <span class="k">else</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-262"><a href="#RESTClientObject.request-262"><span class="linenos">262</span></a>                <span class="n">r</span> <span class="o">=</span> <span class="bp">self</span><span class="o">.</span><span class="n">pool_manager</span><span class="o">.</span><span class="n">request</span><span class="p">(</span>
+</span><span id="RESTClientObject.request-263"><a href="#RESTClientObject.request-263"><span class="linenos">263</span></a>                    <span class="n">method</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-264"><a href="#RESTClientObject.request-264"><span class="linenos">264</span></a>                    <span class="n">url</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-265"><a href="#RESTClientObject.request-265"><span class="linenos">265</span></a>                    <span class="n">fields</span><span class="o">=</span><span class="p">{},</span>
+</span><span id="RESTClientObject.request-266"><a href="#RESTClientObject.request-266"><span class="linenos">266</span></a>                    <span class="n">timeout</span><span class="o">=</span><span class="n">timeout</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-267"><a href="#RESTClientObject.request-267"><span class="linenos">267</span></a>                    <span class="n">headers</span><span class="o">=</span><span class="n">headers</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-268"><a href="#RESTClientObject.request-268"><span class="linenos">268</span></a>                    <span class="n">preload_content</span><span class="o">=</span><span class="kc">False</span><span class="p">,</span>
+</span><span id="RESTClientObject.request-269"><a href="#RESTClientObject.request-269"><span class="linenos">269</span></a>                <span class="p">)</span>
+</span><span id="RESTClientObject.request-270"><a href="#RESTClientObject.request-270"><span class="linenos">270</span></a>        <span class="k">except</span> <span class="n">urllib3</span><span class="o">.</span><span class="n">exceptions</span><span class="o">.</span><span class="n">SSLError</span> <span class="k">as</span> <span class="n">e</span><span class="p">:</span>
+</span><span id="RESTClientObject.request-271"><a href="#RESTClientObject.request-271"><span class="linenos">271</span></a>            <span class="n">msg</span> <span class="o">=</span> <span class="s2">&quot;</span><span class="se">\n</span><span class="s2">&quot;</span><span class="o">.</span><span class="n">join</span><span class="p">([</span><span class="nb">type</span><span class="p">(</span><span class="n">e</span><span class="p">)</span><span class="o">.</span><span class="vm">__name__</span><span class="p">,</span> <span class="nb">str</span><span class="p">(</span><span class="n">e</span><span class="p">)])</span>
+</span><span id="RESTClientObject.request-272"><a href="#RESTClientObject.request-272"><span class="linenos">272</span></a>            <span class="k">raise</span> <span class="n">ApiException</span><span class="p">(</span><span class="n">status</span><span class="o">=</span><span class="mi">0</span><span class="p">,</span> <span class="n">reason</span><span class="o">=</span><span class="n">msg</span><span class="p">)</span>
+</span><span id="RESTClientObject.request-273"><a href="#RESTClientObject.request-273"><span class="linenos">273</span></a>
+</span><span id="RESTClientObject.request-274"><a href="#RESTClientObject.request-274"><span class="linenos">274</span></a>        <span class="k">return</span> <span class="n">RESTResponse</span><span class="p">(</span><span class="n">r</span><span class="p">)</span>
+</span></pre></div>
+
+
+            <div class="docstring"><p>Perform requests.</p>
+
+<h6 id="parameters">Parameters</h6>
+
+<ul>
+<li><strong>method</strong>:  http request method</li>
+<li><strong>url</strong>:  http request url</li>
+<li><strong>headers</strong>:  http request headers</li>
+<li><strong>body</strong>:  request json body, for <code>application/json</code></li>
+<li><p><strong>post_params</strong>:  request post parameters for
+                <code>application/x-www-form-urlencoded</code> or
+                <code>multipart/form-data</code>. Accepts either a
+                <code>dict</code> or any iterable of <code>(key, value)</code>
+                pairs. Values that are <code>dict</code>, <code>list</code> or
+                <code>tuple</code> are JSON serialized.</p>
+
+<pre><code>            Examples:
+                post_params = {"a": 1, "meta": {"b": 2}}
+                post_params = [("a", 1), ("meta", {"b": 2})]
+</code></pre></li>
+<li><strong>_request_timeout</strong>:  timeout setting for this request. If one
+number provided, it will be total request
+timeout. It can also be a pair (tuple) of
+(connection, read) timeouts.</li>
+</ul>
+</div>
+
+
+                            </div>
+                </section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document that RESTClientObject.request accepts post_params as a dict or iterable of pairs
- add examples illustrating dict and list-of-tuples inputs
- regenerate REST client docs

## Testing
- `pytest -q libs/py-sdk` (fails: Coverage failure: total of 0 is less than fail-under=85)
- `mypy --strict libs/py-sdk` (fails: There are no .py[i] files in directory 'libs/py-sdk')
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aaf2ff49dc832aab0c11fec773f76d