### PR TITLE
[handlers] support custom reminder snooze duration

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -47,7 +47,9 @@ try:
 except ImportError:  # pragma: no cover - optional db runner
     run_db = None
 except Exception as exc:  # pragma: no cover - log unexpected errors
-    logging.getLogger(__name__).exception("Unexpected error importing run_db", exc_info=exc)
+    logging.getLogger(__name__).exception(
+        "Unexpected error importing run_db", exc_info=exc
+    )
     raise
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
@@ -131,7 +133,9 @@ def _schedule_with_next(rem: Reminder, user: User | None = None) -> tuple[str, s
     next_dt: datetime.datetime | None
     if rem.time:
         type_icon = "⏰"
-        next_dt = now.replace(hour=rem.time.hour, minute=rem.time.minute, second=0, microsecond=0)
+        next_dt = now.replace(
+            hour=rem.time.hour, minute=rem.time.minute, second=0, microsecond=0
+        )
         if next_dt <= now:
             next_dt += timedelta(days=1)
         base = rem.time.strftime("%H:%M")
@@ -159,7 +163,9 @@ def _schedule_with_next(rem: Reminder, user: User | None = None) -> tuple[str, s
     return type_icon, schedule
 
 
-def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboardMarkup | None]:
+def _render_reminders(
+    session: Session, user_id: int
+) -> tuple[str, InlineKeyboardMarkup | None]:
     rems = session.query(Reminder).filter_by(telegram_id=user_id).all()
     user = session.query(User).filter_by(telegram_id=user_id).first()
     limit = _limit_for(user)
@@ -220,7 +226,9 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
     lines: list[str] = []
     buttons: list[list[InlineKeyboardButton]] = []
 
-    def extend(section: str, items: list[tuple[str, list[InlineKeyboardButton]]]) -> None:
+    def extend(
+        section: str, items: list[tuple[str, list[InlineKeyboardButton]]]
+    ) -> None:
         if not items:
             return
         if lines:
@@ -431,12 +439,16 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         with SessionLocal() as session:
             status, db_user, limit, rid_or_count = db_add(session)
     else:
-        status, db_user, limit, rid_or_count = await run_db(db_add, sessionmaker=SessionLocal)
+        status, db_user, limit, rid_or_count = await run_db(
+            db_add, sessionmaker=SessionLocal
+        )
 
     if status == "limit":
         count = rid_or_count
         await message.reply_text(
-            (f"У вас уже {count} активных из {limit}. Отключите одно или Апгрейд до Pro, чтобы поднять лимит до 10"),
+            (
+                f"У вас уже {count} активных из {limit}. Отключите одно или Апгрейд до Pro, чтобы поднять лимит до 10"
+            ),
         )
         return
     if status == "error":
@@ -452,7 +464,9 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await message.reply_text(f"Сохранено: {_describe(reminder, db_user)}")
 
 
-async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def reminder_webapp_save(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     """Save reminder data sent from the web app."""
     msg: Message | None = update.effective_message
     user = update.effective_user
@@ -489,13 +503,17 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
     else:
         if not re.fullmatch(r"\d{1,2}:\d{2}|\d+h", value):
             logger.warning("Invalid reminder value format: %s", value)
-            await msg.reply_text("❌ Неверный формат. Используйте HH:MM или число часов с суффиксом h.")
+            await msg.reply_text(
+                "❌ Неверный формат. Используйте HH:MM или число часов с суффиксом h."
+            )
             return
         try:
             parsed = parse_time_interval(value)
         except ValueError:
             logger.warning("Failed to parse reminder value: %s", value)
-            await msg.reply_text("❌ Неверный формат. Используйте HH:MM или число часов с суффиксом h.")
+            await msg.reply_text(
+                "❌ Неверный формат. Используйте HH:MM или число часов с суффиксом h."
+            )
             return
         minutes = None
 
@@ -512,7 +530,11 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
             if not rem or rem.telegram_id != user_id:
                 return "not_found", None, None, None
         else:
-            count = session.query(Reminder).filter_by(telegram_id=user_id, is_enabled=True).count()
+            count = (
+                session.query(Reminder)
+                .filter_by(telegram_id=user_id, is_enabled=True)
+                .count()
+            )
             user = session.get(User, user_id)
             plan = getattr(user, "plan", "free").lower()
             limit = PLAN_LIMITS.get(plan, PLAN_LIMITS["free"])
@@ -554,7 +576,9 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
         if plan is None:
             return
         await msg.reply_text(
-            (f"У вас уже {limit} активных (лимит {plan.upper()}). Отключите одно или откройте PRO."),
+            (
+                f"У вас уже {limit} активных (лимит {plan.upper()}). Отключите одно или откройте PRO."
+            ),
         )
         return
     if status == "error":
@@ -580,7 +604,9 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
 
 
 async def delete_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    message: Message | None = update.message or (update.callback_query.message if update.callback_query else None)
+    message: Message | None = update.message or (
+        update.callback_query.message if update.callback_query else None
+    )
     args = getattr(context, "args", [])
     if not args:
         if message:
@@ -638,13 +664,17 @@ async def reminder_job(context: ContextTypes.DEFAULT_TYPE) -> None:
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton("Отложить 10 мин", callback_data=f"remind_snooze:{rid}"),
+                InlineKeyboardButton(
+                    "Отложить 10 мин", callback_data=f"remind_snooze:{rid}:10"
+                ),
                 InlineKeyboardButton("Отмена", callback_data=f"remind_cancel:{rid}"),
             ]
         ]
     )
     try:
-        await context.bot.send_message(chat_id=chat_id, text=text, reply_markup=keyboard)
+        await context.bot.send_message(
+            chat_id=chat_id, text=text, reply_markup=keyboard
+        )
     except TelegramError:
         logger.exception("Failed to send reminder %s to chat %s", rid, chat_id)
 
@@ -654,8 +684,20 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     user = update.effective_user
     if query is None or query.data is None or user is None:
         return
-    action, rid_str = query.data.split(":")
-    rid = int(rid_str)
+    parts = query.data.split(":")
+    if len(parts) < 2:
+        return
+    action, rid_str = parts[0], parts[1]
+    try:
+        rid = int(rid_str)
+    except ValueError:
+        return
+    minutes = None
+    if len(parts) > 2:
+        try:
+            minutes = int(parts[2])
+        except ValueError:
+            minutes = None
     chat_id = user.id
     with SessionLocal() as session:
         rem = session.get(Reminder, rid)
@@ -663,23 +705,31 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             await query.answer("Не найдено", show_alert=True)
             return
         await query.answer()
-        session.add(ReminderLog(reminder_id=rid, telegram_id=chat_id, action=action))
+        log_action = action if minutes is None else f"{action}:{minutes}"
+        session.add(
+            ReminderLog(reminder_id=rid, telegram_id=chat_id, action=log_action)
+        )
         try:
             commit(session)
         except CommitError:
-            logger.error("Failed to log reminder action %s for reminder %s", action, rid)
+            logger.error(
+                "Failed to log reminder action %s for reminder %s", log_action, rid
+            )
             return
     if action == "remind_snooze":
-        job_queue: DefaultJobQueue | None = cast(DefaultJobQueue | None, context.job_queue)
+        mins = minutes or 10
+        job_queue: DefaultJobQueue | None = cast(
+            DefaultJobQueue | None, context.job_queue
+        )
         if job_queue is not None:
             job_queue.run_once(
                 reminder_job,
-                when=timedelta(minutes=10),
+                when=timedelta(minutes=mins),
                 data={"reminder_id": rid, "chat_id": chat_id},
                 name=f"reminder_{rid}",
             )
         try:
-            await query.edit_message_text("⏰ Отложено на 10 минут")
+            await query.edit_message_text(f"⏰ Отложено на {mins} минут")
         except BadRequest as exc:
             if "Message is not modified" in str(exc):
                 await query.answer()
@@ -695,7 +745,9 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
                 raise
 
 
-async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def reminder_action_cb(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     query = update.callback_query
     user = update.effective_user
     if query is None or query.data is None or user is None:
@@ -785,7 +837,9 @@ async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE)
         )
     try:
         if keyboard is not None:
-            await query.edit_message_text(text, parse_mode="HTML", reply_markup=keyboard)
+            await query.edit_message_text(
+                text, parse_mode="HTML", reply_markup=keyboard
+            )
         else:
             await query.edit_message_text(text, parse_mode="HTML")
     except BadRequest as exc:
@@ -802,7 +856,11 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
         logger.warning("schedule_after_meal called without job_queue")
         return
     with SessionLocal() as session:
-        rems = session.query(Reminder).filter_by(telegram_id=user_id, type="xe_after", is_enabled=True).all()
+        rems = (
+            session.query(Reminder)
+            .filter_by(telegram_id=user_id, type="xe_after", is_enabled=True)
+            .all()
+        )
     for rem in rems:
         minutes_after = rem.minutes_after
         if minutes_after is None:
@@ -815,8 +873,12 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
         )
 
 
-reminder_action_handler = CallbackQueryHandler(reminder_action_cb, pattern="^rem_(del|toggle):")
-reminder_webapp_handler = MessageHandler(filters.StatusUpdate.WEB_APP_DATA, reminder_webapp_save)
+reminder_action_handler = CallbackQueryHandler(
+    reminder_action_cb, pattern="^rem_(del|toggle):"
+)
+reminder_webapp_handler = MessageHandler(
+    filters.StatusUpdate.WEB_APP_DATA, reminder_webapp_save
+)
 
 
 __all__ = [

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -313,7 +313,7 @@ async def test_reminder_callback_commit_failure(
 
     monkeypatch.setattr(reminder_handlers, "commit", failing_commit)
 
-    query = DummyQuery(DummyMessage(), "remind_snooze:1")
+    query = DummyQuery(DummyMessage(), "remind_snooze:1:10")
     update = make_update(callback_query=query, effective_user=make_user(1))
     job_queue = MagicMock(spec=JobQueue)
     job_queue.run_once = MagicMock()
@@ -325,7 +325,9 @@ async def test_reminder_callback_commit_failure(
     assert session.rollback.called
     assert query.edited == []
     assert not context.job_queue.run_once.called
-    assert "Failed to log reminder action remind_snooze for reminder 1" in caplog.text
+    assert (
+        "Failed to log reminder action remind_snooze:10 for reminder 1" in caplog.text
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections.abc import Generator
-from datetime import datetime, time, timezone, tzinfo
+from datetime import datetime, time, timedelta, timezone, tzinfo
 from zoneinfo import ZoneInfo
 from unittest.mock import MagicMock
 from typing import Any, Callable, cast
@@ -13,7 +13,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update, User
-from telegram.ext import CallbackContext, Job
+from telegram.ext import CallbackContext, Job, JobQueue
 
 import services.api.app.diabetes.handlers.reminder_handlers as handlers
 import services.api.app.diabetes.handlers.router as router
@@ -69,7 +69,9 @@ class DummyBot:
     async def send_message(self, chat_id: int | str, text: str, **kwargs: Any) -> None:
         self.messages.append((chat_id, text, kwargs))
 
-    async def answer_callback_query(self, callback_query_id: str, text: str | None = None, **kwargs: Any) -> None:
+    async def answer_callback_query(
+        self, callback_query_id: str, text: str | None = None, **kwargs: Any
+    ) -> None:
         self.cb_answers.append((callback_query_id, text))
 
 
@@ -159,7 +161,11 @@ def test_schedule_reminder_replaces_existing_job() -> None:
     handlers.SessionLocal = TestSession
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="Europe/Moscow"))
-        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
+        session.add(
+            Reminder(
+                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
+            )
+        )
         session.commit()
     job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
     with TestSession() as session:
@@ -191,7 +197,9 @@ def test_schedule_with_next_interval(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(handlers, "datetime", DummyDatetime)
     user = DbUser(telegram_id=1, thread_id="t", timezone="Europe/Moscow")
-    rem = Reminder(telegram_id=1, type="sugar", interval_hours=2, is_enabled=True, user=user)
+    rem = Reminder(
+        telegram_id=1, type="sugar", interval_hours=2, is_enabled=True, user=user
+    )
     icon, schedule = handlers._schedule_with_next(rem)
     assert icon == "⏱"
     assert schedule == "каждые 2 ч (next 12:00)"
@@ -201,7 +209,9 @@ def test_schedule_with_next_invalid_timezone_logs_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     user = DbUser(telegram_id=1, thread_id="t", timezone="Invalid/Zone")
-    rem = Reminder(telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user)
+    rem = Reminder(
+        telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user
+    )
     with caplog.at_level(logging.WARNING):
         icon, schedule = handlers._schedule_with_next(rem)
     assert icon == "⏰"
@@ -212,7 +222,9 @@ def test_schedule_reminder_invalid_timezone_logs_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     user = DbUser(telegram_id=1, thread_id="t", timezone="Bad/Zone")
-    rem = Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user)
+    rem = Reminder(
+        id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user
+    )
     job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
     with caplog.at_level(logging.WARNING):
         handlers.schedule_reminder(rem, job_queue)
@@ -244,7 +256,9 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.add_all(
             [
-                Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True),
+                Reminder(
+                    id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
+                ),
                 Reminder(
                     id=2,
                     telegram_id=1,
@@ -290,7 +304,11 @@ def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("WEBAPP_URL", raising=False)
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
-        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
+        session.add(
+            Reminder(
+                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
+            )
+        )
         session.commit()
     with TestSession() as session:
         text, markup = handlers._render_reminders(session, 1)
@@ -339,7 +357,9 @@ async def test_reminders_list_renders_output(
 
     monkeypatch.setattr(handlers, "SessionLocal", lambda: DummySessionCtx())
 
-    def fake_render(session: Session, user_id: int) -> tuple[str, InlineKeyboardMarkup | None]:
+    def fake_render(
+        session: Session, user_id: int
+    ) -> tuple[str, InlineKeyboardMarkup | None]:
         assert session is session_obj
         assert user_id == 1
         return "rendered", keyboard
@@ -378,7 +398,11 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
-        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
+        session.add(
+            Reminder(
+                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
+            )
+        )
         session.commit()
 
     job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
@@ -524,12 +548,45 @@ async def test_trigger_job_logs(monkeypatch: pytest.MonkeyPatch) -> None:
     assert reply_markup.inline_keyboard
     keyboard = reply_markup.inline_keyboard[0]
     assert len(keyboard) >= 2
-    assert keyboard[0].callback_data == "remind_snooze:1"
+    assert keyboard[0].callback_data == "remind_snooze:1:10"
     assert keyboard[1].callback_data == "remind_cancel:1"
     with TestSession() as session:
         log = session.query(ReminderLog).first()
         assert log is not None
         assert log.action == "trigger"
+
+
+@pytest.mark.asyncio
+async def test_snooze_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    handlers.SessionLocal = TestSession
+    handlers.commit = commit
+
+    with TestSession() as session:
+        session.add(DbUser(telegram_id=1, thread_id="t"))
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0)))
+        session.commit()
+
+    query = DummyCallbackQuery("remind_snooze:1:15", DummyMessage())
+    update = make_update(callback_query=query, effective_user=make_user(1))
+    job_queue = MagicMock(spec=JobQueue)
+    context = make_context(job_queue=job_queue, bot=DummyBot())
+    await handlers.reminder_callback(update, context)
+    job_queue.run_once.assert_called_once()
+    _, kwargs = job_queue.run_once.call_args
+    assert kwargs["when"] == timedelta(minutes=15)
+    assert kwargs["data"] == {"reminder_id": 1, "chat_id": 1}
+    assert kwargs["name"] == "reminder_1"
+    assert query.edited is not None
+    edited_text, _ = query.edited
+    assert edited_text == "⏰ Отложено на 15 минут"
+    assert query.answers == [None]
+    with TestSession() as session:
+        log = session.query(ReminderLog).first()
+        assert log is not None
+        assert log.action == "remind_snooze:15"
 
 
 @pytest.mark.asyncio
@@ -610,7 +667,9 @@ def client(
         yield test_client
 
 
-def test_empty_returns_200(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_empty_returns_200(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -619,7 +678,9 @@ def test_empty_returns_200(client: TestClient, session_factory: sessionmaker[Ses
     assert resp.json() == []
 
 
-def test_nonempty_returns_list(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_nonempty_returns_list(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(
@@ -652,7 +713,9 @@ def test_nonempty_returns_list(client: TestClient, session_factory: sessionmaker
     ]
 
 
-def test_get_single_reminder(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_get_single_reminder(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(
@@ -691,7 +754,9 @@ def test_real_404(client: TestClient) -> None:
     assert resp.json() == []
 
 
-def test_get_single_reminder_not_found(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_get_single_reminder_not_found(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -700,7 +765,9 @@ def test_get_single_reminder_not_found(client: TestClient, session_factory: sess
     assert resp.json() == {"detail": "reminder not found"}
 
 
-def test_post_reminder_forbidden(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_post_reminder_forbidden(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -715,7 +782,9 @@ def test_post_reminder_forbidden(client: TestClient, session_factory: sessionmak
     fastapi_app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
 
 
-def test_patch_reminder_forbidden(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_patch_reminder_forbidden(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(


### PR DESCRIPTION
## Summary
- include snooze duration in callback data and reminder logging
- reschedule reminder using selected snooze minutes
- test snooze callback and commit failures

## Testing
- `ruff check services/api/app/diabetes/handlers/reminder_handlers.py tests/test_handlers_commit_failures.py tests/test_reminders.py`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac872b2dcc832aa09f430fc03413fe