### PR TITLE
[handlers] Revert reminders list to inline output

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -28,7 +28,7 @@ commands = [
     BotCommand("report", "Отчёт"),
     BotCommand("sugar", "Расчёт сахара"),
     BotCommand("gpt", "Чат с GPT"),
-    BotCommand("reminders", "Напоминания (WebApp)"),
+    BotCommand("reminders", "Список напоминаний"),
     BotCommand("addreminder", "Добавить напоминание"),
     BotCommand("delreminder", "Удалить напоминание"),
     BotCommand("help", "Справка"),


### PR DESCRIPTION
## Summary
- list reminders using `_render_reminders` instead of WebApp button
- update `/reminders` command description to "Список напоминаний"
- adjust tests to new reminders list behavior

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68abe4bd4330832a93b723766e1222fe