### PR TITLE
handlers: guard optional Telegram attributes

### DIFF
--- a/services/api/app/diabetes/handlers/security_handlers.py
+++ b/services/api/app/diabetes/handlers/security_handlers.py
@@ -14,7 +14,8 @@ async def hypo_alert_faq(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         "Раннее предупреждение даёт шанс быстро принять углеводы и привлечь помощь, "
         "предотвращая тяжёлые последствия."
     )
-    await update.message.reply_text(text)
+    if update.message is not None:
+        await update.message.reply_text(text)
 
 
 __all__ = ["hypo_alert_faq"]


### PR DESCRIPTION
## Summary
- ensure optional `Update` fields are checked in reminder and security handlers
- use explicit casts in reminder tests for mypy

## Testing
- `mypy --follow-imports=skip services/api/app/diabetes/handlers/reminder_handlers.py services/api/app/diabetes/handlers/security_handlers.py tests/test_reminders.py`
- `ruff check services/api/app/diabetes/handlers/reminder_handlers.py services/api/app/diabetes/handlers/security_handlers.py tests/test_reminders.py`
- `pytest tests/test_reminders.py` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaebfec10832aa8c81208f7cc3b63