### PR TITLE
[reminders] add API hook and day picker

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/reminders.ts
+++ b/services/webapp/ui/src/features/reminders/api/reminders.ts
@@ -1,0 +1,13 @@
+import { DefaultApi, Reminder } from "@sdk";
+
+const api = new DefaultApi();
+
+export function useRemindersApi() {
+  return {
+    createReminder(reminder: Reminder) {
+      return api.remindersPost({ reminder });
+    },
+  };
+}
+
+export type { Reminder };

--- a/services/webapp/ui/src/features/reminders/components/DayOfWeekPicker.tsx
+++ b/services/webapp/ui/src/features/reminders/components/DayOfWeekPicker.tsx
@@ -1,0 +1,32 @@
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+const DAYS = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"];
+
+export interface DayOfWeekPickerProps {
+  value?: number[];
+  onChange(next: number[]): void;
+}
+
+export function DayOfWeekPicker({ value = [], onChange }: DayOfWeekPickerProps) {
+  return (
+    <ToggleGroup
+      type="multiple"
+      value={value.map(String)}
+      onValueChange={(vals) => onChange(vals.map(Number))}
+      className="justify-start"
+    >
+      {DAYS.map((label, idx) => (
+        <ToggleGroupItem
+          key={idx}
+          value={String(idx + 1)}
+          className="w-8 h-8"
+          aria-label={label}
+        >
+          {label}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  );
+}
+
+export default DayOfWeekPicker;

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -2,7 +2,9 @@ import { useState, useEffect } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { MedicalButton, Sheet } from "@/components";
 import { cn } from "@/lib/utils";
-import { createReminder, updateReminder, getReminder } from "@/api/reminders";
+import { updateReminder, getReminder } from "@/api/reminders";
+import { useRemindersApi } from "@/features/reminders/api/reminders";
+import DayOfWeekPicker from "@/features/reminders/components/DayOfWeekPicker";
 import { useTelegram } from "@/hooks/useTelegram";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -74,6 +76,7 @@ export default function CreateReminder() {
   const params = useParams();
   const { user, sendData } = useTelegram();
   const { toast } = useToast();
+  const { createReminder } = useRemindersApi();
   const [editing, setEditing] = useState<Reminder | undefined>(
     (location.state as Reminder | undefined) ?? undefined,
   );
@@ -86,6 +89,7 @@ export default function CreateReminder() {
   const [time, setTime] = useState(editing?.time ?? "");
   const [interval, setInterval] = useState<number | undefined>(editing?.interval ?? 60);
   const [minutesAfter, setMinutesAfter] = useState<number | undefined>();
+  const [daysOfWeek, setDaysOfWeek] = useState<number[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [typeOpen, setTypeOpen] = useState(false);
 
@@ -143,6 +147,7 @@ export default function CreateReminder() {
       time,
       intervalMinutes: interval,
       minutesAfter,
+      daysOfWeek,
       title,
       isEnabled: true,
     };
@@ -181,6 +186,7 @@ export default function CreateReminder() {
     time,
     intervalMinutes: interval,
     minutesAfter,
+    daysOfWeek,
     title,
   });
   const typeInfo = TYPES[type];
@@ -287,6 +293,11 @@ export default function CreateReminder() {
           />
         </div>
       )}
+
+      <div>
+        <label className="block mb-1">Дни недели</label>
+        <DayOfWeekPicker value={daysOfWeek} onChange={setDaysOfWeek} />
+      </div>
 
       <Sheet open={typeOpen} onClose={() => setTypeOpen(false)}>
         <div className="p-4 grid grid-cols-3 gap-4">


### PR DESCRIPTION
## Summary
- add useRemindersApi wrapper around SDK createReminder
- add DayOfWeekPicker component for selecting weekdays
- wire create reminder form to use new API hook and day picker

## Testing
- `npx vitest run`
- `npm run lint` (fails: Fast refresh only works..., @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)
- `pytest` (fails: async def functions are not natively supported)

------
https://chatgpt.com/codex/tasks/task_e_68abefd6ada0832a9d6a38f52963bc61