### PR TITLE
[profile] support quiet hours in profile schema

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Float,
     Text,
     TIMESTAMP,
+    Time,
     ForeignKey,
     Boolean,
     func,
@@ -99,6 +100,8 @@ class Profile(Base):
     high_threshold = Column(Float)  # верхний порог сахара
     sos_contact = Column(String)  # контакт для экстренной связи
     sos_alerts_enabled = Column(Boolean, default=True)
+    quiet_start = Column(Time)  # начало тихого режима
+    quiet_end = Column(Time)  # конец тихого режима
     org_id = Column(Integer)
     user = relationship("User")
 

--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel
+from datetime import time
+
+from pydantic import BaseModel, Field
 
 
 class ProfileSchema(BaseModel):
@@ -9,3 +11,8 @@ class ProfileSchema(BaseModel):
     low: float
     high: float
     org_id: int | None = None
+    quiet_start: time | None = Field(default=None, alias="quietStart")
+    quiet_end: time | None = Field(default=None, alias="quietEnd")
+
+    class Config:
+        allow_population_by_field_name = True

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -49,6 +49,8 @@ async def save_profile(data: ProfileSchema) -> None:
         profile.target_bg = data.target
         profile.low_threshold = data.low
         profile.high_threshold = data.high
+        profile.quiet_start = data.quiet_start
+        profile.quiet_end = data.quiet_end
         session.commit()
 
     await run_db(_save, sessionmaker=SessionLocal)


### PR DESCRIPTION
## Summary
- add quiet_start and quiet_end fields to profile schema
- persist quiet hours in profile service and database model

## Testing
- `ruff check services/api/app tests`
- `pytest` *(fails: async def functions are not natively supported)*
- `mypy --strict services/api/app/schemas/profile.py services/api/app/services/profile.py` *(fails: Returning Any from function declared to return "int", Invalid base class "Base", Function is missing a type annotation, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68adf9daeb24832abd874b1134ef01ca