### PR TITLE
[schemas] add reminders pydantic schema

### DIFF
--- a/services/api/app/diabetes/schemas/__init__.py
+++ b/services/api/app/diabetes/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic schemas for diabetes features."""

--- a/services/api/app/diabetes/schemas/reminders.py
+++ b/services/api/app/diabetes/schemas/reminders.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class ReminderType(str, Enum):
+    sugar = "sugar"
+    insulin_short = "insulin_short"
+    insulin_long = "insulin_long"
+    after_meal = "after_meal"
+    meal = "meal"
+    sensor_change = "sensor_change"
+    injection_site = "injection_site"
+    custom = "custom"
+
+
+class ScheduleKind(str, Enum):
+    at_time = "at_time"
+    every = "every"
+    after_event = "after_event"
+
+
+DayOfWeek = Literal[1, 2, 3, 4, 5, 6, 7]
+
+
+class ReminderIn(BaseModel):
+    telegramId: int = Field(alias="telegramId")
+    id: Optional[int] = None
+    type: ReminderType
+    title: Optional[str] = None
+
+    kind: ScheduleKind = ScheduleKind.at_time
+    time: Optional[str] = None
+    intervalMinutes: Optional[int] = None
+    minutesAfter: Optional[int] = None
+
+    # back-compat
+    intervalHours: Optional[int] = None
+
+    daysOfWeek: Optional[List[DayOfWeek]] = None
+    isEnabled: bool = True
+    orgId: Optional[int] = None
+
+    @field_validator("time")
+    @classmethod
+    def _hhmm(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        import re
+
+        if not re.match(r"^([01]\d|2[0-3]):[0-5]\d$", v):
+            raise ValueError("time must be HH:MM")
+        return v
+
+    @model_validator(mode="after")
+    def _normalize(self) -> "ReminderIn":
+        if self.intervalHours and not self.intervalMinutes:
+            self.intervalMinutes = self.intervalHours * 60
+
+        provided = [
+            bool(self.time),
+            bool(self.intervalMinutes),
+            bool(self.minutesAfter),
+        ]
+        if sum(provided) != 1:
+            raise ValueError(
+                "exactly one of time, intervalMinutes or minutesAfter must be provided"
+            )
+
+        if self.kind == ScheduleKind.at_time and not self.time:
+            raise ValueError("kind=at_time requires time")
+        if self.kind == ScheduleKind.every and not self.intervalMinutes:
+            raise ValueError("kind=every requires intervalMinutes")
+        if self.kind == ScheduleKind.after_event and not self.minutesAfter:
+            raise ValueError("kind=after_event requires minutesAfter")
+        return self
+
+
+class ReminderOut(ReminderIn):
+    nextAt: Optional[str] = None  # ISO datetime, filled by service

--- a/tests/test_diabetes_reminders_schema.py
+++ b/tests/test_diabetes_reminders_schema.py
@@ -1,0 +1,71 @@
+import importlib
+
+import pytest
+
+from services.api.app.diabetes.schemas.reminders import (
+    ReminderIn,
+    ReminderType,
+    ScheduleKind,
+)
+
+
+def test_module_import() -> None:
+    module = importlib.import_module("services.api.app.diabetes.schemas.reminders")
+    assert hasattr(module, "ReminderIn")
+
+
+def test_at_time_valid() -> None:
+    reminder = ReminderIn(telegramId=1, type=ReminderType.sugar, time="08:00")
+    assert reminder.kind is ScheduleKind.at_time
+    assert reminder.time == "08:00"
+    assert reminder.intervalMinutes is None
+
+
+def test_every_interval_hours_normalization() -> None:
+    reminder = ReminderIn(
+        telegramId=1,
+        type=ReminderType.insulin_short,
+        kind=ScheduleKind.every,
+        intervalHours=2,
+    )
+    assert reminder.intervalMinutes == 120
+
+
+def test_after_event_valid() -> None:
+    reminder = ReminderIn(
+        telegramId=1,
+        type=ReminderType.sugar,
+        kind=ScheduleKind.after_event,
+        minutesAfter=30,
+    )
+    assert reminder.minutesAfter == 30
+
+
+def test_exactly_one_provided_invalid() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        ReminderIn(
+            telegramId=1,
+            type=ReminderType.sugar,
+            time="08:00",
+            intervalMinutes=10,
+        )
+
+
+def test_kind_requires_interval() -> None:
+    with pytest.raises(ValueError, match="kind=every requires intervalMinutes"):
+        ReminderIn(
+            telegramId=1,
+            type=ReminderType.sugar,
+            kind=ScheduleKind.every,
+            time="08:00",
+        )
+
+
+def test_kind_requires_time() -> None:
+    with pytest.raises(ValueError, match="kind=at_time requires time"):
+        ReminderIn(
+            telegramId=1,
+            type=ReminderType.sugar,
+            kind=ScheduleKind.at_time,
+            minutesAfter=15,
+        )


### PR DESCRIPTION
## Summary
- add diabetes ReminderType and schedule schemas
- normalize intervalHours to intervalMinutes and validate schedule mode
- add tests for schema validation

## Testing
- `pytest -q tests/test_diabetes_reminders_schema.py -o addopts=`
- `mypy --strict services/api/app/diabetes/schemas/reminders.py tests/test_diabetes_reminders_schema.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab6e9f6008832abd38c7e280ad86ae