### PR TITLE
[bot] configure commands

### DIFF
--- a/services/bot/configure_commands.py
+++ b/services/bot/configure_commands.py
@@ -1,0 +1,33 @@
+"""Helpers for configuring bot commands."""
+
+from typing import Any
+
+from telegram import BotCommand
+from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
+
+DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]
+DefaultApplication = Application[
+    ExtBot[None],
+    ContextTypes.DEFAULT_TYPE,
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    DefaultJobQueue,
+]
+
+COMMANDS: list[BotCommand] = [
+    BotCommand("history", "📊 История"),
+    BotCommand("profile", "👤 Профиль"),
+    BotCommand("subscription", "⭐️ Подписка"),
+    BotCommand("reminders", "⏰ Напоминания"),
+    BotCommand("report", "📈 Отчёт"),
+    BotCommand("help", "ℹ️ Помощь"),
+]
+
+
+async def configure_commands(app: DefaultApplication) -> None:
+    """Register default bot commands."""
+    await app.bot.set_my_commands(COMMANDS)
+
+
+__all__ = ["COMMANDS", "configure_commands"]

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -29,7 +29,7 @@ def test_log_level_debug(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(bot, "init_db", lambda: None)
 
     class DummyBot:
-        def set_my_commands(self, commands: list[tuple[str, str]]) -> None:
+        async def set_my_commands(self, commands: list[tuple[str, str]]) -> None:
             return None
 
     class DummyApp:
@@ -38,9 +38,7 @@ def test_log_level_debug(monkeypatch: pytest.MonkeyPatch) -> None:
 
         def add_error_handler(
             self,
-            handler: Callable[
-                [object, ContextTypes.DEFAULT_TYPE], Awaitable[None]
-            ],
+            handler: Callable[[object, ContextTypes.DEFAULT_TYPE], Awaitable[None]],
         ) -> None:
             return None
 
@@ -65,9 +63,7 @@ def test_log_level_debug(monkeypatch: pytest.MonkeyPatch) -> None:
         def builder() -> DummyBuilder:
             return DummyBuilder()
 
-        def __class_getitem__(
-            cls, _: object
-        ) -> type[DummyApplication]:  # Support subscripting in type hints
+        def __class_getitem__(cls, _: object) -> type[DummyApplication]:  # Support subscripting in type hints
             return cls
 
     monkeypatch.setattr(bot, "Application", DummyApplication)

--- a/tests/test_configure_commands.py
+++ b/tests/test_configure_commands.py
@@ -1,0 +1,29 @@
+import pytest
+from telegram import BotCommand
+from telegram.ext import Application
+
+from services.bot.configure_commands import COMMANDS, configure_commands
+
+
+@pytest.mark.asyncio
+async def test_configure_commands_sets_my_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = Application.builder().token("123:ABC").build()
+
+    store: list[BotCommand] = []
+
+    async def fake_set(self: object, commands: list[BotCommand]) -> None:
+        store[:] = commands
+
+    async def fake_get(self: object) -> list[BotCommand]:
+        return store
+
+    monkeypatch.setattr(app.bot.__class__, "set_my_commands", fake_set)
+    monkeypatch.setattr(app.bot.__class__, "get_my_commands", fake_get)
+
+    await configure_commands(app)
+    try:
+        assert await app.bot.get_my_commands() == COMMANDS
+    finally:
+        await app.shutdown()


### PR DESCRIPTION
## Summary
- centralize bot command setup with configure_commands helper
- register commands during bot startup
- test command configuration logic

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b5a5f4c832abaf39701bca7aea3