### PR TITLE
[py-sdk] validate REST method

### DIFF
--- a/libs/py-sdk/diabetes_sdk/rest.py
+++ b/libs/py-sdk/diabetes_sdk/rest.py
@@ -145,7 +145,8 @@ class RESTClientObject:
                                  (connection, read) timeouts.
         """
         method = method.upper()
-        assert method in ["GET", "HEAD", "DELETE", "POST", "PUT", "PATCH", "OPTIONS"]
+        if method not in ["GET", "HEAD", "DELETE", "POST", "PUT", "PATCH", "OPTIONS"]:
+            raise ApiValueError(f"Unsupported method '{method}'")
 
         if post_params and body:
             raise ApiValueError(

--- a/libs/py-sdk/test/test_rest_multipart.py
+++ b/libs/py-sdk/test/test_rest_multipart.py
@@ -86,3 +86,11 @@ def test_multipart_invalid_string() -> None:
             post_params="invalid",
         )
 
+
+def test_request_invalid_method() -> None:
+    client = _client()
+    with pytest.raises(ApiValueError):
+        client.request(  # type: ignore[no-untyped-call]
+            "TRACE",
+            "http://example.com",
+        )


### PR DESCRIPTION
## Summary
- handle unsupported HTTP methods with an explicit `ApiValueError`
- test REST client rejects unknown methods

## Testing
- `pytest -q --cov --cov-fail-under=85` (fails: async plugin missing, coverage 49%)
- `pytest libs/py-sdk/test/test_rest_multipart.py -q --cov=diabetes_sdk.rest --cov-fail-under=85` (fails: coverage 61%)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ae0033cab4832abfae97cd37c8600a