### PR TITLE
[menu] remove WebApp command

### DIFF
--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -2,15 +2,9 @@
 
 from __future__ import annotations
 
-from telegram import (
-    InlineKeyboardButton,
-    InlineKeyboardMarkup,
-    Update,
-    WebAppInfo,
-)
+from telegram import Update
 from telegram.ext import ContextTypes
 
-from services.api.app import config
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
 
@@ -18,9 +12,7 @@ async def menu_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     """Display the main menu keyboard using ``menu_keyboard``."""
     message = update.message
     if message:
-        await message.reply_text(
-            "📋 Выберите действие:", reply_markup=menu_keyboard()
-        )
+        await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
 
 
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -87,27 +79,9 @@ async def smart_input_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         await message.reply_text(text, parse_mode="Markdown")
 
 
-async def open_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Send a button that opens the WebApp if configured."""
-
-    webapp_url = config.get_webapp_url()
-    if not webapp_url:
-        return
-
-    button = InlineKeyboardButton(
-        "Открыть приложение",
-        web_app=WebAppInfo(webapp_url),
-    )
-    markup = InlineKeyboardMarkup([[button]])
-    message = update.message
-    if message:
-        await message.reply_text("🌐 WebApp", reply_markup=markup)
-
-
 __all__ = [
     "menu_keyboard",
     "menu_command",
     "help_command",
     "smart_input_help",
-    "open_command",
 ]

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -16,7 +16,7 @@ from telegram.ext import (
 from sqlalchemy.exc import SQLAlchemyError
 
 from .onboarding_handlers import onboarding_conv, onboarding_poll_answer
-from .common_handlers import menu_command, help_command, smart_input_help, open_command
+from .common_handlers import menu_command, help_command, smart_input_help
 from .router import callback_router
 from ..utils.ui import (
     PROFILE_BUTTON_TEXT,
@@ -49,20 +49,12 @@ def register_profile_handlers(
     app.add_handler(profile.profile_conv)
     app.add_handler(profile.profile_webapp_handler)
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex(f"^{PROFILE_BUTTON_TEXT}$"), profile.profile_view
-        )
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex(f"^{PROFILE_BUTTON_TEXT}$"), profile.profile_view)
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
-            profile.profile_security, pattern="^profile_security"
-        )
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](profile.profile_security, pattern="^profile_security")
     )
-    app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
-            profile.profile_back, pattern="^profile_back$"
-        )
-    )
+    app.add_handler(CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](profile.profile_back, pattern="^profile_back$"))
 
 
 def register_reminder_handlers(
@@ -79,32 +71,18 @@ def register_reminder_handlers(
 
     from . import reminder_handlers
 
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "reminders", reminder_handlers.reminders_list
-        )
-    )
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "addreminder", reminder_handlers.add_reminder
-        )
-    )
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("reminders", reminder_handlers.reminders_list))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("addreminder", reminder_handlers.add_reminder))
     app.add_handler(reminder_handlers.reminder_action_handler)
     app.add_handler(reminder_handlers.reminder_webapp_handler)
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "delreminder", reminder_handlers.delete_reminder
-        )
-    )
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("delreminder", reminder_handlers.delete_reminder))
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
             filters.Regex(f"^{REMINDERS_BUTTON_TEXT}$"), reminder_handlers.reminders_list
         )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
-            reminder_handlers.reminder_callback, pattern="^remind_"
-        )
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](reminder_handlers.reminder_callback, pattern="^remind_")
     )
 
     job_queue = app.job_queue
@@ -142,39 +120,20 @@ def register_handlers(
 
     app.add_handler(onboarding_conv)
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("menu", menu_command))
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("open", open_command))
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "report", reporting_handlers.report_request
-        )
-    )
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("report", reporting_handlers.report_request))
     app.add_handler(dose_calc.dose_conv)
     # Register profile conversation before sugar conversation so that numeric
     # inputs for profile aren't captured by sugar logging
     register_profile_handlers(app)
     app.add_handler(sugar_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE]("cancel", dose_calc.dose_cancel)
-    )
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("cancel", dose_calc.dose_cancel))
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("help", help_command))
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE]("gpt", gpt_handlers.chat_with_gpt)
-    )
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("gpt", gpt_handlers.chat_with_gpt))
     register_reminder_handlers(app)
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "alertstats", alert_handlers.alert_stats
-        )
-    )
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "hypoalert", security_handlers.hypo_alert_faq
-        )
-    )
-    app.add_handler(
-        PollAnswerHandler[ContextTypes.DEFAULT_TYPE](onboarding_poll_answer)
-    )
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("alertstats", alert_handlers.alert_stats))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("hypoalert", security_handlers.hypo_alert_faq))
+    app.add_handler(PollAnswerHandler[ContextTypes.DEFAULT_TYPE](onboarding_poll_answer))
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
             filters.Regex(f"^{REPORT_BUTTON_TEXT}$"), reporting_handlers.report_request
@@ -186,40 +145,20 @@ def register_handlers(
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), photo_handlers.photo_prompt
-        )
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), photo_handlers.photo_prompt)
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex(f"^{QUICK_INPUT_BUTTON_TEXT}$"), smart_input_help
-        )
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex(f"^{QUICK_INPUT_BUTTON_TEXT}$"), smart_input_help)
+    )
+    app.add_handler(MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex(f"^{HELP_BUTTON_TEXT}$"), help_command))
+    app.add_handler(
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex(f"^{SOS_BUTTON_TEXT}$"), sos_handlers.sos_contact_start)
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex(f"^{HELP_BUTTON_TEXT}$"), help_command
-        )
+        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler)
     )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex(f"^{SOS_BUTTON_TEXT}$"), sos_handlers.sos_contact_start
-        )
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler
-        )
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.PHOTO, photo_handlers.photo_handler
-        )
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Document.IMAGE, photo_handlers.doc_handler
-        )
-    )
+    app.add_handler(MessageHandler[ContextTypes.DEFAULT_TYPE](filters.PHOTO, photo_handlers.photo_handler))
+    app.add_handler(MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Document.IMAGE, photo_handlers.doc_handler))
     app.add_handler(
         CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
             reporting_handlers.report_period_callback, pattern="^report_back$"

--- a/tests/test_menu_button.py
+++ b/tests/test_menu_button.py
@@ -1,15 +1,8 @@
 import importlib
-from types import SimpleNamespace
-from typing import Any, cast
-
 import pytest
-from telegram import InlineKeyboardButton, MenuButtonDefault, Update
+from telegram import MenuButtonDefault
 from telegram.error import BadRequest
-from telegram.ext import (
-    ApplicationBuilder,
-    CallbackContext,
-    ExtBot,
-)
+from telegram.ext import ApplicationBuilder, ExtBot
 
 
 def _reload_config() -> None:
@@ -29,11 +22,9 @@ async def test_post_init_sets_default_menu(monkeypatch: pytest.MonkeyPatch) -> N
 
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
-    async def fake_set_chat_menu_button(
-        self, *args: object, **kwargs: object
-    ) -> bool:
-        menu_button = kwargs["menu_button"]
-        if isinstance(menu_button, list):
+    async def fake_set_chat_menu_button(self, *args: object, **kwargs: object) -> bool:
+        menu_button_obj = kwargs["menu_button"]
+        if isinstance(menu_button_obj, list):
             raise BadRequest("Too many menu buttons")
         calls.append((args, kwargs))
         return True
@@ -47,36 +38,3 @@ async def test_post_init_sets_default_menu(monkeypatch: pytest.MonkeyPatch) -> N
     _, kwargs = calls[0]
     button = kwargs["menu_button"]
     assert isinstance(button, MenuButtonDefault)
-
-
-@pytest.mark.asyncio
-async def test_open_command_launches_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
-    base_url = "https://example.com"
-    monkeypatch.setenv("WEBAPP_URL", base_url)
-    _reload_config()
-    from services.api.app.diabetes.handlers.common_handlers import open_command
-
-    class DummyMessage:
-        def __init__(self) -> None:
-            self.replies: list[str] = []
-            self.kwargs: list[dict[str, Any]] = []
-
-        async def reply_text(self, text: str, **kwargs: Any) -> None:
-            self.replies.append(text)
-            self.kwargs.append(kwargs)
-
-    message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message))
-    context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(),
-    )
-
-    await open_command(update, context)
-
-    assert message.kwargs
-    markup = message.kwargs[0]["reply_markup"]
-    button = markup.inline_keyboard[0][0]
-    assert isinstance(button, InlineKeyboardButton)
-    assert button.web_app is not None
-    assert button.web_app.url == base_url


### PR DESCRIPTION
## Summary
- remove WebApp opening command from common handlers and registration
- keep only default Telegram command menu
- adjust tests for new menu configuration

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68ab50175188832a882a926ecf84f060