### PR TITLE
[py-sdk] Normalize multipart post params

### DIFF
--- a/libs/py-sdk/diabetes_sdk/rest.py
+++ b/libs/py-sdk/diabetes_sdk/rest.py
@@ -212,7 +212,7 @@ class RESTClientObject:
                             item, (str, bytes)
                         ):
                             raise ApiValueError(
-                                "post_params elements must be pairs",
+                                "Invalid number of elements in post_params",
                             )
                         pair = list(item)
                         if len(pair) != 2:

--- a/libs/py-sdk/test/test_rest_multipart.py
+++ b/libs/py-sdk/test/test_rest_multipart.py
@@ -75,6 +75,26 @@ def test_multipart_tuple() -> None:
     ]
 
 
+def test_multipart_generator() -> None:
+    client = _client()
+    mock = MagicMock(return_value=_mock_response())
+    client.pool_manager.request = mock  # type: ignore[method-assign]
+    params = ((k, v) for k, v in [("foo", "bar"), ("baz", {"a": 1})])
+    client.request(  # type: ignore[no-untyped-call]
+        "POST",
+        "http://example.com",
+        headers={"Content-Type": "multipart/form-data"},
+        post_params=params,
+    )
+    kwargs = mock.call_args.kwargs
+    assert kwargs["encode_multipart"] is True
+    assert all(len(item) == 2 for item in kwargs["fields"])
+    assert kwargs["fields"] == [
+        ("foo", "bar"),
+        ("baz", json.dumps({"a": 1})),
+    ]
+
+
 def test_multipart_mapping() -> None:
     client = _client()
     mock = MagicMock(return_value=_mock_response())


### PR DESCRIPTION
## Summary
- normalize multipart post_params to handle generic iterables and validate pair lengths
- JSON-serialize nested values before multipart encoding
- test multipart support across mappings, iterables, generators and invalid cases

## Testing
- `pytest libs/py-sdk/test/test_rest_multipart.py -q --override-ini=addopts=`
- `ruff check libs/py-sdk/diabetes_sdk/rest.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac88264350832ab014fab2cb50e9cc