### PR TITLE
[ui] Open reminders webapp from menu

### DIFF
--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -15,6 +15,7 @@ from telegram import (
     WebAppInfo,
 )
 from services.api.app import config
+from services.api.app.diabetes.handlers import reminder_handlers
 
 PROFILE_BUTTON_TEXT = "📄 Мой профиль"
 REMINDERS_BUTTON_TEXT = "⏰ Напоминания"
@@ -63,14 +64,16 @@ def menu_keyboard() -> ReplyKeyboardMarkup:
     webapp_url = config.get_webapp_url()
     profile_button = (
         KeyboardButton(
-            PROFILE_BUTTON_TEXT, web_app=WebAppInfo(f"{webapp_url}/profile")
+            PROFILE_BUTTON_TEXT,
+            web_app=WebAppInfo(reminder_handlers.build_webapp_url("/profile")),
         )
         if webapp_url
         else KeyboardButton(PROFILE_BUTTON_TEXT)
     )
     reminders_button = (
         KeyboardButton(
-            REMINDERS_BUTTON_TEXT, web_app=WebAppInfo(f"{webapp_url}/reminders")
+            REMINDERS_BUTTON_TEXT,
+            web_app=WebAppInfo(reminder_handlers.build_webapp_url("/reminders")),
         )
         if webapp_url
         else KeyboardButton(REMINDERS_BUTTON_TEXT)
@@ -87,6 +90,7 @@ def menu_keyboard() -> ReplyKeyboardMarkup:
         one_time_keyboard=False,
         input_field_placeholder="Выберите действие…",
     )
+
 
 dose_keyboard = ReplyKeyboardMarkup(
     keyboard=[

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -5,8 +5,18 @@ import pytest
 import services.api.app.diabetes.utils.ui as ui
 
 
-@pytest.mark.parametrize("base_url", ["https://example.com", "https://example.com/"])
-def test_menu_keyboard_webapp_urls(monkeypatch: pytest.MonkeyPatch, base_url: str) -> None:
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://example.com",
+        "https://example.com/",
+        "https://example.com/ui",
+        "https://example.com/ui/",
+    ],
+)
+def test_menu_keyboard_webapp_urls(
+    monkeypatch: pytest.MonkeyPatch, base_url: str
+) -> None:
     """Menu buttons should open webapp paths for profile and reminders."""
     monkeypatch.setenv("WEBAPP_URL", base_url)
 
@@ -15,6 +25,6 @@ def test_menu_keyboard_webapp_urls(monkeypatch: pytest.MonkeyPatch, base_url: st
     reminders_btn = next(b for b in buttons if b.text == ui.REMINDERS_BUTTON_TEXT)
 
     assert profile_btn.web_app is not None
-    assert urlparse(profile_btn.web_app.url).path == "/profile"
+    assert urlparse(profile_btn.web_app.url).path.endswith("/profile")
     assert reminders_btn.web_app is not None
-    assert urlparse(reminders_btn.web_app.url).path == "/reminders"
+    assert urlparse(reminders_btn.web_app.url).path.endswith("/reminders")


### PR DESCRIPTION
## Summary
- use centralized `build_webapp_url` when creating profile and reminders buttons
- test menu keyboard with complex WEBAPP_URL values

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab660498f8832aaa806e67e80cb990