### PR TITLE
[reminders] Reset schedule fields on kind change

### DIFF
--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -217,7 +217,13 @@ export default function CreateReminder() {
           id="kind"
           className="input"
           value={kind}
-          onChange={(e) => setKind(e.target.value as ScheduleKind)}
+          onChange={(e) => {
+            const nextKind = e.target.value as ScheduleKind;
+            setKind(nextKind);
+            setTime("");
+            setInterval(undefined);
+            setMinutesAfter(undefined);
+          }}
         >
           <option value="at_time">По времени</option>
           <option value="every">Каждые N мин</option>


### PR DESCRIPTION
## Summary
- reset time, interval, and minutes-after values when schedule kind changes

## Testing
- `npm test`
- `ruff check services/api/app tests`
- `pytest tests` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68abefd0ddf4832a91c8bb153433e2fb