### PR TITLE
[menu_button] Add cast import

### DIFF
--- a/services/api/app/menu_button.py
+++ b/services/api/app/menu_button.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 
 from telegram import (


### PR DESCRIPTION
## Summary
- use `typing.cast` in menu button setup

## Testing
- `pytest -q --cov` *(fails: SyntaxError in services/bot/main.py)*
- `mypy --strict .` *(fails: services/bot/main.py: Invalid syntax)*
- `ruff check .` *(fails: SyntaxError in services/bot/main.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4f796328832aaf2410d75873cda5