### PR TITLE
[ui] replace glow shadow classes

### DIFF
--- a/services/webapp/ui/src/index.css
+++ b/services/webapp/ui/src/index.css
@@ -12,8 +12,8 @@ Design tokens and base styles live in styles/theme.css
 @layer components {
   /* Медицинские компоненты */
   .medical-card {
-    @apply bg-card border border-border rounded-xl p-6 shadow-[var(--shadow-soft)]
-           hover:shadow-[var(--shadow-medium)] transition-all duration-200;
+    @apply bg-card border border-border rounded-xl p-6 shadow-soft
+           hover:shadow-medium transition-all duration-200;
   }
 
   .medical-tile {
@@ -25,7 +25,7 @@ Design tokens and base styles live in styles/theme.css
 
   .medical-list-item {
     @apply bg-card border border-border rounded-lg p-4 mb-3
-           hover:shadow-[var(--shadow-soft)] transition-all duration-200;
+           hover:shadow-soft transition-all duration-200;
   }
 
   .modal-card {


### PR DESCRIPTION
## Summary
- replace undefined `shadow-glow` utility with existing `shadow-soft` and `shadow-medium`
- ensure Tailwind build completes

## Testing
- `pnpm --filter vite_react_shadcn_ts build`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ae1384c0e0832aac6270ede4aa7eb1