### PR TITLE
[webapp] add ts-sdk path aliases

### DIFF
--- a/services/webapp/ui/tsconfig.app.json
+++ b/services/webapp/ui/tsconfig.app.json
@@ -23,7 +23,9 @@
 
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@sdk": ["../../../libs/ts-sdk"],
+      "@sdk/*": ["../../../libs/ts-sdk/*"]
     }
   },
   "include": ["src"]

--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -8,7 +8,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@sdk": ["../../../libs/ts-sdk"]
+      "@sdk": ["../../../libs/ts-sdk"],
+      "@sdk/*": ["../../../libs/ts-sdk/*"]
     },
     "noImplicitAny": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Summary
- add @sdk and @sdk/* path aliases for the webapp to resolve the generated SDK

## Testing
- `npm run build`
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: Interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ae8f44dc98832a9ee1af789a50cee3