### PR TITLE
[utils] centralize button texts in ui constants

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -26,6 +26,13 @@ from services.api.app.diabetes.utils.functions import (
     smart_input,
 )
 from services.api.app.diabetes.utils.ui import (
+    BACK_BUTTON_TEXT,
+    DOSE_BUTTON_TEXT,
+    HISTORY_BUTTON_TEXT,
+    PHOTO_BUTTON_TEXT,
+    PROFILE_BUTTON_TEXT,
+    REPORT_BUTTON_TEXT,
+    SUGAR_BUTTON_TEXT,
     confirm_keyboard,
     dose_keyboard,
     menu_keyboard,
@@ -327,7 +334,7 @@ chat_with_gpt = _gpt_handlers.chat_with_gpt
 dose_conv = ConversationHandler(
     entry_points=[
         CommandHandler("dose", dose_start),
-        MessageHandler(filters.Regex("^💉 Доза инсулина$"), dose_start),
+        MessageHandler(filters.Regex(f"^{DOSE_BUTTON_TEXT}$"), dose_start),
     ],
     states={
         DOSE_METHOD: [
@@ -338,23 +345,23 @@ dose_conv = ConversationHandler(
         DOSE_SUGAR: [MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), dose_sugar)],
     },
     fallbacks=[
-        MessageHandler(filters.Regex("^↩️ Назад$"), dose_cancel),
+        MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), dose_cancel),
         CommandHandler("menu", cast(object, _cancel_then(menu_command))),
         MessageHandler(
-            filters.Regex("^📷 Фото еды$"), cast(object, _cancel_then(photo_prompt))
+            filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), cast(object, _cancel_then(photo_prompt))
         ),
         MessageHandler(
-            filters.Regex("^🩸 Уровень сахара$"),
+            filters.Regex(f"^{SUGAR_BUTTON_TEXT}$"),
             cast(object, _cancel_then(sugar_start)),
         ),
         MessageHandler(
-            filters.Regex("^📊 История$"), cast(object, _cancel_then(history_view))
+            filters.Regex(f"^{HISTORY_BUTTON_TEXT}$"), cast(object, _cancel_then(history_view))
         ),
         MessageHandler(
-            filters.Regex("^📈 Отчёт$"), cast(object, _cancel_then(report_request))
+            filters.Regex(f"^{REPORT_BUTTON_TEXT}$"), cast(object, _cancel_then(report_request))
         ),
         MessageHandler(
-            filters.Regex("^📄 Мой профиль$"), cast(object, _cancel_then(profile_view))
+            filters.Regex(f"^{PROFILE_BUTTON_TEXT}$"), cast(object, _cancel_then(profile_view))
         ),
     ],
 )

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -35,8 +35,9 @@ from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import (
 
 from services.api.app.diabetes.services.db import SessionLocal, User, Profile, Reminder
 from services.api.app.diabetes.utils.ui import (
-    menu_keyboard,
+    PHOTO_BUTTON_TEXT,
     build_timezone_webapp_button,
+    menu_keyboard,
 )
 from services.api.app.diabetes.services.repository import commit
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -519,7 +520,7 @@ onboarding_conv = ConversationHandler(
     },
     fallbacks=[
         CommandHandler("cancel", onboarding_skip),
-        MessageHandler(filters.Regex("^📷 Фото еды$"), _photo_fallback),
+        MessageHandler(filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), _photo_fallback),
     ],
     per_message=False,
 )

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -30,6 +30,7 @@ from services.api.app.diabetes.services.db import (
     Reminder,
     User,
 )
+from services.api.app.diabetes.utils.ui import BACK_BUTTON_TEXT, PHOTO_BUTTON_TEXT
 
 logger = logging.getLogger(__name__)
 
@@ -854,9 +855,9 @@ profile_conv = ConversationHandler(
         ],
     },
     fallbacks=[
-        MessageHandler(filters.Regex("^↩️ Назад$"), profile_cancel),
+        MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), profile_cancel),
         CommandHandler("cancel", profile_cancel),
-        MessageHandler(filters.Regex("^📷 Фото еды$"), _photo_fallback),
+        MessageHandler(filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), _photo_fallback),
     ],
     # Subsequent steps depend on ``MessageHandler`` for text inputs. Enabling
     # ``per_message=True`` would store state per message and reset the

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -15,6 +15,16 @@ from telegram.ext import (
 )
 from sqlalchemy.exc import SQLAlchemyError
 
+from ..utils.ui import (
+    HELP_BUTTON_TEXT,
+    HISTORY_BUTTON_TEXT,
+    PHOTO_BUTTON_TEXT,
+    PROFILE_BUTTON_TEXT,
+    QUICK_INPUT_BUTTON_TEXT,
+    REMINDERS_BUTTON_TEXT,
+    REPORT_BUTTON_TEXT,
+    SOS_CONTACT_BUTTON_TEXT,
+)
 from .onboarding_handlers import onboarding_conv, onboarding_poll_answer
 from .common_handlers import menu_command, help_command, smart_input_help
 from .router import callback_router
@@ -73,31 +83,43 @@ def register_handlers(
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("hypoalert", security_handlers.hypo_alert_faq))
     app.add_handler(PollAnswerHandler[ContextTypes.DEFAULT_TYPE](onboarding_poll_answer))
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📄 Мой профиль$"), profile.profile_view)
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📈 Отчёт$"), reporting_handlers.report_request)
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📊 История$"), reporting_handlers.history_view)
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^📷 Фото еды$"), photo_handlers.photo_prompt)
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^🕹 Быстрый ввод$"), smart_input_help)
-    )
-    app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex("^⏰ Напоминания$"), reminder_handlers.reminders_list
+            filters.Regex(f"^{PROFILE_BUTTON_TEXT}$"), profile.profile_view
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex("^ℹ️ Помощь$"), help_command)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Regex(f"^{REPORT_BUTTON_TEXT}$"), reporting_handlers.report_request
+        )
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex("^🆘 SOS контакт$"), sos_handlers.sos_contact_start
+            filters.Regex(f"^{HISTORY_BUTTON_TEXT}$"), reporting_handlers.history_view
+        )
+    )
+    app.add_handler(
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), photo_handlers.photo_prompt
+        )
+    )
+    app.add_handler(
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Regex(f"^{QUICK_INPUT_BUTTON_TEXT}$"), smart_input_help
+        )
+    )
+    app.add_handler(
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Regex(f"^{REMINDERS_BUTTON_TEXT}$"), reminder_handlers.reminders_list
+        )
+    )
+    app.add_handler(
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Regex(f"^{HELP_BUTTON_TEXT}$"), help_command
+        )
+    )
+    app.add_handler(
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Regex(f"^{SOS_CONTACT_BUTTON_TEXT}$"), sos_handlers.sos_contact_start
         )
     )
     app.add_handler(

--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -14,7 +14,12 @@ from telegram.ext import (
 )
 
 from services.api.app.diabetes.services.db import SessionLocal, Profile
-from services.api.app.diabetes.utils.ui import back_keyboard, menu_keyboard
+from services.api.app.diabetes.utils.ui import (
+    BACK_BUTTON_TEXT,
+    PHOTO_BUTTON_TEXT,
+    back_keyboard,
+    menu_keyboard,
+)
 from services.api.app.diabetes.services.repository import commit
 from . import dose_calc, _cancel_then
 
@@ -103,10 +108,10 @@ sos_contact_conv = ConversationHandler(
     entry_points=[CommandHandler("soscontact", sos_contact_start)],
     states={SOS_CONTACT: [MessageHandler(filters.TEXT & ~filters.COMMAND, sos_contact_save)]},
     fallbacks=[
-        MessageHandler(filters.Regex("^↩️ Назад$"), sos_contact_cancel),
+        MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), sos_contact_cancel),
         CommandHandler("cancel", sos_contact_cancel),
         MessageHandler(
-            filters.Regex("^📷 Фото еды$"),
+            filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"),
             _cancel_then(dose_calc.photo_prompt),
         ),
     ],

--- a/services/api/app/diabetes/handlers/sugar_handlers.py
+++ b/services/api/app/diabetes/handlers/sugar_handlers.py
@@ -16,7 +16,13 @@ from sqlalchemy.orm import Session
 from services.api.app.diabetes.services.db import Entry, SessionLocal
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.functions import _safe_float
-from services.api.app.diabetes.utils.ui import menu_keyboard, sugar_keyboard
+from services.api.app.diabetes.utils.ui import (
+    BACK_BUTTON_TEXT,
+    PHOTO_BUTTON_TEXT,
+    SUGAR_BUTTON_TEXT,
+    menu_keyboard,
+    sugar_keyboard,
+)
 
 from . import EntryData, UserData
 from .alert_handlers import check_alert
@@ -133,16 +139,16 @@ prompt_sugar = sugar_start
 sugar_conv = ConversationHandler(
     entry_points=[
         CommandHandler("sugar", sugar_start),
-        MessageHandler(filters.Regex("^🩸 Уровень сахара$"), sugar_start),
+        MessageHandler(filters.Regex(f"^{SUGAR_BUTTON_TEXT}$"), sugar_start),
     ],
     states={
         SUGAR_VAL: [MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), sugar_val)],
     },
     fallbacks=[
-        MessageHandler(filters.Regex("^↩️ Назад$"), dose_cancel),
+        MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), dose_cancel),
         CommandHandler("menu", cast(object, _cancel_then(menu_command))),
         MessageHandler(
-            filters.Regex("^📷 Фото еды$"), cast(object, _cancel_then(photo_prompt))
+            filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), cast(object, _cancel_then(photo_prompt))
         ),
     ],
 )

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -8,15 +8,38 @@ UI-компоненты бота «Diabet Buddy».
 """
 
 from telegram import (
-    InlineKeyboardMarkup,
     InlineKeyboardButton,
-    ReplyKeyboardMarkup,
+    InlineKeyboardMarkup,
     KeyboardButton,
+    ReplyKeyboardMarkup,
     WebAppInfo,
 )
 from services.api.app import config
 
+PHOTO_BUTTON_TEXT = "📷 Фото еды"
+SUGAR_BUTTON_TEXT = "🩸 Уровень сахара"
+DOSE_BUTTON_TEXT = "💉 Доза инсулина"
+HISTORY_BUTTON_TEXT = "📊 История"
+REPORT_BUTTON_TEXT = "📈 Отчёт"
+PROFILE_BUTTON_TEXT = "📄 Мой профиль"
+QUICK_INPUT_BUTTON_TEXT = "🕹 Быстрый ввод"
+HELP_BUTTON_TEXT = "ℹ️ Помощь"
+REMINDERS_BUTTON_TEXT = "⏰ Напоминания"
+SOS_CONTACT_BUTTON_TEXT = "🆘 SOS контакт"
+BACK_BUTTON_TEXT = "↩️ Назад"
+
 __all__ = (
+    "PHOTO_BUTTON_TEXT",
+    "SUGAR_BUTTON_TEXT",
+    "DOSE_BUTTON_TEXT",
+    "HISTORY_BUTTON_TEXT",
+    "REPORT_BUTTON_TEXT",
+    "PROFILE_BUTTON_TEXT",
+    "QUICK_INPUT_BUTTON_TEXT",
+    "HELP_BUTTON_TEXT",
+    "REMINDERS_BUTTON_TEXT",
+    "SOS_CONTACT_BUTTON_TEXT",
+    "BACK_BUTTON_TEXT",
     "menu_keyboard",
     "dose_keyboard",
     "sugar_keyboard",
@@ -30,23 +53,23 @@ _WEBAPP_URL = config.settings.webapp_url.rstrip("/") if config.settings.webapp_u
 
 # Create WebApp buttons when WebApp is configured, fall back to text buttons otherwise
 profile_button = (
-    KeyboardButton("📄 Мой профиль", web_app=WebAppInfo(f"{_WEBAPP_URL}/profile"))
+    KeyboardButton(PROFILE_BUTTON_TEXT, web_app=WebAppInfo(f"{_WEBAPP_URL}/profile"))
     if _WEBAPP_URL
-    else KeyboardButton("📄 Мой профиль")
+    else KeyboardButton(PROFILE_BUTTON_TEXT)
 )
 reminders_button = (
-    KeyboardButton("⏰ Напоминания", web_app=WebAppInfo(f"{_WEBAPP_URL}/reminders"))
+    KeyboardButton(REMINDERS_BUTTON_TEXT, web_app=WebAppInfo(f"{_WEBAPP_URL}/reminders"))
     if _WEBAPP_URL
-    else KeyboardButton("⏰ Напоминания")
+    else KeyboardButton(REMINDERS_BUTTON_TEXT)
 )
 
 menu_keyboard = ReplyKeyboardMarkup(
     keyboard=[
-        [KeyboardButton("📷 Фото еды"), KeyboardButton("🩸 Уровень сахара")],
-        [KeyboardButton("💉 Доза инсулина"), KeyboardButton("📊 История")],
-        [KeyboardButton("📈 Отчёт"), profile_button],
-        [KeyboardButton("🕹 Быстрый ввод"), KeyboardButton("ℹ️ Помощь")],
-        [reminders_button, KeyboardButton("🆘 SOS контакт")],
+        [KeyboardButton(PHOTO_BUTTON_TEXT), KeyboardButton(SUGAR_BUTTON_TEXT)],
+        [KeyboardButton(DOSE_BUTTON_TEXT), KeyboardButton(HISTORY_BUTTON_TEXT)],
+        [KeyboardButton(REPORT_BUTTON_TEXT), profile_button],
+        [KeyboardButton(QUICK_INPUT_BUTTON_TEXT), KeyboardButton(HELP_BUTTON_TEXT)],
+        [reminders_button, KeyboardButton(SOS_CONTACT_BUTTON_TEXT)],
     ],
     resize_keyboard=True,
     one_time_keyboard=False,
@@ -56,7 +79,7 @@ menu_keyboard = ReplyKeyboardMarkup(
 dose_keyboard = ReplyKeyboardMarkup(
     keyboard=[
         [KeyboardButton("ХЕ"), KeyboardButton("Углеводы")],
-        [KeyboardButton("↩️ Назад")],
+        [KeyboardButton(BACK_BUTTON_TEXT)],
     ],
     resize_keyboard=True,
     one_time_keyboard=True,
@@ -64,14 +87,14 @@ dose_keyboard = ReplyKeyboardMarkup(
 )
 
 sugar_keyboard = ReplyKeyboardMarkup(
-    keyboard=[[KeyboardButton("↩️ Назад")]],
+    keyboard=[[KeyboardButton(BACK_BUTTON_TEXT)]],
     resize_keyboard=True,
     one_time_keyboard=True,
     input_field_placeholder="Введите уровень сахара…",
 )
 
 back_keyboard = ReplyKeyboardMarkup(
-    keyboard=[[KeyboardButton("↩️ Назад")]],
+    keyboard=[[KeyboardButton(BACK_BUTTON_TEXT)]],
     resize_keyboard=True,
     one_time_keyboard=True,
 )

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -13,6 +13,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import dose_calc
+from services.api.app.diabetes.utils.ui import PHOTO_BUTTON_TEXT
 
 
 def _find_handler(
@@ -48,8 +49,8 @@ class DummyMessage:
 
 @pytest.mark.asyncio
 async def test_photo_button_cancels_and_prompts_photo() -> None:
-    handler = _find_handler(dose_calc.dose_conv.fallbacks, "^📷 Фото еды$")
-    message = DummyMessage("📷 Фото еды")
+    handler = _find_handler(dose_calc.dose_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$")
+    message = DummyMessage(PHOTO_BUTTON_TEXT)
     update = cast(
         Update,
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -5,6 +5,7 @@ from typing import Any, Sequence, cast
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext, CommandHandler
+from services.api.app.diabetes.utils.ui import PHOTO_BUTTON_TEXT
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -56,7 +57,7 @@ async def test_sugar_conv_menu_then_photo() -> None:
     assert any("выберите" in r.lower() for r in message.replies[1:])
     assert context.user_data == {}
 
-    next_message = DummyMessage("📷 Фото еды")
+    next_message = DummyMessage(PHOTO_BUTTON_TEXT)
     next_update = cast(
         Update,
         SimpleNamespace(message=next_message, effective_user=SimpleNamespace(id=1)),
@@ -88,7 +89,7 @@ async def test_dose_conv_menu_then_photo() -> None:
     assert any("выберите" in r.lower() for r in message.replies[1:])
     assert context.user_data == {}
 
-    next_message = DummyMessage("📷 Фото еды")
+    next_message = DummyMessage(PHOTO_BUTTON_TEXT)
     next_update = cast(
         Update,
         SimpleNamespace(message=next_message, effective_user=SimpleNamespace(id=1)),

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -19,8 +19,8 @@ def test_menu_keyboard_webapp_urls(monkeypatch: pytest.MonkeyPatch, base_url: st
     importlib.reload(ui)
 
     buttons = [btn for row in ui.menu_keyboard.keyboard for btn in row]
-    profile_btn = next(b for b in buttons if b.text == "📄 Мой профиль")
-    reminders_btn = next(b for b in buttons if b.text == "⏰ Напоминания")
+    profile_btn = next(b for b in buttons if b.text == ui.PROFILE_BUTTON_TEXT)
+    reminders_btn = next(b for b in buttons if b.text == ui.REMINDERS_BUTTON_TEXT)
 
     assert profile_btn.web_app is not None
     assert urlparse(profile_btn.web_app.url).path == "/profile"

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -15,10 +15,11 @@ os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import (
     dose_calc,
-    profile as profile_handlers,
     onboarding_handlers,
+    profile as profile_handlers,
     sos_handlers,
 )
+from services.api.app.diabetes.utils.ui import PHOTO_BUTTON_TEXT
 
 
 def _find_handler(
@@ -57,7 +58,7 @@ async def _exercise(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
     ],
 ) -> None:
-    message = DummyMessage("📷 Фото еды")
+    message = DummyMessage(PHOTO_BUTTON_TEXT)
     update = cast(
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
@@ -75,25 +76,25 @@ async def _exercise(
 
 @pytest.mark.asyncio
 async def test_profile_conv_photo_fallback() -> None:
-    handler = _find_handler(profile_handlers.profile_conv.fallbacks, "^📷 Фото еды$")
+    handler = _find_handler(profile_handlers.profile_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$")
     await _exercise(handler)
 
 
 @pytest.mark.asyncio
 async def test_sugar_conv_photo_fallback() -> None:
-    handler = _find_handler(dose_calc.sugar_conv.fallbacks, "^📷 Фото еды$")
+    handler = _find_handler(dose_calc.sugar_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$")
     await _exercise(handler)
 
 
 @pytest.mark.asyncio
 async def test_onboarding_conv_photo_fallback() -> None:
     handler = _find_handler(
-        onboarding_handlers.onboarding_conv.fallbacks, "^📷 Фото еды$"
+        onboarding_handlers.onboarding_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$"
     )
     await _exercise(handler)
 
 
 @pytest.mark.asyncio
 async def test_sos_contact_conv_photo_fallback() -> None:
-    handler = _find_handler(sos_handlers.sos_contact_conv.fallbacks, "^📷 Фото еды$")
+    handler = _find_handler(sos_handlers.sos_contact_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$")
     await _exercise(handler)

--- a/tests/test_quick_input_help_button.py
+++ b/tests/test_quick_input_help_button.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import services.api.app.diabetes.handlers.common_handlers as handlers
+from services.api.app.diabetes.utils.ui import QUICK_INPUT_BUTTON_TEXT
 
 
 class DummyMessage:
@@ -20,7 +21,7 @@ class DummyMessage:
 async def test_quick_input_help_button() -> None:
     """Simulate the "🕹 Быстрый ввод" menu button and verify the hint."""
 
-    message = DummyMessage("🕹 Быстрый ввод")
+    message = DummyMessage(QUICK_INPUT_BUTTON_TEXT)
     update: Any = SimpleNamespace(message=message)
     context: Any = SimpleNamespace()
 

--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -3,7 +3,10 @@ import re
 from typing import cast
 
 from telegram.ext import ApplicationBuilder, MessageHandler, filters
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.utils.ui import (
+    REMINDERS_BUTTON_TEXT,
+    menu_keyboard,
+)
 import services.api.app.diabetes.handlers.registration as handlers
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
@@ -14,7 +17,7 @@ def test_reminders_button_matches_regex() -> None:
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
     button_texts = [btn.text for row in menu_keyboard.keyboard for btn in row]
-    assert "⏰ Напоминания" in button_texts
+    assert REMINDERS_BUTTON_TEXT in button_texts
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
     handlers.register_handlers(app)
@@ -25,5 +28,5 @@ def test_reminders_button_matches_regex() -> None:
         and h.callback is reminder_handlers.reminders_list
     )
     pattern = cast(filters.Regex, reminder_handler.filters).pattern.pattern
-    assert pattern == "^⏰ Напоминания$"
-    assert re.fullmatch(pattern, "⏰ Напоминания")
+    assert pattern == f"^{REMINDERS_BUTTON_TEXT}$"
+    assert re.fullmatch(pattern, REMINDERS_BUTTON_TEXT)

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -18,7 +18,7 @@ import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
 import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
 import services.api.app.diabetes.handlers.registration as handlers
 from services.api.app.diabetes.services.repository import commit
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.utils.ui import SOS_CONTACT_BUTTON_TEXT, menu_keyboard
 
 
 class DummyMessage:
@@ -164,7 +164,7 @@ async def test_sos_contact_menu_button_starts_conv(
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
     button_texts = [btn.text for row in menu_keyboard.keyboard for btn in row]
-    assert "🆘 SOS контакт" in button_texts
+    assert SOS_CONTACT_BUTTON_TEXT in button_texts
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
     handlers.register_handlers(app)
@@ -175,9 +175,9 @@ async def test_sos_contact_menu_button_starts_conv(
         and h.callback is sos_handlers.sos_contact_start
     )
     pattern = cast(filters.Regex, sos_handler.filters).pattern.pattern
-    assert re.fullmatch(pattern, "🆘 SOS контакт")
+    assert re.fullmatch(pattern, SOS_CONTACT_BUTTON_TEXT)
 
-    message = DummyMessage("🆘 SOS контакт")
+    message = DummyMessage(SOS_CONTACT_BUTTON_TEXT)
     update = cast(Update, SimpleNamespace(message=message))
     context = cast(ContextTypes.DEFAULT_TYPE, SimpleNamespace())
     state = await sos_handler.callback(update, context)

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -7,6 +7,7 @@ from telegram import Update
 
 import pytest
 from telegram.ext import CallbackContext, ConversationHandler, MessageHandler
+from services.api.app.diabetes.utils.ui import BACK_BUTTON_TEXT
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -36,9 +37,9 @@ async def test_sugar_back_fallback_cancels() -> None:
     handler = next(
         h
         for h in dose_calc.sugar_conv.fallbacks
-        if isinstance(h, MessageHandler) and _filter_pattern_equals(h, "^↩️ Назад$")
+        if isinstance(h, MessageHandler) and _filter_pattern_equals(h, f"^{BACK_BUTTON_TEXT}$")
     )
-    message = DummyMessage("↩️ Назад")
+    message = DummyMessage(BACK_BUTTON_TEXT)
     update = cast(
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
@@ -73,6 +74,6 @@ def test_sugar_conv_has_back_fallback() -> None:
     assert any(
         isinstance(h, MessageHandler)
         and h.callback is dose_calc.dose_cancel
-        and _filter_pattern_equals(h, "^↩️ Назад$")
+        and _filter_pattern_equals(h, f"^{BACK_BUTTON_TEXT}$")
         for h in fallbacks
     )


### PR DESCRIPTION
## Summary
- export reusable button text constants from `utils.ui`
- reference these constants in regex patterns instead of hardcoded strings
- update tests to use constants

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab2961b268832a9f488a18b2e7a199