### PR TITLE
[handlers] add type hints and typed db wrappers

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -2,24 +2,16 @@ from __future__ import annotations
 
 import datetime
 import logging
-from typing import Callable
 
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session
 from telegram import Update
 from telegram.error import TelegramError
 from telegram.ext import CallbackContext, JobQueue
 
-from services.api.app.diabetes.services.db import (
-    Alert,
-    Profile,
-    SessionLocal as _SessionLocal,
-    run_db,
-)
-from services.api.app.diabetes.services.repository import commit as _commit
+from services.api.app.diabetes.services.db import Alert, Profile
+from services.api.app.diabetes.services.repository import commit
+from .db import SessionLocal, run_db
 from services.api.app.diabetes.utils.helpers import get_coords_and_link
-
-SessionLocal: sessionmaker[Session] = _SessionLocal
-commit: Callable[[Session], bool] = _commit
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +99,7 @@ async def evaluate_sugar(
     context: CallbackContext | None = None,
     first_name: str = "",
 ) -> None:
-    def db_eval(session: Session):
+    def db_eval(session: Session) -> tuple[bool, dict[str, object] | None]:
         profile = session.get(Profile, user_id)
         if not profile:
             return False, None

--- a/services/api/app/diabetes/handlers/db.py
+++ b/services/api/app/diabetes/handlers/db.py
@@ -1,0 +1,33 @@
+"""Typed wrappers for database helpers used by handlers."""
+
+from __future__ import annotations
+
+from typing import Callable, TypeVar, ParamSpec, Concatenate
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from services.api.app.diabetes.services.db import (
+    SessionLocal as _SessionLocal,
+    run_db as _run_db,
+)
+
+# Explicitly type the session factory so calls to ``SessionLocal()`` are typed.
+SessionLocal: sessionmaker[Session] = _SessionLocal
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+async def run_db(
+    fn: Callable[Concatenate[Session, P], R],
+    *args: P.args,
+    sessionmaker: sessionmaker[Session] = SessionLocal,
+    **kwargs: P.kwargs,
+) -> R:
+    """Proxy to :func:`services.api.app.diabetes.services.db.run_db` with types."""
+
+    return await _run_db(fn, *args, sessionmaker=sessionmaker, **kwargs)
+
+
+__all__ = ["SessionLocal", "run_db"]
+

--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -23,13 +23,8 @@ from telegram.ext import (
 )
 from sqlalchemy.orm import Session
 
-from services.api.app.diabetes.services.db import (
-    SessionLocal,
-    User,
-    Entry,
-    Profile,
-    run_db,
-)
+from services.api.app.diabetes.services.db import User, Entry, Profile
+from .db import SessionLocal, run_db
 from services.api.app.diabetes.utils.functions import (
     extract_nutrition_info,
     calc_bolus,
@@ -554,7 +549,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     "Доза инсулина не может быть отрицательной."
                 )
             return
-        def db_update(session: Session):
+        def db_update(session: Session) -> tuple[str, Entry | None]:
             entry = session.get(Entry, context.user_data["edit_id"])
             if not entry:
                 return "missing", None
@@ -649,7 +644,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         }
         missing = [f for f in ("sugar", "xe", "dose") if quick[f] is None]
         if not missing:
-            def db_save(session: Session):
+            def db_save(session: Session) -> bool:
                 entry = Entry(**entry_data)
                 session.add(entry)
                 return commit(session)

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -30,7 +30,8 @@ from telegram.ext import (
 )
 from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import CallbackQueryNoWarnHandler
 
-from services.api.app.diabetes.services.db import SessionLocal, User, Profile, Reminder
+from services.api.app.diabetes.services.db import User, Profile, Reminder
+from .db import SessionLocal
 from services.api.app.diabetes.utils.ui import menu_keyboard, build_timezone_webapp_button
 from services.api.app.diabetes.services.repository import commit
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -417,7 +418,9 @@ async def onboarding_poll_answer(
     logger.info("Onboarding poll result from %s: %s", user_id, option)
 
 
-async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+async def _photo_fallback(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     from .dose_handlers import _cancel_then, photo_prompt
 
     handler = _cancel_then(photo_prompt)

--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -4,7 +4,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from services.api.app.config import settings
-from services.api.app.diabetes.services.db import Profile, SessionLocal, User
+from services.api.app.diabetes.services.db import Profile, User
 from services.api.app.diabetes.services.repository import commit
 
 logger = logging.getLogger(__name__)

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -17,13 +17,12 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from sqlalchemy.orm import Session
 
 from services.api.app.diabetes.services.db import (
-    SessionLocal,
     Profile,
     Alert,
     Reminder,
     User,
-    run_db,
 )
+from ..db import SessionLocal, run_db
 
 from services.api.app.diabetes.handlers.alert_handlers import evaluate_sugar
 from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import (
@@ -369,7 +368,9 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
     return ConversationHandler.END
 
 
-def _security_db(session: Session, user_id: int, action: str | None):
+def _security_db(
+    session: Session, user_id: int, action: str | None
+) -> dict[str, bool | float | str | None]:
     profile = session.get(Profile, user_id)
     user = session.get(User, user_id)
     if not profile:
@@ -710,7 +711,9 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     return ConversationHandler.END
 
 
-async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+async def _photo_fallback(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     from ..dose_handlers import _cancel_then, photo_prompt
 
     handler = _cancel_then(photo_prompt)

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -18,7 +18,8 @@ from telegram import (
 )
 from telegram.ext import ContextTypes
 
-from services.api.app.diabetes.services.db import SessionLocal, Entry, User
+from services.api.app.diabetes.services.db import Entry, User
+from .db import SessionLocal
 from services.api.app.diabetes.services.gpt_client import (
     send_message,
     _get_client,

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -4,7 +4,8 @@ import logging
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, ForceReply
 from telegram.ext import ContextTypes
 
-from services.api.app.diabetes.services.db import Entry, SessionLocal
+from services.api.app.diabetes.services.db import Entry
+from .db import SessionLocal
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
 from services.api.app.diabetes.services.repository import commit

--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -13,7 +13,8 @@ from telegram.ext import (
     filters,
 )
 
-from services.api.app.diabetes.services.db import SessionLocal, Profile
+from services.api.app.diabetes.services.db import Profile
+from .db import SessionLocal
 from services.api.app.diabetes.utils.ui import back_keyboard, menu_keyboard
 from services.api.app.diabetes.services.repository import commit
 from . import dose_handlers


### PR DESCRIPTION
## Summary
- add typed SessionLocal and run_db wrappers for handlers
- annotate handler helper functions with explicit return types
- type fallback handlers to avoid untyped calls

## Testing
- `ruff check services/api/app/diabetes/handlers/db.py services/api/app/diabetes/handlers/reminder_handlers.py services/api/app/diabetes/handlers/dose_handlers.py services/api/app/diabetes/handlers/profile/conversation.py services/api/app/diabetes/handlers/onboarding_handlers.py services/api/app/diabetes/handlers/alert_handlers.py services/api/app/diabetes/handlers/router.py services/api/app/diabetes/handlers/sos_handlers.py services/api/app/diabetes/handlers/reporting_handlers.py services/api/app/diabetes/handlers/profile/api.py`
- `pytest tests/test_utils.py -q`
- `pytest tests/test_handlers_profile.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb52ae914832a85e38f481ed4afd2