### PR TITLE
[menu] Restore default menu without WebApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ EOF
 curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/getChatMenuButton"
 ```
 
-Команды зависят от значения `WEBAPP_URL`, которое должно указывать на публичный HTTPS‑адрес вашего WebApp. Чтобы удалить кастомную кнопку и вернуться к стандартному меню, выполните:
+Команды зависят от значения `WEBAPP_URL`, которое должно указывать на публичный HTTPS‑адрес вашего WebApp. Чтобы вручную удалить кастомную кнопку и вернуться к стандартному меню, выполните:
 
 ```bash
 curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/setChatMenuButton" \
@@ -202,7 +202,7 @@ curl "https://api.telegram.org/bot${TELEGRAM_TOKEN}/setChatMenuButton" \
   -d '{"menu_button":{"type":"default"}}'
 ```
 
-После этого переменную `WEBAPP_URL` можно очистить или убрать из `.env`.
+После этого переменную `WEBAPP_URL` можно очистить или убрать из `.env` — без неё бот автоматически восстанавливает стандартное меню команд.
 
 ### Docker Compose
 

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -11,10 +11,7 @@ from pydantic import Field, field_validator
 try:  # pragma: no cover - import guard
     from pydantic_settings import BaseSettings, SettingsConfigDict
 except ModuleNotFoundError as exc:  # pragma: no cover - executed at import time
-    raise ImportError(
-        "`pydantic-settings` is required. Install it with "
-        "`pip install pydantic-settings`."
-    ) from exc
+    raise ImportError("`pydantic-settings` is required. Install it with `pip install pydantic-settings`.") from exc
 
 
 logger = logging.getLogger(__name__)
@@ -51,21 +48,21 @@ class Settings(BaseSettings):
     uvicorn_workers: int = Field(default=1, alias="UVICORN_WORKERS")
 
     # Optional service URLs and API keys
-    webapp_url: Optional[str] = Field(default=None, alias="WEBAPP_URL")
+    webapp_url: Optional[str] = Field(
+        default=None,
+        alias="WEBAPP_URL",
+        description="Base WebApp URL; if missing, default menu is kept",
+    )
     api_url: Optional[str] = Field(default=None, alias="API_URL")
     openai_api_key: Optional[str] = Field(default=None, alias="OPENAI_API_KEY")
-    openai_assistant_id: Optional[str] = Field(
-        default=None, alias="OPENAI_ASSISTANT_ID"
-    )
+    openai_assistant_id: Optional[str] = Field(default=None, alias="OPENAI_ASSISTANT_ID")
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
     font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
     telegram_token: Optional[str] = Field(default=None, alias="TELEGRAM_TOKEN")
 
     @field_validator("log_level", mode="before")
     @classmethod
-    def parse_log_level(
-        cls, v: int | str | None
-    ) -> int:  # pragma: no cover - simple parsing
+    def parse_log_level(cls, v: int | str | None) -> int:  # pragma: no cover - simple parsing
         if isinstance(v, str):
             v_lower = v.lower()
             if v_lower in {"1", "true", "debug"}:

--- a/services/api/app/menu_button.py
+++ b/services/api/app/menu_button.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from telegram import MenuButton, MenuButtonWebApp, WebAppInfo
+from telegram import (
+    MenuButton,
+    MenuButtonDefault,
+    MenuButtonWebApp,
+    WebAppInfo,
+)
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
 
 from . import config
@@ -22,21 +27,22 @@ async def post_init(
         DefaultJobQueue,
     ],
 ) -> None:
-    """Set chat menu buttons to open WebApp sections if configured."""
+    """Set chat menu buttons to open WebApp sections if configured.
 
-    base_url = config.settings.webapp_url
+    Falls back to ``MenuButtonDefault`` when WebApp URLs are disabled.
+    """
+
+    base_url = config.get_webapp_url()
     if not base_url:
+        await app.bot.set_chat_menu_button(menu_button=MenuButtonDefault())
         return
-    base_url = base_url.rstrip("/")
     buttons: list[MenuButtonWebApp] = [
         MenuButtonWebApp("Reminders", WebAppInfo(f"{base_url}/reminders")),
         MenuButtonWebApp("Stats", WebAppInfo(f"{base_url}/history")),
         MenuButtonWebApp("Profile", WebAppInfo(f"{base_url}/profile")),
         MenuButtonWebApp("Billing", WebAppInfo(f"{base_url}/subscription")),
     ]
-    await app.bot.set_chat_menu_button(
-        menu_button=cast(MenuButton, buttons)
-    )
+    await app.bot.set_chat_menu_button(menu_button=cast(MenuButton, buttons))
 
 
 __all__ = ["post_init"]

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -6,7 +6,7 @@ Bot entry point and configuration.
 import logging
 import os
 import sys
-from typing import Any
+from typing import Any, cast
 
 from telegram import BotCommand, MenuButtonWebApp, WebAppInfo
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
@@ -52,7 +52,6 @@ async def post_init(
         logger.warning("WEBAPP_URL not configured, skip ChatMenuButton")
         return
 
-
     menu = [
         MenuButtonWebApp("⏰", WebAppInfo(url=f"{webapp_url}/reminders")),
         MenuButtonWebApp("📊", WebAppInfo(url=f"{webapp_url}/history")),
@@ -62,13 +61,9 @@ async def post_init(
     await app.bot.set_chat_menu_button(menu_button=cast(Any, menu))
 
 
-
-
 async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Log errors that occur while processing updates."""
-    logger.exception(
-        "Exception while handling update %s", update, exc_info=context.error
-    )
+    logger.exception("Exception while handling update %s", update, exc_info=context.error)
 
 
 def main() -> None:
@@ -86,9 +81,7 @@ def main() -> None:
         sys.exit("Invalid configuration. Please check your settings and try again.")
     except SQLAlchemyError as exc:
         logger.error("Failed to initialize the database", exc_info=exc)
-        sys.exit(
-            "Database initialization failed. Please check your configuration and try again."
-        )
+        sys.exit("Database initialization failed. Please check your configuration and try again.")
 
     BOT_TOKEN = TELEGRAM_TOKEN
     if not BOT_TOKEN:

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from telegram import MenuButtonWebApp
 
 from services.bot.main import commands, post_init
 
@@ -35,8 +34,6 @@ async def test_post_init_sets_chat_menu_button(
         "https://app.example/profile",
         "https://app.example/subscription",
     ]
-
-
 
 
 @pytest.mark.asyncio

--- a/tests/test_menu_button.py
+++ b/tests/test_menu_button.py
@@ -2,12 +2,13 @@ import importlib
 from urllib.parse import urlparse
 
 import pytest
-from telegram import MenuButtonWebApp
+from telegram import MenuButtonDefault, MenuButtonWebApp
 from telegram.ext import ApplicationBuilder, ExtBot
 
 
 def _reload_config() -> None:
     import services.api.app.config as config
+
     importlib.reload(config)
 
 
@@ -17,6 +18,7 @@ async def test_post_init_sets_chat_menu(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setenv("WEBAPP_URL", base_url)
     _reload_config()
     import services.api.app.menu_button as menu_button
+
     importlib.reload(menu_button)
 
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
@@ -40,3 +42,30 @@ async def test_post_init_sets_chat_menu(monkeypatch: pytest.MonkeyPatch) -> None
         assert isinstance(btn, MenuButtonWebApp)
         assert btn.web_app is not None
         assert urlparse(btn.web_app.url).path == path
+
+
+@pytest.mark.asyncio
+async def test_post_init_uses_default_menu_without_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("WEBAPP_URL", raising=False)
+    _reload_config()
+    import services.api.app.menu_button as menu_button
+
+    importlib.reload(menu_button)
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    async def fake_set_chat_menu_button(self, *args: object, **kwargs: object) -> bool:
+        calls.append((args, kwargs))
+        return True
+
+    monkeypatch.setattr(ExtBot, "set_chat_menu_button", fake_set_chat_menu_button)
+
+    app = ApplicationBuilder().token("TEST").post_init(menu_button.post_init).build()
+    await app.post_init(app)
+
+    assert len(calls) == 1
+    _, kwargs = calls[0]
+    button = kwargs["menu_button"]
+    assert isinstance(button, MenuButtonDefault)


### PR DESCRIPTION
## Summary
- Use MenuButtonDefault when WEBAPP_URL is unset
- Document automatic fallback to Telegram command menu
- Add regression test for default menu and fix lint imports

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/test_menu_button.py --cov=services.api.app.diabetes --cov=services.api.app.menu_button --cov-fail-under=0 --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68ab46a1186c832aac342d27470d6807