### PR TITLE
[ui] fix sdk imports and alias

### DIFF
--- a/services/webapp/ui/src/api/history.api.test.ts
+++ b/services/webapp/ui/src/api/history.api.test.ts
@@ -1,18 +1,23 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { Configuration } from '@sdk/runtime';
 
 const mockHistoryGet = vi.hoisted(() => vi.fn());
 const mockHistoryPost = vi.hoisted(() => vi.fn());
 const mockHistoryIdDelete = vi.hoisted(() => vi.fn());
 
-vi.mock('@sdk', () => ({
-  HistoryApi: vi.fn(() => ({
-    historyGet: mockHistoryGet,
-    historyPost: mockHistoryPost,
-    historyIdDelete: mockHistoryIdDelete,
-  })),
-  Configuration,
-}));
+vi.mock(
+  '@sdk',
+  () => ({
+    HistoryApi: vi.fn(() => ({
+      historyGet: mockHistoryGet,
+      historyPost: mockHistoryPost,
+      historyIdDelete: mockHistoryIdDelete,
+    })),
+    Configuration: class {},
+  }),
+  { virtual: true },
+);
+
+import { Configuration } from '@sdk';
 
 import { getHistory, updateRecord, deleteRecord } from './history';
 

--- a/services/webapp/ui/src/api/history.ts
+++ b/services/webapp/ui/src/api/history.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { HistoryApi } from '@sdk';
-import { Configuration } from '@sdk/runtime';
+import { Configuration } from '@sdk';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 

--- a/services/webapp/ui/src/api/profile.api.test.ts
+++ b/services/webapp/ui/src/api/profile.api.test.ts
@@ -1,17 +1,31 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ResponseError, Configuration } from '@sdk/runtime';
 import type { ProfileSchema as Profile } from '@sdk/models';
 
 const mockProfilesGet = vi.hoisted(() => vi.fn());
 const mockProfilesPost = vi.hoisted(() => vi.fn());
 
-vi.mock('@sdk', () => ({
-  ProfilesApi: vi.fn(() => ({
-    profilesGet: mockProfilesGet,
-    profilesPost: mockProfilesPost,
-  })),
-  Configuration,
-}));
+vi.mock(
+  '@sdk',
+  () => {
+    class ResponseError extends Error {
+      constructor(public response: Response) {
+        super('ResponseError');
+      }
+    }
+    class Configuration {}
+    return {
+      ProfilesApi: vi.fn(() => ({
+        profilesGet: mockProfilesGet,
+        profilesPost: mockProfilesPost,
+      })),
+      ResponseError,
+      Configuration,
+    };
+  },
+  { virtual: true },
+);
+
+import { ResponseError, Configuration } from '@sdk';
 
 import { getProfile, saveProfile } from './profile';
 

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -3,7 +3,7 @@ import {
   instanceOfProfileSchema as instanceOfProfile,
   type ProfileSchema as Profile,
 } from '@sdk/models';
-import { Configuration, ResponseError } from '@sdk/runtime';
+import { Configuration, ResponseError } from '@sdk';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 

--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { ResponseError, Configuration } from '@sdk/runtime';
 
 const mockRemindersGet = vi.hoisted(() => vi.fn());
 const mockRemindersIdGet = vi.hoisted(() => vi.fn());
@@ -10,32 +9,28 @@ const mockInstanceOfReminder = vi.hoisted(() => vi.fn());
 const mockTgFetch = vi.hoisted(() => vi.fn());
 
 vi.mock(
-  '@sdk/runtime',
-  () => ({
-    ResponseError: class extends Error {
+  '@sdk',
+  () => {
+    class ResponseError extends Error {
       response: Response;
       constructor(response: Response) {
         super('ResponseError');
         this.response = response;
       }
-    },
-    Configuration: class {},
-  }),
-  { virtual: true },
-);
-
-vi.mock(
-  '@sdk',
-  () => ({
-    RemindersApi: vi.fn(() => ({
-      remindersGet: mockRemindersGet,
-      remindersIdGet: mockRemindersIdGet,
-      remindersPost: mockRemindersPost,
-      remindersPatch: mockRemindersPatch,
-      remindersDelete: mockRemindersDelete,
-    })),
-    Configuration,
-  }),
+    }
+    class Configuration {}
+    return {
+      RemindersApi: vi.fn(() => ({
+        remindersGet: mockRemindersGet,
+        remindersIdGet: mockRemindersIdGet,
+        remindersPost: mockRemindersPost,
+        remindersPatch: mockRemindersPatch,
+        remindersDelete: mockRemindersDelete,
+      })),
+      Configuration,
+      ResponseError,
+    };
+  },
   { virtual: true },
 );
 
@@ -49,6 +44,7 @@ vi.mock(
 
 vi.mock('../lib/tgFetch', () => ({ tgFetch: mockTgFetch }), { virtual: true });
 
+import { ResponseError, Configuration } from '@sdk';
 import {
   getReminder,
   getReminders,

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,5 @@
 import { RemindersApi } from '@sdk';
-import { Configuration, ResponseError } from '@sdk/runtime';
+import { Configuration, ResponseError } from '@sdk';
 import {
   instanceOfReminderSchema as instanceOfReminder,
   type ReminderSchema as Reminder,

--- a/services/webapp/ui/src/api/stats.api.test.ts
+++ b/services/webapp/ui/src/api/stats.api.test.ts
@@ -4,7 +4,7 @@ const mockGetAnalytics = vi.hoisted(() => vi.fn());
 const mockGetStats = vi.hoisted(() => vi.fn());
 
 vi.mock(
-  '@sdk/runtime',
+  '@sdk',
   () => {
     class Configuration {}
     class ResponseError extends Error {
@@ -12,21 +12,19 @@ vi.mock(
         super('Response error');
       }
     }
-    return { Configuration, ResponseError };
+    return {
+      DefaultApi: vi.fn(() => ({
+        getAnalyticsAnalyticsGet: mockGetAnalytics,
+        getStatsStatsGet: mockGetStats,
+      })),
+      Configuration,
+      ResponseError,
+    };
   },
   { virtual: true },
 );
 
-vi.mock(
-  '@sdk',
-  () => ({
-    DefaultApi: vi.fn(() => ({
-      getAnalyticsAnalyticsGet: mockGetAnalytics,
-      getStatsStatsGet: mockGetStats,
-    })),
-  }),
-  { virtual: true },
-);
+import { ResponseError } from '@sdk';
 
 import {
   fetchAnalytics,
@@ -35,12 +33,6 @@ import {
   getFallbackDayStats,
   type DayStats,
 } from './stats';
-
-let ResponseError: new (arg: { status: number }) => Error;
-
-beforeAll(async () => {
-  ({ ResponseError } = await import('@sdk/runtime'));
-});
 
 afterEach(() => {
   mockGetAnalytics.mockReset();

--- a/services/webapp/ui/src/api/stats.ts
+++ b/services/webapp/ui/src/api/stats.ts
@@ -1,5 +1,5 @@
 import { DefaultApi } from '@sdk';
-import { Configuration, ResponseError } from '@sdk/runtime';
+import { Configuration, ResponseError } from '@sdk';
 import { tgFetch } from '../lib/tgFetch';
 import { API_BASE } from './base';
 

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -80,14 +80,17 @@ export default defineConfig(async ({ mode, command }) => {
     base,
     plugins,
     resolve: {
-      alias: {
-        '@': path.resolve(__dirname, './src'),
-        '@sdk': path.resolve(__dirname, '../../../libs/ts-sdk'),
-        '@sdk/runtime': path.resolve(
-          __dirname,
-          '../../../libs/ts-sdk/runtime.ts',
-        ),
-      },
+      alias: [
+        {
+          find: '@sdk/runtime',
+          replacement: path.resolve(
+            __dirname,
+            '../../../libs/ts-sdk/runtime.ts',
+          ),
+        },
+        { find: '@sdk', replacement: path.resolve(__dirname, '../../../libs/ts-sdk') },
+        { find: '@', replacement: path.resolve(__dirname, './src') },
+      ],
     },
     server: { host: '::', port: 5173 },
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,8 +6,16 @@ export default defineConfig({
     environment: 'jsdom',
   },
   resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './services/webapp/ui/src'),
-    },
+    alias: [
+      {
+        find: '@sdk/runtime',
+        replacement: path.resolve(
+          __dirname,
+          './libs/ts-sdk/runtime.ts',
+        ),
+      },
+      { find: '@sdk', replacement: path.resolve(__dirname, './libs/ts-sdk') },
+      { find: '@', replacement: path.resolve(__dirname, './services/webapp/ui/src') },
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- resolve SDK runtime via `@sdk` and add explicit alias order
- update Vite and Vitest configs for `@sdk/runtime`
- adjust tests and mocks accordingly

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68aea843500c832a901a114ef1896bb9