### PR TITLE
[bot] Use menu_button_post_init for chat menu

### DIFF
--- a/services/api/app/menu_button.py
+++ b/services/api/app/menu_button.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 
 from telegram import (

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -5,15 +5,14 @@ Bot entry point and configuration.
 
 import logging
 import sys
-from typing import Any, cast
+from typing import Any
 
+from sqlalchemy.exc import SQLAlchemyError
 from telegram import BotCommand
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
-from sqlalchemy.exc import SQLAlchemyError
-
-from services.api.app.diabetes.services.db import init_db
 
 from services.api.app.config import settings
+from services.api.app.diabetes.services.db import init_db
 from services.api.app.menu_button import post_init as menu_button_post_init
 
 DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]
@@ -47,16 +46,7 @@ async def post_init(
     ],
 ) -> None:
     await app.bot.set_my_commands(commands)
-
-
-=======
-    menu = [
-        MenuButtonWebApp("⏰", WebAppInfo(url=f"{webapp_url}/reminders")),
-        MenuButtonWebApp("📊", WebAppInfo(url=f"{webapp_url}/history")),
-        MenuButtonWebApp("📄", WebAppInfo(url=f"{webapp_url}/profile")),
-        MenuButtonWebApp("💳", WebAppInfo(url=f"{webapp_url}/subscription")),
-    ]
-    await app.bot.set_chat_menu_button(menu_button=cast(Any, menu))
+    await menu_button_post_init(app)
 
 
 

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -6,6 +6,7 @@ from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from telegram import MenuButtonDefault, MenuButtonWebApp
 
 
 def _reload_main() -> ModuleType:
@@ -37,8 +38,9 @@ async def test_post_init_sets_chat_menu_button(
 
     menu = bot.set_chat_menu_button.call_args.kwargs["menu_button"]
 
-    assert isinstance(menu, MenuButtonWebApp)
-    assert menu.web_app.url == "https://app.example"
+    assert isinstance(menu, list)
+    assert all(isinstance(btn, MenuButtonWebApp) for btn in menu)
+    assert menu[0].web_app.url == "https://app.example/reminders"
 
 
 @pytest.mark.asyncio
@@ -55,4 +57,6 @@ async def test_post_init_skips_chat_menu_button_without_url(
     app = SimpleNamespace(bot=bot)
     await main.post_init(app)
     bot.set_my_commands.assert_awaited_once_with(main.commands)
-    bot.set_chat_menu_button.assert_not_called()
+    bot.set_chat_menu_button.assert_awaited_once()
+    button = bot.set_chat_menu_button.call_args.kwargs["menu_button"]
+    assert isinstance(button, MenuButtonDefault)

--- a/tests/test_menu_button.py
+++ b/tests/test_menu_button.py
@@ -3,6 +3,7 @@ import importlib
 import pytest
 from telegram import MenuButtonDefault, MenuButtonWebApp
 from telegram.ext import ApplicationBuilder, ExtBot
+from urllib.parse import urlparse
 
 
 def _reload_config() -> None:


### PR DESCRIPTION
## Summary
- remove leftover merge-conflict markers and manual chat menu setup
- configure chat menu via `menu_button_post_init`
- tidy imports and fix missing references

## Testing
- `ruff check`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68ab4b28a940832a9a5d53a2bfdfd976