### PR TITLE
[menu_button] Use single web app menu button

### DIFF
--- a/services/api/app/menu_button.py
+++ b/services/api/app/menu_button.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 
 from telegram import (
-    MenuButton,
     MenuButtonDefault,
     MenuButtonWebApp,
     WebAppInfo,
@@ -29,7 +28,6 @@ async def post_init(
         DefaultJobQueue,
     ],
 ) -> None:
-
     """Set chat menu buttons to open WebApp sections if configured.
 
 
@@ -41,14 +39,8 @@ async def post_init(
         await app.bot.set_chat_menu_button(menu_button=MenuButtonDefault())
         return
 
-    buttons: list[MenuButtonWebApp] = [
-        MenuButtonWebApp("Reminders", WebAppInfo(f"{base_url}/reminders")),
-        MenuButtonWebApp("Stats", WebAppInfo(f"{base_url}/history")),
-        MenuButtonWebApp("Profile", WebAppInfo(f"{base_url}/profile")),
-        MenuButtonWebApp("Billing", WebAppInfo(f"{base_url}/subscription")),
-    ]
-    await app.bot.set_chat_menu_button(menu_button=cast(MenuButton, buttons))
-
+    button = MenuButtonWebApp("Menu", WebAppInfo(f"{base_url}"))
+    await app.bot.set_chat_menu_button(menu_button=button)
 
 
 __all__ = ["post_init"]

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -8,8 +8,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from telegram import MenuButtonWebApp
-
+from telegram import MenuButtonDefault, MenuButtonWebApp
 
 
 def _reload_main() -> ModuleType:
@@ -41,9 +40,9 @@ async def test_post_init_sets_chat_menu_button(
 
     menu = bot.set_chat_menu_button.call_args.kwargs["menu_button"]
 
-    assert isinstance(menu, list)
-    assert all(isinstance(btn, MenuButtonWebApp) for btn in menu)
-    assert menu[0].web_app.url == "https://app.example/reminders"
+    assert isinstance(menu, MenuButtonWebApp)
+    assert menu.text == "Menu"
+    assert menu.web_app.url == "https://app.example"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace chat menu button list with a single root WebApp button
- adjust tests for new menu button behavior

## Testing
- `PYTEST_ADDOPTS="" pytest tests/test_menu_button.py tests/test_chat_menu_button.py -q --no-cov`
- `ruff check services/api/app/menu_button.py tests/test_menu_button.py tests/test_chat_menu_button.py`
- `mypy --strict services/api/app/menu_button.py tests/test_menu_button.py tests/test_chat_menu_button.py` *(fails: process hung)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5181a124832a866cb06725966f2f