### PR TITLE
ci: guard lovable sync paths

### DIFF
--- a/.github/workflows/lovable-sync.yml
+++ b/.github/workflows/lovable-sync.yml
@@ -83,6 +83,16 @@ jobs:
           git status
           git --no-pager diff --stat || true
 
+      - name: Guard changed paths
+        run: |
+          git fetch origin ${{ env.TARGET_BRANCH }}
+          CHANGED=$(git diff --name-only remotes/origin/${{ env.TARGET_BRANCH }}...HEAD)
+          echo "$CHANGED" | awk '{print " - " $0}'
+          echo "$CHANGED" | grep -E '^(services/webapp/ui/(src|public)/|libs/ts-sdk/)' || {
+            echo "::error ::Changes outside allowed paths detected"
+            exit 1
+          }
+
       - name: Build webapp UI
         working-directory: services/webapp/ui
         run: |


### PR DESCRIPTION
## Summary
- fail lovable sync PRs if changes touch paths outside webapp UI or ts-sdk

## Testing
- `pre-commit run --files .github/workflows/lovable-sync.yml`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `timeout 30s mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab6f29d1dc832a96c21f79100b2b7d