### PR TITLE
[py-sdk] validate multipart params

### DIFF
--- a/libs/py-sdk/diabetes_sdk/rest.py
+++ b/libs/py-sdk/diabetes_sdk/rest.py
@@ -206,20 +206,18 @@ class RESTClientObject:
                         raise ApiValueError(
                             "post_params must be a mapping or iterable of (key, value) pairs",
                         )
-                    fields = []
+                    fields: list[tuple[str, str]] = []
                     for item in items:
-                        if not isinstance(item, Iterable) or isinstance(
-                            item, (str, bytes)
-                        ):
+                        if isinstance(item, (str, bytes)):
                             raise ApiValueError(
                                 "Items in post_params must be 2-item iterables",
                             )
-                        pair = list(item)
-                        if len(pair) != 2:
+                        try:
+                            key, value = item  # type: ignore[misc]
+                        except (TypeError, ValueError) as exc:
                             raise ApiValueError(
                                 "Items in post_params must be 2-item iterables",
-                            )
-                        key, value = pair
+                            ) from exc
                         if isinstance(value, Mapping) or (
                             isinstance(value, Iterable)
                             and not isinstance(value, (str, bytes))


### PR DESCRIPTION
## Summary
- validate `multipart/form-data` params in REST client
- encode mapping and iterable values as JSON
- test multipart handling for dicts, mappings, lists, and invalid inputs

## Testing
- `ruff check libs/py-sdk/diabetes_sdk/rest.py libs/py-sdk/test/test_rest_multipart.py`
- `mypy --strict libs/py-sdk/diabetes_sdk/rest.py libs/py-sdk/test/test_rest_multipart.py`
- `pytest -q libs/py-sdk/test/test_rest_multipart.py --override-ini "addopts=--cov=diabetes_sdk.rest --cov-report=term-missing --cov-fail-under=85"` *(fails: Required test coverage of 85% not reached. Total coverage: 60.36%)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0120a740832a8b20cb86419e3925