### PR TITLE
[handlers] open webapp via bot commands

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -18,6 +18,12 @@ from sqlalchemy.exc import SQLAlchemyError
 from .onboarding_handlers import onboarding_conv, onboarding_poll_answer
 from .common_handlers import menu_command, help_command, smart_input_help
 from .router import callback_router
+from .webapp_openers import (
+    open_history_webapp,
+    open_profile_webapp,
+    open_reminders_webapp,
+    open_subscription_webapp,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +70,10 @@ def register_handlers(
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("cancel", dose_calc.dose_cancel))
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("help", help_command))
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("gpt", gpt_handlers.chat_with_gpt))
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("reminders", reminder_handlers.reminders_list))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("history", open_history_webapp))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("profile", open_profile_webapp))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("subscription", open_subscription_webapp))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("reminders", open_reminders_webapp))
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("addreminder", reminder_handlers.add_reminder))
     app.add_handler(reminder_handlers.reminder_action_handler)
     app.add_handler(reminder_handlers.reminder_webapp_handler)
@@ -73,24 +82,13 @@ def register_handlers(
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("hypoalert", security_handlers.hypo_alert_faq))
     app.add_handler(PollAnswerHandler[ContextTypes.DEFAULT_TYPE](onboarding_poll_answer))
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📄 Мой профиль$"), profile.profile_view)
-    )
-    app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📈 Отчёт$"), reporting_handlers.report_request)
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📊 История$"), reporting_handlers.history_view)
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📷 Фото еды$"), photo_handlers.photo_prompt)
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^🕹 Быстрый ввод$"), smart_input_help)
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex("^⏰ Напоминания$"), reminder_handlers.reminders_list
-        )
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^ℹ️ Помощь$"), help_command)

--- a/services/api/app/diabetes/handlers/webapp_openers.py
+++ b/services/api/app/diabetes/handlers/webapp_openers.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Helper handlers that open various WebApp sections.
+
+These functions send an inline button that opens the corresponding WebApp
+section when pressed. They rely on :func:`build_webapp_url` to construct
+absolute URLs based on the ``WEBAPP_URL`` setting.
+"""
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, WebAppInfo
+from telegram.ext import ContextTypes
+
+from .reminder_handlers import build_webapp_url
+
+
+async def _open(update: Update, path: str, text: str) -> None:
+    """Send a single button opening ``path`` in the WebApp."""
+    message = update.effective_message
+    if message is None:
+        return
+    url = build_webapp_url(path)
+    button = InlineKeyboardButton(text, web_app=WebAppInfo(url))
+    await message.reply_text(text, reply_markup=InlineKeyboardMarkup([[button]]))
+
+
+async def open_history_webapp(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Open the history WebApp page."""
+    await _open(update, "/history", "📊 История")
+
+
+async def open_profile_webapp(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Open the profile WebApp page."""
+    await _open(update, "/profile", "📄 Мой профиль")
+
+
+async def open_subscription_webapp(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Open the subscription WebApp page."""
+    await _open(update, "/subscription", "💳 Подписка")
+
+
+async def open_reminders_webapp(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Open the reminders WebApp page."""
+    await _open(update, "/reminders", "⏰ Напоминания")

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -16,7 +16,11 @@ from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import (
 from services.api.app.diabetes.handlers.registration import register_handlers
 from services.api.app.diabetes.handlers.router import callback_router
 from services.api.app.diabetes.handlers.onboarding_handlers import start_command
-from services.api.app.diabetes.handlers import security_handlers, reminder_handlers
+from services.api.app.diabetes.handlers import (
+    security_handlers,
+    reminder_handlers,
+    webapp_openers,
+)
 
 
 def test_register_handlers_attaches_expected_handlers(
@@ -48,10 +52,14 @@ def test_register_handlers_attaches_expected_handlers(
     assert sugar_handlers.prompt_sugar not in callbacks
     assert callback_router in callbacks
     assert reporting_handlers.report_period_callback in callbacks
-    assert profile_handlers.profile_view in callbacks
     assert profile_handlers.profile_back in callbacks
     assert reporting_handlers.report_request in callbacks
-    assert reporting_handlers.history_view in callbacks
+    assert webapp_openers.open_history_webapp in callbacks
+    assert webapp_openers.open_profile_webapp in callbacks
+    assert webapp_openers.open_subscription_webapp in callbacks
+    assert webapp_openers.open_reminders_webapp in callbacks
+    assert profile_handlers.profile_view not in callbacks
+    assert reporting_handlers.history_view not in callbacks
     assert gpt_handlers.chat_with_gpt in callbacks
     assert security_handlers.hypo_alert_faq in callbacks
     # Reminder handlers should be registered
@@ -161,7 +169,7 @@ def test_register_handlers_attaches_expected_handlers(
         for h in handlers
         if isinstance(h, MessageHandler) and h.callback is profile_handlers.profile_view
     ]
-    assert profile_view_handlers
+    assert not profile_view_handlers
 
     report_handlers = [
         h
@@ -192,7 +200,21 @@ def test_register_handlers_attaches_expected_handlers(
         if isinstance(h, MessageHandler)
         and h.callback is reporting_handlers.history_view
     ]
-    assert history_handlers
+    assert not history_handlers
+
+    reminders_text_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is reminder_handlers.reminders_list
+    ]
+    assert not reminders_text_handlers
+
+    reminders_cmd_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is reminder_handlers.reminders_list
+    ]
+    assert not reminders_cmd_handlers
 
     cb_handlers = [
         h

--- a/tests/test_webapp_command_handlers.py
+++ b/tests/test_webapp_command_handlers.py
@@ -1,0 +1,44 @@
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.ext import ApplicationBuilder, CommandHandler
+
+import services.api.app.diabetes.handlers.registration as registration
+from services.api.app.diabetes.handlers import webapp_openers
+
+
+@pytest.mark.asyncio
+async def test_commands_trigger_webapp_openers(monkeypatch: pytest.MonkeyPatch) -> None:
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+
+    history = AsyncMock()
+    profile = AsyncMock()
+    subscription = AsyncMock()
+    reminders = AsyncMock()
+    monkeypatch.setattr(webapp_openers, "open_history_webapp", history)
+    monkeypatch.setattr(webapp_openers, "open_profile_webapp", profile)
+    monkeypatch.setattr(webapp_openers, "open_subscription_webapp", subscription)
+    monkeypatch.setattr(webapp_openers, "open_reminders_webapp", reminders)
+    monkeypatch.setattr(registration, "open_history_webapp", history)
+    monkeypatch.setattr(registration, "open_profile_webapp", profile)
+    monkeypatch.setattr(registration, "open_subscription_webapp", subscription)
+    monkeypatch.setattr(registration, "open_reminders_webapp", reminders)
+
+    app = ApplicationBuilder().token("TESTTOKEN").build()
+    registration.register_handlers(app)
+
+    handlers = [h for h in app.handlers[0] if isinstance(h, CommandHandler)]
+    cmd_map = {cmd: h.callback for h in handlers for cmd in h.commands}
+
+    await cmd_map["history"](None, None)
+    await cmd_map["profile"](None, None)
+    await cmd_map["subscription"](None, None)
+    await cmd_map["reminders"](None, None)
+
+    history.assert_awaited_once()
+    profile.assert_awaited_once()
+    subscription.assert_awaited_once()
+    reminders.assert_awaited_once()


### PR DESCRIPTION
## Summary
- open history, profile, subscription and reminders webapps via slash commands
- remove old text handlers for profile, history and reminders
- cover new command handlers and old handler removal with tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b57760c832aa11915cb22a34ae3