### PR TITLE
[parser] Allow commands without fields

### DIFF
--- a/services/api/app/schemas/command.py
+++ b/services/api/app/schemas/command.py
@@ -11,4 +11,4 @@ class CommandSchema(BaseModel):
     action: str
     entry_date: Optional[str] = None
     time: Optional[str] = None
-    fields: dict[str, object]
+    fields: Optional[dict[str, object]] = None

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -151,6 +151,29 @@ async def test_parse_command_with_array_multiple_objects(
 
 
 @pytest.mark.asyncio
+async def test_parse_command_without_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        choices = [
+            type(
+                "Choice",
+                (),
+                {"message": type("Msg", (), {"content": '{"action":"get_day_summary"}'})()},
+            )
+        ]
+
+    async def create(*args: Any, **kwargs: Any) -> Any:
+        return FakeResponse()
+
+    monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)
+
+    result = await gpt_command_parser.parse_command("test")
+
+    assert result == {"action": "get_day_summary"}
+
+
+@pytest.mark.asyncio
 async def test_parse_command_with_multiple_json_objects(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- make `fields` optional in command schema
- allow GPT to omit fields and validate commands accordingly
- add coverage for commands without parameters

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab3a3fe82c832abb18c8b7c09f4668