### PR TITLE
handlers: type user_data dict

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -8,7 +8,7 @@ import asyncio
 import os
 import re
 from pathlib import Path
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Any
 
 from openai import OpenAIError
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, Message
@@ -68,6 +68,7 @@ async def photo_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
 async def sugar_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Prompt user for current sugar level."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
@@ -89,6 +90,7 @@ async def sugar_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
 async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Store the provided sugar level to the diary."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
@@ -105,7 +107,7 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     if sugar < 0:
         await message.reply_text("Сахар не может быть отрицательным.")
         return SUGAR_VAL
-    entry_data = context.user_data.pop("pending_entry", None) or {
+    entry_data: dict[str, Any] = context.user_data.pop("pending_entry", None) or {
         "telegram_id": user.id,
         "event_time": datetime.datetime.now(datetime.timezone.utc),
     }
@@ -128,6 +130,7 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Entry point for dose calculation conversation."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     if message is None:
         return
@@ -143,6 +146,7 @@ async def dose_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_method_choice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle method selection for dose calculation."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     if message is None:
         return
@@ -166,6 +170,7 @@ async def dose_method_choice(update: Update, context: ContextTypes.DEFAULT_TYPE)
 
 async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Capture XE amount from user."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
@@ -190,6 +195,7 @@ async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Capture carbohydrates in grams."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
@@ -216,6 +222,7 @@ async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Finalize dose calculation after receiving sugar level."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
@@ -230,7 +237,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         await message.reply_text("Сахар не может быть отрицательным.")
         return DOSE_SUGAR
 
-    entry = context.user_data.get("pending_entry", {})
+    entry: dict[str, Any] = context.user_data.get("pending_entry", {})
     entry["sugar_before"] = sugar
     xe = entry.get("xe")
     carbs_g = entry.get("carbs_g")
@@ -283,6 +290,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Cancel dose calculation conversation."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     if message is None:
         return
@@ -311,6 +319,7 @@ def _cancel_then(
 
 async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle freeform text commands for adding diary entries."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
@@ -340,7 +349,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         context.user_data.pop("awaiting_report_date", None)
         return
 
-    pending_entry = context.user_data.get("pending_entry")
+    pending_entry: dict[str, Any] | None = context.user_data.get("pending_entry")
     pending_fields = context.user_data.get("pending_fields")
     edit_id = context.user_data.get("edit_id")
     if pending_entry is not None and edit_id is None and pending_fields:
@@ -587,8 +596,10 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     "Доза инсулина не может быть отрицательной."
                 )
             return
+        edit_id = context.user_data.get("edit_id")
         def db_update(session: Session) -> tuple[str, Entry | None]:
-            entry = session.get(Entry, context.user_data["edit_id"])
+            assert edit_id is not None
+            entry = session.get(Entry, edit_id)
             if not entry:
                 return "missing", None
             field_map = {"sugar": "sugar_before", "xe": "xe", "dose": "dose"}
@@ -616,14 +627,15 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             await check_alert(update, context, value)
         render_text = render_entry(entry)
         edit_info = context.user_data.get("edit_entry", {})
+        assert edit_id is not None
         markup = InlineKeyboardMarkup(
             [
                 [
                     InlineKeyboardButton(
-                        "✏️ Изменить", callback_data=f"edit:{context.user_data['edit_id']}"
+                        "✏️ Изменить", callback_data=f"edit:{edit_id}"
                     ),
                     InlineKeyboardButton(
-                        "🗑 Удалить", callback_data=f"del:{context.user_data['edit_id']}"
+                        "🗑 Удалить", callback_data=f"del:{edit_id}"
                     ),
                 ]
             ]
@@ -672,7 +684,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 "Значения не могут быть отрицательными."
             )
             return
-        entry_data = {
+        entry_data: dict[str, Any] = {
             "telegram_id": user_id,
             "event_time": datetime.datetime.now(datetime.timezone.utc),
             "sugar_before": sugar,
@@ -797,6 +809,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
 async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Placeholder GPT chat handler."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     if message is None:
         return
@@ -809,6 +822,7 @@ async def photo_handler(
     demo: bool = False,
 ) -> int:
     """Process food photos and trigger nutrition analysis."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message | None = update.message or (
         update.callback_query.message if update.callback_query else None
     )
@@ -1007,7 +1021,7 @@ async def photo_handler(
             )
             return ConversationHandler.END
 
-        pending_entry = context.user_data.get("pending_entry") or {
+        pending_entry: dict[str, Any] = context.user_data.get("pending_entry") or {
             "telegram_id": user_id,
             "event_time": datetime.datetime.now(datetime.timezone.utc),
         }
@@ -1059,6 +1073,7 @@ async def doc_handler(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> int:
     """Handle images sent as documents."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -38,6 +38,7 @@ from services.api.app.diabetes.services.repository import commit
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from openai import OpenAIError
+from typing import Any
 
 
 logger = logging.getLogger(__name__)
@@ -115,6 +116,7 @@ def _skip_markup() -> InlineKeyboardMarkup:
 
 async def onboarding_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle ICR input."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     if message is None:
         return
@@ -140,6 +142,7 @@ async def onboarding_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 async def onboarding_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle CF input."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     if message is None:
         return
@@ -165,6 +168,7 @@ async def onboarding_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
 
 async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle target BG input and proceed to demo."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -15,6 +15,7 @@ import logging
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy.orm import Session
+from typing import Any
 
 from services.api.app.diabetes.services.db import (
     Profile,
@@ -538,6 +539,7 @@ async def profile_edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
 
 async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle ICR input."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     raw_text = update.message.text.strip()
     if "назад" in raw_text.lower():
         return await profile_cancel(update, context)
@@ -560,6 +562,7 @@ async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
 async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle CF input."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     raw_text = update.message.text.strip()
     if "назад" in raw_text.lower():
         await update.message.reply_text(
@@ -586,6 +589,7 @@ async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle target BG input."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     raw_text = update.message.text.strip()
     if "назад" in raw_text.lower():
         await update.message.reply_text(
@@ -616,6 +620,7 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle low threshold input."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     raw_text = update.message.text.strip()
     if "назад" in raw_text.lower():
         await update.message.reply_text(
@@ -644,6 +649,7 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     return PROFILE_HIGH
 async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle high threshold input and save profile."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     raw_text = update.message.text.strip()
     if "назад" in raw_text.lower():
         await update.message.reply_text(

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -17,6 +17,7 @@ from telegram import (
     Update,
 )
 from telegram.ext import ContextTypes
+from typing import Any
 
 from services.api.app.diabetes.services.db import Entry, User
 from .db import SessionLocal
@@ -142,6 +143,7 @@ async def report_period_callback(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> None:
     """Handle report period selection via inline buttons."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     query = update.callback_query
     await query.answer()
     if query.data == "report_back":
@@ -192,6 +194,7 @@ async def send_report(
     query: CallbackQuery | None = None,
 ) -> None:
     """Generate and send a PDF report for entries after ``date_from``."""
+    context.user_data: dict[str, Any] = context.user_data or {}
     user_id = update.effective_user.id
 
     def _fetch_entries() -> list[Entry]:


### PR DESCRIPTION
## Summary
- type `context.user_data` in handler modules and default to `{}`
- guard direct indexing by using `dict.get` and assertions
- annotate temporary dict variables in handlers

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb7fbbb94832abfd17403d26a1e21