### PR TITLE
[infra] Add VITE_TELEGRAM_INIT_DATA env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@
 Приложение автоматически загружает переменные окружения из этого файла в корне проекта.
 
 - обязательные значения: `TELEGRAM_TOKEN` (токен бота), `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
-- дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `UVICORN_WORKERS`
+- дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `UVICORN_WORKERS`, `VITE_TELEGRAM_INIT_DATA` (для локального тестирования WebApp)
 - при необходимости настройте прокси для OpenAI через переменные окружения
 
 Telegram‑клиенты не могут обращаться к `localhost`, поэтому `WEBAPP_URL` должен быть публичным **HTTPS**‑адресом. Для локальной разработки используйте туннель (например, [ngrok](https://ngrok.com/)).

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -30,3 +30,6 @@ FONT_DIR=infra/fonts
 
 # Telegram
 TELEGRAM_TOKEN=your-telegram-bot-token
+
+# WebApp testing
+VITE_TELEGRAM_INIT_DATA=telegram-init-data-hash  # used for local WebApp testing


### PR DESCRIPTION
## Summary
- document VITE_TELEGRAM_INIT_DATA for local WebApp testing
- mention optional env var in README

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68adfd046360832ab4a37652d5f0f90b