### PR TITLE
feat(ui): dev Telegram auth mock for lovable preview

### DIFF
--- a/services/webapp/ui/src/api/http.ts
+++ b/services/webapp/ui/src/api/http.ts
@@ -1,0 +1,32 @@
+import { getTelegramAuthHeaders } from '@/lib/telegram-auth';
+
+const API_BASE = '/api';
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init.headers || {}),
+      ...getTelegramAuthHeaders(),
+    },
+  });
+
+  const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) {
+    const msg = typeof data.detail === 'string' ? data.detail : 'Request failed';
+    throw new Error(msg);
+  }
+  return data as T;
+}
+
+export const http = {
+  get: <T>(path: string) => request<T>(path),
+  post: <T>(path: string, body: unknown) =>
+    request<T>(path, { method: 'POST', body: JSON.stringify(body) }),
+  patch: <T>(path: string, body: unknown) =>
+    request<T>(path, { method: 'PATCH', body: JSON.stringify(body) }),
+  delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
+};
+
+export type HttpClient = typeof http;

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,23 +1,11 @@
-import { DefaultApi, Reminder } from '@sdk';
-
-const api = new DefaultApi();
+import { Reminder } from '@sdk';
+import { http } from './http';
 
 export async function getReminders(telegramId: number): Promise<Reminder[]> {
   try {
-    const data = await api.remindersGet({ telegramId });
-
-    if (!data) {
-      return [];
-    }
-
-    if (!Array.isArray(data)) {
-      console.error('Unexpected reminders API response:', data);
-      return [];
-    }
-
-    return data;
+    return await http.get<Reminder[]>(`/reminders?telegramId=${telegramId}`);
   } catch (error) {
-    console.error('Failed to fetch reminders:', error);
+    console.error('[API] Failed to fetch reminders:', error);
     throw new Error('Не удалось загрузить напоминания');
   }
 }
@@ -27,11 +15,10 @@ export async function getReminder(
   id: number,
 ): Promise<Reminder | null> {
   try {
-    const data = await api.remindersGet({ telegramId, id });
-    if (Array.isArray(data)) {
-      return data[0] ?? null;
-    }
-    return data ?? null;
+    const data = await http.get<Reminder | Reminder[]>(
+      `/reminders?telegramId=${telegramId}&id=${id}`,
+    );
+    return Array.isArray(data) ? data[0] ?? null : data ?? null;
   } catch (error) {
     console.error('Failed to fetch reminder:', error);
     throw new Error('Не удалось загрузить напоминание');
@@ -40,7 +27,7 @@ export async function getReminder(
 
 export async function createReminder(reminder: Reminder) {
   try {
-    return await api.remindersPost({ reminder });
+    return await http.post<Reminder>('/reminders', { reminder });
   } catch (error) {
     console.error('Failed to create reminder:', error);
     throw new Error('Не удалось создать напоминание');
@@ -49,7 +36,7 @@ export async function createReminder(reminder: Reminder) {
 
 export async function updateReminder(reminder: Reminder) {
   try {
-    return await api.remindersPatch({ reminder });
+    return await http.patch<Reminder>('/reminders', { reminder });
   } catch (error) {
     console.error('Failed to update reminder:', error);
     throw new Error('Не удалось обновить напоминание');
@@ -58,7 +45,7 @@ export async function updateReminder(reminder: Reminder) {
 
 export async function deleteReminder(telegramId: number, id: number) {
   try {
-    return await api.remindersDelete({ telegramId, id });
+    return await http.delete(`/reminders/${id}?telegramId=${telegramId}`);
   } catch (error) {
     console.error('Failed to delete reminder:', error);
     throw new Error('Не удалось удалить напоминание');

--- a/services/webapp/ui/src/hooks/useTelegram.ts
+++ b/services/webapp/ui/src/hooks/useTelegram.ts
@@ -150,5 +150,16 @@ export const useTelegram = (
   };
   const hideBackButton = () => tg?.BackButton?.hide?.();
 
-  return { tg, isReady, user, colorScheme, sendData, showMainButton, hideMainButton, showBackButton, hideBackButton };
+  return {
+    tg,
+    isReady,
+    user,
+    colorScheme,
+    sendData,
+    showMainButton,
+    hideMainButton,
+    showBackButton,
+    hideBackButton,
+    isTelegram: Boolean(tg),
+  };
 };

--- a/services/webapp/ui/src/lib/telegram-auth.ts
+++ b/services/webapp/ui/src/lib/telegram-auth.ts
@@ -1,0 +1,25 @@
+const HEADER = 'x-telegram-init-data';
+const LS_KEY = 'tg_init_data';
+
+function getDevInitData(): string | null {
+  if (typeof localStorage !== 'undefined') {
+    const ls = localStorage.getItem(LS_KEY);
+    if (ls) return ls;
+  }
+  const envData = (import.meta.env as Record<string, string | undefined>).VITE_TELEGRAM_INIT_DATA;
+  return envData ?? null;
+}
+
+export function getTelegramAuthHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const globalInitData = (
+    window as unknown as { Telegram?: { WebApp?: { initData?: string } } }
+  )?.Telegram?.WebApp?.initData;
+  const initData = globalInitData || (import.meta.env.DEV ? getDevInitData() : null);
+  if (initData) {
+    headers[HEADER] = initData;
+  }
+  return headers;
+}
+
+export { LS_KEY as TELEGRAM_INIT_DATA_KEY };

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,0 +1,32 @@
+import { getTelegramAuthHeaders } from '@/lib/telegram-auth';
+
+const API_BASE = '/api';
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init.headers || {}),
+      ...getTelegramAuthHeaders(),
+    },
+  });
+
+  const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) {
+    const msg = typeof data.detail === 'string' ? data.detail : 'Request failed';
+    throw new Error(msg);
+  }
+  return data as T;
+}
+
+export const http = {
+  get: <T>(path: string) => request<T>(path),
+  post: <T>(path: string, body: unknown) =>
+    request<T>(path, { method: 'POST', body: JSON.stringify(body) }),
+  patch: <T>(path: string, body: unknown) =>
+    request<T>(path, { method: 'PATCH', body: JSON.stringify(body) }),
+  delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
+};
+
+export type HttpClient = typeof http;

--- a/src/api/reminders.ts
+++ b/src/api/reminders.ts
@@ -1,24 +1,9 @@
-import { DefaultApi, Reminder } from '@sdk';
-
-const api = new DefaultApi();
+import { Reminder } from '@sdk';
+import { http } from './http';
 
 export async function getReminders(telegramId: number): Promise<Reminder[]> {
   try {
-    console.log('[API] Getting reminders for telegramId:', telegramId);
-    const data = await api.remindersGet({ telegramId });
-    console.log('[API] Reminders response:', data);
-
-    if (!data) {
-      console.log('[API] No data received, returning empty array');
-      return [];
-    }
-
-    if (!Array.isArray(data)) {
-      console.error('[API] Unexpected reminders API response:', data);
-      return [];
-    }
-
-    return data;
+    return await http.get<Reminder[]>(`/reminders?telegramId=${telegramId}`);
   } catch (error) {
     console.error('[API] Failed to fetch reminders:', error);
     throw new Error('Не удалось загрузить напоминания');
@@ -30,11 +15,10 @@ export async function getReminder(
   id: number,
 ): Promise<Reminder | null> {
   try {
-    const data = await api.remindersGet({ telegramId, id });
-    if (Array.isArray(data)) {
-      return data[0] ?? null;
-    }
-    return data ?? null;
+    const data = await http.get<Reminder | Reminder[]>(
+      `/reminders?telegramId=${telegramId}&id=${id}`,
+    );
+    return Array.isArray(data) ? data[0] ?? null : data ?? null;
   } catch (error) {
     console.error('Failed to fetch reminder:', error);
     throw new Error('Не удалось загрузить напоминание');
@@ -43,7 +27,7 @@ export async function getReminder(
 
 export async function createReminder(reminder: Reminder) {
   try {
-    return await api.remindersPost({ reminder });
+    return await http.post<Reminder>('/reminders', { reminder });
   } catch (error) {
     console.error('Failed to create reminder:', error);
     throw new Error('Не удалось создать напоминание');
@@ -52,7 +36,7 @@ export async function createReminder(reminder: Reminder) {
 
 export async function updateReminder(reminder: Reminder) {
   try {
-    return await api.remindersPatch({ reminder });
+    return await http.patch<Reminder>('/reminders', { reminder });
   } catch (error) {
     console.error('Failed to update reminder:', error);
     throw new Error('Не удалось обновить напоминание');
@@ -61,7 +45,7 @@ export async function updateReminder(reminder: Reminder) {
 
 export async function deleteReminder(telegramId: number, id: number) {
   try {
-    return await api.remindersDelete({ telegramId, id });
+    return await http.delete(`/reminders/${id}?telegramId=${telegramId}`);
   } catch (error) {
     console.error('Failed to delete reminder:', error);
     throw new Error('Не удалось удалить напоминание');

--- a/src/hooks/useTelegram.ts
+++ b/src/hooks/useTelegram.ts
@@ -185,5 +185,16 @@ export const useTelegram = (
   };
   const hideBackButton = () => tg?.BackButton?.hide?.();
 
-  return { tg, isReady, user, colorScheme, sendData, showMainButton, hideMainButton, showBackButton, hideBackButton };
+  return {
+    tg,
+    isReady,
+    user,
+    colorScheme,
+    sendData,
+    showMainButton,
+    hideMainButton,
+    showBackButton,
+    hideBackButton,
+    isTelegram: Boolean(tg),
+  };
 };

--- a/src/lib/telegram-auth.ts
+++ b/src/lib/telegram-auth.ts
@@ -1,0 +1,25 @@
+const HEADER = 'x-telegram-init-data';
+const LS_KEY = 'tg_init_data';
+
+function getDevInitData(): string | null {
+  if (typeof localStorage !== 'undefined') {
+    const ls = localStorage.getItem(LS_KEY);
+    if (ls) return ls;
+  }
+  const envData = (import.meta.env as Record<string, string | undefined>).VITE_TELEGRAM_INIT_DATA;
+  return envData ?? null;
+}
+
+export function getTelegramAuthHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const globalInitData = (
+    window as unknown as { Telegram?: { WebApp?: { initData?: string } } }
+  )?.Telegram?.WebApp?.initData;
+  const initData = globalInitData || (import.meta.env.DEV ? getDevInitData() : null);
+  if (initData) {
+    headers[HEADER] = initData;
+  }
+  return headers;
+}
+
+export { LS_KEY as TELEGRAM_INIT_DATA_KEY };


### PR DESCRIPTION
## Summary
- add Telegram init data header helper for dev environments
- introduce shared HTTP client using Telegram auth
- expose Telegram environment flag in useTelegram hook
- refactor reminders API to use shared HTTP client

## Testing
- `npm run build` *(fails: vite: not found)*
- `npm --prefix services/webapp/ui run build` *(fails: unresolved import /ui/telegram-init.js)*
- `npm --prefix services/webapp/ui run lint` *(fails: 6 errors, 7 warnings)*
- `pre-commit run --files src/lib/telegram-auth.ts src/api/http.ts src/hooks/useTelegram.ts src/api/reminders.ts services/webapp/ui/src/lib/telegram-auth.ts services/webapp/ui/src/api/http.ts services/webapp/ui/src/hooks/useTelegram.ts services/webapp/ui/src/api/reminders.ts`
- `pytest` *(fails: 125 failed, 107 passed, 1 warning)*


------
https://chatgpt.com/codex/tasks/task_e_68ab48f6cdec832a8f69ff65fea717e9