### PR TITLE
[ui] add glow shadow style

### DIFF
--- a/services/webapp/ui/src/index.css
+++ b/services/webapp/ui/src/index.css
@@ -13,7 +13,7 @@ Design tokens and base styles live in styles/theme.css
   /* Медицинские компоненты */
   .medical-card {
     @apply bg-card border border-border rounded-xl p-6 shadow-soft
-           hover:shadow-medium transition-all duration-200;
+           hover:shadow-glow transition-all duration-200;
   }
 
   .medical-tile {

--- a/services/webapp/ui/tailwind.config.ts
+++ b/services/webapp/ui/tailwind.config.ts
@@ -94,11 +94,12 @@ export default {
 				'gradient-card': 'var(--gradient-card)',
 				'gradient-button': 'var(--gradient-button)'
 			},
-			boxShadow: {
-				'soft': 'var(--shadow-soft)',
-				'medium': 'var(--shadow-medium)',
-				'strong': 'var(--shadow-strong)'
-			},
+                        boxShadow: {
+                                glow: '0 0 10px hsl(var(--medical-blue) / 0.4)',
+                                soft: 'var(--shadow-soft)',
+                                medium: 'var(--shadow-medium)',
+                                strong: 'var(--shadow-strong)',
+                        },
 			borderRadius: {
 				lg: 'var(--radius)',
 				md: 'calc(var(--radius) - 2px)',


### PR DESCRIPTION
## Summary
- add glow shadow to Tailwind config
- use glow shadow on medical cards

## Testing
- `npm run build`
- `pytest -q --cov` *(fails: async def functions not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ae15eba4bc832a8f5588478d73efa7