### PR TITLE
chore: update ts-sdk after reminders changes

### DIFF
--- a/libs/ts-sdk/.openapi-generator/FILES
+++ b/libs/ts-sdk/.openapi-generator/FILES
@@ -3,7 +3,6 @@ apis/HistoryApi.ts
 apis/ProfilesApi.ts
 apis/RemindersApi.ts
 apis/index.ts
-index.ts
 models/AnalyticsPoint.ts
 models/DayStats.ts
 models/HTTPValidationError.ts
@@ -20,4 +19,5 @@ models/ValidationError.ts
 models/ValidationErrorLocInner.ts
 models/WebUser.ts
 models/index.ts
+index.ts
 runtime.ts

--- a/scripts/gen_ts_sdk.sh
+++ b/scripts/gen_ts_sdk.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(dirname "$(dirname "$0")")"
+SPEC="$ROOT_DIR/libs/contracts/openapi.yaml"
+OUT_DIR="$ROOT_DIR/libs/ts-sdk"
+TMP_DIR="$(mktemp -d)"
+
+openapi-generator-cli generate \
+  -i "$SPEC" \
+  -g typescript-fetch \
+  -o "$TMP_DIR" \
+  --additional-properties=typescriptThreePlus=true,npmName=@offonika/diabetes-ts-sdk
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+cp -r "$TMP_DIR/src"/* "$OUT_DIR/"
+cp -r "$TMP_DIR/.openapi-generator" "$OUT_DIR/"
+cp "$TMP_DIR/.openapi-generator-ignore" "$OUT_DIR/.openapi-generator-ignore"
+cat <<'JSON' > "$OUT_DIR/package.json"
+{
+  "name": "@offonika/diabetes-ts-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "index.ts",
+  "types": "index.ts",
+  "description": "TypeScript SDK for the Diabetes Assistant API",
+  "license": "MIT"
+}
+JSON
+
+( cd "$OUT_DIR" && { find apis models -type f | sort; echo index.ts; echo runtime.ts; } > .openapi-generator/FILES )
+
+rm -rf "$TMP_DIR"


### PR DESCRIPTION
## Summary
- regenerate TypeScript SDK from latest OpenAPI spec
- add helper script to regenerate SDK

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68abe7d16e2c832ab0777aba835519f6