### PR TITLE
[services] Use time objects for profile quiet hours

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -1,4 +1,6 @@
 import logging
+from datetime import time as dt_time
+
 from fastapi import APIRouter, HTTPException, Query
 
 from .routers.reminders import router as reminders_router
@@ -43,14 +45,14 @@ async def profiles_get(
         low=float(low_threshold) if low_threshold is not None else 0.0,
         high=float(high_threshold) if high_threshold is not None else 0.0,
         quietStart=(
-            profile.quiet_start.strftime("%H:%M")
+            profile.quiet_start
             if profile.quiet_start is not None
-            else "23:00"
+            else dt_time.fromisoformat("23:00")
         ),
         quietEnd=(
-            profile.quiet_end.strftime("%H:%M")
+            profile.quiet_end
             if profile.quiet_end is not None
-            else "07:00"
+            else dt_time.fromisoformat("07:00")
         ),
         orgId=profile.org_id,
         sosContact=profile.sos_contact or "",

--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Optional
 
+from datetime import time as dt_time
+
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 
@@ -14,13 +16,13 @@ class ProfileSchema(BaseModel):
     target: float
     low: float
     high: float
-    quietStart: str = Field(
-        default="23:00",
+    quietStart: dt_time = Field(
+        default=dt_time.fromisoformat("23:00"),
         alias="quietStart",
         validation_alias=AliasChoices("quietStart", "quiet_start"),
     )
-    quietEnd: str = Field(
-        default="07:00",
+    quietEnd: dt_time = Field(
+        default=dt_time.fromisoformat("07:00"),
         alias="quietEnd",
         validation_alias=AliasChoices("quietEnd", "quiet_end"),
     )

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from fastapi import HTTPException
 from typing import cast
-from datetime import time as dt_time
 
 from sqlalchemy.orm import Session
 
@@ -43,13 +42,6 @@ def _validate_profile(data: ProfileSchema) -> None:
     if not (data.low < data.target < data.high):
         raise ValueError("target must be between low and high")
 
-    for t in (data.quietStart, data.quietEnd):
-        try:
-            dt_time.fromisoformat(t)
-        except ValueError:
-            raise ValueError("invalid quiet time format")
-
-
 async def save_profile(data: ProfileSchema) -> None:
     _validate_profile(data)
 
@@ -65,14 +57,12 @@ async def save_profile(data: ProfileSchema) -> None:
         profile.target_bg = data.target
         profile.low_threshold = data.low
         profile.high_threshold = data.high
-        profile.quiet_start = dt_time.fromisoformat(data.quietStart)
-        profile.quiet_end = dt_time.fromisoformat(data.quietEnd)
+        profile.quiet_start = data.quietStart
+        profile.quiet_end = data.quietEnd
         profile.sos_contact = data.sosContact or ""
         profile.sos_alerts_enabled = (
             data.sosAlertsEnabled if data.sosAlertsEnabled is not None else True
         )
-        profile.quiet_start = data.quietStart
-        profile.quiet_end = data.quietEnd
         try:
             commit(cast(Session, session))
         except CommitError:

--- a/tests/test_profile_sos_fields.py
+++ b/tests/test_profile_sos_fields.py
@@ -114,6 +114,6 @@ async def test_save_profile_defaults_quiet_hours(
     await profile_service.save_profile(data)
     prof = await profile_service.get_profile(4)
     assert prof is not None
-    assert prof.quiet_start == time(22, 0)
+    assert prof.quiet_start == time(23, 0)
     assert prof.quiet_end == time(7, 0)
     engine.dispose()


### PR DESCRIPTION
## Summary
- treat quiet hours as `datetime.time` values across API
- return `time` objects for quiet hours in legacy endpoints
- fix test to align with default quiet hour values

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ae060dcde8832ab652a9ab663fb427