### PR TITLE
[py-sdk] validate multipart post params

### DIFF
--- a/libs/py-sdk/diabetes_sdk/rest.py
+++ b/libs/py-sdk/diabetes_sdk/rest.py
@@ -208,13 +208,22 @@ class RESTClientObject:
                         )
                     fields = []
                     for item in items:
-                        try:
-                            key, value = item
-                        except (TypeError, ValueError) as exc:
+                        if not isinstance(item, Iterable) or isinstance(
+                            item, (str, bytes)
+                        ):
+                            raise ApiValueError(
+                                "post_params elements must be pairs",
+                            )
+                        pair = list(item)
+                        if len(pair) != 2:
                             raise ApiValueError(
                                 "Invalid number of elements in post_params",
-                            ) from exc
-                        if isinstance(value, (Mapping, list, tuple)):
+                            )
+                        key, value = pair
+                        if isinstance(value, Mapping) or (
+                            isinstance(value, Iterable)
+                            and not isinstance(value, (str, bytes))
+                        ):
                             value = json.dumps(value)
                         fields.append((key, value))
                     r = self.pool_manager.request(

--- a/libs/py-sdk/test/test_rest_multipart.py
+++ b/libs/py-sdk/test/test_rest_multipart.py
@@ -146,14 +146,22 @@ def test_multipart_tuple_value() -> None:
     assert kwargs["fields"] == [("tuple", json.dumps(value))]
 
 
-def test_multipart_invalid_post_params() -> None:
+@pytest.mark.parametrize(
+    "post_params",
+    [
+        [("foo",)],
+        [("foo", "bar", "baz")],
+        [("foo", "bar"), "baz"],
+    ],
+)
+def test_multipart_invalid_post_params(post_params: list[object]) -> None:
     client = _client()
     with pytest.raises(ApiValueError):
         client.request(  # type: ignore[no-untyped-call]
             "POST",
             "http://example.com",
             headers={"Content-Type": "multipart/form-data"},
-            post_params=[("foo",)],
+            post_params=post_params,
         )
 
 


### PR DESCRIPTION
## Summary
- validate and serialize multipart post params safely
- test multipart invalid elements raise ApiValueError

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict libs/py-sdk/diabetes_sdk/rest.py libs/py-sdk/test/test_rest_multipart.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ac7aa2fddc832aa67d9d24c058e7ff