### PR TITLE
[api] Init DB at startup

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -42,17 +42,17 @@ from services.api.app.diabetes.utils.openai_utils import dispose_http_client
 
 # ────────── init ──────────
 logger = logging.getLogger(__name__)
-try:
-    init_db()  # создаёт/инициализирует БД
-except (ValueError, SQLAlchemyError) as exc:
-    logger.error("Failed to initialize the database: %s", exc)
-    raise RuntimeError(
-        "Database initialization failed. Please check your configuration and try again."
-    ) from exc
 
 
 @asynccontextmanager
 async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    try:
+        init_db()  # создаёт/инициализирует БД
+    except (ValueError, SQLAlchemyError) as exc:
+        logger.error("Failed to initialize the database: %s", exc)
+        raise RuntimeError(
+            "Database initialization failed. Please check your configuration and try again."
+        ) from exc
     yield
     dispose_http_client()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,17 @@ setattr(sqlalchemy, "create_engine", _tracking_create_engine)
 db_module.init_db = lambda: None
 
 
+@pytest.fixture(autouse=True)
+def _reset_init_db() -> Iterator[None]:
+    yield
+    from services.api.app.diabetes.services import db as db_module
+    db_module.init_db = lambda: None
+    import sys
+    main_module = sys.modules.get("services.api.app.main")
+    if main_module is not None:
+        setattr(main_module, "init_db", db_module.init_db)
+
+
 @pytest.fixture(autouse=True, scope="session")
 def _build_ui_assets() -> Iterator[None]:
     """Build webapp UI if static assets are missing."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,3 +26,4 @@ def test_init_db_raises_when_no_password(monkeypatch: pytest.MonkeyPatch) -> Non
     assert config.get_db_password() is None
     with pytest.raises(ValueError):
         db.init_db()
+    db.init_db = lambda: None

--- a/tests/test_webapp_server_startup.py
+++ b/tests/test_webapp_server_startup.py
@@ -1,5 +1,6 @@
 """Tests for API server startup checks."""
 
+import asyncio
 import importlib
 from pathlib import Path
 
@@ -25,4 +26,6 @@ def test_app_import_without_ui(monkeypatch: pytest.MonkeyPatch) -> None:
     from services.api.app.diabetes.services import db
 
     monkeypatch.setattr(db, "init_db", lambda: None)
-    importlib.reload(importlib.import_module("services.api.app.main"))
+    main = importlib.reload(importlib.import_module("services.api.app.main"))
+    asyncio.run(main.app.router.startup())
+    asyncio.run(main.app.router.shutdown())


### PR DESCRIPTION
## Summary
- initialize the database during FastAPI startup via `lifespan`
- ensure server tests trigger startup and reset DB init state

## Testing
- `pytest`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab295f0544832a9adddc46e6aa92cb