### PR TITLE
[ui] use SDK runtime alias in reminders api

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,5 @@
 import { RemindersApi } from '@sdk';
-import { Configuration, ResponseError } from '@sdk';
+import { Configuration, ResponseError } from '@sdk/runtime';
 import {
   instanceOfReminderSchema as instanceOfReminder,
   type ReminderSchema as Reminder,


### PR DESCRIPTION
## Summary
- use `@sdk/runtime` alias in reminders API to get Configuration and ResponseError

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aead3e5ebc832aa55bf189b6fafaba