### PR TITLE
[ui] Add @sdk runtime alias

### DIFF
--- a/services/webapp/ui/tsconfig.app.json
+++ b/services/webapp/ui/tsconfig.app.json
@@ -25,7 +25,8 @@
     "paths": {
       "@/*": ["./src/*"],
       "@sdk": ["../../../libs/ts-sdk"],
-      "@sdk/*": ["../../../libs/ts-sdk/*"]
+      "@sdk/*": ["../../../libs/ts-sdk/*"],
+      "@sdk/runtime": ["../../../libs/ts-sdk/runtime.ts"]
     }
   },
   "include": ["src"]

--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -9,7 +9,8 @@
     "paths": {
       "@/*": ["./src/*"],
       "@sdk": ["../../../libs/ts-sdk"],
-      "@sdk/*": ["../../../libs/ts-sdk/*"]
+      "@sdk/*": ["../../../libs/ts-sdk/*"],
+      "@sdk/runtime": ["../../../libs/ts-sdk/runtime.ts"]
     },
     "noImplicitAny": true,
     "noUnusedParameters": true,

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -83,6 +83,10 @@ export default defineConfig(async ({ mode, command }) => {
       alias: {
         '@': path.resolve(__dirname, './src'),
         '@sdk': path.resolve(__dirname, '../../../libs/ts-sdk'),
+        '@sdk/runtime': path.resolve(
+          __dirname,
+          '../../../libs/ts-sdk/runtime.ts',
+        ),
       },
     },
     server: { host: '::', port: 5173 },


### PR DESCRIPTION
## Summary
- map `@sdk/runtime` to generated SDK runtime
- expose alias in TypeScript configs

## Testing
- `npm run build`
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ae93618788832a87152d406c1962a6