### PR TITLE
[reminders] Open reminders page from add button

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -8,7 +8,6 @@ import logging
 import re
 from datetime import time, timedelta, timezone
 from typing import Awaitable, Callable, Literal, cast
-from urllib.parse import urljoin
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy.orm import Session, sessionmaker
@@ -175,7 +174,7 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
-                web_app=WebAppInfo(build_webapp_url("/reminders/new")),
+                web_app=WebAppInfo(build_webapp_url("/reminders")),
             )
         ]
     if not rems:

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -279,7 +279,7 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
         if btn.text == "➕ Добавить"
     )
     assert add_btn.web_app is not None
-    assert add_btn.web_app.url.endswith("/reminders/new")
+    assert add_btn.web_app.url.endswith("/reminders")
 
 
 def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- fix Add button in reminders list to open Reminders webapp page
- update tests for new reminders link

## Testing
- `pytest tests/test_reminders.py -q --cov` *(fails: Coverage failure: total of 47 is less than fail-under=85)*
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py`
- `ruff check services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac5266298c832a9bff51a241cfbb3a