### PR TITLE
tests: replace simplenamespace with typed updates

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,13 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+from telegram import Update
+from telegram.ext import CallbackContext
+
+
+def make_update(**kwargs: Any) -> Update:
+    return cast(Update, SimpleNamespace(**kwargs))
+
+
+def make_context(**kwargs: Any) -> CallbackContext[Any, Any, Any, Any]:
+    return cast(CallbackContext[Any, Any, Any, Any], SimpleNamespace(**kwargs))

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import sessionmaker
 import services.api.app.diabetes.handlers.alert_handlers as handlers
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.services.db import Base, User, Profile, Alert
+from tests.helpers import make_update
 
 
 class DummyJob:
@@ -180,7 +181,7 @@ async def test_three_alerts_notify(monkeypatch: pytest.MonkeyPatch) -> None:
         async def send_message(self, chat_id: int | str, text: str) -> None:
             self.sent.append((chat_id, text))
 
-    update = SimpleNamespace(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
+    update = make_update(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
     context = cast(AlertContext, ContextStub(bot=DummyBot()))
     async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
         return ("0,0", "link")
@@ -227,7 +228,7 @@ async def test_alert_message_without_coords(monkeypatch: pytest.MonkeyPatch) -> 
         async def send_message(self, chat_id: int | str, text: str) -> None:
             self.sent.append((chat_id, text))
 
-    update = SimpleNamespace(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
+    update = make_update(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
     context = cast(AlertContext, ContextStub(bot=DummyBot()))
 
     async def fake_get_coords_and_link() -> tuple[str | None, str | None]:

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -8,6 +8,7 @@ from telegram import Update
 from telegram.ext import CallbackContext
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from tests.helpers import make_update
 
 os.environ.setdefault("DB_PASSWORD", "test")
 from services.api.app.diabetes.services.db import Base, User, Entry
@@ -77,7 +78,7 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
 
     entry_message = DummyMessage(chat_id=42, message_id=24)
     query = DummyQuery(f"edit:{entry_id}", message=entry_message)
-    update_cb = SimpleNamespace(
+    update_cb = make_update(
         callback_query=query, effective_user=SimpleNamespace(id=1)
     )
     context = cast(
@@ -88,7 +89,7 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
     await router.callback_router(update_cb, context)
 
     field_query = DummyQuery(f"edit_field:{entry_id}:dose", message=entry_message)
-    update_cb2 = SimpleNamespace(callback_query=field_query, effective_user=SimpleNamespace(id=1))
+    update_cb2 = make_update(callback_query=field_query, effective_user=SimpleNamespace(id=1))
     await router.callback_router(update_cb2, context)
     assert context.user_data["edit_field"] == "dose"
 

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -7,6 +7,7 @@ from telegram import Message, Update
 from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as handlers
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage(Message):
@@ -46,8 +47,8 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
         mime_type="image/png",
     )
     message = SimpleNamespace(document=document, photo=None)
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(bot=dummy_bot, user_data={})
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
+    context = make_context(bot=dummy_bot, user_data={})
 
     monkeypatch.setattr(handlers, "photo_handler", fake_photo_handler)
     monkeypatch.setattr(handlers.os, "makedirs", lambda *args, **kwargs: None)
@@ -74,8 +75,8 @@ async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> 
         mime_type=None,
     )
     message = SimpleNamespace(document=document, photo=None)
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={})
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
+    context = make_context(user_data={})
 
     monkeypatch.setattr(handlers, "photo_handler", fake_photo_handler)
 
@@ -89,8 +90,8 @@ async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> 
 @pytest.mark.asyncio
 async def test_photo_handler_handles_typeerror() -> None:
     message = DummyMessage(photo=None)
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={})
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
+    context = make_context(user_data={})
 
     result = await handlers.photo_handler(update, context)
 
@@ -113,7 +114,7 @@ async def test_photo_handler_preserves_file(
         pass
 
     message = SimpleNamespace(photo=[DummyPhoto()], reply_text=reply_text)
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
 
     class DummyFile:
         async def download_to_drive(self, path) -> None:
@@ -123,7 +124,7 @@ async def test_photo_handler_preserves_file(
         return DummyFile()
 
     dummy_bot = SimpleNamespace(get_file=fake_get_file)
-    context = SimpleNamespace(bot=dummy_bot, user_data={"thread_id": "tid"})
+    context = make_context(bot=dummy_bot, user_data={"thread_id": "tid"})
 
     call = {}
 
@@ -209,7 +210,7 @@ async def test_photo_then_freeform_calculates_dose(
     monkeypatch.setattr(handlers, "confirm_keyboard", lambda: None)
 
     photo_msg = DummyMessage(photo=[DummyPhoto()])
-    update_photo = SimpleNamespace(
+    update_photo = make_update(
         message=photo_msg, effective_user=SimpleNamespace(id=1)
     )
     context = cast(

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -9,6 +9,7 @@ from telegram.ext import CallbackContext
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import sessionmaker
+from tests.helpers import make_update
 
 os.environ.setdefault("DB_PASSWORD", "test")
 from services.api.app.diabetes.services.db import Base, User, Entry
@@ -90,7 +91,7 @@ async def test_history_view_buttons(monkeypatch: pytest.MonkeyPatch) -> None:
         entry_ids = [e.id for e in session.query(Entry).all()]
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     context = cast(
         CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
     )
@@ -162,7 +163,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     entry_message = DummyMessage(chat_id=42, message_id=24)
     query = DummyQuery(f"edit:{entry_id}", message=entry_message)
-    update_cb = SimpleNamespace(
+    update_cb = make_update(
         callback_query=query, effective_user=SimpleNamespace(id=1)
     )
     context = cast(
@@ -183,7 +184,7 @@ async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert f"edit_field:{entry_id}:dose" in buttons
 
     field_query = DummyQuery(f"edit_field:{entry_id}:xe", message=entry_message)
-    update_cb2 = SimpleNamespace(
+    update_cb2 = make_update(
         callback_query=field_query, effective_user=SimpleNamespace(id=1)
     )
     await router.callback_router(update_cb2, context)

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -8,6 +8,7 @@ from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 import services.api.app.diabetes.handlers.router as router
+from tests.helpers import make_update
 
 
 class DummyMessage:
@@ -129,7 +130,7 @@ async def test_photo_flow_saves_entry(
     context.user_data["thread_id"] = "tid"
 
     msg_photo = DummyMessage(photo=[DummyPhoto()])
-    update_photo = SimpleNamespace(
+    update_photo = make_update(
         message=msg_photo, effective_user=SimpleNamespace(id=1)
     )
     await dose_handlers.photo_handler(update_photo, context)
@@ -157,7 +158,7 @@ async def test_photo_flow_saves_entry(
     monkeypatch.setattr(alert_handlers, "check_alert", noop)
 
     query = DummyQuery("confirm_entry")
-    update_confirm = SimpleNamespace(callback_query=query)
+    update_confirm = make_update(callback_query=query)
     await router.callback_router(update_confirm, context)
 
     assert len(session.added) == 1

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -10,6 +10,7 @@ from telegram.ext import ConversationHandler
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
 from services.api.app.diabetes.services.db import Base, User, Profile
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
@@ -54,8 +55,8 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
         session.commit()
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=123))
-    context = SimpleNamespace(args=args, user_data={})
+    update = make_update(message=message, effective_user=SimpleNamespace(id=123))
+    context = make_context(args=args, user_data={})
 
     await handlers.profile_command(update, context)
     assert message.markups[0] is menu_keyboard
@@ -66,8 +67,8 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
     assert f"• Высокий порог: {expected_high} ммоль/л" in message.texts[0]
 
     message2 = DummyMessage()
-    update2 = SimpleNamespace(message=message2, effective_user=SimpleNamespace(id=123))
-    context2 = SimpleNamespace(user_data={})
+    update2 = make_update(message=message2, effective_user=SimpleNamespace(id=123))
+    context2 = make_context(user_data={})
 
     await handlers.profile_view(update2, context2)
     assert f"• ИКХ: {expected_icr} г/ед." in message2.texts[0]
@@ -108,8 +109,8 @@ async def test_profile_command_invalid_values(monkeypatch, args) -> None:
     monkeypatch.setattr(handlers, "SessionLocal", session_local_mock)
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(args=args, user_data={})
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
+    context = make_context(args=args, user_data={})
 
     await handlers.profile_command(update, context)
 
@@ -129,16 +130,16 @@ async def test_profile_command_help_and_dialog(monkeypatch) -> None:
 
     # Test /profile help
     help_msg = DummyMessage()
-    update = SimpleNamespace(message=help_msg, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(args=["help"], user_data={})
+    update = make_update(message=help_msg, effective_user=SimpleNamespace(id=1))
+    context = make_context(args=["help"], user_data={})
     result = await handlers.profile_command(update, context)
     assert result == ConversationHandler.END
     assert "Формат команды" in help_msg.texts[0]
 
     # Test starting dialog with empty args
     dialog_msg = DummyMessage()
-    update2 = SimpleNamespace(message=dialog_msg, effective_user=SimpleNamespace(id=1))
-    context2 = SimpleNamespace(args=[], user_data={})
+    update2 = make_update(message=dialog_msg, effective_user=SimpleNamespace(id=1))
+    context2 = make_context(args=[], user_data={})
     result2 = await handlers.profile_command(update2, context2)
     assert result2 == handlers.PROFILE_ICR
     assert dialog_msg.texts[0].startswith("Введите коэффициент ИКХ")
@@ -166,8 +167,8 @@ async def test_profile_view_preserves_user_data(monkeypatch) -> None:
         session.commit()
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={"thread_id": "tid", "foo": "bar"})
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
+    context = make_context(user_data={"thread_id": "tid", "foo": "bar"})
 
     await handlers.profile_view(update, context)
 
@@ -188,8 +189,8 @@ async def test_profile_view_missing_profile_shows_webapp_button(monkeypatch) -> 
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: None)
 
     msg = DummyMessage()
-    update = SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace()
+    update = make_update(message=msg, effective_user=SimpleNamespace(id=1))
+    context = make_context()
 
     await handlers.profile_view(update, context)
 

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from tests.helpers import make_context, make_update
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -24,7 +25,7 @@ class DummyMessage:
 @pytest.mark.asyncio
 async def test_prompt_photo_sends_message() -> None:
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
+    update = make_update(message=message)
     await dose_handlers.prompt_photo(update, SimpleNamespace())
     assert any("фото" in t.lower() for t in message.texts)
 
@@ -32,8 +33,8 @@ async def test_prompt_photo_sends_message() -> None:
 @pytest.mark.asyncio
 async def test_prompt_sugar_sends_message() -> None:
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={})
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
+    context = make_context(user_data={})
     await dose_handlers.prompt_sugar(update, context)
     assert any("сахар" in t.lower() for t in message.texts)
     assert message.kwargs and message.kwargs[0].get("reply_markup") is sugar_keyboard
@@ -42,8 +43,8 @@ async def test_prompt_sugar_sends_message() -> None:
 @pytest.mark.asyncio
 async def test_prompt_dose_sends_message() -> None:
     message = DummyMessage()
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={})
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
+    context = make_context(user_data={})
     await dose_handlers.prompt_dose(update, context)
     assert any("доз" in t.lower() for t in message.texts)
 

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
+from tests.helpers import make_update
 
 
 class DummyMessage:
@@ -40,7 +41,7 @@ async def test_report_request_and_custom_flow(
     import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 
     message = DummyMessage()
-    update = SimpleNamespace(
+    update = make_update(
         message=message, effective_user=SimpleNamespace(id=1)
     )
     context = cast(
@@ -53,7 +54,7 @@ async def test_report_request_and_custom_flow(
     assert message.replies[0][1].get("reply_markup") is not None
 
     query = DummyQuery("report_period:custom")
-    update_cb = SimpleNamespace(
+    update_cb = make_update(
         callback_query=query, effective_user=SimpleNamespace(id=1)
     )
 
@@ -115,7 +116,7 @@ async def test_report_period_callback_week(
     monkeypatch.setattr(reporting_handlers.datetime, "datetime", DummyDateTime)
 
     query = DummyQuery("report_period:week")
-    update_cb = SimpleNamespace(
+    update_cb = make_update(
         callback_query=query, effective_user=SimpleNamespace(id=1)
     )
     context = cast(

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
@@ -35,7 +36,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch, tmp_path) -> None:
     async def fake_send_chat_action(*args: Any, **kwargs: Any) -> None:
         pass
 
-    context = SimpleNamespace(
+    context = make_context(
         user_data={"thread_id": "tid"},
         bot=SimpleNamespace(get_file=fake_get_file, send_chat_action=fake_send_chat_action),
     )
@@ -79,7 +80,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
     msg_photo = DummyMessage(photo=[DummyPhoto()])
-    update = SimpleNamespace(message=msg_photo, effective_user=SimpleNamespace(id=1))
+    update = make_update(message=msg_photo, effective_user=SimpleNamespace(id=1))
 
     await dose_handlers.photo_handler(update, context)
 

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -1,8 +1,8 @@
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
 import services.api.app.diabetes.handlers.common_handlers as handlers
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
@@ -20,8 +20,8 @@ async def test_help_includes_new_features() -> None:
     """Ensure /help mentions wizard, smart-input and edit features."""
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+    update = make_update(message=message)
+    context = make_context()
 
     await handlers.help_command(update, context)
 
@@ -38,8 +38,8 @@ async def test_help_includes_security_block() -> None:
     """Ensure /help mentions security settings."""
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+    update = make_update(message=message)
+    context = make_context()
 
     await handlers.help_command(update, context)
 
@@ -57,8 +57,8 @@ async def test_help_lists_reminder_commands_and_menu_button() -> None:
     """Ensure reminder commands and menu button are documented."""
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+    update = make_update(message=message)
+    context = make_context()
 
     await handlers.help_command(update, context)
 
@@ -74,8 +74,8 @@ async def test_help_lists_sos_contact_command() -> None:
     """Ensure /help documents SOS contact configuration."""
 
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+    update = make_update(message=message)
+    context = make_context()
 
     await handlers.help_command(update, context)
 

--- a/tests/test_history_view_async.py
+++ b/tests/test_history_view_async.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 from services.api.app.diabetes.handlers import reporting_handlers
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
@@ -46,11 +47,11 @@ async def test_history_view_does_not_block_event_loop(monkeypatch) -> None:
 
     monkeypatch.setattr(reporting_handlers, "SessionLocal", slow_session)
 
-    update = SimpleNamespace(
+    update = make_update(
         effective_user=SimpleNamespace(id=1),
         message=DummyMessage(),
     )
-    context = SimpleNamespace()
+    context = make_context()
 
     flag = False
 

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 from telegram.ext import CommandHandler
+from tests.helpers import make_context, make_update
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -34,8 +35,8 @@ def _get_menu_handler(fallbacks):
 async def test_sugar_conv_menu_then_photo() -> None:
     handler = _get_menu_handler(dose_handlers.sugar_conv.fallbacks)
     message = DummyMessage("/menu")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}})
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
+    context = make_context(user_data={"pending_entry": {"foo": "bar"}})
 
     await handler.callback(update, context)
 
@@ -44,7 +45,7 @@ async def test_sugar_conv_menu_then_photo() -> None:
     assert context.user_data == {}
 
     next_message = DummyMessage("📷 Фото еды")
-    next_update = SimpleNamespace(
+    next_update = make_update(
         message=next_message, effective_user=SimpleNamespace(id=1)
     )
     await dose_handlers.photo_prompt(next_update, context)
@@ -54,8 +55,8 @@ async def test_sugar_conv_menu_then_photo() -> None:
 async def test_dose_conv_menu_then_photo() -> None:
     handler = _get_menu_handler(dose_handlers.dose_conv.fallbacks)
     message = DummyMessage("/menu")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}})
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
+    context = make_context(user_data={"pending_entry": {"foo": "bar"}})
 
     await handler.callback(update, context)
 
@@ -64,7 +65,7 @@ async def test_dose_conv_menu_then_photo() -> None:
     assert context.user_data == {}
 
     next_message = DummyMessage("📷 Фото еды")
-    next_update = SimpleNamespace(
+    next_update = make_update(
         message=next_message, effective_user=SimpleNamespace(id=1)
     )
     await dose_handlers.photo_prompt(next_update, context)

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -8,6 +8,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from services.api.app.diabetes.services.db import Base
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
@@ -45,10 +46,10 @@ async def test_onboarding_demo_photo_missing(monkeypatch, caplog) -> None:
     monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
 
     message = DummyMessage()
-    update = SimpleNamespace(
+    update = make_update(
         message=message, effective_user=SimpleNamespace(id=1, first_name="Ann")
     )
-    context = SimpleNamespace(user_data={}, bot_data={})
+    context = make_context(user_data={}, bot_data={})
 
     await onboarding.start_command(update, context)
     update.message.text = "10"

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from telegram.ext import ConversationHandler
 
 from services.api.app.diabetes.services.db import Base, User
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
@@ -65,10 +66,10 @@ async def test_onboarding_flow(monkeypatch) -> None:
     monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
 
     message = DummyMessage()
-    update = SimpleNamespace(
+    update = make_update(
         message=message, effective_user=SimpleNamespace(id=1, first_name="Ann")
     )
-    context = SimpleNamespace(user_data={}, bot_data={})
+    context = make_context(user_data={}, bot_data={})
 
     state = await onboarding.start_command(update, context)
     assert state == onboarding.ONB_PROFILE_ICR
@@ -92,13 +93,13 @@ async def test_onboarding_flow(monkeypatch) -> None:
     assert message.photos
 
     query = DummyQuery(message, "onb_next")
-    update_cb = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
+    update_cb = make_update(callback_query=query, effective_user=SimpleNamespace(id=1))
     state = await onboarding.onboarding_demo_next(update_cb, context)
     assert state == onboarding.ONB_REMINDERS
     assert "3/3" in message.texts[-1]
 
     query2 = DummyQuery(message, "onb_rem_no")
-    update_cb2 = SimpleNamespace(callback_query=query2, effective_user=SimpleNamespace(id=1))
+    update_cb2 = make_update(callback_query=query2, effective_user=SimpleNamespace(id=1))
     state = await onboarding.onboarding_reminders(update_cb2, context)
     assert state == ConversationHandler.END
     assert message.polls
@@ -108,10 +109,10 @@ async def test_onboarding_flow(monkeypatch) -> None:
         assert user.onboarding_complete is True
 
     message2 = DummyMessage()
-    update2 = SimpleNamespace(
+    update2 = make_update(
         message=message2, effective_user=SimpleNamespace(id=1, first_name="Ann")
     )
-    context2 = SimpleNamespace(user_data={}, bot_data={})
+    context2 = make_context(user_data={}, bot_data={})
     state2 = await onboarding.start_command(update2, context2)
     assert state2 == ConversationHandler.END
     assert any("Выберите" in t for t in message2.texts)

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 import pytest
 from telegram.ext import CallbackContext, MessageHandler
+from tests.helpers import make_update
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -40,7 +41,7 @@ class DummyMessage:
 
 async def _exercise(handler) -> None:
     message = DummyMessage("📷 Фото еды")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     context = cast(
         CallbackContext[Any, Any, Any, Any],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}, "dose_method": "xe"}),

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from tests.helpers import make_context, make_update
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -39,23 +40,23 @@ async def test_profile_input_not_logged_as_sugar(monkeypatch) -> None:
 
     # Start sugar conversation
     sugar_msg = DummyMessage("/sugar")
-    sugar_update = SimpleNamespace(
+    sugar_update = make_update(
         message=sugar_msg,
         effective_user=SimpleNamespace(id=1),
         effective_chat=SimpleNamespace(id=1),
     )
     shared_chat_data: dict = {}
-    sugar_context = SimpleNamespace(user_data={}, chat_data=shared_chat_data)
+    sugar_context = make_context(user_data={}, chat_data=shared_chat_data)
     await dose_handlers.sugar_start(sugar_update, sugar_context)
 
     # Start profile conversation which should cancel sugar conversation
     prof_msg = DummyMessage("/profile")
-    prof_update = SimpleNamespace(
+    prof_update = make_update(
         message=prof_msg,
         effective_user=SimpleNamespace(id=1),
         effective_chat=SimpleNamespace(id=1),
     )
-    prof_context = SimpleNamespace(args=[], user_data={}, chat_data=shared_chat_data)
+    prof_context = make_context(args=[], user_data={}, chat_data=shared_chat_data)
     result = await profile_handlers.profile_command(prof_update, prof_context)
     assert result == profile_handlers.PROFILE_ICR
     assert "ИКХ" in prof_msg.replies[0]
@@ -63,12 +64,12 @@ async def test_profile_input_not_logged_as_sugar(monkeypatch) -> None:
 
     # Send ICR value
     icr_msg = DummyMessage("10")
-    icr_update = SimpleNamespace(
+    icr_update = make_update(
         message=icr_msg,
         effective_user=SimpleNamespace(id=1),
         effective_chat=SimpleNamespace(id=1),
     )
-    icr_context = SimpleNamespace(user_data={}, chat_data=shared_chat_data)
+    icr_context = make_context(user_data={}, chat_data=shared_chat_data)
     result_icr = await profile_handlers.profile_icr(icr_update, icr_context)
     assert result_icr == profile_handlers.PROFILE_CF
     assert "КЧ" in icr_msg.replies[0]

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -11,6 +11,7 @@ from services.api.app.diabetes.services.repository import commit
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
 from services.api.app.config import settings
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
@@ -45,8 +46,8 @@ async def test_profile_view_has_security_button(monkeypatch) -> None:
     )
 
     msg = DummyMessage()
-    update = SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace()
+    update = make_update(message=msg, effective_user=SimpleNamespace(id=1))
+    context = make_context()
 
     await handlers.profile_view(update, context)
 
@@ -97,8 +98,8 @@ async def test_profile_security_threshold_changes(monkeypatch, action, expected_
     monkeypatch.setattr(handlers, "evaluate_sugar", fake_eval)
 
     query = DummyQuery(f"profile_security:{action}")
-    update = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(application=SimpleNamespace(job_queue="jq"))
+    update = make_update(callback_query=query, effective_user=SimpleNamespace(id=1))
+    context = make_context(application=SimpleNamespace(job_queue="jq"))
 
     await handlers.profile_security(update, context)
 
@@ -142,8 +143,8 @@ async def test_profile_security_toggle_sos_alerts(monkeypatch) -> None:
     monkeypatch.setattr(handlers, "evaluate_sugar", fake_eval)
 
     query = DummyQuery("profile_security:toggle_sos")
-    update = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(application=SimpleNamespace(job_queue="jq"))
+    update = make_update(callback_query=query, effective_user=SimpleNamespace(id=1))
+    context = make_context(application=SimpleNamespace(job_queue="jq"))
 
     await handlers.profile_security(update, context)
 
@@ -179,8 +180,8 @@ async def test_profile_security_shows_reminders(monkeypatch) -> None:
         session.commit()
 
     query = DummyQuery("profile_security")
-    update = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(application=SimpleNamespace(job_queue="jq"))
+    update = make_update(callback_query=query, effective_user=SimpleNamespace(id=1))
+    context = make_context(application=SimpleNamespace(job_queue="jq"))
 
     await handlers.profile_security(update, context)
 
@@ -210,14 +211,14 @@ async def test_profile_security_add_delete_calls_handlers(monkeypatch) -> None:
 
     monkeypatch.setattr(settings, "webapp_url", "http://example")
     query_add = DummyQuery("profile_security:add")
-    update_add = SimpleNamespace(callback_query=query_add, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(application=SimpleNamespace(job_queue="jq"))
+    update_add = make_update(callback_query=query_add, effective_user=SimpleNamespace(id=1))
+    context = make_context(application=SimpleNamespace(job_queue="jq"))
 
     await handlers.profile_security(update_add, context)
     assert query_add.message.texts[-1] == "Создать напоминание:"
 
     query_del = DummyQuery("profile_security:del")
-    update_del = SimpleNamespace(callback_query=query_del, effective_user=SimpleNamespace(id=1))
+    update_del = make_update(callback_query=query_del, effective_user=SimpleNamespace(id=1))
 
     await handlers.profile_security(update_del, context)
     assert called["del"] is True
@@ -245,8 +246,8 @@ async def test_profile_security_sos_contact_calls_handler(monkeypatch) -> None:
     monkeypatch.setattr(sos_handlers, "sos_contact_start", fake_sos)
 
     query = DummyQuery("profile_security:sos_contact")
-    update = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(application=SimpleNamespace(job_queue="jq"))
+    update = make_update(callback_query=query, effective_user=SimpleNamespace(id=1))
+    context = make_context(application=SimpleNamespace(job_queue="jq"))
 
     await handlers.profile_security(update, context)
     assert called is True

--- a/tests/test_quick_input_help_button.py
+++ b/tests/test_quick_input_help_button.py
@@ -1,8 +1,8 @@
 import pytest
-from types import SimpleNamespace
 from typing import Any
 
 import services.api.app.diabetes.handlers.common_handlers as handlers
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
@@ -21,8 +21,8 @@ async def test_quick_input_help_button() -> None:
     """Simulate the "🕹 Быстрый ввод" menu button and verify the hint."""
 
     message = DummyMessage("🕹 Быстрый ввод")
-    update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+    update = make_update(message=message)
+    context = make_context()
 
     await handlers.smart_input_help(update, context)
 

--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import sessionmaker
 from services.api.app.diabetes.services.db import Base, User, Reminder, Entry
 import services.api.app.diabetes.handlers.reminder_handlers as handlers
 from services.api.app.diabetes.services.repository import commit
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
@@ -48,8 +49,8 @@ def _setup_db():
 async def test_bad_input_does_not_create_entry() -> None:
     TestSession = _setup_db()
     msg = DummyMessage(json.dumps({"id": 1, "type": "sugar", "value": "bad"}))
-    update = SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(job_queue=DummyJobQueue())
+    update = make_update(effective_message=msg, effective_user=SimpleNamespace(id=1))
+    context = make_context(job_queue=DummyJobQueue())
     await handlers.reminder_webapp_save(update, context)
     assert msg.replies and "Неверный формат" in msg.replies[0]
     with TestSession() as session:
@@ -60,8 +61,8 @@ async def test_bad_input_does_not_create_entry() -> None:
 async def test_good_input_updates_and_ends() -> None:
     TestSession = _setup_db()
     msg = DummyMessage(json.dumps({"id": 1, "type": "sugar", "value": "09:30"}))
-    update = SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(job_queue=DummyJobQueue())
+    update = make_update(effective_message=msg, effective_user=SimpleNamespace(id=1))
+    context = make_context(job_queue=DummyJobQueue())
     await handlers.reminder_webapp_save(update, context)
     with TestSession() as session:
         rem = session.get(Reminder, 1)

--- a/tests/test_reminder_limit_free_vs_pro.py
+++ b/tests/test_reminder_limit_free_vs_pro.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import sessionmaker
 
 import services.api.app.diabetes.handlers.reminder_handlers as handlers
 from services.api.app.diabetes.services.db import Base, Reminder, User
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
@@ -42,8 +43,8 @@ async def test_reminder_limit_free_vs_pro(plan, limit, monkeypatch) -> None:
 
     msg = DummyMessage()
     msg.web_app_data.data = json.dumps({"type": "sugar", "value": "09:00"})
-    update = SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace(job_queue=SimpleNamespace(run_daily=lambda *a, **k: None, run_repeating=lambda *a, **k: None, get_jobs_by_name=lambda name: []))
+    update = make_update(effective_message=msg, effective_user=SimpleNamespace(id=1))
+    context = make_context(job_queue=SimpleNamespace(run_daily=lambda *a, **k: None, run_repeating=lambda *a, **k: None, get_jobs_by_name=lambda name: []))
 
     await handlers.reminder_webapp_save(update, context)
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,3 +1,4 @@
+from tests.helpers import make_context, make_update
 # test_reporting.py
 
 import datetime
@@ -180,10 +181,10 @@ async def test_send_report_uses_gpt(monkeypatch) -> None:
             self.docs.append(document)
 
     message = DummyMessage()
-    update = SimpleNamespace(
+    update = make_update(
         message=message, effective_user=SimpleNamespace(id=1)
     )
-    context = SimpleNamespace(user_data={"thread_id": "tid"})
+    context = make_context(user_data={"thread_id": "tid"})
 
     class Run:
         status = "completed"

--- a/tests/test_security_handlers.py
+++ b/tests/test_security_handlers.py
@@ -1,8 +1,8 @@
 import pytest
-from types import SimpleNamespace
 from typing import Any
 
 import services.api.app.diabetes.handlers.security_handlers as handlers
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
@@ -16,8 +16,8 @@ class DummyMessage:
 @pytest.mark.asyncio
 async def test_hypoalert_faq_returns_message() -> None:
     message = DummyMessage()
-    update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+    update = make_update(message=message)
+    context = make_context()
 
     await handlers.hypo_alert_faq(update, context)
 

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -20,6 +20,7 @@ import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
 import services.api.app.diabetes.handlers.registration as handlers
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.ui import menu_keyboard
+from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
@@ -52,8 +53,8 @@ async def test_soscontact_stores_contact(test_session, contact) -> None:
         session.commit()
 
     message = DummyMessage(contact)
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    context = SimpleNamespace()
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
+    context = make_context()
 
     result = await sos_handlers.sos_contact_save(update, context)
 
@@ -74,10 +75,10 @@ async def test_alert_notifies_user_and_contact(test_session, monkeypatch) -> Non
 
     # Save SOS contact via handler
     message = DummyMessage("@alice")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     await sos_handlers.sos_contact_save(update, SimpleNamespace())
 
-    update_alert = SimpleNamespace(
+    update_alert = make_update(
         effective_user=SimpleNamespace(id=1, first_name="Ivan")
     )
     context: AlertContext = ContextStub(bot=cast(Bot, SimpleNamespace()))
@@ -115,7 +116,7 @@ async def test_alert_skips_phone_contact(test_session, monkeypatch) -> None:
         )
         session.commit()
 
-    update_alert = SimpleNamespace(
+    update_alert = make_update(
         effective_user=SimpleNamespace(id=1, first_name="Ivan")
     )
     context: AlertContext = ContextStub(bot=cast(Bot, SimpleNamespace()))
@@ -156,8 +157,8 @@ async def test_sos_contact_menu_button_starts_conv(monkeypatch) -> None:
     assert re.fullmatch(pattern, "🆘 SOS контакт")
 
     message = DummyMessage("🆘 SOS контакт")
-    update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+    update = make_update(message=message)
+    context = make_context()
     state = await sos_handler.callback(update, context)
 
     assert state == sos_handlers.SOS_CONTACT

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 import pytest
 from telegram.ext import CallbackContext, ConversationHandler, MessageHandler
+from tests.helpers import make_update
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -37,7 +38,7 @@ async def test_sugar_back_fallback_cancels() -> None:
         if isinstance(h, MessageHandler) and _filter_pattern_equals(h, "^↩️ Назад$")
     )
     message = DummyMessage("↩️ Назад")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     context = cast(
         CallbackContext[Any, Any, Any, Any],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
@@ -51,7 +52,7 @@ async def test_sugar_back_fallback_cancels() -> None:
 @pytest.mark.asyncio
 async def test_cancel_command_clears_state() -> None:
     message = DummyMessage("/cancel")
-    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     context = cast(
         CallbackContext[Any, Any, Any, Any],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),


### PR DESCRIPTION
## Summary
- add `make_update` and `make_context` helpers for typed telegram stubs
- refactor tests to use typed helpers instead of `SimpleNamespace`

## Testing
- `ruff check tests`
- `pytest tests/test_help_command.py`
- `pytest tests` *(fails: KeyboardInterrupt after collecting tests)*
- `python -m mypy tests` *(fails: many existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaec57254832a91381346add17d3e