### PR TITLE
[handlers] add webapp webapp openers

### DIFF
--- a/services/api/app/diabetes/handlers/webapp_openers.py
+++ b/services/api/app/diabetes/handlers/webapp_openers.py
@@ -1,0 +1,52 @@
+# file: diabetes/handlers/webapp_openers.py
+"""Helpers to open external WebApp pages via inline buttons."""
+
+from __future__ import annotations
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, WebAppInfo
+from telegram.ext import ContextTypes
+
+from services.api.app import config
+
+
+async def _open_webapp(update: Update, path: str, text: str) -> None:
+    message = update.message
+    if message is None:
+        return
+    base_url = config.settings.webapp_url
+    if not base_url:
+        await message.reply_text("WebApp не настроен.")
+        return
+    url = f"{base_url.rstrip('/')}{path}"
+    keyboard = InlineKeyboardMarkup(
+        [[InlineKeyboardButton(text, web_app=WebAppInfo(url))]]
+    )
+    await message.reply_text("Откройте WebApp:", reply_markup=keyboard)
+
+
+async def open_history_webapp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send a button to open the history WebApp page."""
+    await _open_webapp(update, "/history", "📊 История")
+
+
+async def open_profile_webapp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send a button to open the profile WebApp page."""
+    await _open_webapp(update, "/profile", "📄 Мой профиль")
+
+
+async def open_subscription_webapp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send a button to open the subscription WebApp page."""
+    await _open_webapp(update, "/subscription", "💎 Подписка")
+
+
+async def open_reminders_webapp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send a button to open the reminders WebApp page."""
+    await _open_webapp(update, "/reminders", "⏰ Напоминания")
+
+
+__all__ = [
+    "open_history_webapp",
+    "open_profile_webapp",
+    "open_subscription_webapp",
+    "open_reminders_webapp",
+]

--- a/tests/test_webapp_openers.py
+++ b/tests/test_webapp_openers.py
@@ -1,0 +1,47 @@
+import importlib
+from types import SimpleNamespace
+from typing import Any, Callable, cast
+
+import pytest
+from telegram import InlineKeyboardMarkup, WebAppInfo, Update
+
+handlers = importlib.import_module(
+    "services.api.app.diabetes.handlers.webapp_openers"
+)
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.kwargs: list[dict[str, Any]] = []
+        self.texts: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.texts.append(text)
+        self.kwargs.append(kwargs)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("func", "path"),
+    [
+        (handlers.open_history_webapp, "/history"),
+        (handlers.open_profile_webapp, "/profile"),
+        (handlers.open_subscription_webapp, "/subscription"),
+        (handlers.open_reminders_webapp, "/reminders"),
+    ],
+)
+async def test_webapp_openers(monkeypatch: pytest.MonkeyPatch, func: Callable[..., Any], path: str) -> None:
+    base_url = "https://example.com/app/"
+    monkeypatch.setattr(handlers.config.settings, "webapp_url", base_url)
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context: Any = SimpleNamespace()
+
+    await func(update, context)
+
+    assert message.kwargs, "Expected a reply"
+    markup = message.kwargs[0].get("reply_markup")
+    assert isinstance(markup, InlineKeyboardMarkup)
+    button = markup.inline_keyboard[0][0]
+    assert isinstance(button.web_app, WebAppInfo)
+    assert button.web_app.url == base_url.rstrip("/") + path


### PR DESCRIPTION
## Summary
- add handlers to open history, profile, subscription and reminders WebApp pages via inline buttons
- cover webapp opener handlers with async tests

## Testing
- `python -m pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b53bd08832abc62776870a58633