### PR TITLE
[ui] Fix @sdk path alias to repository libs

### DIFF
--- a/services/webapp/ui/package-lock.json
+++ b/services/webapp/ui/package-lock.json
@@ -75,7 +75,8 @@
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",
-        "vite": "^5.4.19"
+        "vite": "^5.4.19",
+        "vite-tsconfig-paths": "^4.3.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4384,6 +4385,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -6357,6 +6365,27 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
@@ -6611,6 +6640,26 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz",
+      "integrity": "sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
           "optional": true
         }
       }

--- a/services/webapp/ui/package.json
+++ b/services/webapp/ui/package.json
@@ -80,6 +80,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vite-tsconfig-paths": "^4.3.2"
   }
 }

--- a/services/webapp/ui/tsconfig.app.json
+++ b/services/webapp/ui/tsconfig.app.json
@@ -23,7 +23,7 @@
 
     "baseUrl": ".",
     "paths": {
-      "@sdk/*": ["../../../libs/ts-sdk/*"],
+      "@sdk/*": ["/workspace/saharlight-ux/libs/ts-sdk/*"],
       "@/*": ["./src/*"]
     }
   },

--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -7,7 +7,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@sdk/*": ["../../../libs/ts-sdk/*"],
+      "@sdk/*": ["/workspace/saharlight-ux/libs/ts-sdk/*"],
       "@/*": ["./src/*"]
     },
     "noImplicitAny": false,

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -3,11 +3,12 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import tsconfigPaths from 'vite-tsconfig-paths'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
 
 export default defineConfig(async ({ mode }) => {
-  const plugins = [react()]
+  const plugins = [react(), tsconfigPaths()]
   if (mode === 'development') {
     const { componentTagger } = await import('lovable-tagger')
     plugins.push(componentTagger())
@@ -20,7 +21,7 @@ export default defineConfig(async ({ mode }) => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),
-        '@sdk': path.resolve(__dirname, '../../../libs/ts-sdk'),
+        '@sdk': path.resolve(__dirname, '../../..', 'libs/ts-sdk'),
       },
     },
     server: { host: '::', port: 8080 },


### PR DESCRIPTION
## Summary
- point `@sdk` alias to repo-level `libs/ts-sdk`
- ensure tsconfig uses absolute path to `ts-sdk`
- add `vite-tsconfig-paths` to keep absolute imports during build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aeb9d5b234832aa59dcf735540055c