### PR TITLE
[tests] import MenuButtonWebApp in chat menu button test

### DIFF
--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -1,4 +1,5 @@
 """Tests for ChatMenuButton configuration in bot.main."""
+
 from __future__ import annotations
 
 import importlib
@@ -6,6 +7,7 @@ from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from telegram import MenuButtonWebApp
 
 
 def _reload_main() -> ModuleType:


### PR DESCRIPTION
## Summary
- import `MenuButtonWebApp` for chat menu button tests

## Testing
- `pytest -q` *(fails: SyntaxError in services/bot/main.py)*
- `mypy --strict .` *(fails: Invalid syntax in services/bot/main.py)*
- `ruff check .` *(fails: invalid syntax and undefined names)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4f7be4e8832aa3375bc112849bb0