### PR TITLE
[reminders] Add payload builder tests

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/buildPayload.test.ts
+++ b/services/webapp/ui/src/features/reminders/api/buildPayload.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { buildReminderPayload, ReminderFormValues } from './buildPayload';
+
+const base: ReminderFormValues = {
+  telegramId: 1,
+  type: 'sugar',
+  kind: 'at_time',
+  time: '09:00',
+};
+
+describe('buildReminderPayload', () => {
+  it('builds payload for at_time with generated title', () => {
+    const payload = buildReminderPayload(base);
+    expect(payload).toEqual({
+      telegramId: 1,
+      type: 'sugar',
+      kind: 'at_time',
+      time: '09:00',
+      daysOfWeek: undefined,
+      isEnabled: true,
+      title: 'Измерение сахара · 09:00',
+    });
+    expect('intervalMinutes' in payload).toBe(false);
+    expect('minutesAfter' in payload).toBe(false);
+  });
+
+  it('builds payload for every with intervalMinutes', () => {
+    const payload = buildReminderPayload({
+      telegramId: 2,
+      type: 'insulin_short',
+      kind: 'every',
+      intervalMinutes: 30,
+      daysOfWeek: [1, 3],
+      isEnabled: false,
+    });
+    expect(payload).toEqual({
+      telegramId: 2,
+      type: 'insulin_short',
+      kind: 'every',
+      intervalMinutes: 30,
+      daysOfWeek: [1, 3],
+      isEnabled: false,
+      title: 'Инсулин (короткий) · каждые 30 мин',
+    });
+    expect('time' in payload).toBe(false);
+    expect('minutesAfter' in payload).toBe(false);
+  });
+
+  it('uses custom title and minutesAfter for after_event', () => {
+    const payload = buildReminderPayload({
+      telegramId: 3,
+      type: 'meal',
+      kind: 'after_event',
+      minutesAfter: 15,
+      title: '  My title  ',
+    });
+    expect(payload).toEqual({
+      telegramId: 3,
+      type: 'meal',
+      kind: 'after_event',
+      minutesAfter: 15,
+      daysOfWeek: undefined,
+      isEnabled: true,
+      title: 'My title',
+    });
+    expect('time' in payload).toBe(false);
+    expect('intervalMinutes' in payload).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `buildReminderPayload` covering schedule fields and title generation

## Testing
- `npm test`
- `ruff check services/api/app tests`
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68abeec0af38832ab6e36444b2168a5b