### PR TITLE
[webapp] Add aria-pressed to day picker buttons

### DIFF
--- a/services/webapp/ui/src/features/reminders/components/DayOfWeekPicker.tsx
+++ b/services/webapp/ui/src/features/reminders/components/DayOfWeekPicker.tsx
@@ -1,0 +1,54 @@
+import { cn } from "@/lib/utils";
+import { useCallback } from "react";
+
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const WEEKDAY_LABELS = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+];
+
+export interface DayOfWeekPickerProps {
+  value: number[];
+  onChange: (value: number[]) => void;
+}
+
+export default function DayOfWeekPicker({ value, onChange }: DayOfWeekPickerProps) {
+  const toggle = useCallback(
+    (index: number) => {
+      const next = value.includes(index)
+        ? value.filter((d) => d !== index)
+        : [...value, index];
+      onChange(next);
+    },
+    [value, onChange],
+  );
+
+  return (
+    <div className="flex gap-2">
+      {WEEKDAYS.map((day, index) => {
+        const active = value.includes(index);
+        return (
+          <button
+            key={day}
+            type="button"
+            onClick={() => toggle(index)}
+            className={cn(
+              "w-8 h-8 rounded-full border text-sm",
+              active && "bg-primary text-primary-foreground border-primary",
+            )}
+            aria-pressed={active}
+            aria-label={WEEKDAY_LABELS[index]}
+          >
+            {day[0]}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add DayOfWeekPicker component with `aria-pressed` and `aria-label` for accessible weekday selection

## Testing
- `npm --prefix services/webapp/ui run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `pytest tests` *(fails: async def functions are not natively supported)*
- `ruff check services/api/app tests`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf0477db0832aa6cd2d919d047065