### PR TITLE
[py-sdk] handle mapping and iterable post params

### DIFF
--- a/libs/py-sdk/diabetes_sdk/rest.py
+++ b/libs/py-sdk/diabetes_sdk/rest.py
@@ -126,14 +126,17 @@ class RESTClientObject:
         :param url: http request url
         :param headers: http request headers
         :param body: request json body, for `application/json`
-        :param post_params: request post parameters for
-                            `application/x-www-form-urlencoded` or
-                            `multipart/form-data`. Accepts either a
-                            ``dict`` or any iterable of ``(key, value)``
-                            pairs. Values that are ``dict``, ``list`` or
-                            ``tuple`` are JSON serialized.
+        :param post_params: request parameters for
+                            ``application/x-www-form-urlencoded`` or
+                            ``multipart/form-data``. May be provided as a
+                            mapping (e.g. ``dict``) or as any iterable of
+                            ``(key, value)`` pairs. Each item **must**
+                            contain exactly two elements. Values that are
+                            themselves mappings or non-string iterables are
+                            JSON serialized before being sent.
 
-                            Examples:
+                            Examples::
+
                                 post_params = {"a": 1, "meta": {"b": 2}}
                                 post_params = [("a", 1), ("meta", {"b": 2})]
         :param _request_timeout: timeout setting for this request. If one
@@ -212,12 +215,12 @@ class RESTClientObject:
                             item, (str, bytes)
                         ):
                             raise ApiValueError(
-                                "Invalid number of elements in post_params",
+                                "Items in post_params must be 2-item iterables",
                             )
                         pair = list(item)
                         if len(pair) != 2:
                             raise ApiValueError(
-                                "Invalid number of elements in post_params",
+                                "Items in post_params must be 2-item iterables",
                             )
                         key, value = pair
                         if isinstance(value, Mapping) or (

--- a/libs/py-sdk/test/test_rest_multipart.py
+++ b/libs/py-sdk/test/test_rest_multipart.py
@@ -176,7 +176,7 @@ def test_multipart_tuple_value() -> None:
 )
 def test_multipart_invalid_post_params(post_params: list[object]) -> None:
     client = _client()
-    with pytest.raises(ApiValueError):
+    with pytest.raises(ApiValueError, match="2-item"):
         client.request(  # type: ignore[no-untyped-call]
             "POST",
             "http://example.com",


### PR DESCRIPTION
## Summary
- clarify multipart `post_params` docstring
- validate multipart param pairs and serialize nested structures
- extend multipart tests for mappings and list values

## Testing
- `pytest -q --cov` *(fails: ImportError while loading conftest - SyntaxError: invalid character '≠')*
- `pytest libs/py-sdk/test/test_rest_multipart.py -q -o addopts=''`
- `mypy --strict .` *(fails: Invalid character '≠' in services/api/app/diabetes/services/db.py)*
- `mypy --strict libs/py-sdk/diabetes_sdk/rest.py libs/py-sdk/test/test_rest_multipart.py`
- `ruff check .` *(fails: SyntaxError and F811 in other modules)*
- `ruff check libs/py-sdk/diabetes_sdk/rest.py libs/py-sdk/test/test_rest_multipart.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac8d666db4832abc886422ac154353