### PR TITLE
[reminders] add api hook and weekday picker

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/reminders.ts
+++ b/services/webapp/ui/src/features/reminders/api/reminders.ts
@@ -1,17 +1,22 @@
+import { useMemo } from "react";
 import { Configuration } from "@sdk/runtime";
 import { DefaultApi as RemindersApi } from "@sdk/apis";
+import type { Reminder } from "@sdk";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 
-export function makeRemindersApi(initData: string) {
-  const cfg = new Configuration({
-    basePath: "/api",
-    headers: { "X-Telegram-Init-Data": initData },
-  });
-  return new RemindersApi(cfg);
-}
-
-// Пример: в компоненте
 export function useRemindersApi() {
   const initData = useTelegramInitData();
-  return makeRemindersApi(initData);
+  const api = useMemo(() => {
+    const cfg = new Configuration({
+      basePath: "/api",
+      headers: { "X-Telegram-Init-Data": initData },
+    });
+    return new RemindersApi(cfg);
+  }, [initData]);
+
+  const createReminder = (reminder: Reminder) =>
+    api.remindersPost({ reminder });
+
+  return { createReminder };
 }
+

--- a/services/webapp/ui/src/features/reminders/components/DayOfWeekPicker.tsx
+++ b/services/webapp/ui/src/features/reminders/components/DayOfWeekPicker.tsx
@@ -13,11 +13,14 @@ const WEEKDAY_LABELS = [
 ];
 
 export interface DayOfWeekPickerProps {
-  value: number[];
-  onChange: (value: number[]) => void;
+  value?: number[];
+  onChange: (next: number[]) => void;
 }
 
-export default function DayOfWeekPicker({ value, onChange }: DayOfWeekPickerProps) {
+export default function DayOfWeekPicker({
+  value = [],
+  onChange,
+}: DayOfWeekPickerProps) {
   const toggle = useCallback(
     (index: number) => {
       const next = value.includes(index)

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { MedicalButton, Sheet } from "@/components";
 import { cn } from "@/lib/utils";
-import { createReminder, updateReminder, getReminder } from "@/api/reminders";
+import { updateReminder, getReminder } from "@/api/reminders";
+import { useRemindersApi } from "@/features/reminders/api/reminders";
 import { useTelegram } from "@/hooks/useTelegram";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -74,6 +75,7 @@ export default function CreateReminder() {
   const params = useParams();
   const { user, sendData } = useTelegram();
   const { toast } = useToast();
+  const { createReminder } = useRemindersApi();
   const [editing, setEditing] = useState<Reminder | undefined>(
     (location.state as Reminder | undefined) ?? undefined,
   );


### PR DESCRIPTION
## Summary
- add reminders API hook wrapping SDK createReminder
- make DayOfWeekPicker accept optional value
- use new reminders API in reminder creation page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abf4d04f64832a91c4b6e74705eacc