### PR TITLE
[services] add reminders schedule service

### DIFF
--- a/services/api/app/diabetes/services/reminders_schedule.py
+++ b/services/api/app/diabetes/services/reminders_schedule.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, tzinfo, timezone
+
+from .db import Reminder
+
+
+def compute_next(rem: Reminder, user_tz: tzinfo) -> datetime | None:
+    """Return next fire time for a reminder in UTC.
+
+    Parameters
+    ----------
+    rem:
+        Reminder instance containing scheduling info.
+    user_tz:
+        User's timezone.
+    """
+    now = datetime.now(user_tz)
+
+    if rem.kind == "at_time" and rem.time is not None:
+        days_mask = rem.days_mask or 0
+        for offset in range(0, 14):
+            day = now.date() + timedelta(days=offset)
+            weekday = day.isoweekday()
+            if days_mask == 0 or (days_mask & (1 << (weekday - 1))):
+                candidate = datetime.combine(day, rem.time, tzinfo=user_tz)
+                if candidate > now:
+                    return candidate.astimezone(timezone.utc)
+        return None
+
+    if rem.kind == "every" and rem.interval_minutes is not None:
+        return (now + timedelta(minutes=rem.interval_minutes)).astimezone(timezone.utc)
+
+    return None

--- a/tests/test_reminders_schedule.py
+++ b/tests/test_reminders_schedule.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime, time, timezone, tzinfo
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from services.api.app.diabetes.services.db import Reminder
+from services.api.app.diabetes.services import reminders_schedule
+from services.api.app.diabetes.services.reminders_schedule import compute_next
+
+
+def _patch_now(monkeypatch: pytest.MonkeyPatch, dt: datetime) -> None:
+    class DummyDatetime(datetime):
+        @classmethod
+        def now(cls, tz: tzinfo | None = None) -> "DummyDatetime":
+            result = dt
+            if tz is not None:
+                result = result.replace(tzinfo=tz)
+            return result  # type: ignore[return-value]
+
+    monkeypatch.setattr(reminders_schedule, "datetime", DummyDatetime)
+
+
+def test_compute_next_at_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    tz = ZoneInfo("Europe/Moscow")
+    _patch_now(monkeypatch, datetime(2024, 1, 1, 10, 0))
+    rem = Reminder(kind="at_time", time=time(9, 0), days_mask=1)
+    next_dt = compute_next(rem, tz)
+    assert next_dt == datetime(2024, 1, 8, 6, 0, tzinfo=timezone.utc)
+
+
+def test_compute_next_every(monkeypatch: pytest.MonkeyPatch) -> None:
+    tz = ZoneInfo("Europe/Moscow")
+    _patch_now(monkeypatch, datetime(2024, 1, 1, 10, 0))
+    rem = Reminder(kind="every", interval_minutes=30)
+    next_dt = compute_next(rem, tz)
+    assert next_dt == datetime(2024, 1, 1, 7, 30, tzinfo=timezone.utc)
+
+
+def test_compute_next_after_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    tz = ZoneInfo("UTC")
+    _patch_now(monkeypatch, datetime(2024, 1, 1, 10, 0))
+    rem = Reminder(kind="after_event", minutes_after=15)
+    assert compute_next(rem, tz) is None


### PR DESCRIPTION
## Summary
- add compute_next service to determine next reminder fire time
- cover scheduling logic for at_time, every interval, and after_event reminders

## Testing
- `python -m ruff check .`
- `mypy --strict services/api/app/diabetes/services/reminders_schedule.py tests/test_reminders_schedule.py`
- `pytest tests/test_reminders_schedule.py -q --cov --cov-fail-under=0`
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68abe78ff66c832a87ed89a27071736f