### PR TITLE
[webapp] Resolve theme module from base URL

### DIFF
--- a/services/webapp/public/telegram-init.js
+++ b/services/webapp/public/telegram-init.js
@@ -1,5 +1,7 @@
 (async function () {
-    const { default: applyTheme } = await import("./assets/telegram-theme.js");
+    const { default: applyTheme } = await import(
+        new URL('./telegram-theme.js', import.meta.url),
+    );
     const app = window.Telegram?.WebApp;
     if (!app) {
         return;

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -19,7 +19,7 @@ function telegramInitPlugin(): Plugin {
       if (id === 'telegram-init.js' || id === '/ui/telegram-init.js') {
         return telegramInitPath
       }
-      if (importer === telegramInitPath && id === './assets/telegram-theme.js') {
+      if (importer === telegramInitPath && id === './telegram-theme.js') {
         return { id, external: true }
       }
       return null
@@ -76,7 +76,7 @@ export default defineConfig(async ({ mode, command }) => {
     output: {
       entryFileNames: (chunk) =>
         chunk.name === 'telegram-theme'
-          ? 'assets/telegram-theme.js'
+          ? 'telegram-theme.js'
           : 'assets/[name]-[hash].js',
       manualChunks: {
         vendor: ['react', 'react-dom', 'react-router-dom'],


### PR DESCRIPTION
## Summary
- load Telegram theme using base URL
- emit theme bundle alongside telegram-init

## Testing
- `pnpm --filter "./services/webapp/ui" build`
- `pnpm --filter "./services/webapp/ui" lint` *(fails: @typescript-eslint/no-explicit-any)*
- `pnpm --filter "./services/webapp/ui" test` *(fails: ReferenceError: afterEach is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ac72355120832aabd2108c546441fb