### PR TITLE
[setup] Update frontend build path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,7 @@ pip install --upgrade pip
 pip install -r requirements.txt
 
 echo "Сборка фронтенда (npm ci && npm run build)…"
-pushd webapp/ui >/dev/null
+pushd services/webapp/ui >/dev/null
 npm ci
 npm run build
 popd >/dev/null
@@ -25,5 +25,5 @@ if [ ! -f ".env" ]; then
 fi
 
 echo "Установка завершена! Проверьте файл .env и заполните свои токены и пароли."
-echo "Фронтенд собран в webapp/ui/dist."
+echo "Фронтенд собран в services/webapp/ui/dist."
 echo "Для запуска API: source venv/bin/activate && python services/api/app/main.py"


### PR DESCRIPTION
## Summary
- point setup script to build UI from `services/webapp/ui`
- adjust final message to reference `services/webapp/ui/dist`

## Testing
- `bash setup.sh`
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68adfd002e3c832a8b215a3c2fe239a4