### PR TITLE
[webapp] Add profile navigation buttons

### DIFF
--- a/services/webapp/ui/src/pages/Profile.test.tsx
+++ b/services/webapp/ui/src/pages/Profile.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+const navigate = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigate }
+})
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }))
+vi.mock('@/contexts/telegram-context', () => ({ useTelegramContext: () => ({ user: { id: 1 } }) }))
+vi.mock('@/api/profile', () => ({ getProfile: vi.fn(), saveProfile: vi.fn() }))
+
+import Profile from './Profile'
+
+afterEach(() => cleanup())
+
+beforeEach(() => navigate.mockReset())
+
+describe('Profile navigation buttons', () => {
+  it('renders history and subscription buttons', async () => {
+    render(<Profile />)
+    expect(await screen.findByRole('button', { name: '📊 История' })).toBeTruthy()
+    expect(await screen.findByRole('button', { name: '💳 Подписка' })).toBeTruthy()
+  })
+
+  it('navigates to history and subscription pages', async () => {
+    render(<Profile />)
+    fireEvent.click(await screen.findByRole('button', { name: '📊 История' }))
+    expect(navigate).toHaveBeenCalledWith('/history')
+    fireEvent.click(await screen.findByRole('button', { name: '💳 Подписка' }))
+    expect(navigate).toHaveBeenCalledWith('/subscription')
+  })
+})

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -300,6 +300,25 @@ const Profile = () => {
                   <Save className="w-4 h-4" />
                   Сохранить настройки
                 </MedicalButton>
+                {/* Дополнительные кнопки */}
+                <div className="mt-4 space-y-2">
+                  <MedicalButton
+                    onClick={() => navigate('/history')}
+                    className="w-full flex items-center justify-center gap-2"
+                    size="lg"
+                    variant="secondary"
+                  >
+                    📊 История
+                  </MedicalButton>
+                  <MedicalButton
+                    onClick={() => navigate('/subscription')}
+                    className="w-full flex items-center justify-center gap-2"
+                    size="lg"
+                    variant="secondary"
+                  >
+                    💳 Подписка
+                  </MedicalButton>
+                </div>
               </div>
             </div>
 

--- a/services/webapp/ui/src/reminders/CreateReminder.test.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.test.tsx
@@ -1,6 +1,6 @@
 
-import { render, waitFor, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 
 const mockNavigate = vi.fn();


### PR DESCRIPTION
## Summary
- add history and subscription buttons on profile page
- cover profile navigation buttons with tests
- fix missing imports in reminder test

## Testing
- `pnpm --dir services/webapp/ui test`
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab21057ed0832a8e978a12eb86a674