### PR TITLE
[reminders] Add extended snooze options

### DIFF
--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -33,7 +33,6 @@ class DummyQuery:
         self.edited: list[str] = []
 
     async def answer(self, text: str | None = None, **kwargs: Any) -> None:
-
         pass
 
     async def edit_message_text(self, text: str, **kwargs: Any) -> None:
@@ -98,9 +97,7 @@ async def test_profile_command_no_local_session(
 
     dummy_api = MagicMock()
     dummy_api.profiles_post = MagicMock()
-    monkeypatch.setattr(
-        profile_handlers, "get_api", lambda: (dummy_api, Exception, MagicMock)
-    )
+    monkeypatch.setattr(profile_handlers, "get_api", lambda: (dummy_api, Exception, MagicMock))
 
     message = DummyMessage()
     update = make_update(message=message, effective_user=make_user(1))
@@ -151,9 +148,7 @@ async def test_callback_router_commit_failure(
 
 
 @pytest.mark.asyncio
-async def test_add_reminder_commit_failure(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_add_reminder_commit_failure(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     session = MagicMock()
     session.__enter__.return_value = session
     session.__exit__.return_value = None
@@ -212,9 +207,7 @@ async def test_reminder_webapp_save_commit_failure(
     render_mock = MagicMock()
     monkeypatch.setattr(reminder_handlers, "_render_reminders", render_mock)
 
-    message = DummyWebAppMessage(
-        json.dumps({"type": "sugar", "value": "23:00", "id": 1})
-    )
+    message = DummyWebAppMessage(json.dumps({"type": "sugar", "value": "23:00", "id": 1}))
     update = make_update(effective_message=message, effective_user=make_user(1))
     context = make_context(job_queue=MagicMock(spec=JobQueue))
 
@@ -259,9 +252,7 @@ async def test_delete_reminder_commit_failure(
 
 
 @pytest.mark.asyncio
-async def test_reminder_job_commit_failure(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_reminder_job_commit_failure(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     session = MagicMock()
     session.__enter__.return_value = session
     session.__exit__.return_value = None
@@ -313,7 +304,7 @@ async def test_reminder_callback_commit_failure(
 
     monkeypatch.setattr(reminder_handlers, "commit", failing_commit)
 
-    query = DummyQuery(DummyMessage(), "remind_snooze:1")
+    query = DummyQuery(DummyMessage(), "remind_snooze:1:10")
     update = make_update(callback_query=query, effective_user=make_user(1))
     job_queue = MagicMock(spec=JobQueue)
     job_queue.run_once = MagicMock()

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections.abc import Generator
-from datetime import datetime, time, timezone, tzinfo
+from datetime import datetime, time, timedelta, timezone, tzinfo
 from zoneinfo import ZoneInfo
 from unittest.mock import MagicMock
 from typing import Any, Callable, cast
@@ -272,12 +272,7 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "📸 Триггер-фото" in text
     assert "2. <s>🔕title2</s>" in text
     assert markup.inline_keyboard
-    add_btn = next(
-        btn
-        for row in markup.inline_keyboard
-        for btn in row
-        if btn.text == "➕ Добавить"
-    )
+    add_btn = next(btn for row in markup.inline_keyboard for btn in row if btn.text == "➕ Добавить")
     assert add_btn.web_app is not None
     assert add_btn.web_app.url.endswith("/reminders/new")
 
@@ -522,10 +517,13 @@ async def test_trigger_job_logs(monkeypatch: pytest.MonkeyPatch) -> None:
     reply_markup = kwargs.get("reply_markup")
     assert reply_markup is not None
     assert reply_markup.inline_keyboard
-    keyboard = reply_markup.inline_keyboard[0]
-    assert len(keyboard) >= 2
-    assert keyboard[0].callback_data == "remind_snooze:1"
-    assert keyboard[1].callback_data == "remind_cancel:1"
+    buttons = [b for row in reply_markup.inline_keyboard for b in row]
+    datas = {b.callback_data for b in buttons}
+    assert "remind_snooze:1:10" in datas
+    assert "remind_snooze:1:15" in datas
+    assert "remind_snooze:1:30" in datas
+    assert "remind_snooze:1:60" in datas
+    assert "remind_cancel:1" in datas
     with TestSession() as session:
         log = session.query(ReminderLog).first()
         assert log is not None
@@ -557,6 +555,40 @@ async def test_cancel_callback(monkeypatch: pytest.MonkeyPatch) -> None:
         log = session.query(ReminderLog).first()
         assert log is not None
         assert log.action == "remind_cancel"
+
+
+@pytest.mark.asyncio
+async def test_snooze_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    handlers.SessionLocal = TestSession
+    handlers.commit = commit
+
+    with TestSession() as session:
+        session.add(DbUser(telegram_id=1, thread_id="t"))
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0)))
+        session.commit()
+
+    query = DummyCallbackQuery("remind_snooze:1:15", DummyMessage())
+    job_queue = MagicMock(spec=DummyJobQueue)
+    context = make_context(job_queue=job_queue)
+    update = make_update(callback_query=query, effective_user=make_user(1))
+    await handlers.reminder_callback(update, context)
+
+    job_queue.run_once.assert_called_once()
+    _, kwargs = job_queue.run_once.call_args
+    assert kwargs["when"] == timedelta(minutes=15)
+    assert kwargs["data"] == {"reminder_id": 1, "chat_id": 1}
+    assert kwargs["name"] == "reminder_1"
+    assert query.edited is not None
+    edited_text, _ = query.edited
+    assert edited_text == "⏰ Отложено на 15 минут"
+    assert query.answers == [None]
+    with TestSession() as session:
+        log = session.query(ReminderLog).first()
+        assert log is not None
+        assert log.action == "remind_snooze"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add 10/15/30/60-minute snooze buttons with encoded callback data
- support variable snooze intervals in reminder callback
- test reminder snooze buttons and callbacks

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ac87282570832a9ea9cdbfbfe88aaf