### PR TITLE
[tests] add type hints

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,14 +3,14 @@ from typing import Any
 from tests.telegram_stubs import CallbackContext, Update
 
 
-def make_update(**kwargs: Any) -> Update:
+def make_update(**kwargs: Any) -> None:
     update = Update()
     for key, value in kwargs.items():
         setattr(update, key, value)
     return update
 
 
-def make_context(**kwargs: Any) -> CallbackContext:
+def make_context(**kwargs: Any) -> None:
     ctx = CallbackContext()
     for key, value in kwargs.items():
         setattr(ctx, key, value)

--- a/tests/test_add_reminder_wizard.py
+++ b/tests/test_add_reminder_wizard.py
@@ -39,7 +39,7 @@ class DummyJobQueue:
     def run_repeating(self, *args: Any, **kwargs: Any) -> None:
         pass
 
-    def get_jobs_by_name(self, name: str) -> list[Any]:
+    def get_jobs_by_name(self, name: str) -> None:
         return []
 
 

--- a/tests/test_alert_stats.py
+++ b/tests/test_alert_stats.py
@@ -34,7 +34,7 @@ async def test_alert_stats_counts(monkeypatch: pytest.MonkeyPatch) -> None:
         @classmethod
         def now(
             cls, tz: dt.tzinfo | None = None
-        ) -> "DummyDateTime":  # pragma: no cover - used for typing
+        ) -> None:  # pragma: no cover - used for typing
             return fixed_now
 
     fixed_now = DummyDateTime(2024, 1, 10, tzinfo=dt.timezone.utc)

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -47,7 +47,7 @@ class DummyJobQueue:
     ) -> None:
         self.jobs.append(DummyJob(callback, when, data, name))
 
-    def get_jobs_by_name(self, name: str) -> list[DummyJob]:
+    def get_jobs_by_name(self, name: str) -> None:
         return [j for j in self.jobs if j.name == name]
 
 
@@ -183,7 +183,7 @@ async def test_three_alerts_notify(monkeypatch: pytest.MonkeyPatch) -> None:
 
     update = make_update(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
     context = cast(AlertContext, ContextStub(bot=DummyBot()))
-    async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
+    async def fake_get_coords_and_link() -> None:
         return ("0,0", "link")
 
     monkeypatch.setattr(handlers, "get_coords_and_link", fake_get_coords_and_link)
@@ -231,7 +231,7 @@ async def test_alert_message_without_coords(monkeypatch: pytest.MonkeyPatch) -> 
     update = make_update(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
     context = cast(AlertContext, ContextStub(bot=DummyBot()))
 
-    async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
+    async def fake_get_coords_and_link() -> None:
         return None, None
 
     monkeypatch.setattr(handlers, "get_coords_and_link", fake_get_coords_and_link)

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -5,12 +5,12 @@ from fastapi.testclient import TestClient
 from services.api.app.middleware.auth import AuthMiddleware
 
 
-def create_app() -> FastAPI:
+def create_app() -> None:
     app = FastAPI()
     app.add_middleware(AuthMiddleware)
 
     @app.get("/whoami")
-    async def whoami(request: Request) -> dict[str, int]:
+    async def whoami(request: Request) -> None:
         return {"user_id": request.state.user_id}
 
     return app

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -3,9 +3,10 @@
 import importlib
 import logging
 import sys
+from typing import Any
 
 
-def test_log_level_debug(monkeypatch):
+def test_log_level_debug(monkeypatch: Any) -> None:
     """Setting LOG_LEVEL=DEBUG enables debug logging in bot.main."""
 
     # Prepare environment for config module
@@ -39,21 +40,21 @@ def test_log_level_debug(monkeypatch):
             return None
 
     class DummyBuilder:
-        def token(self, _: str) -> "DummyBuilder":
+        def token(self, _: str) -> None:
             return self
 
-        def post_init(self, _: object) -> "DummyBuilder":
+        def post_init(self, _: object) -> None:
             return self
 
-        def build(self) -> DummyApp:
+        def build(self) -> None:
             return DummyApp()
 
     class DummyApplication:
         @staticmethod
-        def builder() -> DummyBuilder:
+        def builder() -> None:
             return DummyBuilder()
 
-        def __class_getitem__(cls, _: object):  # Support subscripting in type hints
+        def __class_getitem__(cls, _: object) -> None:  # Support subscripting in type hints
             return cls
 
     monkeypatch.setattr(bot, "Application", DummyApplication)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,20 +4,21 @@ import importlib
 import sys
 
 import pytest
+from typing import Any
 
 
-def _reload(module: str):
+def _reload(module: str) -> None:
     if module in sys.modules:
         del sys.modules[module]
     return importlib.import_module(module)
 
 
-def test_import_config_without_db_password(monkeypatch):
+def test_import_config_without_db_password(monkeypatch: Any) -> None:
     monkeypatch.delenv("DB_PASSWORD", raising=False)
     _reload("services.api.app.config")  # should not raise
 
 
-def test_init_db_raises_when_no_password(monkeypatch):
+def test_init_db_raises_when_no_password(monkeypatch: Any) -> None:
     monkeypatch.delenv("DB_PASSWORD", raising=False)
     config = _reload("services.api.app.config")
     db = _reload("services.api.app.diabetes.services.db")

--- a/tests/test_db_reinit.py
+++ b/tests/test_db_reinit.py
@@ -2,20 +2,21 @@ import importlib
 import sys
 
 import pytest
+from typing import Any
 
 
-def _reload(module: str):
+def _reload(module: str) -> None:
     if module in sys.modules:
         del sys.modules[module]
     return importlib.import_module(module)
 
 
 class DummyEngine:
-    def __init__(self, url):
+    def __init__(self, url: Any) -> None:
         self.url = url
         self.disposed = False
 
-    def dispose(self):
+    def dispose(self) -> None:
         self.disposed = True
 
 
@@ -27,14 +28,14 @@ class DummyEngine:
     ],
 )
 
-def test_init_db_recreates_engine_on_url_change(monkeypatch, attr, orig, new, url_attr):
+def test_init_db_recreates_engine_on_url_change(monkeypatch: Any, attr: Any, orig: Any, new: Any, url_attr: Any) -> None:
     monkeypatch.setenv("DB_PASSWORD", "pwd")
     _reload("services.api.app.config")
     db = _reload("services.api.app.diabetes.services.db")
 
     created = []
 
-    def fake_create_engine(url):
+    def fake_create_engine(url: Any) -> None:
         engine = DummyEngine(url)
         created.append(engine)
         return engine

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -13,7 +13,7 @@ import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F40
 from services.api.app.diabetes.handlers import dose_handlers
 
 
-def _find_handler(fallbacks, regex: str) -> MessageHandler:
+def _find_handler(fallbacks: Any, regex: str) -> None:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)
@@ -24,7 +24,7 @@ def _find_handler(fallbacks, regex: str) -> MessageHandler:
 
 
 class DummyMessage:
-    def __init__(self, text: str = ""):
+    def __init__(self, text: str = "") -> None:
         self.text = text
         self.replies: list[str] = []
         self.kwargs: list[dict[str, Any]] = []

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -61,10 +61,10 @@ async def test_entry_without_dose_has_no_unit(
     )
 
     class DummySession:
-        def __enter__(self) -> "DummySession":
+        def __enter__(self) -> None:
             return self
 
-        def __exit__(self, exc_type, exc, tb) -> None:
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
             pass
 
         def add(self, entry: Any) -> None:
@@ -107,10 +107,10 @@ async def test_entry_without_sugar_has_placeholder(
     )
 
     class DummySession:
-        def __enter__(self) -> "DummySession":
+        def __enter__(self) -> None:
             return self
 
-        def __exit__(self, exc_type, exc, tb) -> None:
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
             pass
 
         def add(self, entry: Any) -> None:

--- a/tests/test_dose_sugar_missing.py
+++ b/tests/test_dose_sugar_missing.py
@@ -14,7 +14,7 @@ from services.api.app.diabetes.handlers import dose_handlers
 
 
 class DummyMessage:
-    def __init__(self, text: str = ""):
+    def __init__(self, text: str = "") -> None:
         self.text = text
         self.replies: list[str] = []
         self.kwargs: list[dict[str, Any]] = []

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -15,7 +15,7 @@ from services.api.app.diabetes.services.db import Base, User, Entry
 
 
 class DummyMessage:
-    def __init__(self, text: str = "", chat_id: int = 1, message_id: int = 1):
+    def __init__(self, text: str = "", chat_id: int = 1, message_id: int = 1) -> None:
         self.text = text
         self.chat_id = chat_id
         self.message_id = message_id
@@ -26,7 +26,7 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str, message: DummyMessage | None = None):
+    def __init__(self, data: str, message: DummyMessage | None = None) -> None:
         self.data = data
         self.message = message or DummyMessage()
         self.markups = []

--- a/tests/test_freeform_handler_unknown.py
+++ b/tests/test_freeform_handler_unknown.py
@@ -10,7 +10,7 @@ import services.api.app.diabetes.handlers.dose_handlers as handlers
 
 
 class DummyMessage:
-    def __init__(self, text: str):
+    def __init__(self, text: str) -> None:
         self.text = text
         self.replies: list[tuple[str, dict[str, Any]]] = []
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -11,164 +11,164 @@ from services.api.app.diabetes.utils.functions import (
 )
 
 
-def test_safe_float_with_spaces():
+def test_safe_float_with_spaces() -> None:
     assert _safe_float(" 1,5 ") == 1.5
 
 
-def test_safe_float_none():
+def test_safe_float_none() -> None:
     assert _safe_float(None) is None
 
 
-def test_calc_bolus_basic():
+def test_calc_bolus_basic() -> None:
     profile = PatientProfile(icr=12, cf=2, target_bg=6)
     result = calc_bolus(carbs_g=60, current_bg=8, profile=profile)
     # meal=60/12=5, correction=(8-6)/2=1, total=6.0
     assert result == 6.0
 
 
-def test_calc_bolus_no_correction():
+def test_calc_bolus_no_correction() -> None:
     profile = PatientProfile(icr=10, cf=2, target_bg=6)
     result = calc_bolus(carbs_g=30, current_bg=5, profile=profile)
     # meal=3, correction=max(0, (5-6)/2)=0, total=3.0
     assert result == 3.0
 
 
-def test_calc_bolus_invalid_icr():
+def test_calc_bolus_invalid_icr() -> None:
     profile = PatientProfile(icr=0, cf=2, target_bg=6)
     with pytest.raises(ValueError, match="icr"):
         calc_bolus(carbs_g=30, current_bg=5, profile=profile)
 
 
-def test_calc_bolus_invalid_cf():
+def test_calc_bolus_invalid_cf() -> None:
     profile = PatientProfile(icr=10, cf=-1, target_bg=6)
     with pytest.raises(ValueError, match="cf"):
         calc_bolus(carbs_g=30, current_bg=5, profile=profile)
 
 
-def test_calc_bolus_invalid_target_bg():
+def test_calc_bolus_invalid_target_bg() -> None:
     profile = PatientProfile(icr=10, cf=2, target_bg=-1)
     with pytest.raises(ValueError, match="target_bg"):
         calc_bolus(carbs_g=30, current_bg=5, profile=profile)
 
 
-def test_calc_bolus_negative_carbs():
+def test_calc_bolus_negative_carbs() -> None:
     profile = PatientProfile(icr=10, cf=2, target_bg=6)
     with pytest.raises(ValueError, match="carbs_g"):
         calc_bolus(carbs_g=-5, current_bg=5, profile=profile)
 
 
-def test_calc_bolus_negative_current_bg():
+def test_calc_bolus_negative_current_bg() -> None:
     profile = PatientProfile(icr=10, cf=2, target_bg=6)
     with pytest.raises(ValueError, match="current_bg"):
         calc_bolus(carbs_g=30, current_bg=-1, profile=profile)
 
 
-def test_extract_nutrition_info_simple():
+def test_extract_nutrition_info_simple() -> None:
     text = "углеводы: 45 г, ХЕ: 3.5"
     carbs, xe = extract_nutrition_info(text)
     assert carbs == 45
     assert xe == 3.5
 
 
-def test_extract_nutrition_info_ranges():
+def test_extract_nutrition_info_ranges() -> None:
     text = "Углеводы: 30–50 г, XE: 2–3"
     carbs, xe = extract_nutrition_info(text)
     assert carbs == 40  # (30+50)/2
     assert xe == 2.5    # (2+3)/2
 
 
-def test_extract_nutrition_info_plus_minus():
+def test_extract_nutrition_info_plus_minus() -> None:
     text = "углеводы: 45 г ± 5 г, XE: 3 ± 0.5"
     carbs, xe = extract_nutrition_info(text)
     assert carbs == 45
     assert xe == 3
 
 
-def test_extract_nutrition_info_plus_minus_no_colon():
+def test_extract_nutrition_info_plus_minus_no_colon() -> None:
     text = "В блюде 30 г ± 10 г углеводов и 2 ± 1 ХЕ"
     carbs, xe = extract_nutrition_info(text)
     assert carbs == 30
     assert xe == 2
 
 
-def test_extract_nutrition_info_plus_minus_with_comma():
+def test_extract_nutrition_info_plus_minus_with_comma() -> None:
     text = "углеводы: 10,5 г ± 0,5 г, ХЕ: 2,5 ± 0,5"
     carbs, xe = extract_nutrition_info(text)
     assert carbs == pytest.approx(10.5)
     assert xe == pytest.approx(2.5)
 
 
-def test_extract_nutrition_info_missing():
+def test_extract_nutrition_info_missing() -> None:
     text = "Нет данных"
     carbs, xe = extract_nutrition_info(text)
     assert carbs is None
     assert xe is None
 
 
-def test_extract_nutrition_info_invalid_carbs():
+def test_extract_nutrition_info_invalid_carbs() -> None:
     text = "углеводы: 5..2 г, ХЕ: 3"
     carbs, xe = extract_nutrition_info(text)
     assert carbs is None
     assert xe == 3
 
 
-def test_extract_nutrition_info_invalid_xe():
+def test_extract_nutrition_info_invalid_xe() -> None:
     text = "углеводы: 45 г, ХЕ: 1..2"
     carbs, xe = extract_nutrition_info(text)
     assert carbs == 45
     assert xe is None
 
 
-def test_extract_nutrition_info_ignores_title_line():
+def test_extract_nutrition_info_ignores_title_line() -> None:
     text = "Борщ\nУглеводы: 25 г\nХЕ: 2"
     carbs, xe = extract_nutrition_info(text)
     assert carbs == 25
     assert xe == 2
 
 
-def test_extract_nutrition_info_first_line_with_data():
+def test_extract_nutrition_info_first_line_with_data() -> None:
     text = "Углеводы: 25 г\nХЕ: 2"
     carbs, xe = extract_nutrition_info(text)
     assert carbs == 25
     assert xe == 2
 
 
-def test_extract_nutrition_info_first_line_xe_only():
+def test_extract_nutrition_info_first_line_xe_only() -> None:
     text = "ХЕ: 3\nПрочее"
     carbs, xe = extract_nutrition_info(text)
     assert carbs is None
     assert xe == 3
 
 
-def test_extract_nutrition_info_non_string():
+def test_extract_nutrition_info_non_string() -> None:
     assert extract_nutrition_info(123) == (None, None)
 
 
-def test_smart_input_basic():
+def test_smart_input_basic() -> None:
     msg = "sugar=7 xe=3 dose=4"
     assert smart_input(msg) == {"sugar": 7.0, "xe": 3.0, "dose": 4.0}
 
 
-def test_smart_input_units_without_labels():
+def test_smart_input_units_without_labels() -> None:
     msg = "7 ммоль/л, 3 XE, 4 ед"
     assert smart_input(msg) == {"sugar": 7.0, "xe": 3.0, "dose": 4.0}
 
 
-def test_smart_input_localized_terms():
+def test_smart_input_localized_terms() -> None:
     msg = "сахар:5,5 доза=2,5"
     assert smart_input(msg) == {"sugar": pytest.approx(5.5), "xe": None, "dose": pytest.approx(2.5)}
 
 
-def test_smart_input_unit_mixup():
+def test_smart_input_unit_mixup() -> None:
     with pytest.raises(ValueError):
         smart_input("сахар 7 XE")
 
 
-def test_smart_input_unit_mixup_xe():
+def test_smart_input_unit_mixup_xe() -> None:
     with pytest.raises(ValueError):
         smart_input("xe 5 ммоль/л")
 
 
-def test_smart_input_unit_mixup_dose():
+def test_smart_input_unit_mixup_dose() -> None:
     with pytest.raises(ValueError):
         smart_input("доза 7 ммоль")

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -8,13 +8,14 @@ from openai import OpenAIError
 
 from services.api.app.diabetes.services import gpt_client
 from services.api.app.config import settings
+from typing import Any
 
 
-def test_get_client_thread_safe(monkeypatch):
+def test_get_client_thread_safe(monkeypatch: Any) -> None:
     fake_client = object()
     call_count = 0
 
-    def fake_get_openai_client():
+    def fake_get_openai_client() -> None:
         nonlocal call_count
         time.sleep(0.01)
         call_count += 1
@@ -24,7 +25,7 @@ def test_get_client_thread_safe(monkeypatch):
     monkeypatch.setattr(gpt_client, "_client", None)
     results = []
 
-    def worker():
+    def worker() -> None:
         results.append(gpt_client._get_client())
 
     threads = [threading.Thread(target=worker) for _ in range(10)]
@@ -38,8 +39,8 @@ def test_get_client_thread_safe(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_send_message_openaierror(monkeypatch, caplog):
-    def raise_error(**kwargs):
+async def test_send_message_openaierror(monkeypatch: Any, caplog: Any) -> None:
+    def raise_error(**kwargs: Any) -> None:
         raise OpenAIError("boom")
 
     fake_client = SimpleNamespace(
@@ -60,8 +61,8 @@ async def test_send_message_openaierror(monkeypatch, caplog):
     assert any("Failed to create message" in r.message for r in caplog.records)
 
 
-def test_create_thread_openaierror(monkeypatch, caplog):
-    def raise_error():
+def test_create_thread_openaierror(monkeypatch: Any, caplog: Any) -> None:
+    def raise_error() -> None:
         raise OpenAIError("boom")
 
     fake_client = SimpleNamespace(beta=SimpleNamespace(threads=SimpleNamespace(create=raise_error)))
@@ -76,11 +77,11 @@ def test_create_thread_openaierror(monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
-async def test_send_message_upload_error_keeps_file(tmp_path, monkeypatch):
+async def test_send_message_upload_error_keeps_file(tmp_path: Any, monkeypatch: Any) -> None:
     img = tmp_path / "img.jpg"
     img.write_bytes(b"data")
 
-    def raise_upload(*_, **__):
+    def raise_upload(*_: Any, **__: Any) -> None:
         raise OpenAIError("boom")
 
     fake_client = SimpleNamespace(files=SimpleNamespace(create=raise_upload))
@@ -93,16 +94,16 @@ async def test_send_message_upload_error_keeps_file(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_send_message_empty_string_preserved(tmp_path, monkeypatch):
+async def test_send_message_empty_string_preserved(tmp_path: Any, monkeypatch: Any) -> None:
     img = tmp_path / "img.jpg"
     img.write_bytes(b"data")
 
     captured = {}
 
-    def fake_files_create(file, purpose):
+    def fake_files_create(file: Any, purpose: Any) -> None:
         return SimpleNamespace(id="f1")
 
-    def fake_messages_create(*, thread_id, role, content):
+    def fake_messages_create(*, thread_id: Any, role: Any, content: Any) -> None:
         captured["content"] = content
 
     fake_client = SimpleNamespace(

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -5,6 +5,7 @@ import logging
 from types import SimpleNamespace
 
 import pytest
+from typing import Any
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -13,8 +14,8 @@ from services.api.app.diabetes import gpt_command_parser  # noqa: E402
 
 
 @pytest.mark.asyncio
-async def test_parse_command_timeout_non_blocking(monkeypatch) -> None:
-    def slow_create(*args, **kwargs):
+async def test_parse_command_timeout_non_blocking(monkeypatch: Any) -> None:
+    def slow_create(*args: Any, **kwargs: Any) -> None:
         time.sleep(1)
 
         class FakeResponse:
@@ -46,7 +47,7 @@ async def test_parse_command_timeout_non_blocking(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_parse_command_with_explanatory_text(monkeypatch) -> None:
+async def test_parse_command_with_explanatory_text(monkeypatch: Any) -> None:
     class FakeResponse:
         choices = [
             type(
@@ -68,7 +69,7 @@ async def test_parse_command_with_explanatory_text(monkeypatch) -> None:
             )
         ]
 
-    def create(*args, **kwargs):
+    def create(*args: Any, **kwargs: Any) -> None:
         return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
@@ -86,7 +87,7 @@ async def test_parse_command_with_explanatory_text(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_parse_command_with_array_response(monkeypatch) -> None:
+async def test_parse_command_with_array_response(monkeypatch: Any) -> None:
     class FakeResponse:
         choices = [
             type(
@@ -96,7 +97,7 @@ async def test_parse_command_with_array_response(monkeypatch) -> None:
             )
         ]
 
-    def create(*args, **kwargs):
+    def create(*args: Any, **kwargs: Any) -> None:
         return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
@@ -114,7 +115,7 @@ async def test_parse_command_with_array_response(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_parse_command_with_scalar_response(monkeypatch) -> None:
+async def test_parse_command_with_scalar_response(monkeypatch: Any) -> None:
     class FakeResponse:
         choices = [
             type(
@@ -124,7 +125,7 @@ async def test_parse_command_with_scalar_response(monkeypatch) -> None:
             )
         ]
 
-    def create(*args, **kwargs):
+    def create(*args: Any, **kwargs: Any) -> None:
         return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
@@ -142,7 +143,7 @@ async def test_parse_command_with_scalar_response(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_parse_command_with_invalid_schema(monkeypatch, caplog) -> None:
+async def test_parse_command_with_invalid_schema(monkeypatch: Any, caplog: Any) -> None:
     class FakeResponse:
         choices = [
             type(
@@ -156,7 +157,7 @@ async def test_parse_command_with_invalid_schema(monkeypatch, caplog) -> None:
             )
         ]
 
-    def create(*args, **kwargs):
+    def create(*args: Any, **kwargs: Any) -> None:
         return FakeResponse()
 
     fake_client = SimpleNamespace(
@@ -177,11 +178,11 @@ async def test_parse_command_with_invalid_schema(monkeypatch, caplog) -> None:
 
 
 @pytest.mark.asyncio
-async def test_parse_command_with_missing_content(monkeypatch, caplog) -> None:
+async def test_parse_command_with_missing_content(monkeypatch: Any, caplog: Any) -> None:
     class FakeResponse:
         choices = [type("Choice", (), {"message": type("Msg", (), {})()})]
 
-    def create(*args, **kwargs):
+    def create(*args: Any, **kwargs: Any) -> None:
         return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
@@ -201,7 +202,7 @@ async def test_parse_command_with_missing_content(monkeypatch, caplog) -> None:
 
 
 @pytest.mark.asyncio
-async def test_parse_command_with_non_string_content(monkeypatch, caplog) -> None:
+async def test_parse_command_with_non_string_content(monkeypatch: Any, caplog: Any) -> None:
     class FakeResponse:
         choices = [
             type(
@@ -211,7 +212,7 @@ async def test_parse_command_with_non_string_content(monkeypatch, caplog) -> Non
             )
         ]
 
-    def create(*args, **kwargs):
+    def create(*args: Any, **kwargs: Any) -> None:
         return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
@@ -231,7 +232,7 @@ async def test_parse_command_with_non_string_content(monkeypatch, caplog) -> Non
 
 
 @pytest.mark.asyncio
-async def test_parse_command_handles_unexpected_exception(monkeypatch, caplog) -> None:
+async def test_parse_command_handles_unexpected_exception(monkeypatch: Any, caplog: Any) -> None:
     def bad_client() -> None:
         raise RuntimeError("boom")
 
@@ -251,7 +252,7 @@ async def test_parse_command_handles_unexpected_exception(monkeypatch, caplog) -
         "ghp_" + "A1b2" * 9 + "Cd",
     ],
 )
-def test_sanitize_masks_api_like_tokens(token):
+def test_sanitize_masks_api_like_tokens(token: Any) -> None:
     text = f"before {token} after"
     assert (
         gpt_command_parser._sanitize_sensitive_data(text)
@@ -259,13 +260,13 @@ def test_sanitize_masks_api_like_tokens(token):
     )
 
 
-def test_sanitize_leaves_numeric_strings():
+def test_sanitize_leaves_numeric_strings() -> None:
     number = "1234567890" * 4 + "12"
     text = f"id {number}"
     assert gpt_command_parser._sanitize_sensitive_data(text) == text
 
 
-def test_extract_first_json_multiple_objects():
+def test_extract_first_json_multiple_objects() -> None:
     text = (
         '{"action":"add_entry","fields":{}} '
         '{"action":"delete_entry","fields":{}}'
@@ -276,13 +277,13 @@ def test_extract_first_json_multiple_objects():
     }
 
 
-def test_extract_first_json_malformed_input():
+def test_extract_first_json_malformed_input() -> None:
     text = '{"action":"add_entry","fields":{}'
     assert gpt_command_parser._extract_first_json(text) is None
 
 
 @pytest.mark.asyncio
-async def test_parse_command_with_multiple_jsons(monkeypatch) -> None:
+async def test_parse_command_with_multiple_jsons(monkeypatch: Any) -> None:
     class FakeResponse:
         choices = [
             type(
@@ -303,7 +304,7 @@ async def test_parse_command_with_multiple_jsons(monkeypatch) -> None:
             )
         ]
 
-    def create(*args, **kwargs):
+    def create(*args: Any, **kwargs: Any) -> None:
         return FakeResponse()
 
     fake_client = SimpleNamespace(
@@ -322,7 +323,7 @@ async def test_parse_command_with_multiple_jsons(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_parse_command_with_malformed_json(monkeypatch, caplog) -> None:
+async def test_parse_command_with_malformed_json(monkeypatch: Any, caplog: Any) -> None:
     class FakeResponse:
         choices = [
             type(
@@ -340,7 +341,7 @@ async def test_parse_command_with_malformed_json(monkeypatch, caplog) -> None:
             )
         ]
 
-    def create(*args, **kwargs):
+    def create(*args: Any, **kwargs: Any) -> None:
         return FakeResponse()
 
     fake_client = SimpleNamespace(

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -9,7 +9,7 @@ from telegram.ext import CallbackContext
 
 
 class DummyMessage:
-    def __init__(self):
+    def __init__(self) -> None:
         self.replies: list[tuple[str, dict[str, Any]]] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
@@ -17,7 +17,7 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str):
+    def __init__(self, data: str) -> None:
         self.data = data
         self.edited: list[str] = []
         self.edit_kwargs: list[dict[str, Any]] = []

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -16,7 +16,7 @@ from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
-    def __init__(self):
+    def __init__(self) -> None:
         self.texts: list[str] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
@@ -24,7 +24,7 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str):
+    def __init__(self, data: str) -> None:
         self.data = data
         self.edited = []
 
@@ -38,13 +38,13 @@ class DummyQuery:
 
 
 class DummyWebAppMessage(DummyMessage):
-    def __init__(self, data: str):
+    def __init__(self, data: str) -> None:
         super().__init__()
         self.web_app_data = SimpleNamespace(data=data)
 
 
 @pytest.mark.asyncio
-async def test_profile_command_no_local_session(monkeypatch) -> None:
+async def test_profile_command_no_local_session(monkeypatch: Any) -> None:
     """Profile command should not touch the local DB session."""
     import os
 
@@ -72,7 +72,7 @@ async def test_profile_command_no_local_session(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_callback_router_commit_failure(monkeypatch, caplog) -> None:
+async def test_callback_router_commit_failure(monkeypatch: Any, caplog: Any) -> None:
     import os
 
     os.environ["OPENAI_API_KEY"] = "test"
@@ -107,7 +107,7 @@ async def test_callback_router_commit_failure(monkeypatch, caplog) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_reminder_commit_failure(monkeypatch, caplog) -> None:
+async def test_add_reminder_commit_failure(monkeypatch: Any, caplog: Any) -> None:
     session = MagicMock()
     session.__enter__.return_value = session
     session.__exit__.return_value = None
@@ -142,7 +142,7 @@ async def test_add_reminder_commit_failure(monkeypatch, caplog) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reminder_webapp_save_commit_failure(monkeypatch, caplog) -> None:
+async def test_reminder_webapp_save_commit_failure(monkeypatch: Any, caplog: Any) -> None:
     session = MagicMock()
     session.__enter__.return_value = session
     session.__exit__.return_value = None
@@ -185,7 +185,7 @@ async def test_reminder_webapp_save_commit_failure(monkeypatch, caplog) -> None:
 
 
 @pytest.mark.asyncio
-async def test_delete_reminder_commit_failure(monkeypatch, caplog) -> None:
+async def test_delete_reminder_commit_failure(monkeypatch: Any, caplog: Any) -> None:
     session = MagicMock()
     session.__enter__.return_value = session
     session.__exit__.return_value = None
@@ -211,7 +211,7 @@ async def test_delete_reminder_commit_failure(monkeypatch, caplog) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reminder_job_commit_failure(monkeypatch, caplog) -> None:
+async def test_reminder_job_commit_failure(monkeypatch: Any, caplog: Any) -> None:
     session = MagicMock()
     session.__enter__.return_value = session
     session.__exit__.return_value = None
@@ -241,7 +241,7 @@ async def test_reminder_job_commit_failure(monkeypatch, caplog) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reminder_callback_commit_failure(monkeypatch, caplog) -> None:
+async def test_reminder_callback_commit_failure(monkeypatch: Any, caplog: Any) -> None:
     session = MagicMock()
     session.__enter__.return_value = session
     session.__exit__.return_value = None
@@ -254,7 +254,7 @@ async def test_reminder_callback_commit_failure(monkeypatch, caplog) -> None:
     monkeypatch.setattr(reminder_handlers, "SessionLocal", lambda: session)
     reminder_handlers.commit = commit
 
-    def failing_commit(sess):
+    def failing_commit(sess: Any) -> None:
         sess.rollback()
         return False
 
@@ -276,7 +276,7 @@ async def test_reminder_callback_commit_failure(monkeypatch, caplog) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reminder_action_cb_commit_failure(monkeypatch, caplog) -> None:
+async def test_reminder_action_cb_commit_failure(monkeypatch: Any, caplog: Any) -> None:
     session = MagicMock()
     session.__enter__.return_value = session
     session.__exit__.return_value = None

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -27,15 +27,15 @@ class DummyMessage(Message):
 async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) -> None:
     called = SimpleNamespace(flag=False)
 
-    async def fake_photo_handler(update, context) -> str:
+    async def fake_photo_handler(update: Any, context: Any) -> None:
         called.flag = True
         return "OK"
 
     class DummyFile:
-        async def download_to_drive(self, path) -> None:
+        async def download_to_drive(self, path: Any) -> None:
             self.path = path
 
-    async def fake_get_file(file_id: str) -> DummyFile:
+    async def fake_get_file(file_id: str) -> None:
         return DummyFile()
 
     dummy_bot = SimpleNamespace(get_file=fake_get_file)
@@ -65,7 +65,7 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
 async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> None:
     called = SimpleNamespace(flag=False)
 
-    async def fake_photo_handler(update, context) -> None:
+    async def fake_photo_handler(update: Any, context: Any) -> None:
         called.flag = True
 
     document = SimpleNamespace(
@@ -102,7 +102,7 @@ async def test_photo_handler_handles_typeerror() -> None:
 
 @pytest.mark.asyncio
 async def test_photo_handler_preserves_file(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
 ) -> None:
     monkeypatch.chdir(tmp_path)
 
@@ -117,10 +117,10 @@ async def test_photo_handler_preserves_file(
     update = make_update(message=message, effective_user=SimpleNamespace(id=1))
 
     class DummyFile:
-        async def download_to_drive(self, path) -> None:
+        async def download_to_drive(self, path: Any) -> None:
             Path(path).write_bytes(b"img")
 
-    async def fake_get_file(file_id: str) -> DummyFile:
+    async def fake_get_file(file_id: str) -> None:
         return DummyFile()
 
     dummy_bot = SimpleNamespace(get_file=fake_get_file)
@@ -128,7 +128,7 @@ async def test_photo_handler_preserves_file(
 
     call = {}
 
-    async def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs: Any) -> None:
         call.update(kwargs)
 
         class Run:
@@ -169,7 +169,7 @@ async def test_photo_handler_preserves_file(
 
 @pytest.mark.asyncio
 async def test_photo_then_freeform_calculates_dose(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
 ) -> None:
     """photo_handler + freeform_handler produce dose in reply and context."""
 
@@ -178,10 +178,10 @@ async def test_photo_then_freeform_calculates_dose(
         file_unique_id = "uid"
 
     class DummyFile:
-        async def download_to_drive(self, path) -> None:
+        async def download_to_drive(self, path: Any) -> None:
             Path(path).write_bytes(b"img")
 
-    async def fake_get_file(file_id: str) -> DummyFile:
+    async def fake_get_file(file_id: str) -> None:
         return DummyFile()
 
     monkeypatch.chdir(tmp_path)
@@ -192,7 +192,7 @@ async def test_photo_then_freeform_calculates_dose(
         thread_id = "tid"
         id = "runid"
 
-    async def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs: Any) -> None:
         return Run()
 
     class DummyClient:
@@ -221,13 +221,13 @@ async def test_photo_then_freeform_calculates_dose(
     await handlers.photo_handler(update_photo, context)
 
     class DummySession:
-        def __enter__(self) -> "DummySession":
+        def __enter__(self) -> None:
             return self
 
-        def __exit__(self, exc_type, exc, tb) -> None:
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
             pass
 
-        def get(self, model, user_id):
+        def get(self, model: Any, user_id: Any) -> None:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
     handlers.SessionLocal = lambda: DummySession()

--- a/tests/test_handlers_freeform_numbers.py
+++ b/tests/test_handlers_freeform_numbers.py
@@ -1,7 +1,7 @@
 import re
 
 
-def parse_values(text: str) -> dict[str, float]:
+def parse_values(text: str) -> None:
     parts = dict(
         re.findall(r"(\w+)\s*=\s*(-?\d+(?:[.,]\d+)?)(?=\s|$)", text)
     )
@@ -19,7 +19,7 @@ def parse_values(text: str) -> dict[str, float]:
     return result
 
 
-def test_parse_comma_and_negative_values():
+def test_parse_comma_and_negative_values() -> None:
     text = "carbs=10,5 dose=-1,5 xe=2 sugar=5,6"
     parsed = parse_values(text)
     assert parsed == {
@@ -30,7 +30,7 @@ def test_parse_comma_and_negative_values():
     }
 
 
-def test_parse_negative_numbers():
+def test_parse_negative_numbers() -> None:
     text = "carbs=-10.5 dose=-2 xe=-1,0 sugar=-4,2"
     parsed = parse_values(text)
     assert parsed == {
@@ -41,13 +41,13 @@ def test_parse_negative_numbers():
     }
 
 
-def test_parse_ignores_invalid_subtraction():
+def test_parse_ignores_invalid_subtraction() -> None:
     text = "xe=1-2 carbs=3"
     parsed = parse_values(text)
     assert parsed == {"carbs": 3.0}
 
 
-def test_parse_invalid_input_returns_empty():
+def test_parse_invalid_input_returns_empty() -> None:
     text = "xe=1-2"
     parsed = parse_values(text)
     assert parsed == {}

--- a/tests/test_handlers_freeform_pending.py
+++ b/tests/test_handlers_freeform_pending.py
@@ -10,7 +10,7 @@ import services.api.app.diabetes.handlers.dose_handlers as handlers
 
 
 class DummyMessage:
-    def __init__(self, text: str):
+    def __init__(self, text: str) -> None:
         self.text = text
         self.replies: list[tuple[str, dict[str, Any]]] = []
 
@@ -59,13 +59,13 @@ async def test_freeform_handler_adds_sugar_to_photo_entry() -> None:
         "photo_path": "photos/img.jpg",
     }
     class DummySession:
-        def __enter__(self) -> "DummySession":
+        def __enter__(self) -> None:
             return self
 
-        def __exit__(self, exc_type, exc, tb) -> None:
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
             pass
 
-        def get(self, model, user_id):
+        def get(self, model: Any, user_id: Any) -> None:
             return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
     handlers.SessionLocal = lambda: DummySession()

--- a/tests/test_handlers_freeform_units.py
+++ b/tests/test_handlers_freeform_units.py
@@ -9,7 +9,7 @@ import services.api.app.diabetes.handlers.dose_handlers as handlers
 
 
 class DummyMessage:
-    def __init__(self, text: str):
+    def __init__(self, text: str) -> None:
         self.text = text
         self.replies: list[tuple[str, dict[str, Any]]] = []
 
@@ -66,7 +66,7 @@ async def test_freeform_handler_guidance_on_valueerror(
         CallbackContext[Any, Any, Any, Any], SimpleNamespace(user_data={})
     )
 
-    def fake_smart_input(_):
+    def fake_smart_input(_: Any) -> None:
         raise ValueError("boom")
 
     monkeypatch.setattr(handlers, "smart_input", fake_smart_input)

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -16,7 +16,7 @@ from services.api.app.diabetes.services.db import Base, User, Entry
 
 
 class DummyMessage:
-    def __init__(self, text: str = "", chat_id: int = 1, message_id: int = 1):
+    def __init__(self, text: str = "", chat_id: int = 1, message_id: int = 1) -> None:
         self.text = text
         self.chat_id = chat_id
         self.message_id = message_id
@@ -27,7 +27,7 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str, message: DummyMessage | None = None):
+    def __init__(self, data: str, message: DummyMessage | None = None) -> None:
         self.data = data
         self.message = message or DummyMessage()
         self.markups = []

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -42,10 +42,10 @@ class DummySession:
     def __init__(self) -> None:
         self.added = []
 
-    def __enter__(self) -> "DummySession":
+    def __enter__(self) -> None:
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         pass
 
     def add(self, entry: Any) -> None:
@@ -54,7 +54,7 @@ class DummySession:
     def commit(self) -> None:
         pass
 
-    def get(self, model, user_id) -> Any:
+    def get(self, model: Any, user_id: Any) -> None:
         return SimpleNamespace(icr=10.0, cf=1.0, target_bg=6.0)
 
 
@@ -63,9 +63,9 @@ session = DummySession()
 
 @pytest.mark.asyncio
 async def test_photo_flow_saves_entry(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
 ) -> None:
-    async def fake_parse_command(text: str) -> dict[str, Any]:
+    async def fake_parse_command(text: str) -> None:
         return {"action": "add_entry", "fields": {}, "entry_date": None, "time": None}
 
     monkeypatch.setattr(dose_handlers, "parse_command", fake_parse_command)
@@ -84,7 +84,7 @@ async def test_photo_flow_saves_entry(
 
     monkeypatch.chdir(tmp_path)
 
-    async def fake_get_file(file_id: str) -> Any:
+    async def fake_get_file(file_id: str) -> None:
         class File:
             async def download_to_drive(self, path: str) -> None:
                 Path(path).write_bytes(b"img")
@@ -98,7 +98,7 @@ async def test_photo_flow_saves_entry(
         thread_id = "tid"
         id = "runid"
 
-    async def fake_send_message(**kwargs: Any) -> Run:
+    async def fake_send_message(**kwargs: Any) -> None:
         return Run()
 
     class DummyClient:

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -10,6 +10,7 @@ from services.api.app.diabetes.utils.ui import menu_keyboard
 from services.api.app.diabetes.services.db import Base, User, Profile
 from tests.helpers import make_context, make_update
 from tests.telegram_stubs import Message, User as TgUser
+from typing import Any
 
 
 @pytest.mark.parametrize(
@@ -23,7 +24,7 @@ from tests.telegram_stubs import Message, User as TgUser
     ],
 )
 @pytest.mark.asyncio
-async def test_profile_command_and_view(monkeypatch, args, expected_icr, expected_cf, expected_target, expected_low, expected_high) -> None:
+async def test_profile_command_and_view(monkeypatch: Any, args: Any, expected_icr: Any, expected_cf: Any, expected_target: Any, expected_low: Any, expected_high: Any) -> None:
     import os
     os.environ["OPENAI_API_KEY"] = "test"
     os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
@@ -81,7 +82,7 @@ async def test_profile_command_and_view(monkeypatch, args, expected_icr, expecte
     ],
 )
 @pytest.mark.asyncio
-async def test_profile_command_invalid_values(monkeypatch, args) -> None:
+async def test_profile_command_invalid_values(monkeypatch: Any, args: Any) -> None:
     import os
 
     os.environ["OPENAI_API_KEY"] = "test"
@@ -106,7 +107,7 @@ async def test_profile_command_invalid_values(monkeypatch, args) -> None:
 
 
 @pytest.mark.asyncio
-async def test_profile_command_help_and_dialog(monkeypatch) -> None:
+async def test_profile_command_help_and_dialog(monkeypatch: Any) -> None:
     import os
 
     os.environ["OPENAI_API_KEY"] = "test"
@@ -133,7 +134,7 @@ async def test_profile_command_help_and_dialog(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_profile_view_preserves_user_data(monkeypatch) -> None:
+async def test_profile_view_preserves_user_data(monkeypatch: Any) -> None:
     import os
 
     os.environ["OPENAI_API_KEY"] = "test"
@@ -164,7 +165,7 @@ async def test_profile_view_preserves_user_data(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_profile_view_missing_profile_shows_webapp_button(monkeypatch) -> None:
+async def test_profile_view_missing_profile_shows_webapp_button(monkeypatch: Any) -> None:
     from urllib.parse import urlparse
     from services.api.app.config import settings as config_settings
     from services.api.app.diabetes.handlers import profile as handlers

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -13,7 +13,7 @@ from services.api.app.diabetes.utils.ui import sugar_keyboard
 
 
 class DummyMessage:
-    def __init__(self):
+    def __init__(self) -> None:
         self.texts: list[str] = []
         self.kwargs: list[dict[str, Any]] = []
 

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -10,7 +10,7 @@ from tests.helpers import make_update
 
 
 class DummyMessage:
-    def __init__(self, text: str = ""):
+    def __init__(self, text: str = "") -> None:
         self.text = text
         self.replies: list[tuple[str, dict[str, Any]]] = []
 
@@ -19,7 +19,7 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str):
+    def __init__(self, data: str) -> None:
         self.data = data
         self.edited: list[str] = []
 
@@ -66,7 +66,7 @@ async def test_report_request_and_custom_flow(
     called = {}
 
     async def dummy_send_report(
-        update, context, date_from, period_label, query=None
+        update: Any, context: Any, date_from: Any, period_label: Any, query: Any=None
     ) -> None:
         called["called"] = True
         expected = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
@@ -99,7 +99,7 @@ async def test_report_period_callback_week(
     called: dict[str, dt.datetime | str] = {}
 
     async def dummy_send_report(
-        update, context, date_from, period_label, query=None
+        update: Any, context: Any, date_from: Any, period_label: Any, query: Any=None
     ) -> None:
         called["date_from"] = date_from
         called["period_label"] = period_label
@@ -108,7 +108,7 @@ async def test_report_period_callback_week(
 
     class DummyDateTime(dt.datetime):
         @classmethod
-        def now(cls, tz: dt.tzinfo | None = None) -> "DummyDateTime":
+        def now(cls, tz: dt.tzinfo | None = None) -> None:
             return fixed_now
 
     fixed_now = DummyDateTime(2024, 1, 10, tzinfo=dt.timezone.utc)

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -8,7 +8,7 @@ from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
-    def __init__(self, text: str | None = None, photo: list[Any] | None = None):
+    def __init__(self, text: str | None = None, photo: list[Any] | None = None) -> None:
         self.text = text
         self.photo = photo
         self.replies: list[tuple[str, dict[str, Any]]] = []
@@ -23,10 +23,10 @@ class DummyPhoto:
 
 
 @pytest.mark.asyncio
-async def test_photo_prompt_includes_dish_name(monkeypatch, tmp_path) -> None:
+async def test_photo_prompt_includes_dish_name(monkeypatch: Any, tmp_path: Any) -> None:
     monkeypatch.chdir(tmp_path)
 
-    async def fake_get_file(file_id: str) -> Any:
+    async def fake_get_file(file_id: str) -> None:
         class File:
             async def download_to_drive(self, path: str) -> None:
                 Path(path).write_bytes(b"img")
@@ -48,7 +48,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch, tmp_path) -> None:
         thread_id = "tid"
         id = "runid"
 
-    async def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs: Any) -> None:
         captured["content"] = kwargs["content"]
         return Run()
 

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -6,7 +6,7 @@ from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
-    def __init__(self):
+    def __init__(self) -> None:
         self.replies: list[str] = []
         self.kwargs: list[dict[str, Any]] = []
 

--- a/tests/test_history_view_async.py
+++ b/tests/test_history_view_async.py
@@ -15,29 +15,29 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_history_view_does_not_block_event_loop(monkeypatch) -> None:
+async def test_history_view_does_not_block_event_loop(monkeypatch: Any) -> None:
     """The database query is executed in a thread and doesn't block."""
 
-    def slow_session():
+    def slow_session() -> None:
         class FakeSession:
-            def __enter__(self):
+            def __enter__(self) -> None:
                 return self
 
-            def __exit__(self, exc_type, exc, tb):
+            def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
                 pass
 
-            def query(self, *args, **kwargs):
+            def query(self, *args: Any, **kwargs: Any) -> None:
                 class Q:
-                    def filter(self, *args, **kwargs):
+                    def filter(self, *args: Any, **kwargs: Any) -> None:
                         return self
 
-                    def order_by(self, *args, **kwargs):
+                    def order_by(self, *args: Any, **kwargs: Any) -> None:
                         return self
 
-                    def limit(self, *args, **kwargs):
+                    def limit(self, *args: Any, **kwargs: Any) -> None:
                         return self
 
-                    def all(self):
+                    def all(self) -> None:
                         time.sleep(0.5)  # Blocking call executed in to_thread
                         return []
 

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -13,7 +13,7 @@ from services.api.app.diabetes.handlers import dose_handlers
 
 
 class DummyMessage:
-    def __init__(self, text: str = ""):
+    def __init__(self, text: str = "") -> None:
         self.text = text
         self.replies: list[str] = []
         self.kwargs: list[dict[str, Any]] = []
@@ -23,7 +23,7 @@ class DummyMessage:
         self.kwargs.append(kwargs)
 
 
-def _get_menu_handler(fallbacks):
+def _get_menu_handler(fallbacks: Any) -> None:
     return next(
         h
         for h in fallbacks

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -1,8 +1,9 @@
 import importlib
 from urllib.parse import urlparse
+from typing import Any
 
 
-def test_menu_keyboard_webapp_urls(monkeypatch):
+def test_menu_keyboard_webapp_urls(monkeypatch: Any) -> None:
     """Menu buttons should open webapp paths for profile and reminders."""
     monkeypatch.setenv("WEBAPP_URL", "https://example.com")
 

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -29,7 +29,7 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_onboarding_demo_photo_missing(monkeypatch, caplog) -> None:
+async def test_onboarding_demo_photo_missing(monkeypatch: Any, caplog: Any) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 
@@ -63,7 +63,7 @@ async def test_onboarding_demo_photo_missing(monkeypatch, caplog) -> None:
 
     orig_open = pathlib.Path.open
 
-    def fake_open(self, *args: Any, **kwargs: Any) -> Any:
+    def fake_open(self, *args: Any, **kwargs: Any) -> None:
         if self == onboarding.DEMO_PHOTO_PATH:
             raise OSError("missing")
         return orig_open(self, *args, **kwargs)

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -13,7 +13,7 @@ from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
-    def __init__(self):
+    def __init__(self) -> None:
         self.texts: list[str] = []
         self.photos: list[tuple[Any, str | None]] = []
         self.polls: list[tuple[str, list[str]]] = []
@@ -31,7 +31,7 @@ class DummyMessage:
 
     async def reply_poll(
         self, question: str, options: list[str], **kwargs: Any
-    ) -> SimpleNamespace:
+    ) -> None:
         self.polls.append((question, options))
         self.markups.append(kwargs.get("reply_markup"))
         return SimpleNamespace(poll=SimpleNamespace(id="p1"))
@@ -41,7 +41,7 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, message, data):
+    def __init__(self, message: Any, data: Any) -> None:
         self.message = message
         self.data = data
 
@@ -50,7 +50,7 @@ class DummyQuery:
 
 
 @pytest.mark.asyncio
-async def test_onboarding_flow(monkeypatch) -> None:
+async def test_onboarding_flow(monkeypatch: Any) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 

--- a/tests/test_parse_time_interval.py
+++ b/tests/test_parse_time_interval.py
@@ -3,13 +3,14 @@ from datetime import time, timedelta
 import pytest
 
 from services.api.app.diabetes.utils.helpers import INVALID_TIME_MSG, parse_time_interval
+from typing import Any
 
 
-def test_parse_time_zero_padded():
+def test_parse_time_zero_padded() -> None:
     assert parse_time_interval("09:30") == time(9, 30)
 
 
-def test_parse_time_single_digit_hour():
+def test_parse_time_single_digit_hour() -> None:
     assert parse_time_interval("9:30") == time(9, 30)
 
 
@@ -20,7 +21,7 @@ def test_parse_time_single_digit_hour():
         ("6:00", time(6, 0)),
     ],
 )
-def test_parse_time_success(text, expected):
+def test_parse_time_success(text: Any, expected: Any) -> None:
     assert parse_time_interval(text) == expected
 
 
@@ -31,7 +32,7 @@ def test_parse_time_success(text, expected):
         ("3d", timedelta(days=3)),
     ],
 )
-def test_parse_interval_success(text, expected):
+def test_parse_interval_success(text: Any, expected: Any) -> None:
     assert parse_time_interval(text) == expected
 
 
@@ -39,7 +40,7 @@ def test_parse_interval_success(text, expected):
     "value",
     ["", "25:00", "5x", "1:60", "2h30", "3 d"],
 )
-def test_parse_time_invalid(value):
+def test_parse_time_invalid(value: Any) -> None:
     with pytest.raises(ValueError) as exc:
         parse_time_interval(value)
     assert str(exc.value) == INVALID_TIME_MSG

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -18,7 +18,7 @@ from services.api.app.diabetes.handlers import (
 )
 
 
-def _find_handler(fallbacks, regex: str) -> MessageHandler:
+def _find_handler(fallbacks: Any, regex: str) -> None:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)
@@ -39,7 +39,7 @@ class DummyMessage:
         self.kwargs.append(kwargs)
 
 
-async def _exercise(handler) -> None:
+async def _exercise(handler: Any) -> None:
     message = DummyMessage("📷 Фото еды")
     update = make_update(message=message, effective_user=SimpleNamespace(id=1))
     context = cast(

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import sessionmaker
 
 
 class DummyMessage:
-    def __init__(self, text: str = ""):
+    def __init__(self, text: str = "") -> None:
         self.text = text
         self.replies: list[str] = []
         self.kwargs: list[dict[str, Any]] = []
@@ -26,7 +26,7 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_profile_input_not_logged_as_sugar(monkeypatch) -> None:
+async def test_profile_input_not_logged_as_sugar(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -15,7 +15,7 @@ from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
-    def __init__(self):
+    def __init__(self) -> None:
         self.texts: list[str] = []
         self.markups: list[Any] = []
 
@@ -25,7 +25,7 @@ class DummyMessage:
 
 
 class DummyQuery:
-    def __init__(self, data: str):
+    def __init__(self, data: str) -> None:
         self.data = data
         self.edits: list[tuple[str, dict[str, Any]]] = []
         self.message = DummyMessage()
@@ -38,7 +38,7 @@ class DummyQuery:
 
 
 @pytest.mark.asyncio
-async def test_profile_view_has_security_button(monkeypatch) -> None:
+async def test_profile_view_has_security_button(monkeypatch: Any) -> None:
     dummy_profile = SimpleNamespace(icr=10, cf=2, target=6, low=4, high=9)
     dummy_api = SimpleNamespace(profiles_get=lambda telegram_id: dummy_profile)
     monkeypatch.setattr(
@@ -67,7 +67,7 @@ async def test_profile_view_has_security_button(monkeypatch) -> None:
     ],
 )
 @pytest.mark.asyncio
-async def test_profile_security_threshold_changes(monkeypatch, action, expected_low, expected_high) -> None:
+async def test_profile_security_threshold_changes(monkeypatch: Any, action: Any, expected_low: Any, expected_high: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -92,7 +92,7 @@ async def test_profile_security_threshold_changes(monkeypatch, action, expected_
 
     calls = []
 
-    async def fake_eval(user_id, sugar, job_queue) -> None:
+    async def fake_eval(user_id: Any, sugar: Any, job_queue: Any) -> None:
         calls.append((user_id, sugar, job_queue))
 
     monkeypatch.setattr(handlers, "evaluate_sugar", fake_eval)
@@ -112,7 +112,7 @@ async def test_profile_security_threshold_changes(monkeypatch, action, expected_
 
 
 @pytest.mark.asyncio
-async def test_profile_security_toggle_sos_alerts(monkeypatch) -> None:
+async def test_profile_security_toggle_sos_alerts(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -137,7 +137,7 @@ async def test_profile_security_toggle_sos_alerts(monkeypatch) -> None:
 
     calls = []
 
-    async def fake_eval(user_id, sugar, job_queue) -> None:
+    async def fake_eval(user_id: Any, sugar: Any, job_queue: Any) -> None:
         calls.append((user_id, sugar, job_queue))
 
     monkeypatch.setattr(handlers, "evaluate_sugar", fake_eval)
@@ -156,7 +156,7 @@ async def test_profile_security_toggle_sos_alerts(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_profile_security_shows_reminders(monkeypatch) -> None:
+async def test_profile_security_shows_reminders(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -190,7 +190,7 @@ async def test_profile_security_shows_reminders(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_profile_security_add_delete_calls_handlers(monkeypatch) -> None:
+async def test_profile_security_add_delete_calls_handlers(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -204,7 +204,7 @@ async def test_profile_security_add_delete_calls_handlers(monkeypatch) -> None:
 
     called = {"del": False}
 
-    async def fake_del(update, context) -> None:
+    async def fake_del(update: Any, context: Any) -> None:
         called["del"] = True
 
     monkeypatch.setattr(reminder_handlers, "delete_reminder", fake_del)
@@ -225,7 +225,7 @@ async def test_profile_security_add_delete_calls_handlers(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_profile_security_sos_contact_calls_handler(monkeypatch) -> None:
+async def test_profile_security_sos_contact_calls_handler(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -239,7 +239,7 @@ async def test_profile_security_sos_contact_calls_handler(monkeypatch) -> None:
 
     called = False
 
-    async def fake_sos(update, context) -> None:
+    async def fake_sos(update: Any, context: Any) -> None:
         nonlocal called
         called = True
 

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -3,9 +3,10 @@ from fastapi import HTTPException
 
 from services.api.app.schemas.profile import ProfileSchema
 from services.api.app.services.profile import _validate_profile
+from typing import Any
 
 
-def test_validate_profile_allows_target_between_limits():
+def test_validate_profile_allows_target_between_limits() -> None:
     data = ProfileSchema(
         telegram_id=1,
         icr=1.0,
@@ -18,7 +19,7 @@ def test_validate_profile_allows_target_between_limits():
 
 
 @pytest.mark.parametrize("target", [3.0, 8.0])
-def test_validate_profile_rejects_target_outside_limits(target):
+def test_validate_profile_rejects_target_outside_limits(target: Any) -> None:
     data = ProfileSchema(
         telegram_id=1,
         icr=1.0,

--- a/tests/test_quick_input_help_button.py
+++ b/tests/test_quick_input_help_button.py
@@ -6,7 +6,7 @@ from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
-    def __init__(self, text: str = ""):
+    def __init__(self, text: str = "") -> None:
         self.text = text
         self.replies: list[str] = []
         self.kwargs: list[dict[str, Any]] = []

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -13,9 +13,10 @@ from services.api.app.diabetes.handlers.registration import register_handlers
 from services.api.app.diabetes.handlers.router import callback_router
 from services.api.app.diabetes.handlers.onboarding_handlers import start_command
 from services.api.app.diabetes.handlers import security_handlers, reminder_handlers
+from typing import Any
 
 
-def test_register_handlers_attaches_expected_handlers(monkeypatch):
+def test_register_handlers_attaches_expected_handlers(monkeypatch: Any) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401

--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -13,7 +13,7 @@ from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
-    def __init__(self, data: str):
+    def __init__(self, data: str) -> None:
         self.web_app_data = SimpleNamespace(data=data)
         self.replies: list[str] = []
 
@@ -22,17 +22,17 @@ class DummyMessage:
 
 
 class DummyJobQueue:
-    def run_daily(self, *a, **k):
+    def run_daily(self, *a: Any, **k: Any) -> None:
         pass
 
-    def run_repeating(self, *a, **k):
+    def run_repeating(self, *a: Any, **k: Any) -> None:
         pass
 
-    def get_jobs_by_name(self, name):
+    def get_jobs_by_name(self, name: Any) -> None:
         return []
 
 
-def _setup_db():
+def _setup_db() -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/tests/test_reminder_limit_free_vs_pro.py
+++ b/tests/test_reminder_limit_free_vs_pro.py
@@ -12,7 +12,7 @@ from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
-    def __init__(self):
+    def __init__(self) -> None:
         self.web_app_data = SimpleNamespace()
         self.replies: list[str] = []
 
@@ -22,7 +22,7 @@ class DummyMessage:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("plan, limit", [("free", 5), ("pro", 10)])
-async def test_reminder_limit_free_vs_pro(plan, limit, monkeypatch) -> None:
+async def test_reminder_limit_free_vs_pro(plan: Any, limit: Any, monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -18,7 +18,7 @@ from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
-    def __init__(self, text: str | None = None):
+    def __init__(self, text: str | None = None) -> None:
         self.text = text
         self.texts: list[str] = []
         self.edited: tuple[str, dict[str, Any]] | None = None
@@ -60,35 +60,35 @@ class DummyBot:
 
 
 class DummyJob:
-    def __init__(self, callback, data, name, time=None):
+    def __init__(self, callback: Any, data: Any, name: Any, time: Any=None) -> None:
         self.callback = callback
         self.data = data
         self.name = name
         self.time = time
         self.removed = False
 
-    def schedule_removal(self):
+    def schedule_removal(self) -> None:
         self.removed = True
 
 
 class DummyJobQueue:
-    def __init__(self):
+    def __init__(self) -> None:
         self.jobs = []
 
-    def run_daily(self, callback, time, data=None, name=None):
+    def run_daily(self, callback: Any, time: Any, data: Any=None, name: Any=None) -> None:
         self.jobs.append(DummyJob(callback, data, name, time))
 
-    def run_repeating(self, callback, interval, data=None, name=None):
+    def run_repeating(self, callback: Any, interval: Any, data: Any=None, name: Any=None) -> None:
         self.jobs.append(DummyJob(callback, data, name))
 
-    def run_once(self, callback, when, data=None, name=None):
+    def run_once(self, callback: Any, when: Any, data: Any=None, name: Any=None) -> None:
         self.jobs.append(DummyJob(callback, data, name))
 
-    def get_jobs_by_name(self, name):
+    def get_jobs_by_name(self, name: Any) -> None:
         return [j for j in self.jobs if j.name == name]
 
 
-def test_schedule_reminder_replaces_existing_job():
+def test_schedule_reminder_replaces_existing_job() -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -110,12 +110,12 @@ def test_schedule_reminder_replaces_existing_job():
     assert active_jobs[0].time.tzinfo.key == "Europe/Moscow"
 
 
-def test_schedule_with_next_interval(monkeypatch):
+def test_schedule_with_next_interval(monkeypatch: Any) -> None:
     now = datetime(2024, 1, 1, 10, 0)
 
     class DummyDatetime(datetime):
         @classmethod
-        def now(cls):  # type: ignore[override]
+        def now(cls) -> None:  # type: ignore[override]
             return now
 
     monkeypatch.setattr(handlers, "datetime", DummyDatetime)
@@ -126,7 +126,7 @@ def test_schedule_with_next_interval(monkeypatch):
     assert schedule == "каждые 2 ч (next 12:00)"
 
 
-def test_schedule_with_next_invalid_timezone_logs_warning(caplog):
+def test_schedule_with_next_invalid_timezone_logs_warning(caplog: Any) -> None:
     user = User(telegram_id=1, thread_id="t", timezone="Invalid/Zone")
     rem = Reminder(telegram_id=1, type="sugar", time="08:00", is_enabled=True, user=user)
     with caplog.at_level(logging.WARNING):
@@ -135,7 +135,7 @@ def test_schedule_with_next_invalid_timezone_logs_warning(caplog):
     assert any("Invalid timezone" in r.message for r in caplog.records)
 
 
-def test_schedule_reminder_invalid_timezone_logs_warning(caplog):
+def test_schedule_reminder_invalid_timezone_logs_warning(caplog: Any) -> None:
     user = User(telegram_id=1, thread_id="t", timezone="Bad/Zone")
     rem = Reminder(id=1, telegram_id=1, type="sugar", time="08:00", is_enabled=True, user=user)
     job_queue = DummyJobQueue()
@@ -146,7 +146,7 @@ def test_schedule_reminder_invalid_timezone_logs_warning(caplog):
     assert any("Invalid timezone" in r.message for r in caplog.records)
 
 
-def test_render_reminders_formatting(monkeypatch):
+def test_render_reminders_formatting(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -193,7 +193,7 @@ def test_render_reminders_formatting(monkeypatch):
     assert btn.web_app and btn.web_app.url.endswith("/reminders")
 
 
-def test_render_reminders_no_webapp(monkeypatch):
+def test_render_reminders_no_webapp(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -212,7 +212,7 @@ def test_render_reminders_no_webapp(monkeypatch):
     assert all(btn.web_app is None for btn in markup.inline_keyboard[0])
 
 
-def test_render_reminders_no_entries_no_webapp(monkeypatch):
+def test_render_reminders_no_entries_no_webapp(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -228,7 +228,7 @@ def test_render_reminders_no_entries_no_webapp(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_reminders_list_no_keyboard(monkeypatch) -> None:
+async def test_reminders_list_no_keyboard(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -255,7 +255,7 @@ async def test_reminders_list_no_keyboard(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_toggle_reminder_cb(monkeypatch) -> None:
+async def test_toggle_reminder_cb(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -286,7 +286,7 @@ async def test_toggle_reminder_cb(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_delete_reminder_cb(monkeypatch) -> None:
+async def test_delete_reminder_cb(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -315,7 +315,7 @@ async def test_delete_reminder_cb(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_edit_reminder(monkeypatch) -> None:
+async def test_edit_reminder(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -349,7 +349,7 @@ async def test_edit_reminder(monkeypatch) -> None:
     assert jobs[1].removed is False
 
 @pytest.mark.asyncio
-async def test_trigger_job_logs(monkeypatch) -> None:
+async def test_trigger_job_logs(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -388,7 +388,7 @@ async def test_trigger_job_logs(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_callback(monkeypatch) -> None:
+async def test_cancel_callback(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -413,7 +413,7 @@ async def test_cancel_callback(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reminder_callback_foreign_rid(monkeypatch) -> None:
+async def test_reminder_callback_foreign_rid(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -6,7 +6,7 @@ import services.api.app.diabetes.handlers.registration as handlers
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
 
-def test_reminders_button_matches_regex():
+def test_reminders_button_matches_regex() -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401

--- a/tests/test_render_entry.py
+++ b/tests/test_render_entry.py
@@ -2,9 +2,10 @@ import datetime
 from types import SimpleNamespace
 
 from services.api.app.diabetes.handlers.reporting_handlers import render_entry
+from typing import Any
 
 
-def make_entry(**kwargs):
+def make_entry(**kwargs: Any) -> None:
     defaults = dict(
         event_time=datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
         sugar_before=5.5,
@@ -16,26 +17,26 @@ def make_entry(**kwargs):
     return SimpleNamespace(**defaults)
 
 
-def test_render_entry_with_xe_and_carbs():
+def test_render_entry_with_xe_and_carbs() -> None:
     entry = make_entry(carbs_g=50, xe=4.1)
     text = render_entry(entry)
     assert "🍞 Углеводы: <b>50 г (4.1 ХЕ)</b>" in text
 
 
-def test_render_entry_with_xe_only():
+def test_render_entry_with_xe_only() -> None:
     entry = make_entry(carbs_g=None, xe=3.0)
     text = render_entry(entry)
     assert "🍞 Углеводы: <b>3.0 ХЕ</b>" in text
 
 
-def test_render_entry_without_xe():
+def test_render_entry_without_xe() -> None:
     entry = make_entry(carbs_g=30, xe=None)
     text = render_entry(entry)
     assert "🍞 Углеводы: <b>30 г</b>" in text
     assert "ХЕ" not in text
 
 
-def test_render_entry_escapes_html():
+def test_render_entry_escapes_html() -> None:
     entry = make_entry(dose="<script>")
     text = render_entry(entry)
     assert "&lt;script&gt;" in text

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -20,7 +20,7 @@ from services.api.app.diabetes.services.reporting import make_sugar_plot, genera
 
 
 class DummyEntry:
-    def __init__(self, event_time, sugar_before, carbs_g, xe, dose):
+    def __init__(self, event_time: Any, sugar_before: Any, carbs_g: Any, xe: Any, dose: Any) -> None:
         self.event_time = event_time
         self.sugar_before = sugar_before
         self.carbs_g = carbs_g
@@ -28,7 +28,7 @@ class DummyEntry:
         self.dose = dose
 
 
-def test_make_sugar_plot():
+def test_make_sugar_plot() -> None:
     entries = [
         DummyEntry(
             datetime.datetime(2025, 7, 1, 9, tzinfo=datetime.timezone.utc),
@@ -51,7 +51,7 @@ def test_make_sugar_plot():
     assert len(buf.read()) > 1000  # есть содержимое
 
 
-def test_make_sugar_plot_sorts_entries(monkeypatch):
+def test_make_sugar_plot_sorts_entries(monkeypatch: Any) -> None:
     entries = [
         DummyEntry(
             datetime.datetime(2025, 7, 1, 14, tzinfo=datetime.timezone.utc),
@@ -70,7 +70,7 @@ def test_make_sugar_plot_sorts_entries(monkeypatch):
     ]
     captured = {}
 
-    def fake_plot(x, y, **kwargs):
+    def fake_plot(x: Any, y: Any, **kwargs: Any) -> None:
         captured["x"] = x
         captured["y"] = y
 
@@ -84,7 +84,7 @@ def test_make_sugar_plot_sorts_entries(monkeypatch):
     assert captured["y"] == [7.0, 9.0]
 
 
-def test_make_sugar_plot_no_data():
+def test_make_sugar_plot_no_data() -> None:
     entries = [
         DummyEntry(
             datetime.datetime(2025, 7, 1, 9, tzinfo=datetime.timezone.utc),
@@ -100,7 +100,7 @@ def test_make_sugar_plot_no_data():
     assert len(buf.read()) > 1000
 
 
-def test_generate_pdf_report():
+def test_generate_pdf_report() -> None:
     entries = [
         DummyEntry(
             datetime.datetime(2025, 7, 1, 9, tzinfo=datetime.timezone.utc),
@@ -126,7 +126,7 @@ def test_generate_pdf_report():
 
 
 @pytest.mark.parametrize("block", ["summary_lines", "errors", "day_lines"])
-def test_generate_pdf_report_page_breaks(block):
+def test_generate_pdf_report_page_breaks(block: Any) -> None:
     long_lines = [f"line {i}" for i in range(100)]
     kwargs = {"summary_lines": [], "errors": [], "day_lines": []}
     kwargs[block] = long_lines
@@ -137,7 +137,7 @@ def test_generate_pdf_report_page_breaks(block):
 
 
 @pytest.mark.asyncio
-async def test_send_report_uses_gpt(monkeypatch) -> None:
+async def test_send_report_uses_gpt(monkeypatch: Any) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst")
     os.environ.setdefault("DB_PASSWORD", "pwd")
@@ -168,7 +168,7 @@ async def test_send_report_uses_gpt(monkeypatch) -> None:
         session.commit()
 
     class DummyMessage:
-        def __init__(self):
+        def __init__(self) -> None:
             self.docs: list[Any] = []
 
         async def reply_text(self, *args: Any, **kwargs: Any) -> None:
@@ -191,7 +191,7 @@ async def test_send_report_uses_gpt(monkeypatch) -> None:
         thread_id = "tid"
         id = "rid"
 
-    async def fake_send_message(**kwargs):
+    async def fake_send_message(**kwargs: Any) -> None:
         return Run()
 
     class DummyClient:

--- a/tests/test_run_db.py
+++ b/tests/test_run_db.py
@@ -10,20 +10,20 @@ from services.api.app.diabetes.services.db import run_db
 
 
 @pytest.mark.asyncio
-async def test_run_db_sqlite_in_memory(monkeypatch) -> None:
+async def test_run_db_sqlite_in_memory(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Session = sessionmaker(bind=engine)
 
     called = False
 
-    async def fake_to_thread(fn, *args: Any, **kwargs: Any) -> Any:
+    async def fake_to_thread(fn: Any, *args: Any, **kwargs: Any) -> None:
         nonlocal called
         called = True
         return fn(*args, **kwargs)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
 
-    def work(session):
+    def work(session: Any) -> None:
         return 42
 
     result = await run_db(work, sessionmaker=Session)
@@ -32,32 +32,32 @@ async def test_run_db_sqlite_in_memory(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_db_postgres(monkeypatch) -> None:
+async def test_run_db_postgres(monkeypatch: Any) -> None:
     dummy_engine = SimpleNamespace(url=SimpleNamespace(drivername="postgresql", database="db"))
 
     class DummySession:
-        def get_bind(self):
+        def get_bind(self) -> None:
             return dummy_engine
 
-        def __enter__(self) -> "DummySession":
+        def __enter__(self) -> None:
             return self
 
-        def __exit__(self, exc_type, exc, tb) -> None:
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
             pass
 
-    def dummy_sessionmaker():
+    def dummy_sessionmaker() -> None:
         return DummySession()
 
     called = False
 
-    async def fake_to_thread(fn, *args: Any, **kwargs: Any) -> Any:
+    async def fake_to_thread(fn: Any, *args: Any, **kwargs: Any) -> None:
         nonlocal called
         called = True
         return fn(*args, **kwargs)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
 
-    def work(session):
+    def work(session: Any) -> None:
         return 42
 
     result = await run_db(work, sessionmaker=dummy_sessionmaker)
@@ -69,7 +69,7 @@ async def test_run_db_postgres(monkeypatch) -> None:
 async def test_run_db_without_engine() -> None:
     Session = sessionmaker()
 
-    def work(session):
+    def work(session: Any) -> None:
         return 42
 
     with pytest.raises(RuntimeError, match="init_db"):

--- a/tests/test_security_handlers.py
+++ b/tests/test_security_handlers.py
@@ -6,7 +6,7 @@ from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
-    def __init__(self):
+    def __init__(self) -> None:
         self.replies: list[str] = []
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:

--- a/tests/test_smart_input.py
+++ b/tests/test_smart_input.py
@@ -1,6 +1,7 @@
 import pytest
 
 from services.api.app.diabetes.utils.functions import smart_input
+from typing import Any
 
 
 @pytest.mark.parametrize(
@@ -12,11 +13,11 @@ from services.api.app.diabetes.utils.functions import smart_input
         ("Xe 1.5 dose 2", {"sugar": None, "xe": 1.5, "dose": 2.0}),
     ],
 )
-def test_smart_input_valid_cases(message, expected):
+def test_smart_input_valid_cases(message: Any, expected: Any) -> None:
     assert smart_input(message) == expected
 
 
-def test_smart_input_invalid_dose():
+def test_smart_input_invalid_dose() -> None:
     with pytest.raises(ValueError):
         smart_input("доза=abc")
 

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -24,7 +24,7 @@ from tests.helpers import make_context, make_update
 
 
 class DummyMessage:
-    def __init__(self, text: str):
+    def __init__(self, text: str) -> None:
         self.text = text
         self.replies: list[str] = []
 
@@ -33,7 +33,7 @@ class DummyMessage:
 
 
 @pytest.fixture
-def test_session(monkeypatch):
+def test_session(monkeypatch: Any) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -46,7 +46,7 @@ def test_session(monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("contact", ["@alice", "123456"])
-async def test_soscontact_stores_contact(test_session, contact) -> None:
+async def test_soscontact_stores_contact(test_session: Any, contact: Any) -> None:
     with test_session() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(Profile(telegram_id=1))
@@ -67,7 +67,7 @@ async def test_soscontact_stores_contact(test_session, contact) -> None:
 
 
 @pytest.mark.asyncio
-async def test_alert_notifies_user_and_contact(test_session, monkeypatch) -> None:
+async def test_alert_notifies_user_and_contact(test_session: Any, monkeypatch: Any) -> None:
     with test_session() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(Profile(telegram_id=1, low_threshold=4, high_threshold=8))
@@ -84,7 +84,7 @@ async def test_alert_notifies_user_and_contact(test_session, monkeypatch) -> Non
     context: AlertContext = ContextStub(bot=cast(Bot, SimpleNamespace()))
     send_mock = AsyncMock()
     monkeypatch.setattr(context.bot, "send_message", send_mock, raising=False)
-    async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
+    async def fake_get_coords_and_link() -> None:
         return ("0,0", "link")
 
     monkeypatch.setattr(alert_handlers, "get_coords_and_link", fake_get_coords_and_link)
@@ -102,7 +102,7 @@ async def test_alert_notifies_user_and_contact(test_session, monkeypatch) -> Non
 
 
 @pytest.mark.asyncio
-async def test_alert_skips_phone_contact(test_session, monkeypatch) -> None:
+async def test_alert_skips_phone_contact(test_session: Any, monkeypatch: Any) -> None:
     with test_session() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(
@@ -123,7 +123,7 @@ async def test_alert_skips_phone_contact(test_session, monkeypatch) -> None:
     send_mock = AsyncMock()
     monkeypatch.setattr(context.bot, "send_message", send_mock, raising=False)
 
-    async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
+    async def fake_get_coords_and_link() -> None:
         return ("0,0", "link")
 
     monkeypatch.setattr(alert_handlers, "get_coords_and_link", fake_get_coords_and_link)
@@ -138,7 +138,7 @@ async def test_alert_skips_phone_contact(test_session, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_sos_contact_menu_button_starts_conv(monkeypatch) -> None:
+async def test_sos_contact_menu_button_starts_conv(monkeypatch: Any) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -13,7 +13,7 @@ import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F40
 from services.api.app.diabetes.handlers import dose_handlers
 
 
-def _filter_pattern_equals(h: Any, regex: str) -> bool:
+def _filter_pattern_equals(h: Any, regex: str) -> None:
     filt = getattr(h, "filters", None)
     pattern = getattr(filt, "pattern", None)
     return isinstance(pattern, Pattern) and pattern.pattern == regex
@@ -46,7 +46,7 @@ async def test_cancel_command_clears_state() -> None:
     assert context.user_data == {}
 
 
-def test_sugar_conv_has_back_fallback():
+def test_sugar_conv_has_back_fallback() -> None:
     fallbacks = dose_handlers.sugar_conv.fallbacks
     assert any(
         isinstance(h, MessageHandler)

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -1,8 +1,9 @@
 import importlib
 from urllib.parse import urlparse
+from typing import Any
 
 
-def test_timezone_button_webapp_url(monkeypatch):
+def test_timezone_button_webapp_url(monkeypatch: Any) -> None:
     """Timezone button should open webapp path for timezone detection."""
     monkeypatch.setenv("WEBAPP_URL", "https://example.com")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,8 +18,9 @@ from services.api.app.diabetes.utils.helpers import (
     parse_time_interval,
     split_text_by_width,
 )
+from typing import Any
 
-def test_clean_markdown():
+def test_clean_markdown() -> None:
     text = "**Жирный**\n# Заголовок\n* элемент\n1. Первый"
     cleaned = clean_markdown(text)
     assert "Жирный" in cleaned
@@ -28,7 +29,7 @@ def test_clean_markdown():
     assert "*" not in cleaned
     assert "1." not in cleaned
 
-def test_split_text_by_width_simple():
+def test_split_text_by_width_simple() -> None:
     text = "Это короткая строка"
     pdfmetrics.registerFont(TTFont("DejaVuSans", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"))
     lines = split_text_by_width(text, "DejaVuSans", 12, 50)
@@ -43,7 +44,7 @@ def test_split_text_by_width_simple():
         "Hello Supercalifragilisticexpialidocious world",
     ],
 )
-def test_split_text_by_width_respects_limit(text):
+def test_split_text_by_width_respects_limit(text: Any) -> None:
     pdfmetrics.registerFont(TTFont("DejaVuSans", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"))
     max_width = 20
     lines = split_text_by_width(text, "DejaVuSans", 12, max_width)
@@ -52,15 +53,15 @@ def test_split_text_by_width_respects_limit(text):
 
 
 @pytest.mark.asyncio
-async def test_get_coords_and_link_non_blocking(monkeypatch) -> None:
-    def slow_urlopen(*args, **kwargs):
+async def test_get_coords_and_link_non_blocking(monkeypatch: Any) -> None:
+    def slow_urlopen(*args: Any, **kwargs: Any) -> None:
         time.sleep(0.2)
 
         class Resp:
-            def __enter__(self):
+            def __enter__(self) -> None:
                 return io.StringIO('{"loc": "1,2"}')
 
-            def __exit__(self, exc_type, exc, tb):
+            def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
                 return False
 
         return Resp()
@@ -76,8 +77,8 @@ async def test_get_coords_and_link_non_blocking(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_coords_and_link_logs_warning(monkeypatch, caplog) -> None:
-    def failing_urlopen(*args, **kwargs):
+async def test_get_coords_and_link_logs_warning(monkeypatch: Any, caplog: Any) -> None:
+    def failing_urlopen(*args: Any, **kwargs: Any) -> None:
         raise OSError("network down")
 
     monkeypatch.setattr(utils, "urlopen", failing_urlopen)
@@ -90,13 +91,13 @@ async def test_get_coords_and_link_logs_warning(monkeypatch, caplog) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_coords_and_link_invalid_loc(monkeypatch, caplog) -> None:
-    def bad_urlopen(*args, **kwargs):
+async def test_get_coords_and_link_invalid_loc(monkeypatch: Any, caplog: Any) -> None:
+    def bad_urlopen(*args: Any, **kwargs: Any) -> None:
         class Resp:
-            def __enter__(self):
+            def __enter__(self) -> None:
                 return io.StringIO('{"loc": "invalid"}')
 
-            def __exit__(self, exc_type, exc, tb):
+            def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
                 return False
 
         return Resp()
@@ -117,5 +118,5 @@ async def test_get_coords_and_link_invalid_loc(monkeypatch, caplog) -> None:
         ("3D", timedelta(days=3)),
     ],
 )
-def test_parse_interval_uppercase(text, expected):
+def test_parse_interval_uppercase(text: Any, expected: Any) -> None:
     assert parse_time_interval(text) == expected

--- a/tests/test_webapp_history.py
+++ b/tests/test_webapp_history.py
@@ -9,23 +9,24 @@ from sqlalchemy.pool import StaticPool
 
 import services.api.app.main as server
 from services.api.app.diabetes.services import db
+from typing import Any
 
 
-def setup_db(monkeypatch):
+def setup_db(monkeypatch: Any) -> None:
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
     )
     Session = sessionmaker(bind=engine)
     db.Base.metadata.create_all(bind=engine)
 
-    async def run_db_wrapper(fn, *args, **kwargs):
+    async def run_db_wrapper(fn: Any, *args: Any, **kwargs: Any) -> None:
         return await db.run_db(fn, *args, sessionmaker=Session, **kwargs)
 
     monkeypatch.setattr(server, "run_db", run_db_wrapper)
     return Session
 
 
-def test_history_persist_and_update(monkeypatch) -> None:
+def test_history_persist_and_update(monkeypatch: Any) -> None:
     Session = setup_db(monkeypatch)
     client = TestClient(server.app)
 
@@ -57,7 +58,7 @@ def test_history_persist_and_update(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_history_concurrent_writes(monkeypatch) -> None:
+async def test_history_concurrent_writes(monkeypatch: Any) -> None:
     Session = setup_db(monkeypatch)
     records = [
         {"id": str(i), "date": "2024-01-01", "time": "12:00", "type": "measurement"}

--- a/tests/test_webapp_server_startup.py
+++ b/tests/test_webapp_server_startup.py
@@ -12,7 +12,7 @@ def test_app_import_without_ui(monkeypatch: pytest.MonkeyPatch) -> None:
     ui_dir = ui_dist.parent
     original_exists = Path.exists
 
-    def fake_exists(self: Path) -> bool:  # noqa: ANN001
+    def fake_exists(self: Path) -> None:  # noqa: ANN001
         if self == ui_dist:
             return False
         if self == ui_dir:

--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -10,23 +10,24 @@ from sqlalchemy.pool import StaticPool
 
 import services.api.app.main as server
 from services.api.app.diabetes.services import db
+from typing import Any
 
 
-def setup_db(monkeypatch):
+def setup_db(monkeypatch: Any) -> None:
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
     )
     Session = sessionmaker(bind=engine)
     db.Base.metadata.create_all(bind=engine)
 
-    async def run_db_wrapper(fn, *args, **kwargs):
+    async def run_db_wrapper(fn: Any, *args: Any, **kwargs: Any) -> None:
         return await db.run_db(fn, *args, sessionmaker=Session, **kwargs)
 
     monkeypatch.setattr(server, "run_db", run_db_wrapper)
     return Session
 
 
-def test_timezone_persist_and_validate(monkeypatch) -> None:
+def test_timezone_persist_and_validate(monkeypatch: Any) -> None:
     Session = setup_db(monkeypatch)
     client = TestClient(server.app)
 
@@ -54,7 +55,7 @@ def test_timezone_persist_and_validate(monkeypatch) -> None:
     assert resp.status_code in {400, 422}
 
 
-def test_timezone_partial_file(monkeypatch) -> None:
+def test_timezone_partial_file(monkeypatch: Any) -> None:
     Session = setup_db(monkeypatch)
     with Session() as session:
         session.add(db.Timezone(id=1, tz="Europe/Mosc"))
@@ -65,7 +66,7 @@ def test_timezone_partial_file(monkeypatch) -> None:
     assert resp.status_code == 500
 
 
-def test_timezone_concurrent_writes(monkeypatch) -> None:
+def test_timezone_concurrent_writes(monkeypatch: Any) -> None:
     Session = setup_db(monkeypatch)
     timezones = ["Europe/Moscow", "America/New_York", "Asia/Tokyo", "Europe/Paris"]
 
@@ -88,7 +89,7 @@ def test_timezone_concurrent_writes(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_timezone_async_writes(monkeypatch) -> None:
+async def test_timezone_async_writes(monkeypatch: Any) -> None:
     Session = setup_db(monkeypatch)
     timezones = ["Europe/Moscow", "America/New_York", "Asia/Tokyo", "Europe/Paris"]
 


### PR DESCRIPTION
## Summary
- add explicit type hints to tests, returning `None` and annotating params

## Testing
- `ruff check services/api/app tests`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68aeb9efa844832a8c4f0f584bec521f