### PR TITLE
[webapp] handle null stats API

### DIFF
--- a/services/webapp/ui/src/api/stats.api.test.ts
+++ b/services/webapp/ui/src/api/stats.api.test.ts
@@ -33,6 +33,7 @@ import {
   fetchDayStats,
   getFallbackAnalytics,
   getFallbackDayStats,
+  type DayStats,
 } from './stats';
 
 let ResponseError: new (arg: { status: number }) => Error;
@@ -92,6 +93,14 @@ describe('fetchDayStats', () => {
   it('returns fallback on invalid response', async () => {
     mockGetStats.mockResolvedValueOnce({ sugar: 'bad' } as unknown as DayStats);
     await expect(fetchDayStats(1)).resolves.toEqual(getFallbackDayStats());
+  });
+
+  it('returns fallback on null response without logging', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetStats.mockResolvedValueOnce(null);
+    await expect(fetchDayStats(1)).resolves.toEqual(getFallbackDayStats());
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 
   it('returns fallback on network error', async () => {

--- a/services/webapp/ui/src/api/stats.ts
+++ b/services/webapp/ui/src/api/stats.ts
@@ -101,7 +101,11 @@ export async function fetchDayStats(telegramId: number): Promise<DayStats> {
   try {
     const data = await api.getStatsStatsGet({ telegramId });
 
-    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    if (data === null) {
+      return getFallbackDayStats();
+    }
+
+    if (typeof data !== 'object' || Array.isArray(data)) {
       console.error('Unexpected stats API response:', data);
       return getFallbackDayStats();
     }


### PR DESCRIPTION
## Summary
- handle null API responses in fetchDayStats without logging errors
- test null stats API responses for fallback handling and no console error

## Testing
- `pnpm vitest run src/api/stats.api.test.ts --config ../../../vitest.config.ts`
- `pnpm --filter ./services/webapp/ui test` *(fails: ReferenceError: afterEach is not defined)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ac7244f078832aa959ff3ebb0a1d1d