### PR TITLE
[migrations] Add fields to reminders and index

### DIFF
--- a/services/api/alembic/versions/8db592ddbe51_reminders_kind_minutes_days_mask.py
+++ b/services/api/alembic/versions/8db592ddbe51_reminders_kind_minutes_days_mask.py
@@ -1,0 +1,71 @@
+"""reminders: kind + minutes + days_mask
+
+Revision ID: 8db592ddbe51
+Revises: 20250820_change_reminder_time_type
+Create Date: 2025-08-24 20:37:49.023280
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '8db592ddbe51'
+down_revision: Union[str, None] = '20250820_change_reminder_time_type'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    columns = [col["name"] for col in inspector.get_columns("reminders")]
+    if "kind" not in columns:
+        op.add_column("reminders", sa.Column("kind", sa.String(), nullable=True))
+    if "interval_minutes" not in columns:
+        op.add_column(
+            "reminders", sa.Column("interval_minutes", sa.Integer(), nullable=True)
+        )
+    if "minutes_after" not in columns:
+        op.add_column(
+            "reminders", sa.Column("minutes_after", sa.Integer(), nullable=True)
+        )
+    if "days_mask" not in columns:
+        op.add_column("reminders", sa.Column("days_mask", sa.Integer(), nullable=True))
+    if "is_enabled" not in columns:
+        op.add_column(
+            "reminders",
+            sa.Column("is_enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+        )
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("reminders")]
+    if "ix_reminders_owner_enabled" not in indexes:
+        op.create_index(
+            "ix_reminders_owner_enabled",
+            "reminders",
+            ["telegram_id", "is_enabled"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("reminders")]
+    if "ix_reminders_owner_enabled" in indexes:
+        op.drop_index("ix_reminders_owner_enabled", table_name="reminders")
+
+    columns = [col["name"] for col in inspector.get_columns("reminders")]
+    if "is_enabled" in columns:
+        op.drop_column("reminders", "is_enabled")
+    if "days_mask" in columns:
+        op.drop_column("reminders", "days_mask")
+    if "minutes_after" in columns:
+        op.drop_column("reminders", "minutes_after")
+    if "interval_minutes" in columns:
+        op.drop_column("reminders", "interval_minutes")
+    if "kind" in columns:
+        op.drop_column("reminders", "kind")

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -218,9 +218,12 @@ class Reminder(Base):
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
     type: Mapped[str] = mapped_column(String, nullable=False)
     title: Mapped[Optional[str]] = mapped_column(String)
+    kind: Mapped[Optional[str]] = mapped_column(String)
     time: Mapped[Optional[time]] = mapped_column(Time)
     interval_hours: Mapped[Optional[int]] = mapped_column(Integer)
+    interval_minutes: Mapped[Optional[int]] = mapped_column(Integer)
     minutes_after: Mapped[Optional[int]] = mapped_column(Integer)
+    days_mask: Mapped[Optional[int]] = mapped_column(Integer)
     is_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now()


### PR DESCRIPTION
## Summary
- add `kind`, `interval_minutes`, `minutes_after`, `days_mask`, and `is_enabled` to reminders
- create `ix_reminders_owner_enabled` compound index
- expose new reminder columns in ORM model

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `alembic -c services/api/alembic.ini upgrade head` *(fails: relation "users" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ab77c1b494832a83cdb5fb8ecebb95