### PR TITLE
[handlers] Add type hints to handlers

### DIFF
--- a/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
+++ b/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
@@ -1,14 +1,18 @@
 import re
-from typing import Optional
+from typing import Any, Callable, Optional
 
 from telegram import CallbackQuery, Update
-from telegram.ext import BaseHandler
+from telegram.ext import BaseHandler, CallbackContext
 
 
 class CallbackQueryNoWarnHandler(BaseHandler):
     """Handle callback queries without triggering ConversationHandler warnings."""
 
-    def __init__(self, callback, pattern: str | None = None):
+    def __init__(
+        self,
+        callback: Callable[[Update, CallbackContext], Any],
+        pattern: str | None = None,
+    ):
         super().__init__(callback)
         self.pattern: Optional[re.Pattern[str]] = re.compile(pattern) if pattern else None
 

--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -1,4 +1,8 @@
 import logging
+from typing import Any
+
+from sqlalchemy.orm import Session
+
 from services.api.app.config import settings
 from services.api.app.diabetes.services.db import Profile, SessionLocal, User
 from services.api.app.diabetes.services.repository import commit
@@ -6,7 +10,7 @@ from services.api.app.diabetes.services.repository import commit
 logger = logging.getLogger(__name__)
 
 
-def get_api():
+def get_api() -> tuple[Any | None, type[Exception] | None, type[Any] | None]:
     """Return API client, its exception type and profile model.
 
     Separate function to make API access testable without importing SDK in UI
@@ -27,7 +31,15 @@ def get_api():
     return api, ApiException, ProfileModel
 
 
-def save_profile(session, user_id: int, icr: float, cf: float, target: float, low: float, high: float) -> bool:
+def save_profile(
+    session: Session,
+    user_id: int,
+    icr: float,
+    cf: float,
+    target: float,
+    low: float,
+    high: float,
+) -> bool:
     """Persist profile values into the local database."""
     prof = session.get(Profile, user_id)
     if not prof:
@@ -41,7 +53,7 @@ def save_profile(session, user_id: int, icr: float, cf: float, target: float, lo
     return commit(session)
 
 
-def set_timezone(session, user_id: int, tz: str) -> tuple[bool, bool]:
+def set_timezone(session: Session, user_id: int, tz: str) -> tuple[bool, bool]:
     """Update user timezone in the database."""
     user = session.get(User, user_id)
     if not user:
@@ -51,7 +63,7 @@ def set_timezone(session, user_id: int, tz: str) -> tuple[bool, bool]:
     return True, ok
 
 
-def fetch_profile(api, ApiException, user_id: int):
+def fetch_profile(api: Any, ApiException: type[Exception], user_id: int) -> Any | None:
     """Fetch profile via synchronous SDK call."""
     try:
         return api.profiles_get(telegram_id=user_id)
@@ -60,9 +72,9 @@ def fetch_profile(api, ApiException, user_id: int):
 
 
 def post_profile(
-    api,
-    ApiException,
-    ProfileModel,
+    api: Any,
+    ApiException: type[Exception],
+    ProfileModel: type[Any],
     user_id: int,
     icr: float,
     cf: float,

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -14,6 +14,8 @@ import json
 import logging
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from sqlalchemy.orm import Session
+
 from services.api.app.diabetes.services.db import (
     SessionLocal,
     Profile,
@@ -367,7 +369,7 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
     return ConversationHandler.END
 
 
-def _security_db(session, user_id: int, action: str | None):
+def _security_db(session: Session, user_id: int, action: str | None):
     profile = session.get(Profile, user_id)
     user = session.get(User, user_id)
     if not profile:

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -9,6 +9,7 @@ import logging
 
 from openai import OpenAIError
 from telegram import (
+    CallbackQuery,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     KeyboardButton,
@@ -185,9 +186,9 @@ async def report_period_callback(
 async def send_report(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
-    date_from,
-    period_label,
-    query=None,
+    date_from: datetime.datetime,
+    period_label: str,
+    query: CallbackQuery | None = None,
 ) -> None:
     """Generate and send a PDF report for entries after ``date_from``."""
     user_id = update.effective_user.id


### PR DESCRIPTION
## Summary
- annotate alert scheduling and stats handlers with Update, CallbackContext, JobQueue, and Session types
- type callback query helper and dose/photo handlers, adding return types
- add typing to profile API utilities and reminder/report helpers

## Testing
- `ruff check services/api/app tests`
- `mypy services/api/app/diabetes/handlers/alert_handlers.py services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py services/api/app/diabetes/handlers/dose_handlers.py services/api/app/diabetes/handlers/profile/api.py services/api/app/diabetes/handlers/profile/conversation.py services/api/app/diabetes/handlers/reminder_handlers.py services/api/app/diabetes/handlers/reporting_handlers.py`
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaebd7520832a9dc793edf80a0623