### PR TITLE
[ui] centralize button texts and refactor regex

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -29,6 +29,13 @@ from services.api.app.diabetes.utils.ui import (
     confirm_keyboard,
     dose_keyboard,
     menu_keyboard,
+    PHOTO_BUTTON_TEXT,
+    SUGAR_BUTTON_TEXT,
+    DOSE_BUTTON_TEXT,
+    HISTORY_BUTTON_TEXT,
+    REPORT_BUTTON_TEXT,
+    PROFILE_BUTTON_TEXT,
+    BACK_BUTTON_TEXT,
 )
 
 from . import EntryData, UserData
@@ -327,7 +334,7 @@ chat_with_gpt = _gpt_handlers.chat_with_gpt
 dose_conv = ConversationHandler(
     entry_points=[
         CommandHandler("dose", dose_start),
-        MessageHandler(filters.Regex("^💉 Доза инсулина$"), dose_start),
+        MessageHandler(filters.Regex(f"^{DOSE_BUTTON_TEXT}$"), dose_start),
     ],
     states={
         DOSE_METHOD: [
@@ -338,23 +345,23 @@ dose_conv = ConversationHandler(
         DOSE_SUGAR: [MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), dose_sugar)],
     },
     fallbacks=[
-        MessageHandler(filters.Regex("^↩️ Назад$"), dose_cancel),
+        MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), dose_cancel),
         CommandHandler("menu", cast(object, _cancel_then(menu_command))),
         MessageHandler(
-            filters.Regex("^📷 Фото еды$"), cast(object, _cancel_then(photo_prompt))
+            filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), cast(object, _cancel_then(photo_prompt))
         ),
         MessageHandler(
-            filters.Regex("^🩸 Уровень сахара$"),
+            filters.Regex(f"^{SUGAR_BUTTON_TEXT}$"),
             cast(object, _cancel_then(sugar_start)),
         ),
         MessageHandler(
-            filters.Regex("^📊 История$"), cast(object, _cancel_then(history_view))
+            filters.Regex(f"^{HISTORY_BUTTON_TEXT}$"), cast(object, _cancel_then(history_view))
         ),
         MessageHandler(
-            filters.Regex("^📈 Отчёт$"), cast(object, _cancel_then(report_request))
+            filters.Regex(f"^{REPORT_BUTTON_TEXT}$"), cast(object, _cancel_then(report_request))
         ),
         MessageHandler(
-            filters.Regex("^📄 Мой профиль$"), cast(object, _cancel_then(profile_view))
+            filters.Regex(f"^{PROFILE_BUTTON_TEXT}$"), cast(object, _cancel_then(profile_view))
         ),
     ],
 )

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -37,6 +37,7 @@ from services.api.app.diabetes.services.db import SessionLocal, User, Profile, R
 from services.api.app.diabetes.utils.ui import (
     menu_keyboard,
     build_timezone_webapp_button,
+    PHOTO_BUTTON_TEXT,
 )
 from services.api.app.diabetes.services.repository import commit
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -519,7 +520,7 @@ onboarding_conv = ConversationHandler(
     },
     fallbacks=[
         CommandHandler("cancel", onboarding_skip),
-        MessageHandler(filters.Regex("^📷 Фото еды$"), _photo_fallback),
+        MessageHandler(filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), _photo_fallback),
     ],
     per_message=False,
 )

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -30,6 +30,7 @@ from services.api.app.diabetes.services.db import (
     Reminder,
     User,
 )
+from services.api.app.diabetes.utils.ui import BACK_BUTTON_TEXT, PHOTO_BUTTON_TEXT
 
 logger = logging.getLogger(__name__)
 
@@ -854,9 +855,9 @@ profile_conv = ConversationHandler(
         ],
     },
     fallbacks=[
-        MessageHandler(filters.Regex("^↩️ Назад$"), profile_cancel),
+        MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), profile_cancel),
         CommandHandler("cancel", profile_cancel),
-        MessageHandler(filters.Regex("^📷 Фото еды$"), _photo_fallback),
+        MessageHandler(filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), _photo_fallback),
     ],
     # Subsequent steps depend on ``MessageHandler`` for text inputs. Enabling
     # ``per_message=True`` would store state per message and reset the

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -18,6 +18,16 @@ from sqlalchemy.exc import SQLAlchemyError
 from .onboarding_handlers import onboarding_conv, onboarding_poll_answer
 from .common_handlers import menu_command, help_command, smart_input_help
 from .router import callback_router
+from ..utils.ui import (
+    PROFILE_BUTTON_TEXT,
+    REMINDERS_BUTTON_TEXT,
+    REPORT_BUTTON_TEXT,
+    HISTORY_BUTTON_TEXT,
+    PHOTO_BUTTON_TEXT,
+    QUICK_INPUT_BUTTON_TEXT,
+    HELP_BUTTON_TEXT,
+    SOS_BUTTON_TEXT,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +50,7 @@ def register_profile_handlers(
     app.add_handler(profile.profile_webapp_handler)
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex("^📄 Мой профиль$"), profile.profile_view
+            filters.Regex(f"^{PROFILE_BUTTON_TEXT}$"), profile.profile_view
         )
     )
     app.add_handler(
@@ -88,7 +98,7 @@ def register_reminder_handlers(
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex("^⏰ Напоминания$"), reminder_handlers.reminders_list
+            filters.Regex(f"^{REMINDERS_BUTTON_TEXT}$"), reminder_handlers.reminders_list
         )
     )
     app.add_handler(
@@ -166,32 +176,32 @@ def register_handlers(
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex("^📈 Отчёт$"), reporting_handlers.report_request
+            filters.Regex(f"^{REPORT_BUTTON_TEXT}$"), reporting_handlers.report_request
         )
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex("^📊 История$"), reporting_handlers.history_view
+            filters.Regex(f"^{HISTORY_BUTTON_TEXT}$"), reporting_handlers.history_view
         )
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex("^📷 Фото еды$"), photo_handlers.photo_prompt
+            filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), photo_handlers.photo_prompt
         )
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex("^🕹 Быстрый ввод$"), smart_input_help
+            filters.Regex(f"^{QUICK_INPUT_BUTTON_TEXT}$"), smart_input_help
         )
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex("^ℹ️ Помощь$"), help_command
+            filters.Regex(f"^{HELP_BUTTON_TEXT}$"), help_command
         )
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex("^🆘 SOS контакт$"), sos_handlers.sos_contact_start
+            filters.Regex(f"^{SOS_BUTTON_TEXT}$"), sos_handlers.sos_contact_start
         )
     )
     app.add_handler(

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -33,7 +33,7 @@ from services.api.app.diabetes.services.reporting import (
     make_sugar_plot,
     generate_pdf_report,
 )
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.utils.ui import menu_keyboard, BACK_BUTTON_TEXT
 from . import UserData
 
 logger = logging.getLogger(__name__)
@@ -88,7 +88,7 @@ def report_keyboard() -> InlineKeyboardMarkup:
             InlineKeyboardButton("Месяц", callback_data="report_period:month"),
             InlineKeyboardButton("Произвольно", callback_data="report_period:custom"),
         ],
-        [InlineKeyboardButton("↩️ Назад", callback_data="report_back")],
+        [InlineKeyboardButton(BACK_BUTTON_TEXT, callback_data="report_back")],
     ]
     return InlineKeyboardMarkup(rows)
 
@@ -193,7 +193,7 @@ async def report_period_callback(
             await message.reply_text(
                 "Ожидаю дату…",
                 reply_markup=ReplyKeyboardMarkup(
-                    [[KeyboardButton("↩️ Назад")]],
+                    [[KeyboardButton(BACK_BUTTON_TEXT)]],
                     resize_keyboard=True,
                     one_time_keyboard=True,
                 ),

--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -14,7 +14,12 @@ from telegram.ext import (
 )
 
 from services.api.app.diabetes.services.db import SessionLocal, Profile
-from services.api.app.diabetes.utils.ui import back_keyboard, menu_keyboard
+from services.api.app.diabetes.utils.ui import (
+    back_keyboard,
+    menu_keyboard,
+    BACK_BUTTON_TEXT,
+    PHOTO_BUTTON_TEXT,
+)
 from services.api.app.diabetes.services.repository import commit
 from . import dose_calc, _cancel_then
 
@@ -103,10 +108,10 @@ sos_contact_conv = ConversationHandler(
     entry_points=[CommandHandler("soscontact", sos_contact_start)],
     states={SOS_CONTACT: [MessageHandler(filters.TEXT & ~filters.COMMAND, sos_contact_save)]},
     fallbacks=[
-        MessageHandler(filters.Regex("^↩️ Назад$"), sos_contact_cancel),
+        MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), sos_contact_cancel),
         CommandHandler("cancel", sos_contact_cancel),
         MessageHandler(
-            filters.Regex("^📷 Фото еды$"),
+            filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"),
             _cancel_then(dose_calc.photo_prompt),
         ),
     ],

--- a/services/api/app/diabetes/handlers/sugar_handlers.py
+++ b/services/api/app/diabetes/handlers/sugar_handlers.py
@@ -16,7 +16,13 @@ from sqlalchemy.orm import Session
 from services.api.app.diabetes.services.db import Entry, SessionLocal
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.functions import _safe_float
-from services.api.app.diabetes.utils.ui import menu_keyboard, sugar_keyboard
+from services.api.app.diabetes.utils.ui import (
+    menu_keyboard,
+    sugar_keyboard,
+    SUGAR_BUTTON_TEXT,
+    BACK_BUTTON_TEXT,
+    PHOTO_BUTTON_TEXT,
+)
 
 from . import EntryData, UserData
 from .alert_handlers import check_alert
@@ -133,16 +139,16 @@ prompt_sugar = sugar_start
 sugar_conv = ConversationHandler(
     entry_points=[
         CommandHandler("sugar", sugar_start),
-        MessageHandler(filters.Regex("^🩸 Уровень сахара$"), sugar_start),
+        MessageHandler(filters.Regex(f"^{SUGAR_BUTTON_TEXT}$"), sugar_start),
     ],
     states={
         SUGAR_VAL: [MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), sugar_val)],
     },
     fallbacks=[
-        MessageHandler(filters.Regex("^↩️ Назад$"), dose_cancel),
+        MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), dose_cancel),
         CommandHandler("menu", cast(object, _cancel_then(menu_command))),
         MessageHandler(
-            filters.Regex("^📷 Фото еды$"), cast(object, _cancel_then(photo_prompt))
+            filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), cast(object, _cancel_then(photo_prompt))
         ),
     ],
 )

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -16,6 +16,20 @@ from telegram import (
 )
 from services.api.app import config
 
+PROFILE_BUTTON_TEXT = "📄 Мой профиль"
+REMINDERS_BUTTON_TEXT = "⏰ Напоминания"
+PHOTO_BUTTON_TEXT = "📷 Фото еды"
+SUGAR_BUTTON_TEXT = "🩸 Уровень сахара"
+DOSE_BUTTON_TEXT = "💉 Доза инсулина"
+HISTORY_BUTTON_TEXT = "📊 История"
+REPORT_BUTTON_TEXT = "📈 Отчёт"
+QUICK_INPUT_BUTTON_TEXT = "🕹 Быстрый ввод"
+HELP_BUTTON_TEXT = "ℹ️ Помощь"
+SOS_BUTTON_TEXT = "🆘 SOS контакт"
+BACK_BUTTON_TEXT = "↩️ Назад"
+XE_BUTTON_TEXT = "ХЕ"
+CARBS_BUTTON_TEXT = "Углеводы"
+
 __all__ = (
     "menu_keyboard",
     "dose_keyboard",
@@ -23,6 +37,19 @@ __all__ = (
     "confirm_keyboard",
     "back_keyboard",
     "build_timezone_webapp_button",
+    "PROFILE_BUTTON_TEXT",
+    "REMINDERS_BUTTON_TEXT",
+    "PHOTO_BUTTON_TEXT",
+    "SUGAR_BUTTON_TEXT",
+    "DOSE_BUTTON_TEXT",
+    "HISTORY_BUTTON_TEXT",
+    "REPORT_BUTTON_TEXT",
+    "QUICK_INPUT_BUTTON_TEXT",
+    "HELP_BUTTON_TEXT",
+    "SOS_BUTTON_TEXT",
+    "BACK_BUTTON_TEXT",
+    "XE_BUTTON_TEXT",
+    "CARBS_BUTTON_TEXT",
 )
 
 
@@ -43,25 +70,25 @@ def menu_keyboard() -> ReplyKeyboardMarkup:
     webapp_url = _webapp_url()
     profile_button = (
         KeyboardButton(
-            "📄 Мой профиль", web_app=WebAppInfo(f"{webapp_url}/profile")
+            PROFILE_BUTTON_TEXT, web_app=WebAppInfo(f"{webapp_url}/profile")
         )
         if webapp_url
-        else KeyboardButton("📄 Мой профиль")
+        else KeyboardButton(PROFILE_BUTTON_TEXT)
     )
     reminders_button = (
         KeyboardButton(
-            "⏰ Напоминания", web_app=WebAppInfo(f"{webapp_url}/reminders")
+            REMINDERS_BUTTON_TEXT, web_app=WebAppInfo(f"{webapp_url}/reminders")
         )
         if webapp_url
-        else KeyboardButton("⏰ Напоминания")
+        else KeyboardButton(REMINDERS_BUTTON_TEXT)
     )
     return ReplyKeyboardMarkup(
         keyboard=[
-            [KeyboardButton("📷 Фото еды"), KeyboardButton("🩸 Уровень сахара")],
-            [KeyboardButton("💉 Доза инсулина"), KeyboardButton("📊 История")],
-            [KeyboardButton("📈 Отчёт"), profile_button],
-            [KeyboardButton("🕹 Быстрый ввод"), KeyboardButton("ℹ️ Помощь")],
-            [reminders_button, KeyboardButton("🆘 SOS контакт")],
+            [KeyboardButton(PHOTO_BUTTON_TEXT), KeyboardButton(SUGAR_BUTTON_TEXT)],
+            [KeyboardButton(DOSE_BUTTON_TEXT), KeyboardButton(HISTORY_BUTTON_TEXT)],
+            [KeyboardButton(REPORT_BUTTON_TEXT), profile_button],
+            [KeyboardButton(QUICK_INPUT_BUTTON_TEXT), KeyboardButton(HELP_BUTTON_TEXT)],
+            [reminders_button, KeyboardButton(SOS_BUTTON_TEXT)],
         ],
         resize_keyboard=True,
         one_time_keyboard=False,
@@ -70,8 +97,8 @@ def menu_keyboard() -> ReplyKeyboardMarkup:
 
 dose_keyboard = ReplyKeyboardMarkup(
     keyboard=[
-        [KeyboardButton("ХЕ"), KeyboardButton("Углеводы")],
-        [KeyboardButton("↩️ Назад")],
+        [KeyboardButton(XE_BUTTON_TEXT), KeyboardButton(CARBS_BUTTON_TEXT)],
+        [KeyboardButton(BACK_BUTTON_TEXT)],
     ],
     resize_keyboard=True,
     one_time_keyboard=True,
@@ -79,14 +106,14 @@ dose_keyboard = ReplyKeyboardMarkup(
 )
 
 sugar_keyboard = ReplyKeyboardMarkup(
-    keyboard=[[KeyboardButton("↩️ Назад")]],
+    keyboard=[[KeyboardButton(BACK_BUTTON_TEXT)]],
     resize_keyboard=True,
     one_time_keyboard=True,
     input_field_placeholder="Введите уровень сахара…",
 )
 
 back_keyboard = ReplyKeyboardMarkup(
-    keyboard=[[KeyboardButton("↩️ Назад")]],
+    keyboard=[[KeyboardButton(BACK_BUTTON_TEXT)]],
     resize_keyboard=True,
     one_time_keyboard=True,
 )

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -13,6 +13,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import dose_calc
+from services.api.app.diabetes.utils.ui import PHOTO_BUTTON_TEXT
 
 
 def _find_handler(
@@ -48,8 +49,8 @@ class DummyMessage:
 
 @pytest.mark.asyncio
 async def test_photo_button_cancels_and_prompts_photo() -> None:
-    handler = _find_handler(dose_calc.dose_conv.fallbacks, "^📷 Фото еды$")
-    message = DummyMessage("📷 Фото еды")
+    handler = _find_handler(dose_calc.dose_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$")
+    message = DummyMessage(PHOTO_BUTTON_TEXT)
     update = cast(
         Update,
         SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -6,6 +6,7 @@ from telegram import Update
 from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.common_handlers as handlers
+from services.api.app.diabetes.utils.ui import REMINDERS_BUTTON_TEXT
 
 
 class DummyMessage:
@@ -81,7 +82,7 @@ async def test_help_lists_reminder_commands_and_menu_button() -> None:
     assert "/reminders - список напоминаний\n" in text
     assert "/addreminder - добавить напоминание\n" in text
     assert "/delreminder - удалить напоминание\n" in text
-    assert "⏰ Напоминания\n" in text
+    assert f"{REMINDERS_BUTTON_TEXT}\n" in text
 
 
 @pytest.mark.asyncio

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -10,6 +10,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import dose_calc
+from services.api.app.diabetes.utils.ui import PHOTO_BUTTON_TEXT
 
 
 class DummyMessage:
@@ -56,7 +57,7 @@ async def test_sugar_conv_menu_then_photo() -> None:
     assert any("выберите" in r.lower() for r in message.replies[1:])
     assert context.user_data == {}
 
-    next_message = DummyMessage("📷 Фото еды")
+    next_message = DummyMessage(PHOTO_BUTTON_TEXT)
     next_update = cast(
         Update,
         SimpleNamespace(message=next_message, effective_user=SimpleNamespace(id=1)),
@@ -88,7 +89,7 @@ async def test_dose_conv_menu_then_photo() -> None:
     assert any("выберите" in r.lower() for r in message.replies[1:])
     assert context.user_data == {}
 
-    next_message = DummyMessage("📷 Фото еды")
+    next_message = DummyMessage(PHOTO_BUTTON_TEXT)
     next_update = cast(
         Update,
         SimpleNamespace(message=next_message, effective_user=SimpleNamespace(id=1)),

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -19,8 +19,8 @@ def test_menu_keyboard_webapp_urls(monkeypatch: pytest.MonkeyPatch, base_url: st
     importlib.reload(ui)
 
     buttons = [btn for row in ui.menu_keyboard().keyboard for btn in row]
-    profile_btn = next(b for b in buttons if b.text == "📄 Мой профиль")
-    reminders_btn = next(b for b in buttons if b.text == "⏰ Напоминания")
+    profile_btn = next(b for b in buttons if b.text == ui.PROFILE_BUTTON_TEXT)
+    reminders_btn = next(b for b in buttons if b.text == ui.REMINDERS_BUTTON_TEXT)
 
     assert profile_btn.web_app is not None
     assert urlparse(profile_btn.web_app.url).path == "/profile"

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -19,6 +19,7 @@ from services.api.app.diabetes.handlers import (
     onboarding_handlers,
     sos_handlers,
 )
+from services.api.app.diabetes.utils.ui import PHOTO_BUTTON_TEXT
 
 
 def _find_handler(
@@ -57,7 +58,7 @@ async def _exercise(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
     ],
 ) -> None:
-    message = DummyMessage("📷 Фото еды")
+    message = DummyMessage(PHOTO_BUTTON_TEXT)
     update = cast(
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
@@ -75,25 +76,29 @@ async def _exercise(
 
 @pytest.mark.asyncio
 async def test_profile_conv_photo_fallback() -> None:
-    handler = _find_handler(profile_handlers.profile_conv.fallbacks, "^📷 Фото еды$")
+    handler = _find_handler(
+        profile_handlers.profile_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$"
+    )
     await _exercise(handler)
 
 
 @pytest.mark.asyncio
 async def test_sugar_conv_photo_fallback() -> None:
-    handler = _find_handler(dose_calc.sugar_conv.fallbacks, "^📷 Фото еды$")
+    handler = _find_handler(dose_calc.sugar_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$")
     await _exercise(handler)
 
 
 @pytest.mark.asyncio
 async def test_onboarding_conv_photo_fallback() -> None:
     handler = _find_handler(
-        onboarding_handlers.onboarding_conv.fallbacks, "^📷 Фото еды$"
+        onboarding_handlers.onboarding_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$"
     )
     await _exercise(handler)
 
 
 @pytest.mark.asyncio
 async def test_sos_contact_conv_photo_fallback() -> None:
-    handler = _find_handler(sos_handlers.sos_contact_conv.fallbacks, "^📷 Фото еды$")
+    handler = _find_handler(
+        sos_handlers.sos_contact_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$"
+    )
     await _exercise(handler)

--- a/tests/test_quick_input_help_button.py
+++ b/tests/test_quick_input_help_button.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import services.api.app.diabetes.handlers.common_handlers as handlers
+from services.api.app.diabetes.utils.ui import QUICK_INPUT_BUTTON_TEXT
 
 
 class DummyMessage:
@@ -20,7 +21,7 @@ class DummyMessage:
 async def test_quick_input_help_button() -> None:
     """Simulate the "🕹 Быстрый ввод" menu button and verify the hint."""
 
-    message = DummyMessage("🕹 Быстрый ввод")
+    message = DummyMessage(QUICK_INPUT_BUTTON_TEXT)
     update: Any = SimpleNamespace(message=message)
     context: Any = SimpleNamespace()
 

--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -3,7 +3,7 @@ import re
 from typing import cast
 
 from telegram.ext import ApplicationBuilder, MessageHandler, filters
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.utils.ui import menu_keyboard, REMINDERS_BUTTON_TEXT
 import services.api.app.diabetes.handlers.registration as handlers
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
@@ -14,7 +14,7 @@ def test_reminders_button_matches_regex() -> None:
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
     button_texts = [btn.text for row in menu_keyboard().keyboard for btn in row]
-    assert "⏰ Напоминания" in button_texts
+    assert REMINDERS_BUTTON_TEXT in button_texts
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
     handlers.register_handlers(app)
@@ -25,5 +25,5 @@ def test_reminders_button_matches_regex() -> None:
         and h.callback is reminder_handlers.reminders_list
     )
     pattern = cast(filters.Regex, reminder_handler.filters).pattern.pattern
-    assert pattern == "^⏰ Напоминания$"
-    assert re.fullmatch(pattern, "⏰ Напоминания")
+    assert pattern == f"^{REMINDERS_BUTTON_TEXT}$"
+    assert re.fullmatch(pattern, REMINDERS_BUTTON_TEXT)

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -18,7 +18,7 @@ import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
 import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
 import services.api.app.diabetes.handlers.registration as handlers
 from services.api.app.diabetes.services.repository import commit
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.utils.ui import menu_keyboard, SOS_BUTTON_TEXT
 
 
 class DummyMessage:
@@ -164,7 +164,7 @@ async def test_sos_contact_menu_button_starts_conv(
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
     button_texts = [btn.text for row in menu_keyboard().keyboard for btn in row]
-    assert "🆘 SOS контакт" in button_texts
+    assert SOS_BUTTON_TEXT in button_texts
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
     handlers.register_handlers(app)
@@ -175,9 +175,9 @@ async def test_sos_contact_menu_button_starts_conv(
         and h.callback is sos_handlers.sos_contact_start
     )
     pattern = cast(filters.Regex, sos_handler.filters).pattern.pattern
-    assert re.fullmatch(pattern, "🆘 SOS контакт")
+    assert re.fullmatch(pattern, SOS_BUTTON_TEXT)
 
-    message = DummyMessage("🆘 SOS контакт")
+    message = DummyMessage(SOS_BUTTON_TEXT)
     update = cast(Update, SimpleNamespace(message=message))
     context = cast(ContextTypes.DEFAULT_TYPE, SimpleNamespace())
     state = await sos_handler.callback(update, context)

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -12,6 +12,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import dose_calc
+from services.api.app.diabetes.utils.ui import BACK_BUTTON_TEXT
 
 
 def _filter_pattern_equals(h: Any, regex: str) -> bool:
@@ -36,9 +37,11 @@ async def test_sugar_back_fallback_cancels() -> None:
     handler = next(
         h
         for h in dose_calc.sugar_conv.fallbacks
-        if isinstance(h, MessageHandler) and _filter_pattern_equals(h, "^↩️ Назад$")
+        if isinstance(h, MessageHandler) and _filter_pattern_equals(
+            h, f"^{BACK_BUTTON_TEXT}$"
+        )
     )
-    message = DummyMessage("↩️ Назад")
+    message = DummyMessage(BACK_BUTTON_TEXT)
     update = cast(
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
@@ -73,6 +76,6 @@ def test_sugar_conv_has_back_fallback() -> None:
     assert any(
         isinstance(h, MessageHandler)
         and h.callback is dose_calc.dose_cancel
-        and _filter_pattern_equals(h, "^↩️ Назад$")
+        and _filter_pattern_equals(h, f"^{BACK_BUTTON_TEXT}$")
         for h in fallbacks
     )


### PR DESCRIPTION
## Summary
- export menu button text constants from `utils.ui`
- reuse button constants in regex-based handlers
- update tests to reference shared constants

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab2d93444c832ab134ae0aa37f4b8f