### PR TITLE
[db] refactor run_db signature and callers

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -7,6 +7,7 @@ import json
 import logging
 import re
 from datetime import time, timedelta, timezone
+from functools import partial
 from typing import Callable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -298,7 +299,7 @@ def schedule_all(job_queue) -> None:
 async def reminders_list(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     user_id = update.effective_user.id
     text, keyboard = await run_db(
-        _render_reminders, user_id, sessionmaker=SessionLocal
+        partial(_render_reminders, user_id=user_id), sessionmaker=SessionLocal
     )
     kwargs = {"parse_mode": "HTML"}
     if keyboard is not None:
@@ -490,7 +491,7 @@ async def reminder_webapp_save(
 
     schedule_reminder(rem, context.job_queue)
     text, keyboard = await run_db(
-        _render_reminders, user_id, sessionmaker=SessionLocal
+        partial(_render_reminders, user_id=user_id), sessionmaker=SessionLocal
     )
     kwargs = {"parse_mode": "HTML"}
     if keyboard is not None:
@@ -665,7 +666,7 @@ async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE)
             job.schedule_removal()
 
     text, keyboard = await run_db(
-        _render_reminders, user_id, sessionmaker=SessionLocal
+        partial(_render_reminders, user_id=user_id), sessionmaker=SessionLocal
     )
     kwargs = {"parse_mode": "HTML"}
     if keyboard is not None:

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -4,6 +4,8 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
+from functools import partial
+
 from pydantic import BaseModel
 
 from .diabetes.services.db import (
@@ -66,7 +68,7 @@ async def put_timezone(data: Timezone) -> dict:
             obj.tz = tz
         session.commit()
 
-    await run_db(_save_timezone, data.tz)
+    await run_db(partial(_save_timezone, tz=data.tz))
     return {"status": "ok"}
 
 
@@ -114,7 +116,7 @@ async def post_history(data: HistoryRecordSchema) -> dict:
         session.commit()
 
     try:
-        await run_db(_save_history, data)
+        await run_db(partial(_save_history, record=data))
     except Exception as exc:  # pragma: no cover - unexpected errors
         logger.exception("failed to save history")
         raise HTTPException(status_code=500, detail="failed to save history") from exc

--- a/tests/test_webapp_history.py
+++ b/tests/test_webapp_history.py
@@ -19,7 +19,9 @@ def setup_db(monkeypatch):
     db.Base.metadata.create_all(bind=engine)
 
     async def run_db_wrapper(fn, *args, **kwargs):
-        return await db.run_db(fn, *args, sessionmaker=Session, **kwargs)
+        return await db.run_db(
+            lambda session: fn(session, *args, **kwargs), sessionmaker=Session
+        )
 
     monkeypatch.setattr(server, "run_db", run_db_wrapper)
     return Session

--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -20,7 +20,9 @@ def setup_db(monkeypatch):
     db.Base.metadata.create_all(bind=engine)
 
     async def run_db_wrapper(fn, *args, **kwargs):
-        return await db.run_db(fn, *args, sessionmaker=Session, **kwargs)
+        return await db.run_db(
+            lambda session: fn(session, *args, **kwargs), sessionmaker=Session
+        )
 
     monkeypatch.setattr(server, "run_db", run_db_wrapper)
     return Session


### PR DESCRIPTION
## Summary
- require run_db callbacks to accept only a session
- bind extra parameters using functools.partial at call sites
- adjust tests to new run_db interface

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: async def functions are not natively supported)*
- `mypy services/api/app/main.py services/api/app/diabetes/handlers/reminder_handlers.py services/api/app/diabetes/handlers/profile/conversation.py services/api/app/diabetes/services/db.py` *(fails: 459 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaec7af4c832aa4974425a0cc0286