### PR TITLE
[reminders] Adjust add reminder button URL

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -175,7 +175,7 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
-                web_app=WebAppInfo(build_webapp_url("/reminders")),
+                web_app=WebAppInfo(build_webapp_url("/reminders/new")),
             )
         ]
     if not rems:

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -272,11 +272,14 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "📸 Триггер-фото" in text
     assert "2. <s>🔕title2</s>" in text
     assert markup.inline_keyboard
-    assert any(
-        btn.web_app is not None and btn.web_app.url.endswith("/reminders")
+    add_btn = next(
+        btn
         for row in markup.inline_keyboard
         for btn in row
+        if btn.text == "➕ Добавить"
     )
+    assert add_btn.web_app is not None
+    assert add_btn.web_app.url.endswith("/reminders/new")
 
 
 def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- direct add reminder button to `/reminders/new` webapp page
- verify `➕ Добавить` button opens correct URL

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68abe6f06628832aa5c7b6b5de6177f5