### PR TITLE
[bot] import cast in main

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -6,7 +6,7 @@ Bot entry point and configuration.
 import logging
 import os
 import sys
-from typing import Any
+from typing import Any, cast
 
 from telegram import BotCommand, MenuButtonWebApp, WebAppInfo
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from telegram import MenuButtonWebApp
 
 from services.bot.main import commands, post_init
 


### PR DESCRIPTION
## Summary
- import `cast` in bot main to fix chat menu button setup
- remove unused import from chat menu button test

## Testing
- `ruff check services/bot/main.py tests/test_chat_menu_button.py`
- `mypy --strict services/bot/main.py tests/test_chat_menu_button.py`
- `pytest tests/test_chat_menu_button.py::test_post_init_sets_chat_menu_button -q --override-ini "addopts="`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab465077cc832aa9e6a3c12b853b31