### PR TITLE
[scripts] add telegram assets checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,3 +286,14 @@ pytest tests/
 pip install -r services/api/app/requirements-dev.txt
 ruff services/api/app/diabetes tests
 ```
+
+### Проверка ресурсов Telegram WebApp
+
+Скрипт убеждается, что `telegram-init.js` и `telegram-theme.js` доступны
+и отдаются с типом `application/javascript`:
+
+```bash
+scripts/check-telegram-assets.sh
+```
+
+При успехе выводится `OK`.

--- a/scripts/check-telegram-assets.sh
+++ b/scripts/check-telegram-assets.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+for f in telegram-init.js telegram-theme.js; do
+    curl -sSI "https://bot.offonika.ru/$f" | \
+      grep -q 'HTTP/1.1 200' && \
+      grep -q 'Content-Type: application/javascript' || exit 1
+done
+echo 'OK'


### PR DESCRIPTION
## Summary
- add check-telegram-assets.sh to verify Telegram JS assets
- document script in README

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ac7b395568832aa3daea6cd7055b59