### PR TITLE
[build] Use explicit filter for webapp scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "node": ">=20"
   },
   "scripts": {
-    "dev":       "pnpm --filter services/webapp/ui dev",
-    "build":     "pnpm --filter services/webapp/ui build",
-    "preview":   "pnpm --filter services/webapp/ui preview",
+    "dev":       "pnpm --filter ./services/webapp/ui dev",
+    "build":     "pnpm --filter ./services/webapp/ui build",
+    "preview":   "pnpm --filter ./services/webapp/ui preview",
     "generate:sdk": "pnpm dlx @openapitools/openapi-generator-cli generate -i libs/contracts/openapi.yaml -g typescript-fetch -o libs/ts-sdk -p useSingleRequestParameter=true && pnpm dlx @openapitools/openapi-generator-cli generate -i libs/contracts/openapi.yaml -g python -o libs/py-sdk -p packageName=diabetes_sdk,modelPropertyNaming=camelCase,snakeCaseIfNeed=false"
   },
   "pnpm": {


### PR DESCRIPTION
## Summary
- ensure root build, dev, and preview scripts filter by webapp path

## Testing
- `pytest -q` *(fails: async plugin missing, coverage under 85)*
- `mypy --strict .`
- `ruff check .`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aeb541022c832a8a11fe1850a19d28