### PR TITLE
[webapp] configure sdk path

### DIFF
--- a/services/webapp/ui/src/api/http.ts
+++ b/services/webapp/ui/src/api/http.ts
@@ -1,4 +1,4 @@
-import { getTelegramAuthHeaders } from '../../../../src/lib/telegram-auth';
+import { getTelegramAuthHeaders } from '../../../../../src/lib/telegram-auth';
 
 const API_BASE = '/api';
 

--- a/services/webapp/ui/tsconfig.app.json
+++ b/services/webapp/ui/tsconfig.app.json
@@ -23,8 +23,9 @@
 
     "baseUrl": ".",
     "paths": {
+      "@sdk/*": ["../../../libs/ts-sdk/*"],
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "../../../libs/ts-sdk"]
 }

--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -7,6 +7,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "@sdk/*": ["../../../libs/ts-sdk/*"],
       "@/*": ["./src/*"]
     },
     "noImplicitAny": false,

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -2,6 +2,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 export default defineConfig(async ({ mode }) => {
   const plugins = [react()]


### PR DESCRIPTION
## Summary
- fix Vite config to resolve `@sdk` from repository root using `fileURLToPath`
- map `@sdk/*` to the shared SDK and include it in TypeScript compilation
- correct http client auth import path so build succeeds

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any, missing deps, forbidden require imports)*
- `pytest tests/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68aea852f734832aa11c52c61459d9aa