### PR TITLE
[ui] Add Telegram init data hook and reminders API wrapper

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/reminders.ts
+++ b/services/webapp/ui/src/features/reminders/api/reminders.ts
@@ -1,0 +1,17 @@
+import { Configuration } from "@sdk/runtime";
+import { DefaultApi as RemindersApi } from "@sdk/apis";
+import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
+
+export function makeRemindersApi(initData: string) {
+  const cfg = new Configuration({
+    basePath: "/api",
+    headers: { "X-Telegram-Init-Data": initData },
+  });
+  return new RemindersApi(cfg);
+}
+
+// Пример: в компоненте
+export function useRemindersApi() {
+  const initData = useTelegramInitData();
+  return makeRemindersApi(initData);
+}

--- a/services/webapp/ui/src/hooks/useTelegramInitData.ts
+++ b/services/webapp/ui/src/hooks/useTelegramInitData.ts
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+
+interface TelegramWebAppWindow extends Window {
+  Telegram?: { WebApp?: { initData?: string } };
+}
+
+export function useTelegramInitData() {
+  return useMemo(() => {
+    const w = typeof window !== "undefined" ? (window as TelegramWebAppWindow) : undefined;
+    if (w?.Telegram?.WebApp?.initData) return w.Telegram.WebApp.initData;
+
+    // DEV: читаем из localStorage (записывается вручную в консоли)
+    return (typeof window !== "undefined" ? localStorage.getItem("tg_init_data") : "") || "";
+  }, []);
+}


### PR DESCRIPTION
## Summary
- add hook for Telegram init data with dev fallback
- wrap reminders SDK with init data header

## Testing
- `npm --prefix services/webapp/ui run lint` *(fails: existing lint errors)*
- `npx eslint src/hooks/useTelegramInitData.ts src/features/reminders/api/reminders.ts` *(passes: no output)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abee79b264832aa3664da607ad6968