### PR TITLE
[migration] add quiet hours columns to profiles

### DIFF
--- a/services/api/alembic/versions/1188e4de1729_add_quiet_hours_to_profiles.py
+++ b/services/api/alembic/versions/1188e4de1729_add_quiet_hours_to_profiles.py
@@ -1,0 +1,56 @@
+"""add quiet hours to profiles
+
+Revision ID: 1188e4de1729
+Revises: 8db592ddbe51
+Create Date: 2025-08-25 15:24:16.293648
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1188e4de1729'
+down_revision: Union[str, None] = '8db592ddbe51'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    columns = [col["name"] for col in inspector.get_columns("profiles")]
+    if "quiet_start" not in columns:
+        op.add_column(
+            "profiles",
+            sa.Column(
+                "quiet_start",
+                sa.Time(),
+                nullable=True,
+                server_default=sa.text("'23:00'"),
+            ),
+        )
+    if "quiet_end" not in columns:
+        op.add_column(
+            "profiles",
+            sa.Column(
+                "quiet_end",
+                sa.Time(),
+                nullable=True,
+                server_default=sa.text("'07:00'"),
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    columns = [col["name"] for col in inspector.get_columns("profiles")]
+    if "quiet_end" in columns:
+        op.drop_column("profiles", "quiet_end")
+    if "quiet_start" in columns:
+        op.drop_column("profiles", "quiet_start")


### PR DESCRIPTION
## Summary
- add `quiet_start` and `quiet_end` columns to profiles

## Testing
- `PYTHONPATH=/workspace/saharlight-ux DATABASE_URL=sqlite:////tmp/test.db alembic upgrade head` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*
- `pytest -q --cov --cov-fail-under=85` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ac7fcd7c50832a87c8125e69bbc306