### PR TITLE
[reminders] Update add button to API URL

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -174,7 +174,7 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
-                web_app=WebAppInfo(build_webapp_url("/reminders")),
+                web_app=WebAppInfo(build_webapp_url("/api/reminders")),
             )
         ]
     if not rems:

--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -169,31 +169,31 @@ async def test_reminder_webapp_save_unknown_type(reminder_handlers: Any) -> None
     assert message.texts == ["Неизвестный тип напоминания."]
 
 
-@pytest.mark.parametrize(
-    "base_url, expected",
-    [
-        ("https://example.com", "https://example.com/reminders"),
-        ("https://example.com/", "https://example.com/reminders"),
-        ("https://example.com/ui", "https://example.com/ui/reminders"),
-        ("https://example.com/ui/", "https://example.com/ui/reminders"),
-    ],
-)
-def test_build_webapp_url(
-    reminder_handlers: Any,
-    monkeypatch: pytest.MonkeyPatch,
-    base_url: str,
-    expected: str,
-) -> None:
-    monkeypatch.setenv("WEBAPP_URL", base_url)
-    url = reminder_handlers.build_webapp_url("/reminders")
-    assert url == expected
-    assert "//" not in url.split("://", 1)[1]
+    @pytest.mark.parametrize(
+        "base_url, expected",
+        [
+            ("https://example.com", "https://example.com/api/reminders"),
+            ("https://example.com/", "https://example.com/api/reminders"),
+            ("https://example.com/ui", "https://example.com/ui/api/reminders"),
+            ("https://example.com/ui/", "https://example.com/ui/api/reminders"),
+        ],
+    )
+    def test_build_webapp_url(
+        reminder_handlers: Any,
+        monkeypatch: pytest.MonkeyPatch,
+        base_url: str,
+        expected: str,
+    ) -> None:
+        monkeypatch.setenv("WEBAPP_URL", base_url)
+        url = reminder_handlers.build_webapp_url("/api/reminders")
+        assert url == expected
+        assert "//" not in url.split("://", 1)[1]
 
 
-def test_build_webapp_url_without_base(
-    reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    path = "/reminders"
-    monkeypatch.delenv("WEBAPP_URL", raising=False)
-    with pytest.raises(RuntimeError, match="WEBAPP_URL not configured"):
-        reminder_handlers.build_webapp_url(path)
+    def test_build_webapp_url_without_base(
+        reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = "/api/reminders"
+        monkeypatch.delenv("WEBAPP_URL", raising=False)
+        with pytest.raises(RuntimeError, match="WEBAPP_URL not configured"):
+            reminder_handlers.build_webapp_url(path)

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -279,7 +279,7 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
         if btn.text == "➕ Добавить"
     )
     assert add_btn.web_app is not None
-    assert add_btn.web_app.url.endswith("/reminders")
+    assert add_btn.web_app.url.endswith("/api/reminders")
 
 
 def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- point reminder add button to `/api/reminders`
- adjust reminder tests for new webapp URL

## Testing
- `pytest -q` *(fails: tests/test_alembic_env.py::test_env_handles_missing_dotenv, tests/test_models_metadata.py::test_models_exports_metadata)*
- `python -m mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py tests/test_reminder_handlers.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ac5c7a00d0832a8d61ad9541be8357