### PR TITLE
[menu] update menu URLs to history and subscription

### DIFF
--- a/services/api/app/menu_button.py
+++ b/services/api/app/menu_button.py
@@ -30,9 +30,9 @@ async def post_init(
     base_url = base_url.rstrip("/")
     buttons: list[MenuButtonWebApp] = [
         MenuButtonWebApp("Reminders", WebAppInfo(f"{base_url}/reminders")),
-        MenuButtonWebApp("Stats", WebAppInfo(f"{base_url}/stats")),
+        MenuButtonWebApp("Stats", WebAppInfo(f"{base_url}/history")),
         MenuButtonWebApp("Profile", WebAppInfo(f"{base_url}/profile")),
-        MenuButtonWebApp("Billing", WebAppInfo(f"{base_url}/billing")),
+        MenuButtonWebApp("Billing", WebAppInfo(f"{base_url}/subscription")),
     ]
     await app.bot.set_chat_menu_button(
         menu_button=cast(MenuButton, buttons)

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -53,9 +53,9 @@ async def post_init(
         return
     menu = [
         MenuButtonWebApp("⏰", WebAppInfo(url=f"{webapp_url}/reminders")),
-        MenuButtonWebApp("📊", WebAppInfo(url=f"{webapp_url}/stats")),
+        MenuButtonWebApp("📊", WebAppInfo(url=f"{webapp_url}/history")),
         MenuButtonWebApp("📄", WebAppInfo(url=f"{webapp_url}/profile")),
-        MenuButtonWebApp("💳", WebAppInfo(url=f"{webapp_url}/billing")),
+        MenuButtonWebApp("💳", WebAppInfo(url=f"{webapp_url}/subscription")),
     ]
     await app.bot.set_chat_menu_button(menu_button=cast(Any, menu))
 

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -28,9 +28,9 @@ async def test_post_init_sets_chat_menu_button(
     menu = bot.set_chat_menu_button.call_args.kwargs["menu_button"]
     assert [b.web_app.url for b in menu] == [
         "https://app.example/reminders",
-        "https://app.example/stats",
+        "https://app.example/history",
         "https://app.example/profile",
-        "https://app.example/billing",
+        "https://app.example/subscription",
     ]
 
 

--- a/tests/test_menu_button.py
+++ b/tests/test_menu_button.py
@@ -35,7 +35,7 @@ async def test_post_init_sets_chat_menu(monkeypatch: pytest.MonkeyPatch) -> None
     buttons = kwargs["menu_button"]
     assert isinstance(buttons, list)
     assert len(buttons) == 4
-    paths = ["/reminders", "/stats", "/profile", "/billing"]
+    paths = ["/reminders", "/history", "/profile", "/subscription"]
     for btn, path in zip(buttons, paths):
         assert isinstance(btn, MenuButtonWebApp)
         assert btn.web_app is not None


### PR DESCRIPTION
## Summary
- replace `/stats` with `/history` and `/billing` with `/subscription` in bot menu
- adjust API menu button and tests for new paths

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab3f0fff54832a8f325925a9373cf6