### PR TITLE
[api] return 400 for invalid timezone

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -113,7 +113,7 @@ async def get_timezone(_: UserContext = Depends(require_tg_user)) -> dict[str, s
     try:
         ZoneInfo(tz_row.tz)
     except ZoneInfoNotFoundError as exc:
-        raise HTTPException(status_code=500, detail="invalid timezone entry") from exc
+        raise HTTPException(status_code=400, detail="invalid timezone entry") from exc
     return {"tz": tz_row.tz}
 
 

--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -99,7 +99,7 @@ def test_timezone_partial_file(
 
     with TestClient(server.app) as client:
         resp = client.get("/api/timezone", headers=auth_headers)
-        assert resp.status_code == 500
+        assert resp.status_code == 400
 
 
 def test_timezone_concurrent_writes(


### PR DESCRIPTION
## Summary
- return 400 when stored timezone is invalid
- adjust timezone tests for bad data

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab2965a444832a8151ddeb05530794