### PR TITLE
[menu] restore default chat menu and add webapp command

### DIFF
--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-from telegram import Update
+from telegram import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Update,
+    WebAppInfo,
+)
 from telegram.ext import ContextTypes
 
+from services.api.app import config
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
 
@@ -81,9 +87,27 @@ async def smart_input_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         await message.reply_text(text, parse_mode="Markdown")
 
 
+async def open_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send a button that opens the WebApp if configured."""
+
+    webapp_url = config.get_webapp_url()
+    if not webapp_url:
+        return
+
+    button = InlineKeyboardButton(
+        "Открыть приложение",
+        web_app=WebAppInfo(webapp_url),
+    )
+    markup = InlineKeyboardMarkup([[button]])
+    message = update.message
+    if message:
+        await message.reply_text("🌐 WebApp", reply_markup=markup)
+
+
 __all__ = [
     "menu_keyboard",
     "menu_command",
     "help_command",
     "smart_input_help",
+    "open_command",
 ]

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -16,7 +16,7 @@ from telegram.ext import (
 from sqlalchemy.exc import SQLAlchemyError
 
 from .onboarding_handlers import onboarding_conv, onboarding_poll_answer
-from .common_handlers import menu_command, help_command, smart_input_help
+from .common_handlers import menu_command, help_command, smart_input_help, open_command
 from .router import callback_router
 from ..utils.ui import (
     PROFILE_BUTTON_TEXT,
@@ -142,6 +142,7 @@ def register_handlers(
 
     app.add_handler(onboarding_conv)
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("menu", menu_command))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("open", open_command))
     app.add_handler(
         CommandHandler[ContextTypes.DEFAULT_TYPE](
             "report", reporting_handlers.report_request

--- a/services/api/app/menu_button.py
+++ b/services/api/app/menu_button.py
@@ -1,19 +1,18 @@
-"""Configure Telegram chat menu button with WebApp links."""
+"""Configure Telegram chat menu button.
+
+The bot previously replaced Telegram's default menu button with a WebApp link
+which hid the built-in command list. To keep the standard menu available we
+always reset the button to :class:`telegram.MenuButtonDefault`.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
 
-from telegram import (
-    MenuButtonDefault,
-    MenuButtonWebApp,
-    WebAppInfo,
-)
+from telegram import MenuButtonDefault
 
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
-
-from . import config
 
 DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]
 
@@ -28,19 +27,9 @@ async def post_init(
         DefaultJobQueue,
     ],
 ) -> None:
-    """Set chat menu buttons to open WebApp sections if configured.
+    """Always restore the default Telegram menu button."""
 
-
-    Falls back to ``MenuButtonDefault`` when WebApp URLs are disabled.
-    """
-
-    base_url = config.get_webapp_url()
-    if not base_url:
-        await app.bot.set_chat_menu_button(menu_button=MenuButtonDefault())
-        return
-
-    button = MenuButtonWebApp("Menu", WebAppInfo(f"{base_url}"))
-    await app.bot.set_chat_menu_button(menu_button=button)
+    await app.bot.set_chat_menu_button(menu_button=MenuButtonDefault())
 
 
 __all__ = ["post_init"]

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from telegram import MenuButtonDefault, MenuButtonWebApp
+from telegram import MenuButtonDefault
 
 
 def _reload_main() -> ModuleType:
@@ -26,7 +26,7 @@ def _reload_main() -> ModuleType:
 async def test_post_init_sets_chat_menu_button(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """WEBAPP_URL triggers chat menu button setup."""
+    """Chat menu button is always set to default."""
     monkeypatch.setenv("WEBAPP_URL", "https://app.example")
     main = _reload_main()
     bot = SimpleNamespace(
@@ -40,16 +40,14 @@ async def test_post_init_sets_chat_menu_button(
 
     menu = bot.set_chat_menu_button.call_args.kwargs["menu_button"]
 
-    assert isinstance(menu, MenuButtonWebApp)
-    assert menu.text == "Menu"
-    assert menu.web_app.url == "https://app.example"
+    assert isinstance(menu, MenuButtonDefault)
 
 
 @pytest.mark.asyncio
 async def test_post_init_skips_chat_menu_button_without_url(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Missing WEBAPP_URL skips setup."""
+    ) -> None:
+    """Default menu is used when WEBAPP_URL is missing."""
     monkeypatch.delenv("WEBAPP_URL", raising=False)
     main = _reload_main()
     bot = SimpleNamespace(

--- a/tests/test_menu_button.py
+++ b/tests/test_menu_button.py
@@ -1,9 +1,15 @@
 import importlib
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
-from telegram import MenuButtonDefault, MenuButtonWebApp
+from telegram import InlineKeyboardButton, MenuButtonDefault, Update
 from telegram.error import BadRequest
-from telegram.ext import ApplicationBuilder, ExtBot
+from telegram.ext import (
+    ApplicationBuilder,
+    CallbackContext,
+    ExtBot,
+)
 
 
 def _reload_config() -> None:
@@ -13,7 +19,7 @@ def _reload_config() -> None:
 
 
 @pytest.mark.asyncio
-async def test_post_init_sets_chat_menu(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_post_init_sets_default_menu(monkeypatch: pytest.MonkeyPatch) -> None:
     base_url = "https://example.com"
     monkeypatch.setenv("WEBAPP_URL", base_url)
     _reload_config()
@@ -23,41 +29,9 @@ async def test_post_init_sets_chat_menu(monkeypatch: pytest.MonkeyPatch) -> None
 
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
-    async def fake_set_chat_menu_button(self, *args: object, **kwargs: object) -> bool:
-        menu_button = kwargs["menu_button"]
-        if isinstance(menu_button, list):
-            raise BadRequest("Too many menu buttons")
-        calls.append((args, kwargs))
-        return True
-
-    monkeypatch.setattr(ExtBot, "set_chat_menu_button", fake_set_chat_menu_button)
-
-    app = ApplicationBuilder().token("TEST").post_init(menu_button.post_init).build()
-    await app.post_init(app)
-
-    assert len(calls) == 1
-    _, kwargs = calls[0]
-
-    button = kwargs["menu_button"]
-    assert isinstance(button, MenuButtonWebApp)
-    assert button.text == "Menu"
-    assert button.web_app is not None
-    assert button.web_app.url == base_url
-
-
-@pytest.mark.asyncio
-async def test_post_init_uses_default_menu_without_url(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("WEBAPP_URL", raising=False)
-    _reload_config()
-    import services.api.app.menu_button as menu_button
-
-    importlib.reload(menu_button)
-
-    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
-
-    async def fake_set_chat_menu_button(self, *args: object, **kwargs: object) -> bool:
+    async def fake_set_chat_menu_button(
+        self, *args: object, **kwargs: object
+    ) -> bool:
         menu_button = kwargs["menu_button"]
         if isinstance(menu_button, list):
             raise BadRequest("Too many menu buttons")
@@ -73,3 +47,36 @@ async def test_post_init_uses_default_menu_without_url(
     _, kwargs = calls[0]
     button = kwargs["menu_button"]
     assert isinstance(button, MenuButtonDefault)
+
+
+@pytest.mark.asyncio
+async def test_open_command_launches_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_url = "https://example.com"
+    monkeypatch.setenv("WEBAPP_URL", base_url)
+    _reload_config()
+    from services.api.app.diabetes.handlers.common_handlers import open_command
+
+    class DummyMessage:
+        def __init__(self) -> None:
+            self.replies: list[str] = []
+            self.kwargs: list[dict[str, Any]] = []
+
+        async def reply_text(self, text: str, **kwargs: Any) -> None:
+            self.replies.append(text)
+            self.kwargs.append(kwargs)
+
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+
+    await open_command(update, context)
+
+    assert message.kwargs
+    markup = message.kwargs[0]["reply_markup"]
+    button = markup.inline_keyboard[0][0]
+    assert isinstance(button, InlineKeyboardButton)
+    assert button.web_app is not None
+    assert button.web_app.url == base_url


### PR DESCRIPTION
## Summary
- always set default Telegram menu button during post init
- add `/open` command with inline WebApp button
- update tests for new menu button behavior and web app access

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab58f9e618832a9c1ed9569ed449e3