### PR TITLE
[handlers] Open reminders webapp from /reminders

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -333,24 +333,18 @@ def schedule_all(job_queue: DefaultJobQueue | None) -> None:
 
 
 async def reminders_list(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Reply with a WebApp button opening the reminders page."""
+
     user = update.effective_user
     message: Message | None = update.message
     if user is None or message is None:
         return
-    user_id = user.id
-    render_fn = cast(
-        Callable[[object], tuple[str, InlineKeyboardMarkup | None]],
-        _render_reminders,
+
+    url = build_webapp_url("/reminders")
+    keyboard = InlineKeyboardMarkup(
+        [[InlineKeyboardButton("Открыть напоминания", web_app=WebAppInfo(url))]]
     )
-    if run_db is None:
-        with SessionLocal() as session:
-            text, keyboard = render_fn(session, user_id)
-    else:
-        text, keyboard = await run_db(render_fn, user_id, sessionmaker=SessionLocal)
-    kwargs = {"parse_mode": "HTML"}
-    if keyboard is not None:
-        kwargs["reply_markup"] = keyboard
-    await message.reply_text(text, **kwargs)
+    await message.reply_text("Перейдите в веб-приложение", reply_markup=keyboard)
 
 
 async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -28,7 +28,7 @@ commands = [
     BotCommand("report", "Отчёт"),
     BotCommand("sugar", "Расчёт сахара"),
     BotCommand("gpt", "Чат с GPT"),
-    BotCommand("reminders", "Список напоминаний"),
+    BotCommand("reminders", "Напоминания (WebApp)"),
     BotCommand("addreminder", "Добавить напоминание"),
     BotCommand("delreminder", "Удалить напоминание"),
     BotCommand("help", "Справка"),


### PR DESCRIPTION
## Summary
- open reminders WebApp via /reminders command
- clarify /reminders bot command description
- test WebApp button is returned for /reminders

## Testing
- `pytest tests/test_reminders.py::test_reminders_list_sends_webapp_button tests/test_register_handlers.py::test_reminders_command_sends_webapp_button -q` (fails: Coverage failure: total of 25 is less than fail-under=85)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ab772c1290832a901520426b02a1da