### PR TITLE
tests: cast handler filters to regex

### DIFF
--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -1,6 +1,9 @@
 import os
 import re
-from telegram.ext import ApplicationBuilder, MessageHandler
+from typing import cast
+
+from telegram.ext import ApplicationBuilder, MessageHandler, filters
+
 from services.api.app.diabetes.utils.ui import menu_keyboard
 import services.api.app.diabetes.handlers.registration as handlers
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
@@ -21,7 +24,7 @@ def test_reminders_button_matches_regex():
         for h in app.handlers[0]
         if isinstance(h, MessageHandler) and h.callback is reminder_handlers.reminders_list
     )
-    pattern = reminder_handler.filters.pattern.pattern
+    pattern = cast(filters.Regex, reminder_handler.filters).pattern.pattern
     assert pattern == "^⏰ Напоминания$"
     assert re.fullmatch(pattern, "⏰ Напоминания")
 

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -1,17 +1,16 @@
 import os
 import re
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, call
 
 import pytest
-from typing import cast
 
 from .context_stub import AlertContext, ContextStub
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from telegram.ext import ApplicationBuilder, CallbackContext, MessageHandler
+from telegram.ext import ApplicationBuilder, CallbackContext, MessageHandler, filters
 from telegram import Bot
 
 from services.api.app.diabetes.services.db import Base, User, Profile
@@ -153,8 +152,10 @@ async def test_sos_contact_menu_button_starts_conv(monkeypatch) -> None:
         for h in app.handlers[0]
         if isinstance(h, MessageHandler) and h.callback is sos_handlers.sos_contact_start
     )
-    pattern = sos_handler.filters.pattern.pattern
-    assert re.fullmatch(pattern, "🆘 SOS контакт")
+    assert re.fullmatch(
+        cast(filters.Regex, sos_handler.filters).pattern.pattern,
+        "🆘 SOS контакт",
+    )
 
     message = DummyMessage("🆘 SOS контакт")
     update = make_update(message=message)


### PR DESCRIPTION
## Summary
- cast handler filters to `filters.Regex` before accessing `pattern`

## Testing
- `ruff check services/api/app tests`
- `pytest tests/test_sos_contact.py tests/test_reminders_button_regex.py`

------
https://chatgpt.com/codex/tasks/task_e_68aeb9f10e44832a9c0ff3ad45289cee