### PR TITLE
[bot] Simplify chat menu button

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -6,7 +6,7 @@ Bot entry point and configuration.
 import logging
 import os
 import sys
-from typing import Any, cast
+from typing import Any
 
 from telegram import BotCommand, MenuButtonWebApp, WebAppInfo
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
@@ -51,13 +51,8 @@ async def post_init(
     if not webapp_url:
         logger.warning("WEBAPP_URL not configured, skip ChatMenuButton")
         return
-    menu = [
-        MenuButtonWebApp("⏰", WebAppInfo(url=f"{webapp_url}/reminders")),
-        MenuButtonWebApp("📊", WebAppInfo(url=f"{webapp_url}/stats")),
-        MenuButtonWebApp("📄", WebAppInfo(url=f"{webapp_url}/profile")),
-        MenuButtonWebApp("💳", WebAppInfo(url=f"{webapp_url}/billing")),
-    ]
-    await app.bot.set_chat_menu_button(menu_button=cast(Any, menu))
+    menu = MenuButtonWebApp("Menu", WebAppInfo(url=f"{webapp_url}/reminders"))
+    await app.bot.set_chat_menu_button(menu_button=menu)
 
 
 async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from telegram import MenuButtonWebApp
 
 from services.bot.main import commands, post_init
 
@@ -26,12 +27,9 @@ async def test_post_init_sets_chat_menu_button(
     bot.set_my_commands.assert_awaited_once_with(commands)
     bot.set_chat_menu_button.assert_awaited_once()
     menu = bot.set_chat_menu_button.call_args.kwargs["menu_button"]
-    assert [b.web_app.url for b in menu] == [
-        "https://app.example/reminders",
-        "https://app.example/stats",
-        "https://app.example/profile",
-        "https://app.example/billing",
-    ]
+    assert isinstance(menu, MenuButtonWebApp)
+    assert menu.web_app is not None
+    assert menu.web_app.url == "https://app.example/reminders"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace list of chat menu buttons with a single WebApp link
- adjust chat menu button test for new API use

## Testing
- `pytest tests/test_chat_menu_button.py tests/test_menu_button.py -q --cov-fail-under=0`
- `mypy --strict services/bot/main.py tests/test_chat_menu_button.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab3ed6164c832aa1b4e2291ad9d6d8