### PR TITLE
refactor: add explicit handler exports

### DIFF
--- a/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
+++ b/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
@@ -22,3 +22,6 @@ class CallbackQueryNoWarnHandler(BaseHandler):
             if self.pattern is None or self.pattern.match(data):
                 return update.callback_query
         return None
+
+
+__all__ = ["CallbackQueryNoWarnHandler"]

--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -1092,6 +1092,8 @@ dose_conv = ConversationHandler(
 
 
 __all__ = [
+    "logger",
+    "_sanitize",
     "DOSE_METHOD",
     "DOSE_XE",
     "DOSE_CARBS",
@@ -1104,15 +1106,18 @@ __all__ = [
     "sugar_start",
     "sugar_val",
     "dose_start",
+    "dose_cancel",
+    "chat_with_gpt",
     "prompt_photo",
     "prompt_sugar",
     "prompt_dose",
+    "_cancel_then",
 
     "sugar_conv",
+    "dose_conv",
 
     "freeform_handler",
     "photo_handler",
     "doc_handler",
-    "dose_conv",
     "ConversationHandler",
 ]

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -760,6 +760,12 @@ profile_webapp_handler = MessageHandler(
 
 
 __all__ = [
+    "PROFILE_ICR",
+    "PROFILE_CF",
+    "PROFILE_TARGET",
+    "PROFILE_LOW",
+    "PROFILE_HIGH",
+    "PROFILE_TZ",
     "profile_command",
     "profile_view",
     "profile_cancel",

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -23,96 +23,88 @@ def register_handlers(app: Application) -> None:
 
     # Import inside the function to avoid heavy imports at module import time
     # (for example OpenAI client initialization).
-    from . import (
-        dose_handlers,
-        profile,
-        reporting_handlers,
-        reminder_handlers,
-        alert_handlers,
-        sos_handlers,
-        security_handlers,
+    from .dose_handlers import (
+        dose_conv,
+        sugar_conv,
+        dose_cancel,
+        chat_with_gpt,
+        freeform_handler,
+        photo_handler,
+        doc_handler,
+        photo_prompt,
     )
+    from .profile import (
+        profile_conv,
+        profile_webapp_handler,
+        profile_view,
+        profile_security,
+        profile_back,
+    )
+    from .reporting_handlers import (
+        report_request,
+        history_view,
+        report_period_callback,
+    )
+    from .reminder_handlers import (
+        reminders_list,
+        add_reminder,
+        reminder_action_handler,
+        reminder_webapp_handler,
+        delete_reminder,
+        reminder_callback,
+        schedule_all,
+    )
+    from .alert_handlers import alert_stats
+    from .sos_handlers import sos_contact_conv, sos_contact_start
+    from .security_handlers import hypo_alert_faq
 
     app.add_handler(onboarding_conv)
     app.add_handler(CommandHandler("menu", menu_command))
-    app.add_handler(CommandHandler("report", reporting_handlers.report_request))
-    app.add_handler(dose_handlers.dose_conv)
+    app.add_handler(CommandHandler("report", report_request))
+    app.add_handler(dose_conv)
     # Register profile conversation before sugar conversation so that numeric
     # inputs for profile aren't captured by sugar logging
-    app.add_handler(profile.profile_conv)
-    app.add_handler(profile.profile_webapp_handler)
-    app.add_handler(dose_handlers.sugar_conv)
-    app.add_handler(sos_handlers.sos_contact_conv)
-    app.add_handler(CommandHandler("cancel", dose_handlers.dose_cancel))
+    app.add_handler(profile_conv)
+    app.add_handler(profile_webapp_handler)
+    app.add_handler(sugar_conv)
+    app.add_handler(sos_contact_conv)
+    app.add_handler(CommandHandler("cancel", dose_cancel))
     app.add_handler(CommandHandler("help", help_command))
-    app.add_handler(CommandHandler("gpt", dose_handlers.chat_with_gpt))
-    app.add_handler(CommandHandler("reminders", reminder_handlers.reminders_list))
-    app.add_handler(CommandHandler("addreminder", reminder_handlers.add_reminder))
-    app.add_handler(reminder_handlers.reminder_action_handler)
-    app.add_handler(reminder_handlers.reminder_webapp_handler)
-    app.add_handler(CommandHandler("delreminder", reminder_handlers.delete_reminder))
-    app.add_handler(CommandHandler("alertstats", alert_handlers.alert_stats))
-    app.add_handler(CommandHandler("hypoalert", security_handlers.hypo_alert_faq))
+    app.add_handler(CommandHandler("gpt", chat_with_gpt))
+    app.add_handler(CommandHandler("reminders", reminders_list))
+    app.add_handler(CommandHandler("addreminder", add_reminder))
+    app.add_handler(reminder_action_handler)
+    app.add_handler(reminder_webapp_handler)
+    app.add_handler(CommandHandler("delreminder", delete_reminder))
+    app.add_handler(CommandHandler("alertstats", alert_stats))
+    app.add_handler(CommandHandler("hypoalert", hypo_alert_faq))
     app.add_handler(PollAnswerHandler(onboarding_poll_answer))
+    app.add_handler(MessageHandler(filters.Regex("^📄 Мой профиль$"), profile_view))
+    app.add_handler(MessageHandler(filters.Regex("^📈 Отчёт$"), report_request))
+    app.add_handler(MessageHandler(filters.Regex("^📊 История$"), history_view))
+    app.add_handler(MessageHandler(filters.Regex("^📷 Фото еды$"), photo_prompt))
+    app.add_handler(MessageHandler(filters.Regex("^🕹 Быстрый ввод$"), smart_input_help))
+    app.add_handler(MessageHandler(filters.Regex("^⏰ Напоминания$"), reminders_list))
+    app.add_handler(MessageHandler(filters.Regex("^ℹ️ Помощь$"), help_command))
+    app.add_handler(MessageHandler(filters.Regex("^🆘 SOS контакт$"), sos_contact_start))
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, freeform_handler))
+    app.add_handler(MessageHandler(filters.PHOTO, photo_handler))
+    app.add_handler(MessageHandler(filters.Document.IMAGE, doc_handler))
+    app.add_handler(CallbackQueryHandler(report_period_callback, pattern="^report_back$"))
     app.add_handler(
-        MessageHandler(filters.Regex("^📄 Мой профиль$"), profile.profile_view)
+        CallbackQueryHandler(report_period_callback, pattern="^report_period:")
     )
-    app.add_handler(
-        MessageHandler(filters.Regex("^📈 Отчёт$"), reporting_handlers.report_request)
-    )
-    app.add_handler(
-        MessageHandler(filters.Regex("^📊 История$"), reporting_handlers.history_view)
-    )
-    app.add_handler(
-        MessageHandler(filters.Regex("^📷 Фото еды$"), dose_handlers.photo_prompt)
-    )
-    app.add_handler(
-        MessageHandler(filters.Regex("^🕹 Быстрый ввод$"), smart_input_help)
-    )
-    app.add_handler(
-        MessageHandler(
-            filters.Regex("^⏰ Напоминания$"), reminder_handlers.reminders_list
-        )
-    )
-    app.add_handler(
-        MessageHandler(filters.Regex("^ℹ️ Помощь$"), help_command)
-    )
-    app.add_handler(
-        MessageHandler(
-            filters.Regex("^🆘 SOS контакт$"), sos_handlers.sos_contact_start
-        )
-    )
-    app.add_handler(
-        MessageHandler(filters.TEXT & ~filters.COMMAND, dose_handlers.freeform_handler)
-    )
-    app.add_handler(MessageHandler(filters.PHOTO, dose_handlers.photo_handler))
-    app.add_handler(
-        MessageHandler(filters.Document.IMAGE, dose_handlers.doc_handler)
-    )
-    app.add_handler(
-        CallbackQueryHandler(
-            reporting_handlers.report_period_callback, pattern="^report_back$"
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandler(
-            reporting_handlers.report_period_callback, pattern="^report_period:"
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandler(
-            profile.profile_security, pattern="^profile_security"
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandler(profile.profile_back, pattern="^profile_back$")
-    )
-    app.add_handler(CallbackQueryHandler(reminder_handlers.reminder_callback, pattern="^remind_"))
+    app.add_handler(CallbackQueryHandler(profile_security, pattern="^profile_security"))
+    app.add_handler(CallbackQueryHandler(profile_back, pattern="^profile_back$"))
+    app.add_handler(CallbackQueryHandler(reminder_callback, pattern="^remind_"))
     app.add_handler(CallbackQueryHandler(callback_router))
 
     job_queue = app.job_queue
     if job_queue:
         try:
-            reminder_handlers.schedule_all(job_queue)
+            schedule_all(job_queue)
         except SQLAlchemyError:
             logger.exception("Failed to schedule reminders")
+
+
+__all__ = ["register_handlers"]

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -134,3 +134,6 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     else:
         logger.warning("Unrecognized callback data: %s", data)
         await query.edit_message_text("Команда не распознана")
+
+
+__all__ = ["callback_router"]

--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -16,8 +16,7 @@ from telegram.ext import (
 from services.api.app.diabetes.services.db import SessionLocal, Profile
 from services.api.app.diabetes.utils.ui import back_keyboard, menu_keyboard
 from services.api.app.diabetes.services.repository import commit
-from . import dose_handlers
-from .dose_handlers import _cancel_then
+from .dose_handlers import _cancel_then, photo_prompt
 
 SOS_CONTACT, = range(1)
 
@@ -89,10 +88,10 @@ sos_contact_conv = ConversationHandler(
         CommandHandler("cancel", sos_contact_cancel),
         MessageHandler(
             filters.Regex("^📷 Фото еды$"),
-            _cancel_then(dose_handlers.photo_prompt),
+            _cancel_then(photo_prompt),
         ),
     ],
     per_message=False,
 )
 
-__all__ = ["sos_contact_conv"]
+__all__ = ["sos_contact_conv", "sos_contact_start"]

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -10,7 +10,7 @@ from telegram.ext import CallbackContext, MessageHandler
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from services.api.app.diabetes.handlers import dose_handlers
+from services.api.app.diabetes.handlers.dose_handlers import dose_conv
 
 
 def _find_handler(fallbacks, regex: str) -> MessageHandler:
@@ -36,7 +36,7 @@ class DummyMessage:
 
 @pytest.mark.asyncio
 async def test_photo_button_cancels_and_prompts_photo() -> None:
-    handler = _find_handler(dose_handlers.dose_conv.fallbacks, "^📷 Фото еды$")
+    handler = _find_handler(dose_conv.fallbacks, "^📷 Фото еды$")
     message = DummyMessage("📷 Фото еды")
     update = cast(
         Update,

--- a/tests/test_dose_handlers_logging.py
+++ b/tests/test_dose_handlers_logging.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from services.api.app.diabetes.handlers import dose_handlers
+from services.api.app.diabetes.handlers.dose_handlers import logger, _sanitize
 
 
 def test_logging_truncates_content(
@@ -10,7 +10,7 @@ def test_logging_truncates_content(
 ) -> None:
     long_text = "A" * 250 + "\x00\x01"
     with caplog.at_level(logging.DEBUG):
-        dose_handlers.logger.debug("test %s", dose_handlers._sanitize(long_text))
+        logger.debug("test %s", _sanitize(long_text))
     record = caplog.records[0]
     assert "A" * 200 in record.message
     assert "A" * 201 not in record.message

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -13,6 +13,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
+from services.api.app.diabetes.handlers.dose_handlers import freeform_handler
 
 
 class DummyMessage:
@@ -78,7 +79,7 @@ async def test_entry_without_dose_has_no_unit(
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
-    await dose_handlers.freeform_handler(update, context)
+    await freeform_handler(update, context)
 
     assert not context.user_data
     assert message.replies
@@ -124,7 +125,7 @@ async def test_entry_without_sugar_has_placeholder(
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
     monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
 
-    await dose_handlers.freeform_handler(update, context)
+    await freeform_handler(update, context)
 
     assert not context.user_data
     assert message.replies

--- a/tests/test_dose_sugar_missing.py
+++ b/tests/test_dose_sugar_missing.py
@@ -10,7 +10,7 @@ from telegram.ext import CallbackContext, ConversationHandler
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from services.api.app.diabetes.handlers import dose_handlers
+from services.api.app.diabetes.handlers.dose_handlers import dose_sugar
 
 
 class DummyMessage:
@@ -39,7 +39,7 @@ async def test_dose_sugar_requires_carbs_or_xe() -> None:
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 
-    result = await dose_handlers.dose_sugar(update, context)
+    result = await dose_sugar(update, context)
 
     assert result == ConversationHandler.END
     assert message.replies and "углев" in message.replies[0].lower()

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -58,6 +58,8 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
     import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
+    from services.api.app.diabetes.handlers.router import callback_router
+    from services.api.app.diabetes.handlers.dose_handlers import freeform_handler
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
@@ -86,18 +88,18 @@ async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(user_data={}, bot=DummyBot()),
     )
 
-    await router.callback_router(update_cb, context)
+    await callback_router(update_cb, context)
 
     field_query = DummyQuery(f"edit_field:{entry_id}:dose", message=entry_message)
     update_cb2 = make_update(callback_query=field_query, effective_user=SimpleNamespace(id=1))
-    await router.callback_router(update_cb2, context)
+    await callback_router(update_cb2, context)
     assert context.user_data["edit_field"] == "dose"
 
     reply_msg = DummyMessage(text="5")
     update_msg = cast(
         Update, SimpleNamespace(message=reply_msg, effective_user=SimpleNamespace(id=1))
     )
-    await dose_handlers.freeform_handler(update_msg, context)
+    await freeform_handler(update_msg, context)
 
     with TestSession() as session:
         updated = session.get(Entry, entry_id)

--- a/tests/test_freeform_handler_unknown.py
+++ b/tests/test_freeform_handler_unknown.py
@@ -6,7 +6,8 @@ from unittest.mock import AsyncMock
 from telegram import Update
 from telegram.ext import CallbackContext
 
-import services.api.app.diabetes.handlers.dose_handlers as handlers
+import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
+from services.api.app.diabetes.handlers.dose_handlers import freeform_handler
 
 
 class DummyMessage:
@@ -31,9 +32,9 @@ async def test_freeform_handler_unknown_command(
         CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
     )
 
-    monkeypatch.setattr(handlers, "parse_command", AsyncMock(return_value=None))
+    monkeypatch.setattr(dose_handlers, "parse_command", AsyncMock(return_value=None))
 
-    await handlers.freeform_handler(update, context)
+    await freeform_handler(update, context)
 
     assert message.replies
     assert message.replies[0][0] == "Не понял, воспользуйтесь /help или кнопками меню"

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -36,8 +36,8 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
-    import services.api.app.diabetes.handlers.router as router
-    from services.api.app.diabetes.handlers import common_handlers
+    from services.api.app.diabetes.handlers.router import callback_router
+    from services.api.app.diabetes.handlers.common_handlers import menu_keyboard
 
     query = DummyQuery("cancel_entry")
     update = cast(Update, SimpleNamespace(callback_query=query))
@@ -46,13 +46,13 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
         SimpleNamespace(user_data={"pending_entry": {"telegram_id": 1}}),
     )
 
-    await router.callback_router(update, context)
+    await callback_router(update, context)
 
     assert query.edited == ["❌ Запись отменена."]
     assert not query.edit_kwargs[0] or "reply_markup" not in query.edit_kwargs[0]
     assert len(query.message.replies) == 1
     text, kwargs = query.message.replies[0]
-    assert kwargs["reply_markup"] == common_handlers.menu_keyboard
+    assert kwargs["reply_markup"] == menu_keyboard
     assert "pending_entry" not in context.user_data
 
 
@@ -63,7 +63,7 @@ async def test_callback_router_invalid_entry_id(
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
-    import services.api.app.diabetes.handlers.router as router
+    from services.api.app.diabetes.handlers.router import callback_router
 
     query = DummyQuery("del:abc")
     update = cast(Update, SimpleNamespace(callback_query=query))
@@ -73,7 +73,7 @@ async def test_callback_router_invalid_entry_id(
     )
 
     with caplog.at_level(logging.WARNING):
-        await router.callback_router(update, context)
+        await callback_router(update, context)
 
     assert query.edited == ["Некорректный идентификатор записи."]
     assert "Invalid entry_id in callback data" in caplog.text
@@ -86,7 +86,7 @@ async def test_callback_router_unknown_data(
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
-    import services.api.app.diabetes.handlers.router as router
+    from services.api.app.diabetes.handlers.router import callback_router
 
     query = DummyQuery("foo")
     update = cast(Update, SimpleNamespace(callback_query=query))
@@ -96,7 +96,7 @@ async def test_callback_router_unknown_data(
     )
 
     with caplog.at_level(logging.WARNING):
-        await router.callback_router(update, context)
+        await callback_router(update, context)
 
     assert query.edited == ["Команда не распознана"]
     assert "Unrecognized callback data" in caplog.text
@@ -107,7 +107,7 @@ async def test_callback_router_ignores_reminder_action() -> None:
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
-    import services.api.app.diabetes.handlers.router as router
+    from services.api.app.diabetes.handlers.router import callback_router
 
     query = DummyQuery("rem_toggle:1")
     update = cast(Update, SimpleNamespace(callback_query=query))
@@ -116,7 +116,7 @@ async def test_callback_router_ignores_reminder_action() -> None:
         SimpleNamespace(user_data={"pending_entry": {}}),
     )
 
-    await router.callback_router(update, context)
+    await callback_router(update, context)
 
     assert query.edited == []
     assert "pending_entry" in context.user_data

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -6,7 +6,15 @@ import pytest
 from telegram import Message, Update
 from telegram.ext import CallbackContext
 
-import services.api.app.diabetes.handlers.dose_handlers as handlers
+import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
+from services.api.app.diabetes.handlers.dose_handlers import (
+    doc_handler,
+    photo_handler,
+    freeform_handler,
+    ConversationHandler,
+    WAITING_GPT_FLAG,
+    PHOTO_SUGAR,
+)
 from tests.helpers import make_context, make_update
 
 
@@ -50,10 +58,10 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
     update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     context = make_context(bot=dummy_bot, user_data={})
 
-    monkeypatch.setattr(handlers, "photo_handler", fake_photo_handler)
-    monkeypatch.setattr(handlers.os, "makedirs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(dose_handlers, "photo_handler", fake_photo_handler)
+    monkeypatch.setattr(dose_handlers.os, "makedirs", lambda *args, **kwargs: None)
 
-    result = await handlers.doc_handler(update, context)
+    result = await doc_handler(update, context)
 
     assert result == "OK"
     assert called.flag
@@ -78,11 +86,11 @@ async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> 
     update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     context = make_context(user_data={})
 
-    monkeypatch.setattr(handlers, "photo_handler", fake_photo_handler)
+    monkeypatch.setattr(dose_handlers, "photo_handler", fake_photo_handler)
 
-    result = await handlers.doc_handler(update, context)
+    result = await doc_handler(update, context)
 
-    assert result == handlers.ConversationHandler.END
+    assert result == ConversationHandler.END
     assert not called.flag
     assert "__file_path" not in context.user_data
 
@@ -93,11 +101,11 @@ async def test_photo_handler_handles_typeerror() -> None:
     update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     context = make_context(user_data={})
 
-    result = await handlers.photo_handler(update, context)
+    result = await photo_handler(update, context)
 
     assert message.texts == ["❗ Файл не распознан как изображение."]
-    assert result == handlers.ConversationHandler.END
-    assert handlers.WAITING_GPT_FLAG not in context.user_data
+    assert result == ConversationHandler.END
+    assert WAITING_GPT_FLAG not in context.user_data
 
 
 @pytest.mark.asyncio
@@ -150,21 +158,21 @@ async def test_photo_handler_preserves_file(
             )
         )
 
-    monkeypatch.setattr(handlers, "send_message", fake_send_message)
-    monkeypatch.setattr(handlers, "_get_client", lambda: DummyClient())
-    monkeypatch.setattr(handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
-    monkeypatch.setattr(handlers, "menu_keyboard", None)
+    monkeypatch.setattr(dose_handlers, "send_message", fake_send_message)
+    monkeypatch.setattr(dose_handlers, "_get_client", lambda: DummyClient())
+    monkeypatch.setattr(dose_handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
+    monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
     monkeypatch.setattr(
-        handlers.os,
+        dose_handlers.os,
         "makedirs",
         lambda path, **kwargs: Path(path).mkdir(parents=True, exist_ok=True),
     )
 
-    result = await handlers.photo_handler(update, context)
+    result = await photo_handler(update, context)
 
     assert call["keep_image"] is True
     assert Path(call["image_path"]).exists()
-    assert result == handlers.PHOTO_SUGAR
+    assert result == PHOTO_SUGAR
 
 
 @pytest.mark.asyncio
@@ -203,11 +211,11 @@ async def test_photo_then_freeform_calculates_dose(
             )
         )
 
-    monkeypatch.setattr(handlers, "send_message", fake_send_message)
-    monkeypatch.setattr(handlers, "_get_client", lambda: DummyClient())
-    monkeypatch.setattr(handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
-    monkeypatch.setattr(handlers, "menu_keyboard", None)
-    monkeypatch.setattr(handlers, "confirm_keyboard", lambda: None)
+    monkeypatch.setattr(dose_handlers, "send_message", fake_send_message)
+    monkeypatch.setattr(dose_handlers, "_get_client", lambda: DummyClient())
+    monkeypatch.setattr(dose_handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
+    monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
+    monkeypatch.setattr(dose_handlers, "confirm_keyboard", lambda: None)
 
     photo_msg = DummyMessage(photo=[DummyPhoto()])
     update_photo = make_update(
@@ -218,7 +226,7 @@ async def test_photo_then_freeform_calculates_dose(
         SimpleNamespace(bot=dummy_bot, user_data={"thread_id": "tid"}),
     )
 
-    await handlers.photo_handler(update_photo, context)
+    await photo_handler(update_photo, context)
 
     class DummySession:
         def __enter__(self) -> "DummySession":
@@ -230,7 +238,7 @@ async def test_photo_then_freeform_calculates_dose(
         def get(self, model, user_id):
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    handlers.SessionLocal = lambda: DummySession()
+    dose_handlers.SessionLocal = lambda: DummySession()
 
     sugar_msg = DummyMessage(text="5")
     update_sugar = cast(
@@ -238,7 +246,7 @@ async def test_photo_then_freeform_calculates_dose(
         SimpleNamespace(message=sugar_msg, effective_user=SimpleNamespace(id=1)),
     )
 
-    await handlers.freeform_handler(update_sugar, context)
+    await freeform_handler(update_sugar, context)
 
     reply = sugar_msg.texts[0]
     assert "Углеводы: 10.0 г" in reply

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -6,7 +6,8 @@ import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
 
-import services.api.app.diabetes.handlers.dose_handlers as handlers
+import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
+from services.api.app.diabetes.handlers.dose_handlers import freeform_handler
 
 
 class DummyMessage:
@@ -39,7 +40,7 @@ async def test_freeform_handler_edits_pending_entry_keeps_state() -> None:
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 
-    await handlers.freeform_handler(update, context)
+    await freeform_handler(update, context)
 
     assert context.user_data["pending_entry"]["dose"] == 3.5
     assert context.user_data["pending_entry"]["carbs_g"] == 30.0
@@ -68,7 +69,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         def get(self, model, user_id):
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
-    handlers.SessionLocal = lambda: DummySession()
+    dose_handlers.SessionLocal = lambda: DummySession()
     message = DummyMessage("5,6")
     update = cast(
         Update,
@@ -79,7 +80,7 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 
-    await handlers.freeform_handler(update, context)
+    await freeform_handler(update, context)
 
     assert context.user_data["pending_entry"]["sugar_before"] == 5.6
     assert "pending_entry" in context.user_data
@@ -108,7 +109,7 @@ async def test_freeform_handler_sugar_only_flow() -> None:
         SimpleNamespace(user_data={"pending_entry": entry}),
     )
 
-    await handlers.freeform_handler(update, context)
+    await freeform_handler(update, context)
 
     assert context.user_data["pending_entry"]["sugar_before"] == 4.2
     assert "pending_entry" in context.user_data

--- a/tests/test_handlers_freeform_units.py
+++ b/tests/test_handlers_freeform_units.py
@@ -5,7 +5,8 @@ from typing import Any, cast
 from telegram import Update
 from telegram.ext import CallbackContext
 
-import services.api.app.diabetes.handlers.dose_handlers as handlers
+import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
+from services.api.app.diabetes.handlers.dose_handlers import freeform_handler
 
 
 class DummyMessage:
@@ -28,7 +29,7 @@ async def test_freeform_handler_warns_on_sugar_unit_mix() -> None:
         CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
     )
 
-    await handlers.freeform_handler(update, context)
+    await freeform_handler(update, context)
 
     assert message.replies
     text, _ = message.replies[0]
@@ -46,7 +47,7 @@ async def test_freeform_handler_warns_on_dose_unit_mix() -> None:
         CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
     )
 
-    await handlers.freeform_handler(update, context)
+    await freeform_handler(update, context)
 
     assert message.replies
     text, _ = message.replies[0]
@@ -69,9 +70,9 @@ async def test_freeform_handler_guidance_on_valueerror(
     def fake_smart_input(_):
         raise ValueError("boom")
 
-    monkeypatch.setattr(handlers, "smart_input", fake_smart_input)
+    monkeypatch.setattr(dose_handlers, "smart_input", fake_smart_input)
 
-    await handlers.freeform_handler(update, context)
+    await freeform_handler(update, context)
 
     assert message.replies
     text, _ = message.replies[0]

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -8,6 +8,11 @@ from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
 import services.api.app.diabetes.handlers.router as router
+from services.api.app.diabetes.handlers.dose_handlers import (
+    freeform_handler,
+    photo_handler,
+)
+from services.api.app.diabetes.handlers.router import callback_router
 from tests.helpers import make_update
 
 
@@ -80,7 +85,7 @@ async def test_photo_flow_saves_entry(
     context = cast(
         CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
     )
-    await dose_handlers.freeform_handler(update_start, context)
+    await freeform_handler(update_start, context)
 
     monkeypatch.chdir(tmp_path)
 
@@ -133,7 +138,7 @@ async def test_photo_flow_saves_entry(
     update_photo = make_update(
         message=msg_photo, effective_user=SimpleNamespace(id=1)
     )
-    await dose_handlers.photo_handler(update_photo, context)
+    await photo_handler(update_photo, context)
 
     entry = context.user_data["pending_entry"]
     assert entry["carbs_g"] == 30.0
@@ -146,7 +151,7 @@ async def test_photo_flow_saves_entry(
         SimpleNamespace(message=msg_sugar, effective_user=SimpleNamespace(id=1)),
     )
     dose_handlers.SessionLocal = lambda: session
-    await dose_handlers.freeform_handler(update_sugar, context)
+    await freeform_handler(update_sugar, context)
     assert context.user_data["pending_entry"]["sugar_before"] == 5.5
 
     monkeypatch.setattr(router, "SessionLocal", lambda: session)
@@ -159,7 +164,7 @@ async def test_photo_flow_saves_entry(
 
     query = DummyQuery("confirm_entry")
     update_confirm = make_update(callback_query=query)
-    await router.callback_router(update_confirm, context)
+    await callback_router(update_confirm, context)
 
     assert len(session.added) == 1
     saved = session.added[0]

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -8,7 +8,11 @@ from tests.helpers import make_context, make_update
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from services.api.app.diabetes.handlers import dose_handlers
+from services.api.app.diabetes.handlers.dose_handlers import (
+    prompt_photo,
+    prompt_sugar,
+    prompt_dose,
+)
 from services.api.app.diabetes.utils.ui import sugar_keyboard
 
 
@@ -26,7 +30,7 @@ class DummyMessage:
 async def test_prompt_photo_sends_message() -> None:
     message = DummyMessage()
     update = make_update(message=message)
-    await dose_handlers.prompt_photo(update, SimpleNamespace())
+    await prompt_photo(update, SimpleNamespace())
     assert any("фото" in t.lower() for t in message.texts)
 
 
@@ -35,7 +39,7 @@ async def test_prompt_sugar_sends_message() -> None:
     message = DummyMessage()
     update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     context = make_context(user_data={})
-    await dose_handlers.prompt_sugar(update, context)
+    await prompt_sugar(update, context)
     assert any("сахар" in t.lower() for t in message.texts)
     assert message.kwargs and message.kwargs[0].get("reply_markup") is sugar_keyboard
 
@@ -45,6 +49,6 @@ async def test_prompt_dose_sends_message() -> None:
     message = DummyMessage()
     update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     context = make_context(user_data={})
-    await dose_handlers.prompt_dose(update, context)
+    await prompt_dose(update, context)
     assert any("доз" in t.lower() for t in message.texts)
 

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import services.api.app.diabetes.handlers.dose_handlers as dose_handlers
+from services.api.app.diabetes.handlers.dose_handlers import photo_handler
 from tests.helpers import make_context, make_update
 
 
@@ -82,7 +83,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch, tmp_path) -> None:
     msg_photo = DummyMessage(photo=[DummyPhoto()])
     update = make_update(message=msg_photo, effective_user=SimpleNamespace(id=1))
 
-    await dose_handlers.photo_handler(update, context)
+    await photo_handler(update, context)
 
     assert "название" in captured["content"]
     # Final reply should include dish name from Vision response

--- a/tests/test_history_view_async.py
+++ b/tests/test_history_view_async.py
@@ -5,7 +5,8 @@ from typing import Any
 
 import pytest
 
-from services.api.app.diabetes.handlers import reporting_handlers
+import services.api.app.diabetes.handlers.reporting_handlers as reporting_handlers
+from services.api.app.diabetes.handlers.reporting_handlers import history_view
 from tests.helpers import make_context, make_update
 
 
@@ -60,7 +61,7 @@ async def test_history_view_does_not_block_event_loop(monkeypatch) -> None:
         await asyncio.sleep(0.1)
         flag = True
 
-    view_task = asyncio.create_task(reporting_handlers.history_view(update, context))
+    view_task = asyncio.create_task(history_view(update, context))
     marker_task = asyncio.create_task(marker())
 
     await asyncio.wait_for(marker_task, timeout=0.2)

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -9,7 +9,11 @@ from tests.helpers import make_context, make_update
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from services.api.app.diabetes.handlers import dose_handlers
+from services.api.app.diabetes.handlers.dose_handlers import (
+    sugar_conv,
+    dose_conv,
+    photo_prompt,
+)
 
 
 class DummyMessage:
@@ -33,7 +37,7 @@ def _get_menu_handler(fallbacks):
 
 @pytest.mark.asyncio
 async def test_sugar_conv_menu_then_photo() -> None:
-    handler = _get_menu_handler(dose_handlers.sugar_conv.fallbacks)
+    handler = _get_menu_handler(sugar_conv.fallbacks)
     message = DummyMessage("/menu")
     update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     context = make_context(user_data={"pending_entry": {"foo": "bar"}})
@@ -48,12 +52,12 @@ async def test_sugar_conv_menu_then_photo() -> None:
     next_update = make_update(
         message=next_message, effective_user=SimpleNamespace(id=1)
     )
-    await dose_handlers.photo_prompt(next_update, context)
+    await photo_prompt(next_update, context)
     assert any("фото" in r.lower() for r in next_message.replies)
 
 @pytest.mark.asyncio
 async def test_dose_conv_menu_then_photo() -> None:
-    handler = _get_menu_handler(dose_handlers.dose_conv.fallbacks)
+    handler = _get_menu_handler(dose_conv.fallbacks)
     message = DummyMessage("/menu")
     update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     context = make_context(user_data={"pending_entry": {"foo": "bar"}})
@@ -68,6 +72,6 @@ async def test_dose_conv_menu_then_photo() -> None:
     next_update = make_update(
         message=next_message, effective_user=SimpleNamespace(id=1)
     )
-    await dose_handlers.photo_prompt(next_update, context)
+    await photo_prompt(next_update, context)
     assert any("фото" in r.lower() for r in next_message.replies)
 

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -10,12 +10,10 @@ from tests.helpers import make_update
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-from services.api.app.diabetes.handlers import (
-    dose_handlers,
-    profile as profile_handlers,
-    onboarding_handlers,
-    sos_handlers,
-)
+from services.api.app.diabetes.handlers.dose_handlers import sugar_conv
+from services.api.app.diabetes.handlers.profile import profile_conv
+from services.api.app.diabetes.handlers.onboarding_handlers import onboarding_conv
+from services.api.app.diabetes.handlers.sos_handlers import sos_contact_conv
 
 
 def _find_handler(fallbacks, regex: str) -> MessageHandler:
@@ -54,23 +52,23 @@ async def _exercise(handler) -> None:
 
 @pytest.mark.asyncio
 async def test_profile_conv_photo_fallback() -> None:
-    handler = _find_handler(profile_handlers.profile_conv.fallbacks, "^📷 Фото еды$")
+    handler = _find_handler(profile_conv.fallbacks, "^📷 Фото еды$")
     await _exercise(handler)
 
 
 @pytest.mark.asyncio
 async def test_sugar_conv_photo_fallback() -> None:
-    handler = _find_handler(dose_handlers.sugar_conv.fallbacks, "^📷 Фото еды$")
+    handler = _find_handler(sugar_conv.fallbacks, "^📷 Фото еды$")
     await _exercise(handler)
 
 
 @pytest.mark.asyncio
 async def test_onboarding_conv_photo_fallback() -> None:
-    handler = _find_handler(onboarding_handlers.onboarding_conv.fallbacks, "^📷 Фото еды$")
+    handler = _find_handler(onboarding_conv.fallbacks, "^📷 Фото еды$")
     await _exercise(handler)
 
 
 @pytest.mark.asyncio
 async def test_sos_contact_conv_photo_fallback() -> None:
-    handler = _find_handler(sos_handlers.sos_contact_conv.fallbacks, "^📷 Фото еды$")
+    handler = _find_handler(sos_contact_conv.fallbacks, "^📷 Фото еды$")
     await _exercise(handler)

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -6,7 +6,8 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from services.api.app.diabetes.services.db import Base, User, Profile, Alert, Reminder
-from services.api.app.diabetes.handlers import profile as handlers
+import services.api.app.diabetes.handlers.profile as handlers
+from services.api.app.diabetes.handlers.profile import profile_view, profile_security
 from services.api.app.diabetes.services.repository import commit
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
@@ -49,7 +50,7 @@ async def test_profile_view_has_security_button(monkeypatch) -> None:
     update = make_update(message=msg, effective_user=SimpleNamespace(id=1))
     context = make_context()
 
-    await handlers.profile_view(update, context)
+    await profile_view(update, context)
 
     markup = msg.markups[0]
     buttons = [b for row in markup.inline_keyboard for b in row]
@@ -101,7 +102,7 @@ async def test_profile_security_threshold_changes(monkeypatch, action, expected_
     update = make_update(callback_query=query, effective_user=SimpleNamespace(id=1))
     context = make_context(application=SimpleNamespace(job_queue="jq"))
 
-    await handlers.profile_security(update, context)
+    await profile_security(update, context)
 
     with TestSession() as session:
         profile = session.get(Profile, 1)
@@ -146,7 +147,7 @@ async def test_profile_security_toggle_sos_alerts(monkeypatch) -> None:
     update = make_update(callback_query=query, effective_user=SimpleNamespace(id=1))
     context = make_context(application=SimpleNamespace(job_queue="jq"))
 
-    await handlers.profile_security(update, context)
+    await profile_security(update, context)
 
     with TestSession() as session:
         profile = session.get(Profile, 1)
@@ -183,7 +184,7 @@ async def test_profile_security_shows_reminders(monkeypatch) -> None:
     update = make_update(callback_query=query, effective_user=SimpleNamespace(id=1))
     context = make_context(application=SimpleNamespace(job_queue="jq"))
 
-    await handlers.profile_security(update, context)
+    await profile_security(update, context)
 
     text, _ = query.edits[0]
     assert "1. 🔔 Замерить сахар ⏰ 08:00" in text
@@ -214,13 +215,13 @@ async def test_profile_security_add_delete_calls_handlers(monkeypatch) -> None:
     update_add = make_update(callback_query=query_add, effective_user=SimpleNamespace(id=1))
     context = make_context(application=SimpleNamespace(job_queue="jq"))
 
-    await handlers.profile_security(update_add, context)
+    await profile_security(update_add, context)
     assert query_add.message.texts[-1] == "Создать напоминание:"
 
     query_del = DummyQuery("profile_security:del")
     update_del = make_update(callback_query=query_del, effective_user=SimpleNamespace(id=1))
 
-    await handlers.profile_security(update_del, context)
+    await profile_security(update_del, context)
     assert called["del"] is True
 
 
@@ -249,5 +250,5 @@ async def test_profile_security_sos_contact_calls_handler(monkeypatch) -> None:
     update = make_update(callback_query=query, effective_user=SimpleNamespace(id=1))
     context = make_context(application=SimpleNamespace(job_queue="jq"))
 
-    await handlers.profile_security(update, context)
+    await profile_security(update, context)
     assert called is True

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -7,23 +7,48 @@ from telegram.ext import (
     ConversationHandler,
     MessageHandler,
 )
-from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import CallbackQueryNoWarnHandler
-
+from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import (
+    CallbackQueryNoWarnHandler,
+)
 from services.api.app.diabetes.handlers.registration import register_handlers
 from services.api.app.diabetes.handlers.router import callback_router
 from services.api.app.diabetes.handlers.onboarding_handlers import start_command
-from services.api.app.diabetes.handlers import security_handlers, reminder_handlers
+from services.api.app.diabetes.handlers.security_handlers import hypo_alert_faq
+from services.api.app.diabetes.handlers.reminder_handlers import (
+    reminder_action_cb,
+    reminder_webapp_save,
+    add_reminder,
+)
+from services.api.app.diabetes.handlers.dose_handlers import (
+    freeform_handler,
+    photo_handler,
+    doc_handler,
+    photo_prompt,
+    dose_cancel,
+    chat_with_gpt,
+    dose_conv,
+    sugar_conv,
+    sugar_start,
+    prompt_sugar,
+)
+from services.api.app.diabetes.handlers.profile import (
+    profile_view,
+    profile_back,
+    profile_conv,
+    profile_command,
+    profile_edit,
+)
+from services.api.app.diabetes.handlers.reporting_handlers import (
+    report_request,
+    history_view,
+    report_period_callback,
+)
 
 
 def test_register_handlers_attaches_expected_handlers(monkeypatch):
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-    from services.api.app.diabetes.handlers import (
-        dose_handlers,
-        profile as profile_handlers,
-        reporting_handlers,
-    )
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
     register_handlers(app)
@@ -31,34 +56,31 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     handlers = app.handlers[0]
     callbacks = [getattr(h, "callback", None) for h in handlers]
 
-    assert dose_handlers.freeform_handler in callbacks
-    assert dose_handlers.photo_handler in callbacks
-    assert dose_handlers.doc_handler in callbacks
-    assert dose_handlers.prompt_photo in callbacks
-    assert dose_handlers.dose_cancel in callbacks
-    assert dose_handlers.prompt_sugar not in callbacks
+    assert freeform_handler in callbacks
+    assert photo_handler in callbacks
+    assert doc_handler in callbacks
+    assert photo_prompt in callbacks
+    assert dose_cancel in callbacks
+    assert prompt_sugar not in callbacks
     assert callback_router in callbacks
-    assert reporting_handlers.report_period_callback in callbacks
-    assert profile_handlers.profile_view in callbacks
-    assert profile_handlers.profile_back in callbacks
-    assert reporting_handlers.report_request in callbacks
-    assert reporting_handlers.history_view in callbacks
-    assert dose_handlers.chat_with_gpt in callbacks
-    assert security_handlers.hypo_alert_faq in callbacks
+    assert report_period_callback in callbacks
+    assert profile_view in callbacks
+    assert profile_back in callbacks
+    assert report_request in callbacks
+    assert history_view in callbacks
+    assert chat_with_gpt in callbacks
+    assert hypo_alert_faq in callbacks
     # Reminder handlers should be registered
     assert any(
-        isinstance(h, CallbackQueryHandler)
-        and h.callback is reminder_handlers.reminder_action_cb
+        isinstance(h, CallbackQueryHandler) and h.callback is reminder_action_cb
         for h in handlers
     )
     assert any(
-        isinstance(h, MessageHandler)
-        and h.callback is reminder_handlers.reminder_webapp_save
+        isinstance(h, MessageHandler) and h.callback is reminder_webapp_save
         for h in handlers
     )
     assert any(
-        isinstance(h, CommandHandler)
-        and h.callback is reminder_handlers.add_reminder
+        isinstance(h, CommandHandler) and h.callback is add_reminder
         for h in handlers
     )
 
@@ -77,56 +99,55 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
 
 
     conv_handlers = [h for h in handlers if isinstance(h, ConversationHandler)]
-    assert dose_handlers.dose_conv in conv_handlers
-    assert dose_handlers.sugar_conv in conv_handlers
-    assert profile_handlers.profile_conv in conv_handlers
+    assert dose_conv in conv_handlers
+    assert sugar_conv in conv_handlers
+    assert profile_conv in conv_handlers
     assert onb_conv[0] in conv_handlers
     conv_cmds = [
         ep
-        for ep in dose_handlers.dose_conv.entry_points
+        for ep in dose_conv.entry_points
         if isinstance(ep, CommandHandler)
     ]
     assert conv_cmds and "dose" in conv_cmds[0].commands
     sugar_conv_cmds = [
         ep
-        for ep in dose_handlers.sugar_conv.entry_points
+        for ep in sugar_conv.entry_points
         if isinstance(ep, CommandHandler)
     ]
     assert sugar_conv_cmds and "sugar" in sugar_conv_cmds[0].commands
     profile_conv_cmd = [
         ep
-        for ep in profile_handlers.profile_conv.entry_points
+        for ep in profile_conv.entry_points
         if isinstance(ep, CommandHandler)
-        and ep.callback is profile_handlers.profile_command
+        and ep.callback is profile_command
         and "profile" in ep.commands
     ]
     assert profile_conv_cmd
     profile_conv_cb = [
         ep
-        for ep in profile_handlers.profile_conv.entry_points
-        if isinstance(ep, CallbackQueryNoWarnHandler)
-        and ep.callback is profile_handlers.profile_edit
+        for ep in profile_conv.entry_points
+        if isinstance(ep, CallbackQueryNoWarnHandler) and ep.callback is profile_edit
     ]
     assert profile_conv_cb
 
     text_handlers = [
         h
         for h in handlers
-        if isinstance(h, MessageHandler) and h.callback is dose_handlers.freeform_handler
+        if isinstance(h, MessageHandler) and h.callback is freeform_handler
     ]
     assert text_handlers
 
     photo_handlers = [
         h
         for h in handlers
-        if isinstance(h, MessageHandler) and h.callback is dose_handlers.photo_handler
+        if isinstance(h, MessageHandler) and h.callback is photo_handler
     ]
     assert photo_handlers
 
     doc_handlers = [
         h
         for h in handlers
-        if isinstance(h, MessageHandler) and h.callback is dose_handlers.doc_handler
+        if isinstance(h, MessageHandler) and h.callback is doc_handler
     ]
     assert doc_handlers
 
@@ -134,56 +155,56 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
     photo_prompt_handlers = [
         h
         for h in handlers
-        if isinstance(h, MessageHandler) and h.callback is dose_handlers.photo_prompt
+        if isinstance(h, MessageHandler) and h.callback is photo_prompt
     ]
     assert photo_prompt_handlers
 
     sugar_cmd = [
         h
         for h in handlers
-        if isinstance(h, CommandHandler) and h.callback is dose_handlers.sugar_start
+        if isinstance(h, CommandHandler) and h.callback is sugar_start
     ]
     assert not sugar_cmd
 
     cancel_cmd = [
         h
         for h in handlers
-        if isinstance(h, CommandHandler) and h.callback is dose_handlers.dose_cancel
+        if isinstance(h, CommandHandler) and h.callback is dose_cancel
     ]
     assert cancel_cmd and "cancel" in cancel_cmd[0].commands
 
     profile_view_handlers = [
         h
         for h in handlers
-        if isinstance(h, MessageHandler) and h.callback is profile_handlers.profile_view
+        if isinstance(h, MessageHandler) and h.callback is profile_view
     ]
     assert profile_view_handlers
 
     report_handlers = [
         h
         for h in handlers
-        if isinstance(h, MessageHandler) and h.callback is reporting_handlers.report_request
+        if isinstance(h, MessageHandler) and h.callback is report_request
     ]
     assert report_handlers
 
     report_cmd = [
         h
         for h in handlers
-        if isinstance(h, CommandHandler) and h.callback is reporting_handlers.report_request
+        if isinstance(h, CommandHandler) and h.callback is report_request
     ]
     assert report_cmd and "report" in report_cmd[0].commands
 
     gpt_cmd = [
         h
         for h in handlers
-        if isinstance(h, CommandHandler) and h.callback is dose_handlers.chat_with_gpt
+        if isinstance(h, CommandHandler) and h.callback is chat_with_gpt
     ]
     assert gpt_cmd and "gpt" in gpt_cmd[0].commands
 
     history_handlers = [
         h
         for h in handlers
-        if isinstance(h, MessageHandler) and h.callback is reporting_handlers.history_view
+        if isinstance(h, MessageHandler) and h.callback is history_view
     ]
     assert history_handlers
 
@@ -197,13 +218,12 @@ def test_register_handlers_attaches_expected_handlers(monkeypatch):
         h
         for h in handlers
         if isinstance(h, CallbackQueryHandler)
-        and h.callback is reporting_handlers.report_period_callback
+        and h.callback is report_period_callback
     ]
     assert report_cb_handlers
     profile_back_handlers = [
         h
         for h in handlers
-        if isinstance(h, CallbackQueryHandler)
-        and h.callback is profile_handlers.profile_back
+        if isinstance(h, CallbackQueryHandler) and h.callback is profile_back
     ]
     assert profile_back_handlers


### PR DESCRIPTION
## Summary
- define explicit `__all__` exports for diabetes handlers
- import handlers via their public APIs in tests and modules

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb52ff3e0832a9952f7ad9816336c