### PR TITLE
[webapp] Handle empty reminder inputs

### DIFF
--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -248,8 +248,8 @@ export default function CreateReminder() {
             step={5}
             value={interval ?? ""}
             onChange={(e) => {
-              const val = parseInt(e.target.value, 10);
-              setInterval(Number.isNaN(val) ? undefined : val);
+              const value = e.target.value ? Number(e.target.value) : undefined;
+              setInterval(value);
             }}
           />
           <div className="flex flex-wrap gap-2 mt-2">
@@ -281,8 +281,8 @@ export default function CreateReminder() {
             step={5}
             value={minutesAfter ?? ""}
             onChange={(e) => {
-              const val = parseInt(e.target.value, 10);
-              setMinutesAfter(Number.isNaN(val) ? undefined : val);
+              const value = e.target.value ? Number(e.target.value) : undefined;
+              setMinutesAfter(value);
             }}
           />
         </div>


### PR DESCRIPTION
## Summary
- Set `intervalMinutes` and `minutesAfter` to `undefined` when the user clears the input

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68abefde84f8832aa469eff1ac62a255