### PR TITLE
[webapp] use built-in hover shadow utility

### DIFF
--- a/services/webapp/ui/src/index.css
+++ b/services/webapp/ui/src/index.css
@@ -25,7 +25,7 @@ Design tokens and base styles live in styles/theme.css
 
   .medical-list-item {
     @apply bg-card border border-border rounded-lg p-4 mb-3
-           hover:shadow-[var(--shadow-soft)] transition-all duration-200;
+           hover:shadow-medium transition-all duration-200;
   }
 
   .modal-card {


### PR DESCRIPTION
## Summary
- replace undefined hover shadow with Tailwind's built-in `hover:shadow-medium`

## Testing
- `pytest tests/test_profile_security.py::test_profile_security_threshold_changes[low_dec-3.5-9.0] -q` (fails: async plugin missing)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ae15dcd560832aa1cdb855b4da0a61