### PR TITLE
[handlers] import SOS fallbacks text constants

### DIFF
--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -15,7 +15,12 @@ from telegram.ext import (
 
 from services.api.app.diabetes.services.db import SessionLocal, Profile
 
-from services.api.app.diabetes.utils.ui import back_keyboard, menu_keyboard
+from services.api.app.diabetes.utils.ui import (
+    BACK_BUTTON_TEXT,
+    PHOTO_BUTTON_TEXT,
+    back_keyboard,
+    menu_keyboard,
+)
 from services.api.app.diabetes.services.repository import CommitError, commit
 
 from . import dose_calc, _cancel_then


### PR DESCRIPTION
## Summary
- Import BACK_BUTTON_TEXT and PHOTO_BUTTON_TEXT constants for SOS handler fallbacks

## Testing
- `ruff check services/api/app/diabetes/handlers/sos_handlers.py`
- `mypy --strict services/api/app/diabetes/handlers/sos_handlers.py`
- `pytest tests/test_photo_fallbacks.py::test_sos_fallback -q` *(fails: no matching test)*
- `python -m services.bot.main` *(fails: DB_PASSWORD environment variable must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68ab32ec01a0832a811898a1be039d22