### PR TITLE
[webapp] Fix telegram-init script paths

### DIFF
--- a/services/webapp/public/timezone.html
+++ b/services/webapp/public/timezone.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
     <title>Часовой пояс</title>
-    <script src="/ui/telegram-init.js"></script>
+    <script src="/telegram-init.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/services/webapp/ui/index.html
+++ b/services/webapp/ui/index.html
@@ -33,7 +33,7 @@
 
     <!-- Telegram SDK + инициализация темы (не бандлим, грузим отдельным скриптом) -->
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
-    <script type="module" src="/ui/telegram-init.js"></script>
+    <script src="/telegram-init.js" type="module"></script>
 
     <!-- Open Graph / Twitter -->
     <meta property="og:title" content="СахарФото — ассистент для диабетиков" />


### PR DESCRIPTION
## Summary
- load telegram-init.js from root for webapp index
- adjust timezone page to use root telegram-init.js

## Testing
- `npm run build`
- `ruff check services/api/app tests`
- `pytest tests` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68adfcfcd118832aa6c15192681c8d31