### PR TITLE
[webapp] route reminders webapp via API

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -505,7 +505,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if action == "add" and config.settings.webapp_url:
         button = InlineKeyboardButton(
             "📝 Новое",
-            web_app=WebAppInfo(reminder_handlers.build_webapp_url("/reminders")),
+            web_app=WebAppInfo(reminder_handlers.build_webapp_url("/api/reminders")),
         )
         keyboard = InlineKeyboardMarkup([[button]])
         await q_message.reply_text("Создать напоминание:", reply_markup=keyboard)

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -175,7 +175,7 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
-                web_app=WebAppInfo(build_webapp_url("/reminders")),
+                web_app=WebAppInfo(build_webapp_url("/api/reminders")),
             )
         ]
     if not rems:
@@ -202,7 +202,7 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
             row.append(
                 InlineKeyboardButton(
                     "✏️",
-                    web_app=WebAppInfo(build_webapp_url(f"/reminders?id={r.id}")),
+                    web_app=WebAppInfo(build_webapp_url(f"/api/reminders?id={r.id}")),
                 )
             )
         row.extend(

--- a/services/api/app/diabetes/handlers/webapp_commands.py
+++ b/services/api/app/diabetes/handlers/webapp_commands.py
@@ -48,7 +48,7 @@ def _make_handler(
 history_command = _make_handler("/history", "📊 История")
 profile_command = _make_handler("/profile", "📄 Мой профиль")
 subscription_command = _make_handler("/subscription", "💳 Подписка")
-reminders_command = _make_handler("/reminders", "⏰ Напоминания")
+reminders_command = _make_handler("/api/reminders", "⏰ Напоминания")
 
 
 __all__ = [

--- a/services/api/app/diabetes/handlers/webapp_openers.py
+++ b/services/api/app/diabetes/handlers/webapp_openers.py
@@ -51,4 +51,4 @@ async def open_reminders_webapp(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     """Open the reminders WebApp page."""
-    await _open(update, "/reminders", "⏰ Напоминания")
+    await _open(update, "/api/reminders", "⏰ Напоминания")

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -35,7 +35,7 @@ profile_button = (
     else KeyboardButton("📄 Мой профиль")
 )
 reminders_button = (
-    KeyboardButton("⏰ Напоминания", web_app=WebAppInfo(f"{_WEBAPP_URL}/reminders"))
+    KeyboardButton("⏰ Напоминания", web_app=WebAppInfo(f"{_WEBAPP_URL}/api/reminders"))
     if _WEBAPP_URL
     else KeyboardButton("⏰ Напоминания")
 )

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -25,7 +25,7 @@ def test_menu_keyboard_webapp_urls(monkeypatch: pytest.MonkeyPatch, base_url: st
     assert profile_btn.web_app is not None
     assert urlparse(profile_btn.web_app.url).path == "/profile"
     assert reminders_btn.web_app is not None
-    assert urlparse(reminders_btn.web_app.url).path == "/reminders"
+    assert urlparse(reminders_btn.web_app.url).path == "/api/reminders"
 
     monkeypatch.delenv("WEBAPP_URL", raising=False)
     importlib.reload(config)

--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -186,10 +186,10 @@ async def test_reminder_webapp_save_unknown_type(reminder_handlers: Any) -> None
 @pytest.mark.parametrize(
     "base_url, expected",
     [
-        ("https://example.com", "https://example.com/reminders"),
-        ("https://example.com/", "https://example.com/reminders"),
-        ("https://example.com/ui", "https://example.com/ui/reminders"),
-        ("https://example.com/ui/", "https://example.com/ui/reminders"),
+        ("https://example.com", "https://example.com/api/reminders"),
+        ("https://example.com/", "https://example.com/api/reminders"),
+        ("https://example.com/ui", "https://example.com/ui/api/reminders"),
+        ("https://example.com/ui/", "https://example.com/ui/api/reminders"),
     ],
 )
 def test_build_webapp_url(
@@ -200,13 +200,13 @@ def test_build_webapp_url(
     expected: str,
 ) -> None:
     monkeypatch.setattr(settings, "webapp_url", base_url)
-    url = reminder_handlers.build_webapp_url("/reminders")
+    url = reminder_handlers.build_webapp_url("/api/reminders")
     assert url == expected
     assert "//" not in url.split("://", 1)[1]
 
 
 def test_build_webapp_url_without_base(reminder_handlers: Any, settings: Any, monkeypatch: pytest.MonkeyPatch) -> None:
-    path = "/reminders"
+    path = "/api/reminders"
     monkeypatch.setattr(settings, "webapp_url", "")
     with pytest.raises(RuntimeError, match="WEBAPP_URL not configured"):
         reminder_handlers.build_webapp_url(path)

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -282,7 +282,7 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "2. <s>🔕title2</s>" in text
     assert markup.inline_keyboard
     assert any(
-        btn.web_app is not None and btn.web_app.url.endswith("/reminders")
+        btn.web_app is not None and btn.web_app.url.endswith("/api/reminders")
         for row in markup.inline_keyboard
         for btn in row
     )

--- a/tests/test_webapp_commands.py
+++ b/tests/test_webapp_commands.py
@@ -71,7 +71,7 @@ async def test_configure_commands_sets_expected_commands() -> None:
         (webapp_commands.history_command, "/history"),
         (webapp_commands.profile_command, "/profile"),
         (webapp_commands.subscription_command, "/subscription"),
-        (webapp_commands.reminders_command, "/reminders"),
+        (webapp_commands.reminders_command, "/api/reminders"),
     ],
 )
 async def test_commands_reply_with_webapp_url(

--- a/tests/test_webapp_openers.py
+++ b/tests/test_webapp_openers.py
@@ -27,14 +27,17 @@ class DummyMessage:
         (handlers.open_history_webapp, "/history"),
         (handlers.open_profile_webapp, "/profile"),
         (handlers.open_subscription_webapp, "/subscription"),
-        (handlers.open_reminders_webapp, "/reminders"),
+        (handlers.open_reminders_webapp, "/api/reminders"),
     ],
 )
 async def test_webapp_openers(monkeypatch: pytest.MonkeyPatch, func: Callable[..., Any], path: str) -> None:
     base_url = "https://example.com/app/"
-    monkeypatch.setattr(handlers.config.settings, "webapp_url", base_url)
+    reminder_handlers = importlib.import_module(
+        "services.api.app.diabetes.handlers.reminder_handlers"
+    )
+    monkeypatch.setattr(reminder_handlers.config.settings, "webapp_url", base_url)
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message))
+    update = cast(Update, SimpleNamespace(effective_message=message))
     context: Any = SimpleNamespace()
 
     await func(update, context)


### PR DESCRIPTION
## Summary
- point menu keyboard and webapp openers to `/api/reminders`
- adjust reminders handler buttons for new API path
- update tests for new reminders WebApp path

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab21044260832ab54bfa7ade15ef18