### PR TITLE
[api] Use http client for stats fetching

### DIFF
--- a/src/api/stats.ts
+++ b/src/api/stats.ts
@@ -1,3 +1,5 @@
+import { http } from './http';
+
 export interface AnalyticsPoint {
   date: string;
   sugar: number;
@@ -24,11 +26,7 @@ export const fallbackDayStats: DayStats = {
 };
 
 export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint[]> {
-  const res = await fetch(`/api/analytics?telegramId=${telegramId}`);
-  if (!res.ok) {
-    throw new Error('Failed to fetch analytics');
-  }
-  const data = await res.json();
+  const data = await http.get<unknown>(`/analytics?telegramId=${telegramId}`);
   if (!Array.isArray(data)) {
     throw new Error('Invalid analytics data');
   }
@@ -36,11 +34,7 @@ export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint
 }
 
 export async function fetchDayStats(telegramId: number): Promise<DayStats> {
-  const res = await fetch(`/api/stats?telegramId=${telegramId}`);
-  if (!res.ok) {
-    throw new Error('Failed to fetch stats');
-  }
-  const data = await res.json();
+  const data = await http.get<unknown>(`/stats?telegramId=${telegramId}`);
 
   if (!data || typeof data !== 'object' || Array.isArray(data)) {
     throw new Error('Invalid stats data');


### PR DESCRIPTION
## Summary
- switch stats API calls to shared http client so telegram auth headers are used
- retain analytics array check and day stats fallback logic

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab5425cd68832aaa7c604fc9453b63