### PR TITLE
[ui] alias ts sdk

### DIFF
--- a/services/webapp/ui/src/api/history.api.test.ts
+++ b/services/webapp/ui/src/api/history.api.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { Configuration } from '@offonika/diabetes-ts-sdk/runtime';
+import { Configuration } from '@sdk/runtime';
 
 const mockHistoryGet = vi.hoisted(() => vi.fn());
 const mockHistoryPost = vi.hoisted(() => vi.fn());
 const mockHistoryIdDelete = vi.hoisted(() => vi.fn());
 
-vi.mock('@offonika/diabetes-ts-sdk', () => ({
+vi.mock('@sdk', () => ({
   HistoryApi: vi.fn(() => ({
     historyGet: mockHistoryGet,
     historyPost: mockHistoryPost,
@@ -103,8 +103,8 @@ describe('HistoryApi serialization', () => {
   it('sends ISO date strings', async () => {
     const fetchMock = vi.fn(async () => new Response('{}'));
     const { HistoryApi, Configuration } = await vi.importActual<
-      typeof import('@offonika/diabetes-ts-sdk')
-    >('@offonika/diabetes-ts-sdk');
+      typeof import('@sdk')
+    >('@sdk');
 
     const api = new HistoryApi(
       new Configuration({ basePath: '', fetchApi: fetchMock }),

--- a/services/webapp/ui/src/api/history.ts
+++ b/services/webapp/ui/src/api/history.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { HistoryApi } from '@offonika/diabetes-ts-sdk';
-import { Configuration } from '@offonika/diabetes-ts-sdk/runtime';
+import { HistoryApi } from '@sdk';
+import { Configuration } from '@sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 

--- a/services/webapp/ui/src/api/profile.api.test.ts
+++ b/services/webapp/ui/src/api/profile.api.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ResponseError, Configuration } from '@offonika/diabetes-ts-sdk/runtime';
-import type { ProfileSchema as Profile } from '@offonika/diabetes-ts-sdk/models';
+import { ResponseError, Configuration } from '@sdk/runtime';
+import type { ProfileSchema as Profile } from '@sdk/models';
 
 const mockProfilesGet = vi.hoisted(() => vi.fn());
 const mockProfilesPost = vi.hoisted(() => vi.fn());
 
-vi.mock('@offonika/diabetes-ts-sdk', () => ({
+vi.mock('@sdk', () => ({
   ProfilesApi: vi.fn(() => ({
     profilesGet: mockProfilesGet,
     profilesPost: mockProfilesPost,

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,9 +1,9 @@
-import { ProfilesApi } from '@offonika/diabetes-ts-sdk';
+import { ProfilesApi } from '@sdk';
 import {
   instanceOfProfileSchema as instanceOfProfile,
   type ProfileSchema as Profile,
-} from '@offonika/diabetes-ts-sdk/models';
-import { Configuration, ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
+} from '@sdk/models';
+import { Configuration, ResponseError } from '@sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 

--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ResponseError, Configuration } from '@offonika/diabetes-ts-sdk/runtime';
+import { ResponseError, Configuration } from '@sdk/runtime';
 
 const mockRemindersGet = vi.hoisted(() => vi.fn());
 const mockRemindersIdGet = vi.hoisted(() => vi.fn());
@@ -10,7 +10,7 @@ const mockInstanceOfReminder = vi.hoisted(() => vi.fn());
 const mockTgFetch = vi.hoisted(() => vi.fn());
 
 vi.mock(
-  '@offonika/diabetes-ts-sdk/runtime',
+  '@sdk/runtime',
   () => ({
     ResponseError: class extends Error {
       response: Response;
@@ -25,7 +25,7 @@ vi.mock(
 );
 
 vi.mock(
-  '@offonika/diabetes-ts-sdk',
+  '@sdk',
   () => ({
     RemindersApi: vi.fn(() => ({
       remindersGet: mockRemindersGet,
@@ -40,7 +40,7 @@ vi.mock(
 );
 
 vi.mock(
-  '@offonika/diabetes-ts-sdk/models',
+  '@sdk/models',
   () => ({
     instanceOfReminderSchema: mockInstanceOfReminder,
   }),

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,9 +1,9 @@
-import { RemindersApi } from '@offonika/diabetes-ts-sdk';
-import { Configuration, ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
+import { RemindersApi } from '@sdk';
+import { Configuration, ResponseError } from '@sdk/runtime';
 import {
   instanceOfReminderSchema as instanceOfReminder,
   type ReminderSchema as Reminder,
-} from '@offonika/diabetes-ts-sdk/models';
+} from '@sdk/models';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 

--- a/services/webapp/ui/src/api/stats.api.test.ts
+++ b/services/webapp/ui/src/api/stats.api.test.ts
@@ -4,7 +4,7 @@ const mockGetAnalytics = vi.hoisted(() => vi.fn());
 const mockGetStats = vi.hoisted(() => vi.fn());
 
 vi.mock(
-  '@offonika/diabetes-ts-sdk/runtime',
+  '@sdk/runtime',
   () => {
     class Configuration {}
     class ResponseError extends Error {
@@ -18,7 +18,7 @@ vi.mock(
 );
 
 vi.mock(
-  '@offonika/diabetes-ts-sdk',
+  '@sdk',
   () => ({
     DefaultApi: vi.fn(() => ({
       getAnalyticsAnalyticsGet: mockGetAnalytics,
@@ -39,7 +39,7 @@ import {
 let ResponseError: new (arg: { status: number }) => Error;
 
 beforeAll(async () => {
-  ({ ResponseError } = await import('@offonika/diabetes-ts-sdk/runtime'));
+  ({ ResponseError } = await import('@sdk/runtime'));
 });
 
 afterEach(() => {

--- a/services/webapp/ui/src/api/stats.ts
+++ b/services/webapp/ui/src/api/stats.ts
@@ -1,5 +1,5 @@
-import { DefaultApi } from '@offonika/diabetes-ts-sdk';
-import { Configuration, ResponseError } from '@offonika/diabetes-ts-sdk/runtime';
+import { DefaultApi } from '@sdk';
+import { Configuration, ResponseError } from '@sdk/runtime';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 

--- a/services/webapp/ui/src/lib/tgFetch.test.ts
+++ b/services/webapp/ui/src/lib/tgFetch.test.ts
@@ -7,8 +7,8 @@ import {
   vi,
   type Mock,
 } from 'vitest';
-import { ProfilesApi } from '@offonika/diabetes-ts-sdk';
-import { Configuration } from '@offonika/diabetes-ts-sdk/runtime';
+import { ProfilesApi } from '@sdk';
+import { Configuration } from '@sdk/runtime';
 import { tgFetch, REQUEST_TIMEOUT_MESSAGE, TG_INIT_DATA_HEADER } from './tgFetch';
 
 interface TelegramWebApp {

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -13,7 +13,7 @@ import {
   type NormalizedReminderType,
 } from '@/lib/reminders'
 import { parseTimeToMinutes } from '@/lib/time'
-import type { ReminderSchema as ApiReminder } from '@offonika/diabetes-ts-sdk/models'
+import type { ReminderSchema as ApiReminder } from '@sdk/models'
 import type { Reminder } from '@/types/reminder'
 
 const TYPE_LABEL: Record<NormalizedReminderType, string> = {

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { MedicalButton, Sheet } from "@/components";
 import { cn } from "@/lib/utils";
 import { createReminder, updateReminder, getReminder } from "@/api/reminders";
-import { Reminder as ApiReminder } from "@offonika/diabetes-ts-sdk";
+import { Reminder as ApiReminder } from "@sdk";
 import { useTelegramContext } from "@/contexts/telegram-context";
 import { useToast } from "@/hooks/use-toast";
 import {

--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -7,7 +7,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@sdk": ["../../../libs/ts-sdk"]
     },
     "noImplicitAny": true,
     "noUnusedParameters": true,

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -80,7 +80,10 @@ export default defineConfig(async ({ mode, command }) => {
     base,
     plugins,
     resolve: {
-      alias: { '@': path.resolve(__dirname, './src') },
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+        '@sdk': path.resolve(__dirname, '../../../libs/ts-sdk'),
+      },
     },
     server: { host: '::', port: 5173 },
 


### PR DESCRIPTION
## Summary
- alias local ts-sdk as `@sdk` and update ui imports
- configure vite and tsconfig for the new sdk alias

## Testing
- `pnpm install`
- `npm run build` (from `services/webapp/ui`)
- `pytest -q --cov` *(fails: async functions not natively supported; missing pytest-asyncio)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68adfebe40f4832a8e7aa7788a3403a5