### PR TITLE
[schemas] remove duplicate quiet field definitions

### DIFF
--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from typing import Optional
-from datetime import time
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
+
 class ProfileSchema(BaseModel):
-    telegramId: int = Field(alias="telegramId", validation_alias=AliasChoices("telegramId", "telegram_id"))
+    telegramId: int = Field(
+        alias="telegramId", validation_alias=AliasChoices("telegramId", "telegram_id")
+    )
     icr: float
     cf: float
     target: float
@@ -31,19 +33,7 @@ class ProfileSchema(BaseModel):
     sosAlertsEnabled: bool = Field(
         default=True,
         alias="sosAlertsEnabled",
-        validation_alias=AliasChoices(
-            "sosAlertsEnabled", "sos_alerts_enabled"
-        ),
-    )
-    quietStart: time = Field(
-        default=time(22, 0),
-        alias="quietStart",
-        validation_alias=AliasChoices("quietStart", "quiet_start"),
-    )
-    quietEnd: time = Field(
-        default=time(7, 0),
-        alias="quietEnd",
-        validation_alias=AliasChoices("quietEnd", "quiet_end"),
+        validation_alias=AliasChoices("sosAlertsEnabled", "sos_alerts_enabled"),
     )
 
     model_config = ConfigDict(populate_by_name=True)


### PR DESCRIPTION
## Summary
- remove duplicate quiet time fields from profile schema

## Testing
- `python -m black services/api/app/schemas/profile.py`
- `ruff check services/api/app/schemas/profile.py`
- `pytest -q` (fails: async def functions not natively supported, 361 failed)
- `mypy --strict services/api/app/schemas/profile.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae0303e9d4832aaf40e6cd19c84cc9