### PR TITLE
[ui] compute menu keyboard dynamically

### DIFF
--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -13,7 +13,7 @@ async def menu_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     message = update.message
     if message:
         await message.reply_text(
-            "📋 Выберите действие:", reply_markup=menu_keyboard
+            "📋 Выберите действие:", reply_markup=menu_keyboard()
         )
 
 
@@ -65,7 +65,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     )
     message = update.message
     if message:
-        await message.reply_text(text, reply_markup=menu_keyboard)
+        await message.reply_text(text, reply_markup=menu_keyboard())
 
 
 async def smart_input_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -201,7 +201,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     if carbs_g is None and xe is None:
         await message.reply_text(
             "Не указаны углеводы или ХЕ. Расчёт невозможен.",
-            reply_markup=menu_keyboard,
+            reply_markup=menu_keyboard(),
         )
         user_data.pop("pending_entry", None)
         return END
@@ -227,7 +227,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     ):
         await message.reply_text(
             "Профиль не настроен. Установите коэффициенты через /profile.",
-            reply_markup=menu_keyboard,
+            reply_markup=menu_keyboard(),
         )
         user_data.pop("pending_entry", None)
         return END
@@ -265,7 +265,7 @@ async def dose_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     message = update.message
     if message is None:
         return END
-    await message.reply_text("Отменено.", reply_markup=menu_keyboard)
+    await message.reply_text("Отменено.", reply_markup=menu_keyboard())
     user_data.pop("pending_entry", None)
     user_data.pop("dose_method", None)
     chat_data = getattr(context, "chat_data", None)
@@ -314,7 +314,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         SessionLocal=SessionLocal,
         commit=commit,
         check_alert=check_alert,
-        menu_keyboard_markup=menu_keyboard,
+        menu_keyboard_markup=menu_keyboard(),
         smart_input=smart_input,
         parse_command=parse_command,
         send_report=send_report,

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -31,7 +31,7 @@ from services.api.app.diabetes.gpt_command_parser import (
 from services.api.app.diabetes.utils.constants import XE_GRAMS
 from services.api.app.diabetes.utils.ui import (
     confirm_keyboard,
-    menu_keyboard as _menu_keyboard,
+    menu_keyboard,
 )
 
 from .alert_handlers import check_alert as _check_alert
@@ -41,7 +41,6 @@ from . import EntryData, UserData
 
 commit = _commit
 check_alert = _check_alert
-menu_keyboard = _menu_keyboard
 
 T = TypeVar("T")
 
@@ -602,7 +601,7 @@ async def freeform_handler(
     SessionLocal = SessionLocal or globals()["SessionLocal"]
     commit = commit or globals()["commit"]
     check_alert = check_alert or globals()["check_alert"]
-    menu_keyboard_markup = menu_keyboard_markup or globals()["menu_keyboard"]
+    menu_keyboard_markup = menu_keyboard_markup or globals()["menu_keyboard"]()
     assert SessionLocal is not None
     assert commit is not None
     assert check_alert is not None

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -101,7 +101,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
             greeting = f"👋 Привет, {first_name}!" if first_name else "👋 Привет!"
             greeting += " Рада видеть тебя. Надеюсь, у тебя сегодня всё отлично."
             await message.reply_text(
-                f"{greeting}\n\n📋 Выберите действие:", reply_markup=menu_keyboard
+                f"{greeting}\n\n📋 Выберите действие:", reply_markup=menu_keyboard()
             )
             return ConversationHandler.END
 
@@ -413,7 +413,7 @@ async def onboarding_reminders(
         logger.warning("Poll message missing poll object for user %s", user_id)
 
     await query.message.reply_text(
-        "Готово! Спасибо за настройку.", reply_markup=menu_keyboard
+        "Готово! Спасибо за настройку.", reply_markup=menu_keyboard()
     )
     return ConversationHandler.END
 
@@ -434,7 +434,7 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             if not commit(session):
                 await query.message.reply_text(
                     "⚠️ Не удалось сохранить настройки.",
-                    reply_markup=menu_keyboard,
+                    reply_markup=menu_keyboard(),
                 )
                 return ConversationHandler.END
 
@@ -449,7 +449,7 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     else:
         logger.warning("Poll message missing poll object for user %s", user_id)
 
-    await query.message.reply_text("Пропущено.", reply_markup=menu_keyboard)
+    await query.message.reply_text("Пропущено.", reply_markup=menu_keyboard())
     return ConversationHandler.END
 
 

--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -37,7 +37,7 @@ async def photo_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     message = update.message
     if message is None:
         return
-    await message.reply_text("📸 Пришлите фото блюда для анализа.", reply_markup=menu_keyboard)
+    await message.reply_text("📸 Пришлите фото блюда для анализа.", reply_markup=menu_keyboard())
 
 
 async def photo_handler(
@@ -220,7 +220,7 @@ async def photo_handler(
                 f"Вот полный ответ Vision:\n<pre>{vision_text}</pre>\n"
                 "Введите /dose и укажите их вручную.",
                 parse_mode="HTML",
-                reply_markup=menu_keyboard,
+                reply_markup=menu_keyboard(),
             )
             return END
 
@@ -250,7 +250,7 @@ async def photo_handler(
                 raise
         await message.reply_text(
             f"🍽️ На фото:\n{vision_text}\n\nВведите текущий сахар (ммоль/л) — и я рассчитаю дозу инсулина.",
-            reply_markup=menu_keyboard,
+            reply_markup=menu_keyboard(),
         )
         return PHOTO_SUGAR
 

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -206,7 +206,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         f"• Низкий порог: {low} ммоль/л\n"
         f"• Высокий порог: {high} ммоль/л" + warning_msg,
         parse_mode="Markdown",
-        reply_markup=menu_keyboard,
+        reply_markup=menu_keyboard(),
     )
     return END
 
@@ -285,13 +285,13 @@ async def profile_webapp_save(
     web_app = getattr(eff_msg, "web_app_data", None)
     error_msg = "⚠️ Некорректные данные из WebApp."
     if web_app is None:
-        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard)
+        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
         return
     raw = web_app.data
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
-        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard)
+        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
         return
     if {
         "icr",
@@ -300,7 +300,7 @@ async def profile_webapp_save(
         "low",
         "high",
     } - data.keys():
-        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard)
+        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
         return
     try:
         icr = float(str(data["icr"]).replace(",", "."))
@@ -309,11 +309,11 @@ async def profile_webapp_save(
         low = float(str(data["low"]).replace(",", "."))
         high = float(str(data["high"]).replace(",", "."))
     except ValueError:
-        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard)
+        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
         return
     user = update.effective_user
     if user is None:
-        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard)
+        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
         return
     user_id = user.id
     ok, err = post_profile(
@@ -330,7 +330,7 @@ async def profile_webapp_save(
     if not ok:
         await eff_msg.reply_text(
             err or "⚠️ Не удалось сохранить профиль.",
-            reply_markup=menu_keyboard,
+            reply_markup=menu_keyboard(),
         )
         return
     await eff_msg.reply_text(
@@ -340,7 +340,7 @@ async def profile_webapp_save(
         f"• Целевой сахар: {target} ммоль/л\n"
         f"• Низкий порог: {low} ммоль/л\n"
         f"• Высокий порог: {high} ммоль/л",
-        reply_markup=menu_keyboard,
+        reply_markup=menu_keyboard(),
     )
 
 
@@ -348,7 +348,7 @@ async def profile_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     """Cancel profile creation conversation."""
     message = update.message
     if message is not None:
-        await message.reply_text("Отменено.", reply_markup=menu_keyboard)
+        await message.reply_text("Отменено.", reply_markup=menu_keyboard())
     return END
 
 
@@ -359,7 +359,7 @@ async def profile_back(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return
     await query.answer()
     await query.message.delete()
-    await query.message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
+    await query.message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
 
 
 async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -420,15 +420,15 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
     else:
         exists, ok = await run_db(db_set_timezone, sessionmaker=SessionLocal)
     if not exists:
-        await message.reply_text("Профиль не найден.", reply_markup=menu_keyboard)
+        await message.reply_text("Профиль не найден.", reply_markup=menu_keyboard())
         return END
     if not ok:
         await message.reply_text(
             "⚠️ Не удалось обновить часовой пояс.",
-            reply_markup=menu_keyboard,
+            reply_markup=menu_keyboard(),
         )
         return END
-    await message.reply_text("✅ Часовой пояс обновлён.", reply_markup=menu_keyboard)
+    await message.reply_text("✅ Часовой пояс обновлён.", reply_markup=menu_keyboard())
     return END
 
 
@@ -526,7 +526,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if not result.get("commit_ok", True):
         await q_message.reply_text(
             "⚠️ Не удалось сохранить настройки.",
-            reply_markup=menu_keyboard,
+            reply_markup=menu_keyboard(),
         )
         return
     alert_sugar = result.get("alert_sugar")
@@ -812,7 +812,7 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         f"• Целевой сахар: {target} ммоль/л\n"
         f"• Низкий порог: {low} ммоль/л\n"
         f"• Высокий порог: {high} ммоль/л" + warning_msg,
-        reply_markup=menu_keyboard,
+        reply_markup=menu_keyboard(),
     )
     return END
 

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -159,7 +159,7 @@ async def report_period_callback(
         if message is not None:
             await message.delete()
             await message.reply_text(
-                "📋 Выберите действие:", reply_markup=menu_keyboard
+                "📋 Выберите действие:", reply_markup=menu_keyboard()
             )
         return
     period = query.data.split(":", 1)[1]

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -94,7 +94,7 @@ async def handle_cancel_entry(
     message = query.message
     if message is None:
         return
-    await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
+    await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
 
 
 async def handle_edit_or_delete(

--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -76,13 +76,13 @@ async def sos_contact_save(
         if not commit(session):
             await message.reply_text(
                 "⚠️ Не удалось сохранить контакт.",
-                reply_markup=menu_keyboard,
+                reply_markup=menu_keyboard(),
             )
             return ConversationHandler.END
 
     await message.reply_text(
         "✅ Контакт для SOS сохранён.",
-        reply_markup=menu_keyboard,
+        reply_markup=menu_keyboard(),
     )
     return ConversationHandler.END
 
@@ -95,7 +95,7 @@ async def sos_contact_cancel(
     if message is None:
         return ConversationHandler.END
     assert message is not None
-    await message.reply_text("Отменено.", reply_markup=menu_keyboard)
+    await message.reply_text("Отменено.", reply_markup=menu_keyboard())
     return ConversationHandler.END
 
 

--- a/services/api/app/diabetes/handlers/sugar_handlers.py
+++ b/services/api/app/diabetes/handlers/sugar_handlers.py
@@ -121,7 +121,7 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     await check_alert(update, context, sugar)
     await message.reply_text(
         f"✅ Уровень сахара {sugar} ммоль/л сохранён.",
-        reply_markup=menu_keyboard,
+        reply_markup=menu_keyboard(),
     )
     if chat_data is not None:
         chat_data.pop("sugar_active", None)

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -25,33 +25,48 @@ __all__ = (
     "build_timezone_webapp_button",
 )
 
-# ─────────────── Reply-клавиатуры (отображаются на экране чата) ───────────────
-_WEBAPP_URL = config.settings.webapp_url.rstrip("/") if config.settings.webapp_url else None
 
-# Create WebApp buttons when WebApp is configured, fall back to text buttons otherwise
-profile_button = (
-    KeyboardButton("📄 Мой профиль", web_app=WebAppInfo(f"{_WEBAPP_URL}/profile"))
-    if _WEBAPP_URL
-    else KeyboardButton("📄 Мой профиль")
-)
-reminders_button = (
-    KeyboardButton("⏰ Напоминания", web_app=WebAppInfo(f"{_WEBAPP_URL}/reminders"))
-    if _WEBAPP_URL
-    else KeyboardButton("⏰ Напоминания")
-)
+def _webapp_url() -> str | None:
+    """Return ``settings.webapp_url`` without a trailing slash."""
 
-menu_keyboard = ReplyKeyboardMarkup(
-    keyboard=[
-        [KeyboardButton("📷 Фото еды"), KeyboardButton("🩸 Уровень сахара")],
-        [KeyboardButton("💉 Доза инсулина"), KeyboardButton("📊 История")],
-        [KeyboardButton("📈 Отчёт"), profile_button],
-        [KeyboardButton("🕹 Быстрый ввод"), KeyboardButton("ℹ️ Помощь")],
-        [reminders_button, KeyboardButton("🆘 SOS контакт")],
-    ],
-    resize_keyboard=True,
-    one_time_keyboard=False,
-    input_field_placeholder="Выберите действие…",
-)
+    url = config.settings.webapp_url
+    return url.rstrip("/") if url else None
+
+
+def menu_keyboard() -> ReplyKeyboardMarkup:
+    """Build the main menu keyboard.
+
+    ``settings.webapp_url`` is read at call time to determine whether WebApp
+    buttons should be used for profile and reminders.
+    """
+
+    webapp_url = _webapp_url()
+    profile_button = (
+        KeyboardButton(
+            "📄 Мой профиль", web_app=WebAppInfo(f"{webapp_url}/profile")
+        )
+        if webapp_url
+        else KeyboardButton("📄 Мой профиль")
+    )
+    reminders_button = (
+        KeyboardButton(
+            "⏰ Напоминания", web_app=WebAppInfo(f"{webapp_url}/reminders")
+        )
+        if webapp_url
+        else KeyboardButton("⏰ Напоминания")
+    )
+    return ReplyKeyboardMarkup(
+        keyboard=[
+            [KeyboardButton("📷 Фото еды"), KeyboardButton("🩸 Уровень сахара")],
+            [KeyboardButton("💉 Доза инсулина"), KeyboardButton("📊 История")],
+            [KeyboardButton("📈 Отчёт"), profile_button],
+            [KeyboardButton("🕹 Быстрый ввод"), KeyboardButton("ℹ️ Помощь")],
+            [reminders_button, KeyboardButton("🆘 SOS контакт")],
+        ],
+        resize_keyboard=True,
+        one_time_keyboard=False,
+        input_field_placeholder="Выберите действие…",
+    )
 
 dose_keyboard = ReplyKeyboardMarkup(
     keyboard=[
@@ -113,10 +128,11 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
         Button instance when ``WEBAPP_URL`` is set and valid, otherwise ``None``.
     """
 
-    if not _WEBAPP_URL:
+    webapp_url = _webapp_url()
+    if not webapp_url:
         return None
 
     return InlineKeyboardButton(
         "Определить автоматически",
-        web_app=WebAppInfo(f"{_WEBAPP_URL}/timezone"),
+        web_app=WebAppInfo(f"{webapp_url}/timezone"),
     )

--- a/tests/handlers/test_onboarding_handlers.py
+++ b/tests/handlers/test_onboarding_handlers.py
@@ -84,7 +84,7 @@ async def test_onboarding_skip_cancels(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
     monkeypatch.setattr(onboarding, "commit", lambda s: True)
-    monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
+    monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
 
     message = DummyMessage()
     query = DummyQuery(message, "onb_skip")

--- a/tests/test_dose_calc_unit.py
+++ b/tests/test_dose_calc_unit.py
@@ -162,7 +162,7 @@ async def test_dose_sugar_profile_required(monkeypatch: pytest.MonkeyPatch) -> N
     context.user_data["pending_entry"] = {"carbs_g": 10}
 
     monkeypatch.setattr(dose_calc, "SessionLocal", lambda: DummySession(None))
-    monkeypatch.setattr(dose_calc, "menu_keyboard", "menu")
+    monkeypatch.setattr(dose_calc, "menu_keyboard", lambda: "menu")
 
     result = await dose_calc.dose_sugar(
         cast(Update, update),

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -90,7 +90,7 @@ async def test_entry_without_dose_has_no_unit(
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
-    monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
+    monkeypatch.setattr(dose_handlers, "menu_keyboard", lambda: None)
 
     monkeypatch.setattr(gpt_handlers, "run_db", None)
 
@@ -145,7 +145,7 @@ async def test_entry_without_sugar_has_placeholder(
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
-    monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
+    monkeypatch.setattr(dose_handlers, "menu_keyboard", lambda: None)
 
     monkeypatch.setattr(gpt_handlers, "run_db", None)
 

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -57,7 +57,8 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     assert len(query.message.replies) == 1
     assert query.message.kwargs
     kwargs = query.message.kwargs[0]
-    assert kwargs.get("reply_markup") == common_handlers.menu_keyboard
+    markup = kwargs.get("reply_markup")
+    assert markup and markup.keyboard == common_handlers.menu_keyboard().keyboard
     assert context.user_data is not None
     user_data = context.user_data
     assert "pending_entry" not in user_data

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -244,7 +244,7 @@ async def test_photo_handler_removes_file(monkeypatch: pytest.MonkeyPatch, tmp_p
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
     monkeypatch.setattr(photo_handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
-    monkeypatch.setattr(photo_handlers, "menu_keyboard", None)
+    monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
     monkeypatch.setattr(
         photo_handlers.os,
         "makedirs",
@@ -295,7 +295,7 @@ async def test_photo_then_freeform_calculates_dose(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
     monkeypatch.setattr(photo_handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
-    monkeypatch.setattr(photo_handlers, "menu_keyboard", None)
+    monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
     monkeypatch.setattr(gpt_handlers, "confirm_keyboard", lambda: None)
 
     photo_msg = DummyMessage(photo=(DummyPhoto(),))

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -84,7 +84,7 @@ async def test_photo_flow_saves_entry(
         return {"action": "add_entry", "fields": {}, "entry_date": None, "time": None}
 
     monkeypatch.setattr(gpt_handlers, "confirm_keyboard", lambda: None)
-    monkeypatch.setattr(photo_handlers, "menu_keyboard", None)
+    monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
 
     msg_start = DummyMessage("/dose")
     update_start = cast(
@@ -215,7 +215,7 @@ async def test_photo_flow_saves_entry(
 async def test_photo_handler_removes_file_on_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    monkeypatch.setattr(photo_handlers, "menu_keyboard", None)
+    monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
 
     async def fake_get_file(file_id: str) -> Any:
         class File:

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -110,7 +110,7 @@ async def test_profile_command_and_view(
         await handlers.profile_view(update2, context2)
         dispose_engine(engine)
 
-    assert message.markups[0] is menu_keyboard
+    assert message.markups[0].keyboard == menu_keyboard().keyboard
     assert f"• ИКХ: {expected_icr} г/ед." in message.texts[0]
     assert f"• КЧ: {expected_cf} ммоль/л" in message.texts[0]
     assert f"• Целевой сахар: {expected_target} ммоль/л" in message.texts[0]

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -88,7 +88,7 @@ async def test_photo_prompt_includes_dish_name(
 
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
-    monkeypatch.setattr(photo_handlers, "menu_keyboard", None)
+    monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
 
     msg_photo = DummyMessage(photo=[DummyPhoto()])
     update = cast(

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -31,7 +31,10 @@ async def test_help_includes_new_features() -> None:
 
     await handlers.help_command(update, context)
 
-    assert message.kwargs[0]["reply_markup"] == handlers.menu_keyboard
+    assert (
+        message.kwargs[0]["reply_markup"].keyboard
+        == handlers.menu_keyboard().keyboard
+    )
     text = message.replies[0]
     assert "🆕 Новые возможности:\n" in text
     assert "• ✨ Мастер настройки при первом запуске\n" in text

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -18,7 +18,7 @@ def test_menu_keyboard_webapp_urls(monkeypatch: pytest.MonkeyPatch, base_url: st
     importlib.reload(config)
     importlib.reload(ui)
 
-    buttons = [btn for row in ui.menu_keyboard.keyboard for btn in row]
+    buttons = [btn for row in ui.menu_keyboard().keyboard for btn in row]
     profile_btn = next(b for b in buttons if b.text == "📄 Мой профиль")
     reminders_btn = next(b for b in buttons if b.text == "⏰ Напоминания")
 

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -53,7 +53,7 @@ async def test_onboarding_demo_photo_missing(
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
+    monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
 
     message = DummyMessage()
     update = cast(

--- a/tests/test_onboarding_edge_cases.py
+++ b/tests/test_onboarding_edge_cases.py
@@ -147,7 +147,7 @@ async def test_onboarding_reminders_repeated(monkeypatch: pytest.MonkeyPatch) ->
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
+    monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -201,7 +201,7 @@ async def test_onboarding_reminders_poll_missing(
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
+    monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -233,7 +233,7 @@ async def test_onboarding_skip_commit_failure(monkeypatch: pytest.MonkeyPatch) -
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
     monkeypatch.setattr(onboarding, "commit", lambda session: False)
-    monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
+    monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -70,7 +70,7 @@ async def test_onboarding_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
+    monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
 
     message = DummyMessage()
     update = cast(

--- a/tests/test_onboarding_start_command.py
+++ b/tests/test_onboarding_start_command.py
@@ -131,7 +131,7 @@ async def test_start_command_existing_user(monkeypatch: pytest.MonkeyPatch) -> N
         session.commit()
 
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
+    monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
 
     def fake_skip_markup() -> str:  # must not be called
         raise AssertionError("_skip_markup should not be used for existing user")

--- a/tests/test_onboarding_timezone_error.py
+++ b/tests/test_onboarding_timezone_error.py
@@ -44,7 +44,7 @@ async def test_onboarding_timezone_error(
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
+    monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
 
     message = DummyMessage()
     update = cast(

--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -13,7 +13,7 @@ def test_reminders_button_matches_regex() -> None:
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
-    button_texts = [btn.text for row in menu_keyboard.keyboard for btn in row]
+    button_texts = [btn.text for row in menu_keyboard().keyboard for btn in row]
     assert "⏰ Напоминания" in button_texts
 
     app = ApplicationBuilder().token("TESTTOKEN").build()

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -163,7 +163,7 @@ async def test_sos_contact_menu_button_starts_conv(
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
-    button_texts = [btn.text for row in menu_keyboard.keyboard for btn in row]
+    button_texts = [btn.text for row in menu_keyboard().keyboard for btn in row]
     assert "🆘 SOS контакт" in button_texts
 
     app = ApplicationBuilder().token("TESTTOKEN").build()


### PR DESCRIPTION
## Summary
- build menu keyboard using `settings.webapp_url` at call time
- call `menu_keyboard()` in handlers instead of a module-level constant
- adapt tests to the new keyboard API

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab295dfe80832a8b9a49037cc43243