### PR TITLE
[api] handle schema validation with 422 responses

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -16,9 +16,9 @@ if __name__ == "__main__" and __package__ is None:  # pragma: no cover
     __package__ = "services.api.app"
 
 # ────────── std / 3-rd party ──────────
-from fastapi import APIRouter, Depends, FastAPI, HTTPException
-from fastapi.responses import FileResponse
-from pydantic import AliasChoices, BaseModel, Field
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
+from fastapi.responses import FileResponse, JSONResponse
+from pydantic import AliasChoices, BaseModel, Field, ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
@@ -58,6 +58,11 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 
 
 app = FastAPI(title="Diabetes Assistant API", version="1.0.0", lifespan=lifespan)
+
+
+@app.exception_handler(ValidationError)
+async def pydantic_422(_: Request, exc: ValidationError) -> JSONResponse:
+    return JSONResponse(status_code=422, content={"detail": exc.errors()})
 
 
 # ────────── роуты статистики / legacy ──────────
@@ -296,6 +301,4 @@ app.include_router(api_router, prefix="/api")
 if __name__ == "__main__":  # pragma: no cover
     import uvicorn
 
-    uvicorn.run(
-        "services.api.app.main:app", host="0.0.0.0", port=8000, ws="wsproto"
-    )
+    uvicorn.run("services.api.app.main:app", host="0.0.0.0", port=8000, ws="wsproto")

--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -69,10 +69,15 @@ async def save_reminder(data: ReminderSchema) -> int:
         assert rem.id is not None
         return rem.id
 
-    return cast(
-        int,
-        await run_db(cast(Callable[[Session], int], _save), sessionmaker=SessionLocal),
-    )
+    try:
+        return cast(
+            int,
+            await run_db(
+                cast(Callable[[Session], int], _save), sessionmaker=SessionLocal
+            ),
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
 
 
 async def delete_reminder(telegram_id: int, reminder_id: int) -> None:

--- a/tests/test_pydantic_handler.py
+++ b/tests/test_pydantic_handler.py
@@ -1,0 +1,22 @@
+import json
+
+import pytest
+from pydantic import BaseModel, ValidationError
+from starlette.requests import Request
+
+from services.api.app import main
+
+
+class DummyModel(BaseModel):
+    num: int
+
+
+@pytest.mark.asyncio
+async def test_pydantic_422_handler_returns_readable_errors() -> None:
+    with pytest.raises(ValidationError) as exc:
+        DummyModel(num="bad")
+
+    response = await main.pydantic_422(Request({"type": "http"}), exc.value)
+    assert response.status_code == 422
+    detail = json.loads(response.body.decode())
+    assert detail["detail"][0]["msg"]

--- a/tests/test_services_reminders.py
+++ b/tests/test_services_reminders.py
@@ -117,6 +117,20 @@ async def test_save_reminder_not_found_or_wrong_user(
 
 
 @pytest.mark.asyncio
+async def test_save_reminder_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fail_run_db(*args: Any, **kwargs: Any) -> Any:
+        raise ValueError("bad data")
+
+    monkeypatch.setattr(reminders, "run_db", fail_run_db)
+
+    with pytest.raises(HTTPException) as exc:
+        await reminders.save_reminder(ReminderSchema(telegramId=1, type="sugar"))
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "bad data"
+
+
+@pytest.mark.asyncio
 async def test_list_reminders_invalid_user(
     monkeypatch: pytest.MonkeyPatch, session_factory: SessionMaker[SASession]
 ) -> None:


### PR DESCRIPTION
## Summary
- add global 422 handler for Pydantic ValidationError
- convert ValueError to HTTPException 422 in reminder saving
- test reminder errors and validation handler behavior

## Testing
- `python -m pytest -q --cov`
- `mypy --strict .`
- `ruff check services/api/app/main.py services/api/app/services/reminders.py tests/test_services_reminders.py tests/test_pydantic_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac77497250832ab88caf3ebe251d47