### PR TITLE
[profile] Fix quiet time typing and reminder logging

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -1,4 +1,6 @@
 import logging
+from datetime import time
+
 from fastapi import APIRouter, HTTPException, Query
 
 from .routers.reminders import router as reminders_router
@@ -42,16 +44,8 @@ async def profiles_get(
         target=float(target_bg) if target_bg is not None else 0.0,
         low=float(low_threshold) if low_threshold is not None else 0.0,
         high=float(high_threshold) if high_threshold is not None else 0.0,
-        quietStart=(
-            profile.quiet_start.strftime("%H:%M")
-            if profile.quiet_start is not None
-            else "23:00"
-        ),
-        quietEnd=(
-            profile.quiet_end.strftime("%H:%M")
-            if profile.quiet_end is not None
-            else "07:00"
-        ),
+        quietStart=profile.quiet_start or time(23, 0),
+        quietEnd=profile.quiet_end or time(7, 0),
         orgId=profile.org_id,
         sosContact=profile.sos_contact or "",
         sosAlertsEnabled=(

--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -5,20 +5,23 @@ from datetime import time
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
+
 class ProfileSchema(BaseModel):
-    telegramId: int = Field(alias="telegramId", validation_alias=AliasChoices("telegramId", "telegram_id"))
+    telegramId: int = Field(
+        alias="telegramId", validation_alias=AliasChoices("telegramId", "telegram_id")
+    )
     icr: float
     cf: float
     target: float
     low: float
     high: float
-    quietStart: str = Field(
-        default="23:00",
+    quietStart: time = Field(
+        default=time(23, 0),
         alias="quietStart",
         validation_alias=AliasChoices("quietStart", "quiet_start"),
     )
-    quietEnd: str = Field(
-        default="07:00",
+    quietEnd: time = Field(
+        default=time(7, 0),
         alias="quietEnd",
         validation_alias=AliasChoices("quietEnd", "quiet_end"),
     )
@@ -31,19 +34,7 @@ class ProfileSchema(BaseModel):
     sosAlertsEnabled: bool = Field(
         default=True,
         alias="sosAlertsEnabled",
-        validation_alias=AliasChoices(
-            "sosAlertsEnabled", "sos_alerts_enabled"
-        ),
-    )
-    quietStart: time = Field(
-        default=time(22, 0),
-        alias="quietStart",
-        validation_alias=AliasChoices("quietStart", "quiet_start"),
-    )
-    quietEnd: time = Field(
-        default=time(7, 0),
-        alias="quietEnd",
-        validation_alias=AliasChoices("quietEnd", "quiet_end"),
+        validation_alias=AliasChoices("sosAlertsEnabled", "sos_alerts_enabled"),
     )
 
     model_config = ConfigDict(populate_by_name=True)

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from fastapi import HTTPException
 from typing import cast
-from datetime import time as dt_time
 
 from sqlalchemy.orm import Session
 
@@ -43,11 +42,7 @@ def _validate_profile(data: ProfileSchema) -> None:
     if not (data.low < data.target < data.high):
         raise ValueError("target must be between low and high")
 
-    for t in (data.quietStart, data.quietEnd):
-        try:
-            dt_time.fromisoformat(t)
-        except ValueError:
-            raise ValueError("invalid quiet time format")
+    # quiet times are validated by Pydantic; no additional checks required
 
 
 async def save_profile(data: ProfileSchema) -> None:
@@ -65,14 +60,12 @@ async def save_profile(data: ProfileSchema) -> None:
         profile.target_bg = data.target
         profile.low_threshold = data.low
         profile.high_threshold = data.high
-        profile.quiet_start = dt_time.fromisoformat(data.quietStart)
-        profile.quiet_end = dt_time.fromisoformat(data.quietEnd)
+        profile.quiet_start = data.quietStart
+        profile.quiet_end = data.quietEnd
         profile.sos_contact = data.sosContact or ""
         profile.sos_alerts_enabled = (
             data.sosAlertsEnabled if data.sosAlertsEnabled is not None else True
         )
-        profile.quiet_start = data.quietStart
-        profile.quiet_end = data.quietEnd
         try:
             commit(cast(Session, session))
         except CommitError:

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -97,7 +97,9 @@ async def test_profile_command_no_local_session(
 
     dummy_api = MagicMock()
     dummy_api.profiles_post = MagicMock()
-    monkeypatch.setattr(profile_handlers, "get_api", lambda: (dummy_api, Exception, MagicMock))
+    monkeypatch.setattr(
+        profile_handlers, "get_api", lambda: (dummy_api, Exception, MagicMock)
+    )
 
     message = DummyMessage()
     update = make_update(message=message, effective_user=make_user(1))
@@ -148,7 +150,9 @@ async def test_callback_router_commit_failure(
 
 
 @pytest.mark.asyncio
-async def test_add_reminder_commit_failure(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+async def test_add_reminder_commit_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     session = MagicMock()
     session.__enter__.return_value = session
     session.__exit__.return_value = None
@@ -207,7 +211,9 @@ async def test_reminder_webapp_save_commit_failure(
     render_mock = MagicMock()
     monkeypatch.setattr(reminder_handlers, "_render_reminders", render_mock)
 
-    message = DummyWebAppMessage(json.dumps({"type": "sugar", "value": "23:00", "id": 1}))
+    message = DummyWebAppMessage(
+        json.dumps({"type": "sugar", "value": "23:00", "id": 1})
+    )
     update = make_update(effective_message=message, effective_user=make_user(1))
     context = make_context(job_queue=MagicMock(spec=JobQueue))
 
@@ -252,7 +258,9 @@ async def test_delete_reminder_commit_failure(
 
 
 @pytest.mark.asyncio
-async def test_reminder_job_commit_failure(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+async def test_reminder_job_commit_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     session = MagicMock()
     session.__enter__.return_value = session
     session.__exit__.return_value = None
@@ -316,9 +324,7 @@ async def test_reminder_callback_commit_failure(
     assert session.rollback.called
     assert query.edited == []
     assert not context.job_queue.run_once.called
-    assert (
-        "Failed to log reminder action remind_snooze:10 for reminder 1" in caplog.text
-    )
+    assert "Failed to log reminder action remind_snooze for reminder 1" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_profile_sos_fields.py
+++ b/tests/test_profile_sos_fields.py
@@ -114,6 +114,6 @@ async def test_save_profile_defaults_quiet_hours(
     await profile_service.save_profile(data)
     prof = await profile_service.get_profile(4)
     assert prof is not None
-    assert prof.quiet_start == time(22, 0)
+    assert prof.quiet_start == time(23, 0)
     assert prof.quiet_end == time(7, 0)
     engine.dispose()

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -286,7 +286,12 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "📸 Триггер-фото" in text
     assert "2. <s>🔕title2</s>" in text
     assert markup.inline_keyboard
-    add_btn = next(btn for row in markup.inline_keyboard for btn in row if btn.text == "➕ Добавить")
+    add_btn = next(
+        btn
+        for row in markup.inline_keyboard
+        for btn in row
+        if btn.text == "➕ Добавить"
+    )
     assert add_btn.web_app is not None
     assert add_btn.web_app.url.endswith("/reminders/new")
 
@@ -586,7 +591,8 @@ async def test_snooze_callback_custom_delay(
     with TestSession() as session:
         log = session.query(ReminderLog).first()
         assert log is not None
-        assert log.action == "remind_snooze:15"
+        assert log.action == "remind_snooze"
+        assert log.snooze_minutes == 15
 
 
 @pytest.mark.asyncio
@@ -787,7 +793,6 @@ def test_empty_returns_200(
     resp = client.get("/api/reminders", params={"telegramId": 1})
     assert resp.status_code == 200
     assert resp.json() == []
-
 
 
 def test_nonempty_returns_list(


### PR DESCRIPTION
## Summary
- replace duplicate quietStart/quietEnd fields with `datetime.time` values
- streamline profile saving and legacy profile defaults
- log reminder snooze minutes separately and adjust tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68adf971f1e0832a9ae5a525236032ea