### PR TITLE
[api] Set Content-Type when body present

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -3,13 +3,18 @@ import { getTelegramAuthHeaders } from '@/lib/telegram-auth';
 const API_BASE = '/api';
 
 async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const headers = new Headers(init.headers);
+
+  if (init.body !== undefined && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  const authHeaders = getTelegramAuthHeaders();
+  Object.entries(authHeaders).forEach(([key, value]) => headers.set(key, value));
+
   const res = await fetch(`${API_BASE}${path}`, {
     ...init,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init.headers || {}),
-      ...getTelegramAuthHeaders(),
-    },
+    headers,
   });
 
   const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- add Content-Type header only when a request body is provided and no custom header exists

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab4c730ccc832aa501cdeaf965217b