### PR TITLE
[api] refine type hints

### DIFF
--- a/services/api/app/menu_button.py
+++ b/services/api/app/menu_button.py
@@ -7,9 +7,6 @@ always reset the button to :class:`telegram.MenuButtonDefault`.
 
 from __future__ import annotations
 
-from typing import Any
-
-
 from telegram import MenuButtonDefault
 
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
@@ -21,9 +18,9 @@ async def post_init(
     app: Application[
         ExtBot[None],
         ContextTypes.DEFAULT_TYPE,
-        dict[str, Any],
-        dict[str, Any],
-        dict[str, Any],
+        dict[str, object],
+        dict[str, object],
+        dict[str, object],
         DefaultJobQueue,
     ],
 ) -> None:

--- a/services/api/app/routers/stats.py
+++ b/services/api/app/routers/stats.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
@@ -13,11 +12,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/stats", response_model=DayStats | dict[str, Any])
+@router.get("/stats", response_model=DayStats | dict[str, object])
 async def get_stats(
     telegram_id: int = Query(alias="telegramId"),
     user: UserContext = Depends(require_tg_user),
-) -> DayStats | dict[str, Any]:
+) -> DayStats | dict[str, object]:
     if telegram_id != user["id"]:
         raise HTTPException(status_code=403, detail="telegram id mismatch")
     stats = await get_day_stats(telegram_id)

--- a/services/api/app/types.py
+++ b/services/api/app/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Protocol, TypeVar
+from typing import Protocol, TypeVar
 
 T = TypeVar("T")
 
@@ -8,10 +8,10 @@ T = TypeVar("T")
 class SessionProtocol(Protocol):
     """Minimal protocol for DB sessions used by services."""
 
-    def get(self, entity: type[T], ident: Any) -> T | None:
+    def get(self, entity: type[T], ident: object) -> T | None:
         """Retrieve an entity by primary key."""
         ...
 
-    def delete(self, instance: Any) -> None:
+    def delete(self, instance: object) -> None:
         """Mark an object for deletion."""
         ...

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -5,7 +5,6 @@ Bot entry point and configuration.
 
 import logging
 import sys
-from typing import Any
 
 from sqlalchemy.exc import SQLAlchemyError
 from telegram import BotCommand
@@ -39,9 +38,9 @@ async def post_init(
     app: Application[
         ExtBot[None],
         ContextTypes.DEFAULT_TYPE,
-        dict[str, Any],
-        dict[str, Any],
-        dict[str, Any],
+        dict[str, object],
+        dict[str, object],
+        dict[str, object],
         DefaultJobQueue,
     ],
 ) -> None:
@@ -49,11 +48,11 @@ async def post_init(
     await menu_button_post_init(app)
 
 
-
 async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
-
     """Log errors that occur while processing updates."""
-    logger.exception("Exception while handling update %s", update, exc_info=context.error)
+    logger.exception(
+        "Exception while handling update %s", update, exc_info=context.error
+    )
 
 
 def main() -> None:  # pragma: no cover
@@ -71,7 +70,9 @@ def main() -> None:  # pragma: no cover
         sys.exit("Invalid configuration. Please check your settings and try again.")
     except SQLAlchemyError as exc:
         logger.error("Failed to initialize the database", exc_info=exc)
-        sys.exit("Database initialization failed. Please check your configuration and try again.")
+        sys.exit(
+            "Database initialization failed. Please check your configuration and try again."
+        )
 
     BOT_TOKEN = TELEGRAM_TOKEN
     if not BOT_TOKEN:
@@ -83,9 +84,9 @@ def main() -> None:  # pragma: no cover
     application: Application[
         ExtBot[None],
         ContextTypes.DEFAULT_TYPE,
-        dict[str, Any],
-        dict[str, Any],
-        dict[str, Any],
+        dict[str, object],
+        dict[str, object],
+        dict[str, object],
         DefaultJobQueue,
     ] = (
         Application.builder()


### PR DESCRIPTION
## Summary
- replace `Any` with concrete types in session protocol
- remove generic `Any` use in menu button post-init
- tighten type handling in telegram auth
- specify response and context data types in stats router and bot entrypoint

## Testing
- `pytest -q`
- `mypy --strict services/api/app/telegram_auth.py services/api/app/menu_button.py services/bot/main.py services/api/app/types.py services/api/app/routers/stats.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ae811fe0f8832a9e877d30afc6dbaa