### PR TITLE
[tests] clarify reminder snooze callback tests

### DIFF
--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -555,7 +555,9 @@ async def test_trigger_job_logs(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_snooze_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_snooze_callback_custom_delay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -616,7 +618,9 @@ async def test_cancel_callback(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_snooze_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_snooze_callback_default_delay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -647,7 +651,9 @@ async def test_snooze_callback(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_snooze_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_snooze_callback_logs_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)


### PR DESCRIPTION
## Summary
- rename duplicated test_snooze_callback functions for custom delay, default delay, and log verification scenarios

## Testing
- `ruff check tests/test_reminders.py`


------
https://chatgpt.com/codex/tasks/task_e_68adf6797e24832a8452e9af170ea2b9