### PR TITLE
[webapp] prioritize runtime alias

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,5 @@
 import { RemindersApi } from '@sdk';
-import { Configuration, ResponseError } from '@sdk/runtime';
+import { Configuration, ResponseError } from '@sdk/runtime.ts';
 import {
   instanceOfReminderSchema as instanceOfReminder,
   type ReminderSchema as Reminder,

--- a/services/webapp/ui/tsconfig.app.json
+++ b/services/webapp/ui/tsconfig.app.json
@@ -24,9 +24,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
+      "@sdk/runtime": ["../../../libs/ts-sdk/runtime.ts"],
       "@sdk": ["../../../libs/ts-sdk"],
-      "@sdk/*": ["../../../libs/ts-sdk/*"],
-      "@sdk/runtime": ["../../../libs/ts-sdk/runtime.ts"]
+      "@sdk/*": ["../../../libs/ts-sdk/*"]
     }
   },
   "include": ["src"]

--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -8,9 +8,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
+      "@sdk/runtime": ["../../../libs/ts-sdk/runtime.ts"],
       "@sdk": ["../../../libs/ts-sdk"],
-      "@sdk/*": ["../../../libs/ts-sdk/*"],
-      "@sdk/runtime": ["../../../libs/ts-sdk/runtime.ts"]
+      "@sdk/*": ["../../../libs/ts-sdk/*"]
     },
     "noImplicitAny": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Summary
- prioritize `@sdk/runtime` path mapping over generic `@sdk` aliases
- reference runtime as `@sdk/runtime.ts` so bundler keeps extension

## Testing
- `npm run build`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aeba02727c832a893058f0a9de59e4