### PR TITLE
[services] Respect quiet window in reminder scheduling

### DIFF
--- a/services/api/app/diabetes/services/reminders_schedule.py
+++ b/services/api/app/diabetes/services/reminders_schedule.py
@@ -1,11 +1,44 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, tzinfo, timezone
+from datetime import datetime, timedelta, time, timezone
+from zoneinfo import ZoneInfo
 
 from .db import Reminder
 
 
-def compute_next(rem: Reminder, user_tz: tzinfo) -> datetime | None:
+def _apply_quiet_window(dt: datetime, tz: ZoneInfo, start: str, end: str) -> datetime:
+    """Shift ``dt`` to the end of a quiet window if it falls within it.
+
+    The window is defined by ``start`` and ``end`` strings in ``HH:MM`` format
+    and interpreted in the provided timezone. When ``start`` is earlier than
+    ``end`` the window lies within a single day. If ``start`` is later than
+    ``end`` the window spans midnight and applies from ``start`` until ``end``
+    on the following day. Datetimes outside the window are returned unchanged.
+    """
+
+    local_dt = dt.astimezone(tz)
+    start_time = time.fromisoformat(start)
+    end_time = time.fromisoformat(end)
+    start_dt = datetime.combine(local_dt.date(), start_time, tzinfo=tz)
+    end_dt = datetime.combine(local_dt.date(), end_time, tzinfo=tz)
+
+    if start_time <= end_time:
+        if start_dt <= local_dt < end_dt:
+            return end_dt
+    else:  # window crosses midnight
+        if local_dt >= start_dt:
+            return end_dt + timedelta(days=1)
+        if local_dt < end_dt:
+            return end_dt
+    return local_dt
+
+
+def compute_next(
+    rem: Reminder,
+    user_tz: ZoneInfo,
+    quiet_start: str = "23:00",
+    quiet_end: str = "07:00",
+) -> datetime | None:
     """Return next fire time for a reminder in UTC.
 
     Parameters
@@ -14,6 +47,9 @@ def compute_next(rem: Reminder, user_tz: tzinfo) -> datetime | None:
         Reminder instance containing scheduling info.
     user_tz:
         User's timezone.
+    quiet_start, quiet_end:
+        Quiet hours in ``HH:MM``. The reminder will be postponed to
+        ``quiet_end`` if the computed time falls inside the window.
     """
     now = datetime.now(user_tz)
 
@@ -25,10 +61,13 @@ def compute_next(rem: Reminder, user_tz: tzinfo) -> datetime | None:
             if days_mask == 0 or (days_mask & (1 << (weekday - 1))):
                 candidate = datetime.combine(day, rem.time, tzinfo=user_tz)
                 if candidate > now:
+                    candidate = _apply_quiet_window(candidate, user_tz, quiet_start, quiet_end)
                     return candidate.astimezone(timezone.utc)
         return None
 
     if rem.kind == "every" and rem.interval_minutes is not None:
-        return (now + timedelta(minutes=rem.interval_minutes)).astimezone(timezone.utc)
+        candidate = now + timedelta(minutes=rem.interval_minutes)
+        candidate = _apply_quiet_window(candidate, user_tz, quiet_start, quiet_end)
+        return candidate.astimezone(timezone.utc)
 
     return None

--- a/tests/test_reminders_schedule.py
+++ b/tests/test_reminders_schedule.py
@@ -43,3 +43,29 @@ def test_compute_next_after_event(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_now(monkeypatch, datetime(2024, 1, 1, 10, 0))
     rem = Reminder(kind="after_event", minutes_after=15)
     assert compute_next(rem, tz) is None
+
+
+def test_quiet_window_same_day(monkeypatch: pytest.MonkeyPatch) -> None:
+    tz = ZoneInfo("Europe/Moscow")
+    _patch_now(monkeypatch, datetime(2024, 1, 1, 11, 0))
+    rem = Reminder(kind="every", interval_minutes=60)
+    next_dt = compute_next(rem, tz, quiet_start="12:00", quiet_end="14:00")
+    assert next_dt == datetime(2024, 1, 1, 11, 0, tzinfo=timezone.utc)
+
+
+def test_quiet_window_cross_midnight_evening(monkeypatch: pytest.MonkeyPatch) -> None:
+    tz = ZoneInfo("Europe/Moscow")
+    _patch_now(monkeypatch, datetime(2024, 1, 1, 22, 30))
+    rem = Reminder(kind="every", interval_minutes=60)
+    next_dt = compute_next(rem, tz)
+    assert next_dt == datetime(2024, 1, 2, 4, 0, tzinfo=timezone.utc)
+
+
+def test_quiet_window_cross_midnight_morning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tz = ZoneInfo("Europe/Moscow")
+    _patch_now(monkeypatch, datetime(2024, 1, 1, 6, 20))
+    rem = Reminder(kind="every", interval_minutes=30)
+    next_dt = compute_next(rem, tz)
+    assert next_dt == datetime(2024, 1, 1, 4, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- shift reminder fire times out of user-defined quiet hours
- accept `quiet_start`/`quiet_end` in `compute_next`
- test same-day and cross-midnight quiet window handling

## Testing
- `pytest -q tests/test_reminders_schedule.py --cov=services.api.app.diabetes.services.reminders_schedule --cov-report=term-missing --cov-fail-under=85 -o addopts=`
- `python -m mypy --strict services/api/app/diabetes/services/reminders_schedule.py tests/test_reminders_schedule.py`
- `ruff check services/api/app/diabetes/services/reminders_schedule.py tests/test_reminders_schedule.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac7fcf1d84832aa2dedd3c2034bf73