### PR TITLE
[handlers] escape button regex patterns

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from telegram.ext import (
     Application,
@@ -49,12 +50,20 @@ def register_profile_handlers(
     app.add_handler(profile.profile_conv)
     app.add_handler(profile.profile_webapp_handler)
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex(f"^{PROFILE_BUTTON_TEXT}$"), profile.profile_view)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view
+        )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](profile.profile_security, pattern="^profile_security")
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
+            profile.profile_security, pattern="^profile_security"
+        )
     )
-    app.add_handler(CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](profile.profile_back, pattern="^profile_back$"))
+    app.add_handler(
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
+            profile.profile_back, pattern="^profile_back$"
+        )
+    )
 
 
 def register_reminder_handlers(
@@ -71,18 +80,33 @@ def register_reminder_handlers(
 
     from . import reminder_handlers
 
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("reminders", reminder_handlers.reminders_list))
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("addreminder", reminder_handlers.add_reminder))
-    app.add_handler(reminder_handlers.reminder_action_handler)
-    app.add_handler(reminder_handlers.reminder_webapp_handler)
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("delreminder", reminder_handlers.delete_reminder))
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex(f"^{REMINDERS_BUTTON_TEXT}$"), reminder_handlers.reminders_list
+        CommandHandler[ContextTypes.DEFAULT_TYPE](
+            "reminders", reminder_handlers.reminders_list
         )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](reminder_handlers.reminder_callback, pattern="^remind_")
+        CommandHandler[ContextTypes.DEFAULT_TYPE](
+            "addreminder", reminder_handlers.add_reminder
+        )
+    )
+    app.add_handler(reminder_handlers.reminder_action_handler)
+    app.add_handler(reminder_handlers.reminder_webapp_handler)
+    app.add_handler(
+        CommandHandler[ContextTypes.DEFAULT_TYPE](
+            "delreminder", reminder_handlers.delete_reminder
+        )
+    )
+    app.add_handler(
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Regex(re.escape(REMINDERS_BUTTON_TEXT)),
+            reminder_handlers.reminders_list,
+        )
+    )
+    app.add_handler(
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
+            reminder_handlers.reminder_callback, pattern="^remind_"
+        )
     )
 
     job_queue = app.job_queue
@@ -120,45 +144,86 @@ def register_handlers(
 
     app.add_handler(onboarding_conv)
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("menu", menu_command))
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("report", reporting_handlers.report_request))
+    app.add_handler(
+        CommandHandler[ContextTypes.DEFAULT_TYPE](
+            "report", reporting_handlers.report_request
+        )
+    )
     app.add_handler(dose_calc.dose_conv)
     # Register profile conversation before sugar conversation so that numeric
     # inputs for profile aren't captured by sugar logging
     register_profile_handlers(app)
     app.add_handler(sugar_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("cancel", dose_calc.dose_cancel))
+    app.add_handler(
+        CommandHandler[ContextTypes.DEFAULT_TYPE]("cancel", dose_calc.dose_cancel)
+    )
     app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("help", help_command))
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("gpt", gpt_handlers.chat_with_gpt))
+    app.add_handler(
+        CommandHandler[ContextTypes.DEFAULT_TYPE]("gpt", gpt_handlers.chat_with_gpt)
+    )
     register_reminder_handlers(app)
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("alertstats", alert_handlers.alert_stats))
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("hypoalert", security_handlers.hypo_alert_faq))
-    app.add_handler(PollAnswerHandler[ContextTypes.DEFAULT_TYPE](onboarding_poll_answer))
+    app.add_handler(
+        CommandHandler[ContextTypes.DEFAULT_TYPE](
+            "alertstats", alert_handlers.alert_stats
+        )
+    )
+    app.add_handler(
+        CommandHandler[ContextTypes.DEFAULT_TYPE](
+            "hypoalert", security_handlers.hypo_alert_faq
+        )
+    )
+    app.add_handler(
+        PollAnswerHandler[ContextTypes.DEFAULT_TYPE](onboarding_poll_answer)
+    )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex(f"^{REPORT_BUTTON_TEXT}$"), reporting_handlers.report_request
+            filters.Regex(re.escape(REPORT_BUTTON_TEXT)),
+            reporting_handlers.report_request,
         )
     )
     app.add_handler(
         MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex(f"^{HISTORY_BUTTON_TEXT}$"), reporting_handlers.history_view
+            filters.Regex(re.escape(HISTORY_BUTTON_TEXT)),
+            reporting_handlers.history_view,
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), photo_handlers.photo_prompt)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Regex(re.escape(PHOTO_BUTTON_TEXT)), photo_handlers.photo_prompt
+        )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex(f"^{QUICK_INPUT_BUTTON_TEXT}$"), smart_input_help)
-    )
-    app.add_handler(MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex(f"^{HELP_BUTTON_TEXT}$"), help_command))
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Regex(f"^{SOS_BUTTON_TEXT}$"), sos_handlers.sos_contact_start)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help
+        )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler)
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command
+        )
     )
-    app.add_handler(MessageHandler[ContextTypes.DEFAULT_TYPE](filters.PHOTO, photo_handlers.photo_handler))
-    app.add_handler(MessageHandler[ContextTypes.DEFAULT_TYPE](filters.Document.IMAGE, photo_handlers.doc_handler))
+    app.add_handler(
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Regex(re.escape(SOS_BUTTON_TEXT)),
+            sos_handlers.sos_contact_start,
+        )
+    )
+    app.add_handler(
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler
+        )
+    )
+    app.add_handler(
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.PHOTO, photo_handlers.photo_handler
+        )
+    )
+    app.add_handler(
+        MessageHandler[ContextTypes.DEFAULT_TYPE](
+            filters.Document.IMAGE, photo_handlers.doc_handler
+        )
+    )
     app.add_handler(
         CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
             reporting_handlers.report_period_callback, pattern="^report_back$"

--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -25,5 +25,5 @@ def test_reminders_button_matches_regex() -> None:
         and h.callback is reminder_handlers.reminders_list
     )
     pattern = cast(filters.Regex, reminder_handler.filters).pattern.pattern
-    assert pattern == f"^{REMINDERS_BUTTON_TEXT}$"
+    assert pattern == re.escape(REMINDERS_BUTTON_TEXT)
     assert re.fullmatch(pattern, REMINDERS_BUTTON_TEXT)


### PR DESCRIPTION
## Summary
- escape UI button texts in registration filters with `re.escape`
- update regex button test

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ae8130fae0832aab31a37ea51f5375