### PR TITLE
[py-sdk] Validate REST method

### DIFF
--- a/libs/py-sdk/diabetes_sdk/rest.py
+++ b/libs/py-sdk/diabetes_sdk/rest.py
@@ -145,7 +145,8 @@ class RESTClientObject:
                                  (connection, read) timeouts.
         """
         method = method.upper()
-        assert method in ["GET", "HEAD", "DELETE", "POST", "PUT", "PATCH", "OPTIONS"]
+        if method not in ["GET", "HEAD", "DELETE", "POST", "PUT", "PATCH", "OPTIONS"]:
+            raise ApiValueError(f"{method} is not a supported HTTP method")
 
         if post_params and body:
             raise ApiValueError(

--- a/libs/py-sdk/test/test_rest_invalid_method.py
+++ b/libs/py-sdk/test/test_rest_invalid_method.py
@@ -1,0 +1,11 @@
+import pytest
+
+from diabetes_sdk.configuration import Configuration
+from diabetes_sdk.exceptions import ApiValueError
+from diabetes_sdk.rest import RESTClientObject
+
+
+def test_request_invalid_method() -> None:
+    client = RESTClientObject(Configuration())
+    with pytest.raises(ApiValueError):
+        client.request("TRACE", "http://example.com")  # type: ignore[no-untyped-call]


### PR DESCRIPTION
## Summary
- raise ApiValueError for unsupported HTTP methods instead of an assertion
- add regression test for invalid method handling

## Testing
- `pytest libs/py-sdk/test/test_rest_invalid_method.py -q --cov=diabetes_sdk --cov-report=term-missing --cov-fail-under=85` *(fails: Required test coverage of 85% not reached. Total coverage: 36.79%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ae01241384832a943f3a4886a3eed1