### PR TITLE
[config] add get_webapp_url helper

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -93,3 +93,10 @@ def get_db_password() -> Optional[str]:
     """
 
     return os.environ.get("DB_PASSWORD")
+
+
+def get_webapp_url() -> str | None:
+    """Return ``WEBAPP_URL`` from the environment without a trailing slash."""
+
+    url = os.getenv("WEBAPP_URL")
+    return url.rstrip("/") if url else None

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -223,7 +223,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     profile = fetch_profile(api, ApiException, user_id)
 
     if not profile:
-        if config.settings.webapp_url:
+        if config.get_webapp_url():
             keyboard = InlineKeyboardMarkup(
                 [
                     [
@@ -260,7 +260,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         [InlineKeyboardButton("🌐 Часовой пояс", callback_data="profile_timezone")],
         [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
     ]
-    if config.settings.webapp_url:
+    if config.get_webapp_url():
         rows.insert(
             1,
             [
@@ -510,7 +510,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
         await sos_handlers.sos_contact_start(update, context)
         return
-    if action == "add" and config.settings.webapp_url:
+    if action == "add" and config.get_webapp_url():
         button = InlineKeyboardButton(
             "📝 Новое",
             web_app=WebAppInfo(reminder_handlers.build_webapp_url("/reminders")),

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -66,15 +66,14 @@ PLAN_LIMITS = {"free": 5, "pro": 10}
 def build_webapp_url(path: str) -> str:
     """Build an absolute webapp URL from ``path``.
 
-    Raises ``RuntimeError`` if ``config.settings.webapp_url`` is not configured.
+    Raises ``RuntimeError`` if ``WEBAPP_URL`` is not configured.
     """
-    base_url = config.settings.webapp_url
+    base_url = config.get_webapp_url()
     if not base_url:
         raise RuntimeError("WEBAPP_URL not configured")
-    base = base_url.rstrip("/")
     if not path.startswith("/"):
         path = "/" + path
-    return base + path
+    return base_url + path
 
 
 # Map reminder type codes to display names
@@ -170,8 +169,9 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
     if active_count > limit:
         header += " ⚠️"
 
+    webapp_url = config.get_webapp_url()
     add_button_row = None
-    if config.settings.webapp_url:
+    if webapp_url:
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
@@ -181,7 +181,7 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
     if not rems:
         text = header
 
-        if config.settings.webapp_url and add_button_row is not None:
+        if webapp_url and add_button_row is not None:
             text += "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
             return text, InlineKeyboardMarkup([add_button_row])
         text += "\nУ вас нет напоминаний. Отправьте /addreminder."
@@ -198,7 +198,7 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
         line = f"{r.id}. {title}"
         status_icon = "🔔" if r.is_enabled else "🔕"
         row: list[InlineKeyboardButton] = []
-        if config.settings.webapp_url:
+        if webapp_url:
             row.append(
                 InlineKeyboardButton(
                     "✏️",

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -53,21 +53,14 @@ __all__ = (
 )
 
 
-def _webapp_url() -> str | None:
-    """Return ``settings.webapp_url`` without a trailing slash."""
-
-    url = config.settings.webapp_url
-    return url.rstrip("/") if url else None
-
-
 def menu_keyboard() -> ReplyKeyboardMarkup:
     """Build the main menu keyboard.
 
-    ``settings.webapp_url`` is read at call time to determine whether WebApp
-    buttons should be used for profile and reminders.
+    ``config.get_webapp_url()`` is read at call time to determine whether
+    WebApp buttons should be used for profile and reminders.
     """
 
-    webapp_url = _webapp_url()
+    webapp_url = config.get_webapp_url()
     profile_button = (
         KeyboardButton(
             PROFILE_BUTTON_TEXT, web_app=WebAppInfo(f"{webapp_url}/profile")
@@ -155,7 +148,7 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
         Button instance when ``WEBAPP_URL`` is set and valid, otherwise ``None``.
     """
 
-    webapp_url = _webapp_url()
+    webapp_url = config.get_webapp_url()
     if not webapp_url:
         return None
 

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -257,16 +257,9 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from urllib.parse import urlparse
-    import importlib
-    import services.api.app.config as config
-    import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
     import services.api.app.diabetes.handlers.profile as handlers
 
     monkeypatch.setenv("WEBAPP_URL", "https://example.com")
-    importlib.reload(config)
-    importlib.reload(reminder_handlers)
-    importlib.reload(handlers.reminder_handlers)
-    handlers.config = config
     monkeypatch.setattr(handlers, "get_api", lambda: (object(), Exception, None))
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: None)
 

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -1,22 +1,14 @@
-import importlib
 from urllib.parse import urlparse
 
 import pytest
 
+import services.api.app.diabetes.utils.ui as ui
 
-@pytest.mark.parametrize(
-    "base_url",
-    ["https://example.com", "https://example.com/"],
-)
+
+@pytest.mark.parametrize("base_url", ["https://example.com", "https://example.com/"])
 def test_menu_keyboard_webapp_urls(monkeypatch: pytest.MonkeyPatch, base_url: str) -> None:
     """Menu buttons should open webapp paths for profile and reminders."""
     monkeypatch.setenv("WEBAPP_URL", base_url)
-
-    import services.api.app.config as config
-    import services.api.app.diabetes.utils.ui as ui
-
-    importlib.reload(config)
-    importlib.reload(ui)
 
     buttons = [btn for row in ui.menu_keyboard().keyboard for btn in row]
     profile_btn = next(b for b in buttons if b.text == ui.PROFILE_BUTTON_TEXT)
@@ -26,7 +18,3 @@ def test_menu_keyboard_webapp_urls(monkeypatch: pytest.MonkeyPatch, base_url: st
     assert urlparse(profile_btn.web_app.url).path == "/profile"
     assert reminders_btn.web_app is not None
     assert urlparse(reminders_btn.web_app.url).path == "/reminders"
-
-    monkeypatch.delenv("WEBAPP_URL", raising=False)
-    importlib.reload(config)
-    importlib.reload(ui)

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -11,7 +11,6 @@ from services.api.app.diabetes.handlers import profile as handlers
 from services.api.app.diabetes.services.repository import commit
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
-from services.api.app import config
 
 
 class DummyMessage:
@@ -229,8 +228,7 @@ async def test_profile_security_add_delete_calls_handlers(
 
     monkeypatch.setattr(reminder_handlers, "delete_reminder", fake_del)
 
-    monkeypatch.setattr(config.settings, "webapp_url", "http://example")
-    monkeypatch.setattr(reminder_handlers.config.settings, "webapp_url", "http://example")
+    monkeypatch.setenv("WEBAPP_URL", "http://example")
     query_add = DummyQuery(DummyMessage(), "profile_security:add")
     update_add = cast(
         Any,

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -15,8 +15,6 @@ from sqlalchemy.pool import StaticPool
 from telegram import Message, Update, User
 from telegram.ext import CallbackContext, Job
 
-# Ensure handlers use current settings after config reloads
-from services.api.app import config
 import services.api.app.diabetes.handlers.reminder_handlers as handlers
 import services.api.app.diabetes.handlers.router as router
 from services.api.app.diabetes.services.db import (
@@ -234,13 +232,6 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
     monkeypatch.setenv("WEBAPP_URL", "https://example.org")
-    import importlib
-    import services.api.app.config as config_module
-
-    importlib.reload(config_module)
-    global config
-    config = config_module
-    importlib.reload(handlers)
     monkeypatch.setattr(handlers, "_limit_for", lambda u: 1)
     # Make _describe deterministic and include status icon to test strikethrough
     monkeypatch.setattr(
@@ -293,7 +284,7 @@ def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.setattr(config.settings, "webapp_url", None)
+    monkeypatch.delenv("WEBAPP_URL", raising=False)
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
@@ -314,7 +305,7 @@ def test_render_reminders_no_entries_no_webapp(monkeypatch: pytest.MonkeyPatch) 
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.setattr(config.settings, "webapp_url", None)
+    monkeypatch.delenv("WEBAPP_URL", raising=False)
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.commit()
@@ -330,7 +321,7 @@ async def test_reminders_list_no_keyboard(monkeypatch: pytest.MonkeyPatch) -> No
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.setattr(config.settings, "webapp_url", None)
+    monkeypatch.delenv("WEBAPP_URL", raising=False)
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.commit()
@@ -362,7 +353,7 @@ async def test_reminders_list_keyboard_no_webapp(
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.setattr(config.settings, "webapp_url", None)
+    monkeypatch.delenv("WEBAPP_URL", raising=False)
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0)))

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -1,25 +1,15 @@
 import pytest
-
-import importlib
 from urllib.parse import urlparse
+
+import services.api.app.diabetes.utils.ui as ui
 
 
 def test_timezone_button_webapp_url(monkeypatch: pytest.MonkeyPatch) -> None:
     """Timezone button should open webapp path for timezone detection."""
     monkeypatch.setenv("WEBAPP_URL", "https://example.com")
 
-    import services.api.app.config as config
-    import services.api.app.diabetes.utils.ui as ui
-
-    importlib.reload(config)
-    importlib.reload(ui)
-
     button = ui.build_timezone_webapp_button()
     assert button is not None
     web_app = button.web_app
     assert web_app is not None
     assert urlparse(web_app.url).path == "/timezone"
-
-    monkeypatch.delenv("WEBAPP_URL", raising=False)
-    importlib.reload(config)
-    importlib.reload(ui)


### PR DESCRIPTION
## Summary
- add `get_webapp_url` helper to read WEBAPP_URL from env without trailing slash
- use helper across UI and reminder/profile handlers
- simplify tests to set WEBAPP_URL via monkeypatch instead of reloading modules

## Testing
- `pytest -q`
- `mypy --strict services/api/app/config.py services/api/app/diabetes/utils/ui.py services/api/app/diabetes/handlers/reminder_handlers.py services/api/app/diabetes/handlers/profile/conversation.py tests/test_menu_keyboard_webapp.py tests/test_timezone_button_webapp.py tests/test_reminder_handlers.py tests/test_reminders.py tests/test_profile_security.py tests/test_handlers_profile.py`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68ab387cf330832abca442252b6ea9a3