### PR TITLE
[ui] Add reminder schedule kinds and payload builder

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/buildPayload.ts
+++ b/services/webapp/ui/src/features/reminders/api/buildPayload.ts
@@ -1,0 +1,53 @@
+export type ReminderType =
+  | 'sugar' | 'insulin_short' | 'insulin_long' | 'after_meal'
+  | 'meal' | 'sensor_change' | 'injection_site' | 'custom';
+export type ScheduleKind = 'at_time' | 'every' | 'after_event';
+
+export interface ReminderFormValues {
+  telegramId: number;
+  type: ReminderType;
+  kind: ScheduleKind;
+  time?: string;
+  intervalMinutes?: number;
+  minutesAfter?: number;
+  daysOfWeek?: number[];
+  title?: string;
+  isEnabled?: boolean;
+}
+
+function titleByType(t: ReminderType) {
+  return ({
+    sugar: 'Измерение сахара',
+    insulin_short: 'Инсулин (короткий)',
+    insulin_long: 'Инсулин (длинный)',
+    after_meal: 'После еды',
+    meal: 'Приём пищи',
+    sensor_change: 'Смена сенсора',
+    injection_site: 'Смена места инъекции',
+    custom: 'Напоминание',
+  } as const)[t];
+}
+
+function generateTitle(v: ReminderFormValues): string {
+  if (v.title?.trim()) return v.title.trim();
+  if (v.kind === 'at_time' && v.time) return `${titleByType(v.type)} · ${v.time}`;
+  if (v.kind === 'every' && v.intervalMinutes) return `${titleByType(v.type)} · каждые ${v.intervalMinutes} мин`;
+  if (v.kind === 'after_event' && v.minutesAfter) return `${titleByType(v.type)} · через ${v.minutesAfter} мин`;
+  return titleByType(v.type);
+}
+
+export function buildReminderPayload(v: ReminderFormValues) {
+  const base = {
+    telegramId: v.telegramId,
+    type: v.type,
+    kind: v.kind,
+    daysOfWeek: v.daysOfWeek?.length ? v.daysOfWeek : undefined,
+    isEnabled: v.isEnabled ?? true,
+  };
+  const schedule =
+    v.kind === 'at_time' ? { time: v.time } :
+    v.kind === 'every'    ? { intervalMinutes: v.intervalMinutes } :
+                            { minutesAfter: v.minutesAfter };
+
+  return { ...base, ...schedule, title: generateTitle(v) };
+}


### PR DESCRIPTION
## Summary
- add Reminder payload builder that auto-generates titles and picks the right schedule field
- support `kind` switch in reminder form to show time, interval or delay

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: existing lint errors in repo)
- `npx eslint src/reminders/CreateReminder.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ab6eff34e0832ab29dd3f4f1913ef0