### PR TITLE
[models] Add Reminder daysOfWeek mapping

### DIFF
--- a/services/api/app/diabetes/models.py
+++ b/services/api/app/diabetes/models.py
@@ -1,5 +1,5 @@
-from .services.db import Base
+from .services.db import Base, Reminder
 
 metadata = Base.metadata
 
-__all__ = ["metadata"]
+__all__ = ["metadata", "Reminder"]

--- a/tests/test_reminder_days_mask.py
+++ b/tests/test_reminder_days_mask.py
@@ -1,0 +1,15 @@
+from services.api.app.diabetes.services.db import Reminder
+
+
+def test_days_of_week_roundtrip() -> None:
+    reminder = Reminder(type="sugar")
+    assert reminder.days_mask is None
+    assert reminder.daysOfWeek is None
+
+    reminder.daysOfWeek = [1, 3, 7]
+    assert reminder.days_mask == (1 << 0) | (1 << 2) | (1 << 6)
+    assert reminder.daysOfWeek == [1, 3, 7]
+
+    reminder.daysOfWeek = None
+    assert reminder.days_mask is None
+    assert reminder.daysOfWeek is None


### PR DESCRIPTION
## Summary
- expose Reminder in models and add daysOfWeek getter/setter mapping bitmask
- provide helper to convert interval hours into minutes
- test Reminder daysOfWeek roundtrip

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68abe75878ac832a81403362537898a2