### PR TITLE
[reminders] Add optimistic delete with rollback

### DIFF
--- a/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
@@ -46,10 +46,12 @@ export default function RemindersList() {
 
   const handleDelete = async (id: number) => {
     if (!user?.id) return;
+    const prevReminders = reminders;
+    setReminders((prev) => prev.filter((r) => r.id !== id));
     try {
       await deleteReminder(user.id, id);
-      setReminders((prev) => prev.filter((r) => r.id !== id));
     } catch (err) {
+      setReminders(prevReminders);
       console.error(err);
     }
   };


### PR DESCRIPTION
## Summary
- handle reminder deletion optimistically and roll back on error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abf9e9d4dc832ab64d0693eba58b77