### PR TITLE
[py-sdk] Improve multipart form serialization

### DIFF
--- a/libs/py-sdk/diabetes_sdk/rest.py
+++ b/libs/py-sdk/diabetes_sdk/rest.py
@@ -16,7 +16,7 @@ import io
 import json
 import re
 import ssl
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 import urllib3
 
@@ -196,7 +196,7 @@ class RESTClientObject:
                     del headers["Content-Type"]
                     # Ensure ``fields`` only contains (key, value) tuples and
                     # serialize nested structures to JSON
-                    if isinstance(post_params, dict):
+                    if isinstance(post_params, Mapping):
                         items = post_params.items()
                     elif isinstance(post_params, Iterable) and not isinstance(
                         post_params, (str, bytes)
@@ -204,7 +204,7 @@ class RESTClientObject:
                         items = post_params
                     else:
                         raise ApiValueError(
-                            "post_params must be a dict or iterable",
+                            "post_params must be a mapping or iterable",
                         )
                     fields = []
                     for item in items:

--- a/libs/py-sdk/test/test_rest_multipart.py
+++ b/libs/py-sdk/test/test_rest_multipart.py
@@ -1,4 +1,5 @@
 import json
+from collections import OrderedDict
 from unittest.mock import MagicMock
 
 import pytest
@@ -64,6 +65,26 @@ def test_multipart_tuple() -> None:
         "http://example.com",
         headers={"Content-Type": "multipart/form-data"},
         post_params=(("foo", "bar"), ("baz", {"a": 1})),
+    )
+    kwargs = mock.call_args.kwargs
+    assert kwargs["encode_multipart"] is True
+    assert all(len(item) == 2 for item in kwargs["fields"])
+    assert kwargs["fields"] == [
+        ("foo", "bar"),
+        ("baz", json.dumps({"a": 1})),
+    ]
+
+
+def test_multipart_mapping() -> None:
+    client = _client()
+    mock = MagicMock(return_value=_mock_response())
+    client.pool_manager.request = mock  # type: ignore[method-assign]
+    params = OrderedDict([("foo", "bar"), ("baz", {"a": 1})])
+    client.request(  # type: ignore[no-untyped-call]
+        "POST",
+        "http://example.com",
+        headers={"Content-Type": "multipart/form-data"},
+        post_params=params,
     )
     kwargs = mock.call_args.kwargs
     assert kwargs["encode_multipart"] is True


### PR DESCRIPTION
## Summary
- handle mapping objects and iterables in multipart requests
- serialize nested data structures before request
- cover multipart mapping handling in tests

## Testing
- `pytest -q --cov --cov-report=term` *(fails: async plugin missing, 345 failed)*
- `mypy --strict libs/py-sdk/diabetes_sdk/rest.py` *(interrupted: command hung)*
- `ruff check .`
- `pytest libs/py-sdk/test/test_rest_multipart.py::test_multipart_mapping -q -o addopts=`


------
https://chatgpt.com/codex/tasks/task_e_68ab6952d8f0832a9deb9d3e4e71c9a3