### PR TITLE
[ui] Add toast hook and night DND option

### DIFF
--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -4,7 +4,7 @@ import { MedicalButton, Sheet } from "@/components";
 import { cn } from "@/lib/utils";
 import { createReminder, updateReminder, getReminder } from "@/api/reminders";
 import { useTelegram } from "@/hooks/useTelegram";
-import { useToast } from "@/hooks/use-toast";
+import { useToast } from "@/shared/toast";
 import {
   buildReminderPayload,
   type ScheduleKind,
@@ -73,7 +73,7 @@ export default function CreateReminder() {
   const location = useLocation();
   const params = useParams();
   const { user, sendData } = useTelegram();
-  const { toast } = useToast();
+  const { success, error: showError } = useToast();
   const [editing, setEditing] = useState<Reminder | undefined>(
     (location.state as Reminder | undefined) ?? undefined,
   );
@@ -112,13 +112,13 @@ export default function CreateReminder() {
           } else {
             const message = "Не удалось загрузить напоминание";
             setError(message);
-            toast({ title: "Ошибка", description: message, variant: "destructive" });
+            showError(message);
           }
         } catch (err) {
           const message =
             err instanceof Error ? err.message : "Не удалось загрузить напоминание";
           setError(message);
-          toast({ title: "Ошибка", description: message, variant: "destructive" });
+          showError(message);
         }
       })();
     }
@@ -164,12 +164,13 @@ export default function CreateReminder() {
       if (rid) {
         sendData({ id: rid, type, value });
       }
+      success("Напоминание сохранено");
       navigate("/reminders");
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Не удалось сохранить напоминание";
       setError(message);
-      toast({ title: "Ошибка", description: message, variant: "destructive" });
+      showError(message);
     }
   };
 

--- a/services/webapp/ui/src/shared/toast.tsx
+++ b/services/webapp/ui/src/shared/toast.tsx
@@ -1,0 +1,13 @@
+import { toast as showToast } from "@/components/ui/use-toast";
+
+export function useToast() {
+  const success = (description: string, title = "Готово") =>
+    showToast({ title, description });
+
+  const error = (description: string, title = "Ошибка") =>
+    showToast({ title, description, variant: "destructive" });
+
+  return { success, error };
+}
+
+export type ToastHook = ReturnType<typeof useToast>;

--- a/src/pages/Reminders.tsx
+++ b/src/pages/Reminders.tsx
@@ -3,7 +3,8 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Plus, Clock, Edit2, Trash2, Bell } from 'lucide-react'
 import { MedicalHeader } from '@/components/MedicalHeader'
-import { useToast } from '@/hooks/use-toast'
+import { Checkbox } from '@/components/ui/checkbox'
+import { useToast } from '@/shared/toast'
 import { getReminders, updateReminder, deleteReminder } from '@/api/reminders'
 import { useTelegram } from '@/hooks/useTelegram'
 import MedicalButton from '@/components/MedicalButton'
@@ -130,8 +131,16 @@ function ReminderRow({
 
 export default function Reminders() {
   const navigate = useNavigate()
-  const { toast } = useToast()
+  const { success, error: showError } = useToast()
   const { user, sendData } = useTelegram()
+
+  const DND_KEY = 'dnd-night'
+  const [dndNight, setDndNight] = useState(() =>
+    localStorage.getItem(DND_KEY) === 'true'
+  )
+  useEffect(() => {
+    localStorage.setItem(DND_KEY, dndNight ? 'true' : 'false')
+  }, [dndNight])
 
   const [reminders, setReminders] = useState<Reminder[]>([])
   const [loading, setLoading] = useState(true)
@@ -182,14 +191,14 @@ export default function Reminders() {
         if (!cancelled) {
           const message = err instanceof Error ? err.message : 'Не удалось загрузить напоминания'
           setError(message)
-          toast({ title: 'Ошибка', description: message, variant: 'destructive' })
+          showError(message)
         }
       } finally {
         if (!cancelled) setLoading(false)
       }
     })()
     return () => { cancelled = true }
-  }, [toast, user?.id])
+  }, [showError, user?.id])
 
   const handleToggleReminder = async (id: number) => {
     if (!user?.id) return
@@ -213,18 +222,11 @@ export default function Reminders() {
       const value =
         hours != null && Number.isInteger(hours) ? `${hours}h` : target.time
       sendData({ id, type: target.type, value })
-      toast({
-        title: 'Напоминание обновлено',
-        description: 'Статус напоминания изменён',
-      })
+      success('Статус напоминания изменён', 'Напоминание обновлено')
     } catch (err) {
       setReminders(prevReminders)
       const message = err instanceof Error ? err.message : 'Не удалось обновить напоминание'
-      toast({
-        title: 'Ошибка',
-        description: message,
-        variant: 'destructive',
-      })
+      showError(message)
     }
   }
 
@@ -234,18 +236,11 @@ export default function Reminders() {
     setReminders(prev => prev.filter(r => r.id !== id))
     try {
       await deleteReminder(user.id, id)
-      toast({
-        title: 'Напоминание удалено',
-        description: 'Напоминание успешно удалено',
-      })
+      success('Напоминание успешно удалено', 'Напоминание удалено')
     } catch (err) {
       setReminders(prevReminders)
       const message = err instanceof Error ? err.message : 'Не удалось удалить напоминание'
-      toast({
-        title: 'Ошибка',
-        description: message,
-        variant: 'destructive',
-      })
+      showError(message)
     }
   }
 
@@ -321,6 +316,16 @@ export default function Reminders() {
       </MedicalHeader>
 
       <main className="container mx-auto px-4 py-6">
+        <div className="flex items-center space-x-2 mb-6">
+          <Checkbox
+            id="dnd-night"
+            checked={dndNight}
+            onCheckedChange={(checked) => setDndNight(checked === true)}
+          />
+          <label htmlFor="dnd-night" className="text-sm text-foreground">
+            Не беспокоить ночью (23:00–07:00)
+          </label>
+        </div>
         {content}
       </main>
     </div>

--- a/src/reminders/CreateReminder.tsx
+++ b/src/reminders/CreateReminder.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import { createReminder, updateReminder, getReminder } from "@/api/reminders";
 import { Reminder as ApiReminder } from "@sdk";
 import { useTelegram } from "@/hooks/useTelegram";
-import { useToast } from "@/hooks/use-toast";
+import { useToast } from "@/shared/toast";
 
 // Reminder type returned from API may contain legacy value "meds",
 // normalize it to "medicine" for UI usage
@@ -54,7 +54,7 @@ export default function CreateReminder() {
   const location = useLocation();
   const params = useParams();
   const { user, sendData } = useTelegram();
-  const { toast } = useToast();
+  const { success, error: showError } = useToast();
   const [editing, setEditing] = useState<Reminder | undefined>(
     (location.state as Reminder | undefined) ?? undefined,
   );
@@ -91,13 +91,13 @@ export default function CreateReminder() {
           } else {
             const message = "Не удалось загрузить напоминание";
             setError(message);
-            toast({ title: "Ошибка", description: message, variant: "destructive" });
+            showError(message);
           }
         } catch (err) {
           const message =
             err instanceof Error ? err.message : "Не удалось загрузить напоминание";
           setError(message);
-          toast({ title: "Ошибка", description: message, variant: "destructive" });
+          showError(message);
         }
       })();
     }
@@ -131,12 +131,13 @@ export default function CreateReminder() {
       if (rid) {
         sendData({ id: rid, type, value });
       }
+      success("Напоминание сохранено");
       navigate("/reminders");
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Не удалось сохранить напоминание";
       setError(message);
-      toast({ title: "Ошибка", description: message, variant: "destructive" });
+      showError(message);
     }
   };
 

--- a/src/shared/toast.tsx
+++ b/src/shared/toast.tsx
@@ -1,0 +1,14 @@
+// Файл: webapp/ui/src/shared/toast.tsx
+import { toast as showToast } from "@/components/ui/use-toast";
+
+export function useToast() {
+  const success = (description: string, title = "Готово") =>
+    showToast({ title, description });
+
+  const error = (description: string, title = "Ошибка") =>
+    showToast({ title, description, variant: "destructive" });
+
+  return { success, error };
+}
+
+export type ToastHook = ReturnType<typeof useToast>;


### PR DESCRIPTION
## Summary
- add reusable success/error toast hook
- show toast alerts for reminder actions
- add "Do not disturb at night" checkbox with local storage

## Testing
- `npm test`
- `ruff check services/api/app tests`


------
https://chatgpt.com/codex/tasks/task_e_68abf09c67f0832aa40c7bc66bdb82d7