### PR TITLE
tests: rename snooze callback tests

### DIFF
--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -560,7 +560,7 @@ async def test_trigger_job_logs(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_snooze_callback_custom_delay(
+async def test_reminder_snooze_custom_delay(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     engine = create_engine("sqlite:///:memory:")
@@ -623,7 +623,7 @@ async def test_cancel_callback(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_snooze_callback_default_delay(
+async def test_reminder_snooze_default_delay(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     engine = create_engine("sqlite:///:memory:")
@@ -656,7 +656,7 @@ async def test_snooze_callback_default_delay(
 
 
 @pytest.mark.asyncio
-async def test_snooze_callback_magicmock(
+async def test_reminder_snooze_magicmock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     engine = create_engine("sqlite:///:memory:")
@@ -692,7 +692,7 @@ async def test_snooze_callback_magicmock(
 
 
 @pytest.mark.asyncio
-async def test_snooze_callback_schedules_job_and_logs(
+async def test_reminder_snooze_schedules_job_and_logs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     engine = create_engine("sqlite:///:memory:")


### PR DESCRIPTION
## Summary
- avoid duplicate test names by renaming snooze callback tests

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: Name "quietStart" already defined on line 15; Name "quietEnd" already defined on line 20; Incompatible types in assignment (expression has type "str", variable has type "SQLCoreOperations[time] | time"); Incompatible types in assignment (expression has type "str", variable has type "SQLCoreOperations[time] | time")*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68adfc03304c832abee09602c4f35b8b