### PR TITLE
[bot] Remove obsolete menu setup

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -5,7 +5,7 @@ Bot entry point and configuration.
 
 import logging
 import sys
-from typing import Any, cast
+from typing import Any
 
 from telegram import BotCommand
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
@@ -47,16 +47,7 @@ async def post_init(
     ],
 ) -> None:
     await app.bot.set_my_commands(commands)
-
-
-=======
-    menu = [
-        MenuButtonWebApp("⏰", WebAppInfo(url=f"{webapp_url}/reminders")),
-        MenuButtonWebApp("📊", WebAppInfo(url=f"{webapp_url}/history")),
-        MenuButtonWebApp("📄", WebAppInfo(url=f"{webapp_url}/profile")),
-        MenuButtonWebApp("💳", WebAppInfo(url=f"{webapp_url}/subscription")),
-    ]
-    await app.bot.set_chat_menu_button(menu_button=cast(Any, menu))
+    await menu_button_post_init(app)
 
 
 


### PR DESCRIPTION
## Summary
- remove leftover merge block from bot main
- hook up menu button post init

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: Name "cast" is not defined)*
- `ruff check .` *(fails: Undefined name `cast` and `MenuButtonWebApp`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4f7a58d0832a8122ccea4c8d2e28