### PR TITLE
[handlers] Add explicit return types

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -270,7 +270,7 @@ async def dose_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
 def _cancel_then(
     handler: Callable[[Update, ContextTypes.DEFAULT_TYPE], Awaitable[int]],
-):
+) -> Callable[[Update, ContextTypes.DEFAULT_TYPE], Awaitable[int]]:
     """Return a wrapper calling ``dose_cancel`` before ``handler``."""
 
     async def wrapped(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -554,7 +554,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     "Доза инсулина не может быть отрицательной."
                 )
             return
-        def db_update(session: Session):
+        def db_update(session: Session) -> tuple[str, Entry | None]:
             entry = session.get(Entry, context.user_data["edit_id"])
             if not entry:
                 return "missing", None
@@ -649,7 +649,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         }
         missing = [f for f in ("sugar", "xe", "dose") if quick[f] is None]
         if not missing:
-            def db_save(session: Session):
+            def db_save(session: Session) -> bool:
                 entry = Entry(**entry_data)
                 session.add(entry)
                 return commit(session)

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -417,11 +417,13 @@ async def onboarding_poll_answer(
     logger.info("Onboarding poll result from %s: %s", user_id, option)
 
 
-async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+async def _photo_fallback(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     from .dose_handlers import _cancel_then, photo_prompt
 
     handler = _cancel_then(photo_prompt)
-    return await handler(update, context)
+    await handler(update, context)
 
 
 onboarding_conv = ConversationHandler(

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -12,7 +12,7 @@ from tests.helpers import make_update
 
 
 class DummyMessage:
-    def __init__(self, text: str | None = None, photo: list[Any] | None = None):
+    def __init__(self, text: str | None = None, photo: list[Any] | None = None) -> None:
         self.text = text
         self.photo = photo
         self.replies: list[tuple[str, dict[str, Any]]] = []
@@ -22,7 +22,7 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str):
+    def __init__(self, data: str) -> None:
         self.data = data
         self.edited: list[str] = []
 
@@ -39,7 +39,7 @@ class DummyPhoto:
 
 
 class DummySession:
-    def __init__(self):
+    def __init__(self) -> None:
         self.added = []
 
     def __enter__(self) -> "DummySession":
@@ -51,10 +51,10 @@ class DummySession:
     def add(self, entry: Any) -> None:
         self.added.append(entry)
 
-    def commit(self):
+    def commit(self) -> None:
         pass
 
-    def get(self, model, user_id):
+    def get(self, model, user_id) -> Any:
         return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
 
@@ -98,7 +98,7 @@ async def test_photo_flow_saves_entry(
         thread_id = "tid"
         id = "runid"
 
-    async def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs: Any) -> Run:
         return Run()
 
     class DummyClient:

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -12,7 +12,7 @@ from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
-    def __init__(self):
+    def __init__(self) -> None:
         self.texts: list[str] = []
         self.photos: list[tuple[Any, str | None]] = []
         self.markups: list[Any] = []
@@ -63,7 +63,7 @@ async def test_onboarding_demo_photo_missing(monkeypatch, caplog) -> None:
 
     orig_open = pathlib.Path.open
 
-    def fake_open(self, *args, **kwargs):
+    def fake_open(self, *args: Any, **kwargs: Any) -> Any:
         if self == onboarding.DEMO_PHOTO_PATH:
             raise OSError("missing")
         return orig_open(self, *args, **kwargs)

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -29,7 +29,7 @@ def _find_handler(fallbacks, regex: str) -> MessageHandler:
 
 
 class DummyMessage:
-    def __init__(self, text: str = ""):
+    def __init__(self, text: str = "") -> None:
         self.text = text
         self.replies: list[str] = []
         self.kwargs: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- annotate dose handlers with concrete return types
- ensure onboarding fallback and tests use explicit `-> None`
- adjust test helpers with precise type hints

## Testing
- `ruff check services/api/app tests`
- `pre-commit run --files services/api/app/diabetes/handlers/dose_handlers.py services/api/app/diabetes/handlers/onboarding_handlers.py tests/test_handlers_photo_sugar_save.py tests/test_onboarding_demo_photo_missing.py tests/test_photo_fallbacks.py`
- `pytest tests` *(fails: InterfaceError: bad parameter or other API misuse)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb52b57d4832aa326f2db866253d1