### PR TITLE
tests: add telegram stubs

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,13 +1,17 @@
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
-from telegram import Update
-from telegram.ext import CallbackContext
+from tests.telegram_stubs import CallbackContext, Update
 
 
 def make_update(**kwargs: Any) -> Update:
-    return cast(Update, SimpleNamespace(**kwargs))
+    update = Update()
+    for key, value in kwargs.items():
+        setattr(update, key, value)
+    return update
 
 
-def make_context(**kwargs: Any) -> CallbackContext[Any, Any, Any, Any]:
-    return cast(CallbackContext[Any, Any, Any, Any], SimpleNamespace(**kwargs))
+def make_context(**kwargs: Any) -> CallbackContext:
+    ctx = CallbackContext()
+    for key, value in kwargs.items():
+        setattr(ctx, key, value)
+    return ctx

--- a/tests/telegram_stubs.py
+++ b/tests/telegram_stubs.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class Message:
+    """Minimal Telegram Message stub for tests."""
+
+    text: str = ""
+    texts: List[str] = field(default_factory=list)
+    markups: List[Any] = field(default_factory=list)
+    kwargs: List[Dict[str, Any]] = field(default_factory=list)
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.texts.append(text)
+        self.markups.append(kwargs.get("reply_markup"))
+        self.kwargs.append(kwargs)
+
+    async def delete(self) -> None:  # pragma: no cover - behavior not needed
+        """Stub delete method."""
+        return None
+
+
+@dataclass
+class User:
+    """Minimal User stub."""
+
+    id: int
+
+
+@dataclass
+class Update:
+    """Minimal Update stub that allows dynamic attributes."""
+
+    message: Message | None = None
+    effective_user: User | None = None
+
+
+@dataclass
+class CallbackContext:
+    """Minimal CallbackContext stub."""
+
+    args: List[str] | None = None
+    user_data: Dict[str, Any] = field(default_factory=dict)
+    chat_data: Dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- add lightweight telegram stubs for Update, Message, CallbackContext
- use new stubs in tests instead of SimpleNamespace

## Testing
- `ruff check tests`
- `pytest tests/test_sugar_exit.py tests/test_handlers_profile.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeb52dfbd4832a9cdf78163f989aef