### PR TITLE
[reminders] Localize DayOfWeekPicker weekday names

### DIFF
--- a/services/webapp/ui/src/features/reminders/components/DayOfWeekPicker.stories.tsx
+++ b/services/webapp/ui/src/features/reminders/components/DayOfWeekPicker.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import DayOfWeekPicker from "./DayOfWeekPicker";
+
+const meta: Meta<typeof DayOfWeekPicker> = {
+  title: "Reminders/DayOfWeekPicker",
+  component: DayOfWeekPicker,
+};
+
+export default meta;
+
+export const Basic: StoryObj<typeof DayOfWeekPicker> = {
+  render: () => {
+    const [value, setValue] = useState<number[]>([]);
+    const short = ["Пн", "Вт", "Ср", "Чт", "Пт", "Сб", "Вс"];
+    const long = [
+      "Понедельник",
+      "Вторник",
+      "Среда",
+      "Четверг",
+      "Пятница",
+      "Суббота",
+      "Воскресенье",
+    ];
+    return (
+      <DayOfWeekPicker
+        value={value}
+        onChange={setValue}
+        shortNames={short}
+        longNames={long}
+      />
+    );
+  },
+};

--- a/services/webapp/ui/src/features/reminders/components/DayOfWeekPicker.tsx
+++ b/services/webapp/ui/src/features/reminders/components/DayOfWeekPicker.tsx
@@ -1,25 +1,18 @@
 import { cn } from "@/lib/utils";
 import { useCallback } from "react";
 
-const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-const WEEKDAY_LABELS = [
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday",
-  "Sunday",
-];
-
 export interface DayOfWeekPickerProps {
   value?: number[];
   onChange: (next: number[]) => void;
+  shortNames: string[];
+  longNames: string[];
 }
 
 export default function DayOfWeekPicker({
   value = [],
   onChange,
+  shortNames,
+  longNames,
 }: DayOfWeekPickerProps) {
   const toggle = useCallback(
     (index: number) => {
@@ -33,7 +26,7 @@ export default function DayOfWeekPicker({
 
   return (
     <div className="flex gap-2">
-      {WEEKDAYS.map((day, index) => {
+      {shortNames.map((day, index) => {
         const active = value.includes(index);
         return (
           <button
@@ -45,9 +38,9 @@ export default function DayOfWeekPicker({
               active && "bg-primary text-primary-foreground border-primary",
             )}
             aria-pressed={active}
-            aria-label={WEEKDAY_LABELS[index]}
+            aria-label={longNames[index]}
           >
-            {day[0]}
+            {day}
           </button>
         );
       })}


### PR DESCRIPTION
## Summary
- accept localized weekday names via props in DayOfWeekPicker
- document DayOfWeekPicker usage with Storybook example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abfa1c6684832a82015daf02fdde98