### PR TITLE
[handlers] narrow exception handling

### DIFF
--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -37,13 +37,19 @@ else:
 # Ожидаем, что в app/diabetes/models.py определён Base
 try:
     from services.api.app.config import settings  # FastAPI/Pydantic settings
-except Exception:
+except ImportError:
+    logger.info(
+        "services.api.app.config not found; falling back to app.config"
+    )
     # альтернативный импорт, если пакетная структура другая
     from app.config import settings  # type: ignore
 
 try:
     from services.api.app.diabetes.services.db import Base
-except Exception:
+except ImportError:
+    logger.info(
+        "services.api.app.diabetes.services.db not found; falling back to app.diabetes.services.db"
+    )
     from app.diabetes.services.db import Base  # type: ignore
 
 target_metadata = Base.metadata

--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -22,12 +22,10 @@ run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    run_db = None
-except Exception as exc:  # pragma: no cover - log unexpected errors
-    logging.getLogger(__name__).exception(
-        "Unexpected error importing run_db", exc_info=exc
+    logging.getLogger(__name__).info(
+        "run_db is unavailable; proceeding without async DB runner"
     )
-    raise
+    run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 

--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -48,12 +48,10 @@ run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    run_db = None
-except Exception as exc:  # pragma: no cover - log unexpected errors
-    logging.getLogger(__name__).exception(
-        "Unexpected error importing run_db", exc_info=exc
+    logging.getLogger(__name__).info(
+        "run_db is unavailable; proceeding without async DB runner"
     )
-    raise
+    run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -57,10 +57,8 @@ run_db: RunDB | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
+    logger.info("run_db is unavailable; proceeding without async DB runner")
     run_db = None
-except Exception as exc:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db", exc_info=exc)
-    raise
 else:
     run_db = cast(RunDB, _run_db)
 

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -38,10 +38,8 @@ run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
+    logger.info("run_db is unavailable; proceeding without async DB runner")
     run_db = None
-except Exception as exc:  # pragma: no cover - log unexpected errors
-    logger.exception("Unexpected error importing run_db", exc_info=exc)
-    raise
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -46,12 +46,10 @@ run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    run_db = None
-except Exception as exc:  # pragma: no cover - log unexpected errors
-    logging.getLogger(__name__).exception(
-        "Unexpected error importing run_db", exc_info=exc
+    logging.getLogger(__name__).info(
+        "run_db is unavailable; proceeding without async DB runner"
     )
-    raise
+    run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 

--- a/services/api/app/diabetes/handlers/sugar_handlers.py
+++ b/services/api/app/diabetes/handlers/sugar_handlers.py
@@ -34,12 +34,10 @@ run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    run_db = None
-except Exception as exc:  # pragma: no cover - log unexpected errors
-    logging.getLogger(__name__).exception(
-        "Unexpected error importing run_db", exc_info=exc
+    logging.getLogger(__name__).info(
+        "run_db is unavailable; proceeding without async DB runner"
     )
-    raise
+    run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
 


### PR DESCRIPTION
## Summary
- narrow optional run_db import handling across handlers
- log ImportError when falling back and let unexpected errors bubble up
- document fallback imports in Alembic env

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trio')*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ae8136666c832a84d34f507a754e7e