### PR TITLE
[reminders] implement delete handling in reminders list

### DIFF
--- a/src/reminders/RemindersList.tsx
+++ b/src/reminders/RemindersList.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { deleteReminder } from "@/api/reminders";
+import { useTelegram } from "@/hooks/useTelegram";
+import { useToast } from "@/hooks/use-toast";
+
+interface Reminder {
+  id: number;
+  title: string;
+}
+
+export default function RemindersList({
+  initialReminders,
+}: {
+  initialReminders: Reminder[];
+}) {
+  const { user } = useTelegram();
+  const { toast } = useToast();
+  const [reminders, setReminders] = useState<Reminder[]>(initialReminders);
+
+  const handleDelete = async (id: number) => {
+    if (!user?.id) return;
+    const prevReminders = [...reminders];
+    setReminders(prev => prev.filter(r => r.id !== id));
+    try {
+      await deleteReminder(user.id, id);
+      toast({
+        title: "Напоминание удалено",
+        description: "Напоминание успешно удалено",
+      });
+    } catch (err) {
+      setReminders(prevReminders);
+      const message =
+        err instanceof Error ? err.message : "Не удалось удалить напоминание";
+      toast({
+        title: "Ошибка",
+        description: message,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {reminders.map(reminder => (
+        <div key={reminder.id} className="flex items-center justify-between">
+          <span>{reminder.title}</span>
+          <button onClick={() => handleDelete(reminder.id)}>Удалить</button>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reminders list component with delete handler

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68abf0063890832ab0d505f83d6232b6