### PR TITLE
[bot] use single chat menu button

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -6,7 +6,7 @@ Bot entry point and configuration.
 import logging
 import os
 import sys
-from typing import Any, cast
+from typing import Any
 
 from telegram import BotCommand, MenuButtonWebApp, WebAppInfo
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
@@ -51,13 +51,10 @@ async def post_init(
     if not webapp_url:
         logger.warning("WEBAPP_URL not configured, skip ChatMenuButton")
         return
-    menu = [
-        MenuButtonWebApp("⏰", WebAppInfo(url=f"{webapp_url}/reminders")),
-        MenuButtonWebApp("📊", WebAppInfo(url=f"{webapp_url}/stats")),
-        MenuButtonWebApp("📄", WebAppInfo(url=f"{webapp_url}/profile")),
-        MenuButtonWebApp("💳", WebAppInfo(url=f"{webapp_url}/billing")),
-    ]
-    await app.bot.set_chat_menu_button(menu_button=cast(Any, menu))
+    menu_button = MenuButtonWebApp(
+        "Menu", WebAppInfo(url=f"{webapp_url}/reminders")
+    )
+    await app.bot.set_chat_menu_button(menu_button=menu_button)
 
 
 async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -25,13 +25,9 @@ async def test_post_init_sets_chat_menu_button(
     await post_init(app)
     bot.set_my_commands.assert_awaited_once_with(commands)
     bot.set_chat_menu_button.assert_awaited_once()
-    menu = bot.set_chat_menu_button.call_args.kwargs["menu_button"]
-    assert [b.web_app.url for b in menu] == [
-        "https://app.example/reminders",
-        "https://app.example/stats",
-        "https://app.example/profile",
-        "https://app.example/billing",
-    ]
+    button = bot.set_chat_menu_button.call_args.kwargs["menu_button"]
+    assert button.web_app.url == "https://app.example/reminders"
+    assert button.text == "Menu"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- use single Menu button linking to reminder webapp
- adjust chat menu test for single button

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab3f6e3aa4832aa4e39335511fd081