### PR TITLE
[services] make commit return None

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -34,7 +34,7 @@ else:
 logger = logging.getLogger(__name__)
 
 SessionLocal: sessionmaker[Session] = _SessionLocal
-commit: Callable[[Session], bool] = _commit
+commit: Callable[[Session], None] = _commit
 
 CustomContext = ContextTypes.DEFAULT_TYPE
 DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -109,7 +109,7 @@ async def _save_entry(
     entry_data: EntryData,
     *,
     SessionLocal: sessionmaker[Session],
-    commit: Callable[[Session], bool],
+    commit: Callable[[Session], None],
 ) -> bool:
     """Persist an entry in the database."""
 
@@ -137,7 +137,7 @@ async def _handle_pending_entry(
     user_id: int,
     *,
     SessionLocal: sessionmaker[Session],
-    commit: Callable[[Session], bool],
+    commit: Callable[[Session], None],
     check_alert: Callable[
         [Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]
     ],
@@ -283,7 +283,7 @@ async def _handle_edit_entry(
     context: ContextTypes.DEFAULT_TYPE,
     *,
     SessionLocal: sessionmaker[Session],
-    commit: Callable[[Session], bool],
+    commit: Callable[[Session], None],
 ) -> bool:
     """Apply edits to an existing entry."""
     edit_id = user_data.get("edit_id")
@@ -372,7 +372,7 @@ async def _handle_smart_input(
     user_id: int,
     *,
     SessionLocal: sessionmaker[Session],
-    commit: Callable[[Session], bool],
+    commit: Callable[[Session], None],
     check_alert: Callable[
         [Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]
     ],
@@ -591,7 +591,7 @@ async def freeform_handler(
     context: ContextTypes.DEFAULT_TYPE,
     *,
     SessionLocal: sessionmaker[Session] | None = None,
-    commit: Callable[[Session], bool] | None = None,
+    commit: Callable[[Session], None] | None = None,
     check_alert: (
         Callable[[Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]] | None
     ) = None,

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -58,7 +58,7 @@ else:
 logger = logging.getLogger(__name__)
 
 SessionLocal: sessionmaker[Session] = _SessionLocal
-commit: Callable[[Session], bool] = _commit
+commit: Callable[[Session], None] = _commit
 
 DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]
 

--- a/services/api/app/diabetes/services/repository.py
+++ b/services/api/app/diabetes/services/repository.py
@@ -14,7 +14,7 @@ class CommitError(RuntimeError):
     """Raised when a database commit fails."""
 
 
-def commit(session: Session) -> bool:
+def commit(session: Session) -> None:
     """Commit an SQLAlchemy session.
 
     Parameters
@@ -22,14 +22,13 @@ def commit(session: Session) -> bool:
     session: Session
         Active SQLAlchemy session.
 
-    Returns
-    -------
-    bool
-        ``True`` if the commit succeeded. ``CommitError`` is raised otherwise.
+    Raises
+    ------
+    CommitError
+        If the commit fails. On success nothing is returned.
     """
     try:
         session.commit()
-        return True
     except SQLAlchemyError as exc:  # pragma: no cover - logging only
         session.rollback()
         logger.exception("DB commit failed")

--- a/tests/handlers/profile/test_api.py
+++ b/tests/handlers/profile/test_api.py
@@ -136,7 +136,7 @@ def test_save_profile_persists(session_factory: sessionmaker[Session]) -> None:
 def test_save_profile_commit_failure(
     monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker[Session]
 ) -> None:
-    def fail_commit(session: object) -> bool:
+    def fail_commit(session: object) -> None:
         raise profile_api.CommitError
 
     monkeypatch.setattr(profile_api, "commit", fail_commit)
@@ -200,7 +200,7 @@ def test_set_timezone_persists(session_factory: sessionmaker[Session]) -> None:
 def test_set_timezone_commit_failure(
     monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker[Session]
 ) -> None:
-    def fail_commit(session: object) -> bool:
+    def fail_commit(session: object) -> None:
         raise profile_api.CommitError
 
     monkeypatch.setattr(profile_api, "commit", fail_commit)
@@ -219,7 +219,7 @@ def test_set_timezone_commit_failure(
 def test_set_timezone_user_missing(
     monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker[Session]
 ) -> None:
-    commit_mock = MagicMock(return_value=True)
+    commit_mock = MagicMock(return_value=None)
     monkeypatch.setattr(profile_api, "commit", commit_mock)
     with session_factory() as session:
         found, ok = profile_api.set_timezone(session, 999, "UTC")

--- a/tests/handlers/test_gpt_handlers.py
+++ b/tests/handlers/test_gpt_handlers.py
@@ -149,7 +149,7 @@ async def test_pending_entry_commit(monkeypatch: pytest.MonkeyPatch) -> None:
     await gpt_handlers.freeform_handler(
         update,
         context,
-        commit=lambda session: True,
+        commit=lambda session: None,
         check_alert=fake_check_alert,
     )
     assert "pending_entry" not in user_data
@@ -230,7 +230,7 @@ async def test_smart_input_complete(monkeypatch: pytest.MonkeyPatch) -> None:
         update,
         context,
         smart_input=fake_smart_input,
-        commit=lambda session: True,
+        commit=lambda session: None,
         check_alert=fake_check_alert,
     )
     assert message.replies[0][0].startswith("✅ Запись сохранена")

--- a/tests/handlers/test_onboarding_handlers.py
+++ b/tests/handlers/test_onboarding_handlers.py
@@ -51,7 +51,7 @@ async def test_start_command_launches_onboarding(
 
     monkeypatch.setattr(gpt_client, "create_thread", fake_thread)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    monkeypatch.setattr(onboarding, "commit", lambda s: True)
+    monkeypatch.setattr(onboarding, "commit", lambda s: None)
 
     message = DummyMessage()
     update = cast(
@@ -83,7 +83,7 @@ async def test_onboarding_skip_cancels(monkeypatch: pytest.MonkeyPatch) -> None:
         session.commit()
 
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    monkeypatch.setattr(onboarding, "commit", lambda s: True)
+    monkeypatch.setattr(onboarding, "commit", lambda s: None)
     monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
 
     message = DummyMessage()
@@ -129,7 +129,7 @@ async def test_onboarding_target_commit_fail(monkeypatch: pytest.MonkeyPatch) ->
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    def fail_commit(session: object) -> bool:
+    def fail_commit(session: object) -> None:
         raise onboarding.CommitError
 
     monkeypatch.setattr(onboarding, "commit", fail_commit)
@@ -165,7 +165,7 @@ async def test_onboarding_timezone_commit_fail(monkeypatch: pytest.MonkeyPatch) 
         session.commit()
 
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    def fail_commit(session: object) -> bool:
+    def fail_commit(session: object) -> None:
         raise onboarding.CommitError
 
     monkeypatch.setattr(onboarding, "commit", fail_commit)

--- a/tests/handlers/test_photo_handler_recognition.py
+++ b/tests/handlers/test_photo_handler_recognition.py
@@ -77,10 +77,9 @@ async def test_photo_handler_recognition_success_db_save(
     session = DummySession()
     commit_called = False
 
-    def fake_commit(sess: Any) -> bool:
+    def fake_commit(sess: Any) -> None:
         nonlocal commit_called
         commit_called = True
-        return True
 
     async def fake_create_thread() -> str:
         return "tid"

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -342,7 +342,7 @@ async def test_commit_failure_logs_error_on_schedule(
         TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
         handlers.SessionLocal = TestSession
 
-        def fake_commit(session: Any) -> bool:
+        def fake_commit(session: Any) -> None:
             raise handlers.CommitError
 
         monkeypatch.setattr(handlers, "commit", fake_commit)
@@ -382,11 +382,11 @@ async def test_commit_failure_logs_error(
         call_count = {"n": 0}
         real_commit = commit
 
-        def fake_commit(session: Any) -> bool:
+        def fake_commit(session: Any) -> None:
             call_count["n"] += 1
             if call_count["n"] == 4:
                 raise handlers.CommitError
-            return real_commit(session)
+            real_commit(session)
 
         monkeypatch.setattr(handlers, "commit", fake_commit)
 

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -88,7 +88,7 @@ async def test_entry_without_dose_has_no_unit(
 
     session_factory: sessionmaker[Session] = sessionmaker(class_=DummySession)
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
-    monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
+    monkeypatch.setattr(dose_handlers, "commit", lambda session: None)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", lambda: None)
 
@@ -143,7 +143,7 @@ async def test_entry_without_sugar_has_placeholder(
 
     session_factory: sessionmaker[Session] = sessionmaker(class_=DummySession)
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
-    monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
+    monkeypatch.setattr(dose_handlers, "commit", lambda session: None)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", lambda: None)
 

--- a/tests/test_gpt_handlers.py
+++ b/tests/test_gpt_handlers.py
@@ -364,7 +364,7 @@ async def test_freeform_handler_quick_entry_complete(
         update,
         context,
         smart_input=fake_smart_input,
-        commit=lambda session: True,
+        commit=lambda session: None,
         check_alert=fake_check_alert,
     )
     assert message.texts[0].startswith("✅ Запись сохранена")
@@ -561,7 +561,7 @@ async def test_freeform_handler_pending_entry_commit(
     await gpt_handlers.freeform_handler(
         update,
         context,
-        commit=lambda session: True,
+        commit=lambda session: None,
         check_alert=fake_check_alert,
     )
     assert "pending_entry" not in user_data
@@ -600,7 +600,7 @@ async def test_freeform_handler_pending_entry_commit_fail(
     def session_factory() -> DummySession:
         return DummySession()
 
-    def fail_commit(_: Any) -> bool:
+    def fail_commit(_: Any) -> None:
         raise gpt_handlers.CommitError
 
     monkeypatch.setattr(gpt_handlers, "run_db", None)
@@ -660,7 +660,7 @@ async def test_freeform_handler_pending_entry_numeric_add_carbs(
 
     monkeypatch.setattr(gpt_handlers, "run_db", None)
     monkeypatch.setattr(gpt_handlers, "SessionLocal", session_factory)
-    await gpt_handlers.freeform_handler(update, context, commit=lambda s: True)
+    await gpt_handlers.freeform_handler(update, context, commit=lambda s: None)
     assert entry["carbs_g"] == 12
     assert "Введите количество углеводов" in message.texts[0]
 

--- a/tests/test_gpt_handlers_blocks.py
+++ b/tests/test_gpt_handlers_blocks.py
@@ -162,7 +162,7 @@ async def test_handle_pending_entry_value_error() -> None:
         context,
         1,
         SessionLocal=SESSION_FACTORY,
-        commit=lambda s: True,
+        commit=lambda s: None,
         check_alert=_noop_alert,
         menu_keyboard=None,
     )
@@ -187,7 +187,7 @@ async def test_handle_pending_entry_negative() -> None:
         context,
         1,
         SessionLocal=SESSION_FACTORY,
-        commit=lambda s: True,
+        commit=lambda s: None,
         check_alert=_noop_alert,
         menu_keyboard=None,
     )
@@ -212,7 +212,7 @@ async def test_handle_pending_entry_next_field() -> None:
         context,
         1,
         SessionLocal=SESSION_FACTORY,
-        commit=lambda s: True,
+        commit=lambda s: None,
         check_alert=_noop_alert,
         menu_keyboard=None,
     )
@@ -251,7 +251,7 @@ async def test_handle_pending_entry_complete(monkeypatch: pytest.MonkeyPatch) ->
         context,
         1,
         SessionLocal=SESSION_FACTORY,
-        commit=lambda s: True,
+        commit=lambda s: None,
         check_alert=fake_check_alert,
         menu_keyboard=None,
     )

--- a/tests/test_gpt_handlers_db_errors.py
+++ b/tests/test_gpt_handlers_db_errors.py
@@ -51,7 +51,7 @@ async def test_freeform_handler_db_error_propagates(
     def session_factory() -> Session:
         return cast(Session, DummySession())
 
-    def failing_commit(session: Session) -> bool:
+    def failing_commit(session: Session) -> None:
         raise AttributeError("db failure")
 
     monkeypatch.setattr(gpt_handlers, "run_db", None)
@@ -59,5 +59,5 @@ async def test_freeform_handler_db_error_propagates(
 
     with pytest.raises(AttributeError):
         await gpt_handlers.freeform_handler(
-            update, context, commit=cast(Callable[[Session], bool], failing_commit)
+            update, context, commit=cast(Callable[[Session], None], failing_commit)
         )

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -306,7 +306,7 @@ async def test_reminder_callback_commit_failure(
     monkeypatch.setattr(reminder_handlers, "SessionLocal", lambda: session)
     reminder_handlers.commit = commit
 
-    def failing_commit(sess: Session) -> bool:
+    def failing_commit(sess: Session) -> None:
         sess.rollback()
         raise reminder_handlers.CommitError
 

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -70,7 +70,7 @@ async def test_freeform_handler_edits_pending_entry_keeps_state(
 
     monkeypatch.setattr(handlers, "run_db", None)
     monkeypatch.setattr(handlers, "SessionLocal", session_factory)
-    monkeypatch.setattr(handlers, "commit", lambda session: True)
+    monkeypatch.setattr(handlers, "commit", lambda session: None)
     monkeypatch.setattr(handlers, "check_alert", fake_check_alert)
 
     await handlers.freeform_handler(update, context)

--- a/tests/test_onboarding_edge_cases.py
+++ b/tests/test_onboarding_edge_cases.py
@@ -232,7 +232,7 @@ async def test_onboarding_skip_commit_failure(monkeypatch: pytest.MonkeyPatch) -
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    def fail_commit(session: object) -> bool:
+    def fail_commit(session: object) -> None:
         raise onboarding.CommitError
 
     monkeypatch.setattr(onboarding, "commit", fail_commit)

--- a/tests/test_photo_handlers_additional.py
+++ b/tests/test_photo_handlers_additional.py
@@ -61,7 +61,7 @@ async def test_photo_handler_commit_failure(
 
     monkeypatch.setattr(photo_handlers, "SessionLocal", lambda: DummySession())
     monkeypatch.setattr(photo_handlers, "create_thread", fake_create_thread)
-    def fail_commit(session: object) -> bool:
+    def fail_commit(session: object) -> None:
         raise photo_handlers.CommitError
 
     monkeypatch.setattr(photo_handlers, "commit", fail_commit)

--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -174,7 +174,7 @@ async def test_add_reminder_valid_type(reminder_handlers: Any, monkeypatch: pyte
 
     monkeypatch.setattr(reminder_handlers, "run_db", None)
     monkeypatch.setattr(reminder_handlers, "SessionLocal", session_factory)
-    monkeypatch.setattr(reminder_handlers, "commit", lambda s: True)
+    monkeypatch.setattr(reminder_handlers, "commit", lambda s: None)
     monkeypatch.setattr(reminder_handlers, "_describe", lambda *a, **k: "desc")
 
     await reminder_handlers.add_reminder(update, context)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -14,7 +14,7 @@ class DummyError(SQLAlchemyError):
 
 def test_commit_success() -> None:
     session = MagicMock()
-    assert repository.commit(session) is True
+    repository.commit(session)
     session.commit.assert_called_once()
     session.rollback.assert_not_called()
 


### PR DESCRIPTION
## Summary
- make repository.commit return None on success and raise CommitError on failure
- adjust handler type hints and tests to match commit's new signature

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ae81336780832a88f643aa083d9157