### PR TITLE
[handlers] Update reminder webapp URL

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -174,7 +174,7 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
-                web_app=WebAppInfo(build_webapp_url("/api/reminders")),
+                web_app=WebAppInfo(build_webapp_url("/reminders/new")),
             )
         ]
     if not rems:

--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -172,10 +172,10 @@ async def test_reminder_webapp_save_unknown_type(reminder_handlers: Any) -> None
     @pytest.mark.parametrize(
         "base_url, expected",
         [
-            ("https://example.com", "https://example.com/api/reminders"),
-            ("https://example.com/", "https://example.com/api/reminders"),
-            ("https://example.com/ui", "https://example.com/ui/api/reminders"),
-            ("https://example.com/ui/", "https://example.com/ui/api/reminders"),
+            ("https://example.com", "https://example.com/reminders/new"),
+            ("https://example.com/", "https://example.com/reminders/new"),
+            ("https://example.com/ui", "https://example.com/ui/reminders/new"),
+            ("https://example.com/ui/", "https://example.com/ui/reminders/new"),
         ],
     )
     def test_build_webapp_url(
@@ -185,7 +185,7 @@ async def test_reminder_webapp_save_unknown_type(reminder_handlers: Any) -> None
         expected: str,
     ) -> None:
         monkeypatch.setenv("WEBAPP_URL", base_url)
-        url = reminder_handlers.build_webapp_url("/api/reminders")
+        url = reminder_handlers.build_webapp_url("/reminders/new")
         assert url == expected
         assert "//" not in url.split("://", 1)[1]
 
@@ -193,7 +193,7 @@ async def test_reminder_webapp_save_unknown_type(reminder_handlers: Any) -> None
     def test_build_webapp_url_without_base(
         reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        path = "/api/reminders"
+        path = "/reminders/new"
         monkeypatch.delenv("WEBAPP_URL", raising=False)
         with pytest.raises(RuntimeError, match="WEBAPP_URL not configured"):
             reminder_handlers.build_webapp_url(path)


### PR DESCRIPTION
## Summary
- switch reminder add button to `/reminders/new`
- adjust reminder webapp URL tests

## Testing
- `pytest tests/test_reminder_handlers.py -q --override-ini=addopts=`
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminder_handlers.py`
- `ruff check services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminder_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac7b1fec04832a9607ec0eddfcfb72