### PR TITLE
[docs] Add Apache aliases for Telegram scripts

### DIFF
--- a/docs/deploy/apache.conf
+++ b/docs/deploy/apache.conf
@@ -1,0 +1,2 @@
+Alias /telegram-init.js  /var/www/html/telegram-init.js
+Alias /telegram-theme.js /var/www/html/telegram-theme.js


### PR DESCRIPTION
## Summary
- document Apache aliases for `telegram-init.js` and `telegram-theme.js`

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`
- `curl -I https://bot.offonika.ru/telegram-init.js`
- `curl -I https://bot.offonika.ru/telegram-theme.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac7b2016c8832aa0c4b4cf9adbef35