### PR TITLE
[ui] use sdk alias for reminders api

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/reminders.ts
+++ b/services/webapp/ui/src/features/reminders/api/reminders.ts
@@ -1,5 +1,5 @@
-import { Configuration } from "../../../../../libs/ts-sdk/runtime";
-import { DefaultApi } from "../../../../../libs/ts-sdk/apis";
+import { Configuration } from "@sdk/runtime";
+import { DefaultApi } from "@sdk/apis";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 
 export function makeRemindersApi(initData: string) {


### PR DESCRIPTION
## Summary
- import Configuration and DefaultApi from @sdk alias in reminders API

## Testing
- `npx vitest run`
- `npm run build` *(fails: Could not resolve "../../../../src/lib/telegram-auth" from "src/api/http.ts")*


------
https://chatgpt.com/codex/tasks/task_e_68ae93565314832a8042fe669be176f8