### PR TITLE
[ui] serve telegram theme asset

### DIFF
--- a/services/webapp/public/telegram-theme.js
+++ b/services/webapp/public/telegram-theme.js
@@ -1,0 +1,42 @@
+export const supportsColorMethods = (app) => {
+  const [major = 0, minor = 0] = (app?.version || "0.0")
+    .split(".")
+    .map((n) => parseInt(n, 10));
+  if (app?.platform === "tdesktop") {
+    return major > 4 || (major === 4 && minor >= 8);
+  }
+  return major > 6 || (major === 6 && minor >= 1);
+};
+
+function applyTheme(src, ignoreScheme = false) {
+  const root = document.documentElement;
+  const p = src?.themeParams ?? {};
+  const map = {
+    "--tg-theme-bg-color": p.bg_color,
+    "--tg-theme-text-color": p.text_color,
+    "--tg-theme-hint-color": p.hint_color,
+    "--tg-theme-link-color": p.link_color,
+    "--tg-theme-button-color": p.button_color,
+    "--tg-theme-button-text-color": p.button_text_color,
+    "--tg-theme-secondary-bg-color": p.secondary_bg_color,
+  };
+  if (ignoreScheme) {
+    Object.keys(map).forEach((k) => root.style.removeProperty(k));
+    root.classList.remove("dark");
+    root.style.colorScheme = "light";
+    if (src && supportsColorMethods(src)) {
+      if (src.setBackgroundColor) src.setBackgroundColor("#ffffff");
+      if (src.setHeaderColor) src.setHeaderColor("#ffffff");
+    }
+    return "light";
+  }
+  Object.entries(map).forEach(([k, v]) => v && root.style.setProperty(k, v));
+  root.style.colorScheme = "";
+  const scheme = src?.colorScheme ?? "light";
+  root.classList.toggle("dark", scheme === "dark");
+  return scheme;
+}
+
+export { applyTheme };
+export default applyTheme;
+

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -7,8 +7,9 @@ import { ServerResponse } from 'node:http'
 
 function telegramInitPlugin(): Plugin {
   const shared = path.resolve(__dirname, '../public')
-  const files = ['telegram-init.js']
+  const files = ['telegram-init.js', 'telegram-theme.js']
   const telegramInitPath = path.join(shared, 'telegram-init.js')
+  const themeId = './telegram-theme.js'
   const serve = async (res: ServerResponse, file: string) => {
     res.setHeader('Content-Type', 'application/javascript')
     res.end(await readFile(path.join(shared, file), 'utf8'))
@@ -19,8 +20,8 @@ function telegramInitPlugin(): Plugin {
       if (id === 'telegram-init.js' || id === '/ui/telegram-init.js') {
         return telegramInitPath
       }
-      if (importer === telegramInitPath && id === './telegram-theme.js') {
-        return { id, external: true }
+      if (importer === telegramInitPath && id === themeId) {
+        return { id: themeId, external: true }
       }
       return null
     },


### PR DESCRIPTION
## Summary
- serve `telegram-theme.js` alongside `telegram-init.js`
- include built `telegram-theme.js` in public assets

## Testing
- `pytest -q --cov` *(fails: unrecognized arguments: --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=85 --cov)*
- `mypy --strict .`
- `ruff check .`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68ac7b1bf1b4832a962465271aea1fbd