### PR TITLE
[hooks] add dev init data fallback

### DIFF
--- a/src/hooks/useTelegram.ts
+++ b/src/hooks/useTelegram.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getDevInitData } from "../lib/telegram-auth";
 
 type Scheme = "light" | "dark";
 
@@ -141,6 +142,19 @@ export const useTelegram = (
   useEffect(() => {
     if (!tg) {
       console.warn("[TG] not in Telegram, enabling dev fallback");
+      if (import.meta.env.DEV) {
+        const initData = getDevInitData();
+        if (initData) {
+          const userStr = new URLSearchParams(initData).get("user");
+          if (userStr) {
+            try {
+              setUser(JSON.parse(userStr));
+            } catch (e) {
+              console.error("[TG] failed to parse dev user:", e);
+            }
+          }
+        }
+      }
       applyTheme(null, forceLight);
       setReady(true);
       return;

--- a/src/lib/telegram-auth.ts
+++ b/src/lib/telegram-auth.ts
@@ -1,7 +1,7 @@
 const HEADER = 'x-telegram-init-data';
 const LS_KEY = 'tg_init_data';
 
-function getDevInitData(): string | null {
+export function getDevInitData(): string | null {
   if (typeof localStorage !== 'undefined') {
     const ls = localStorage.getItem(LS_KEY);
     if (ls) return ls;


### PR DESCRIPTION
## Summary
- export helper to read Telegram init data in dev
- parse fallback init data to set user when Telegram WebApp missing

## Testing
- `pnpm test`
- `pytest tests/test_reminders.py` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68ab58b5d9b0832abd3eef631c582b81