### PR TITLE
[tests] replace SimpleNamespace with CallbackContext stub

### DIFF
--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -76,7 +76,9 @@ async def test_alert_notifies_user_and_contact(test_session, monkeypatch) -> Non
     # Save SOS contact via handler
     message = DummyMessage("@alice")
     update = make_update(message=message, effective_user=SimpleNamespace(id=1))
-    await sos_handlers.sos_contact_save(update, SimpleNamespace())
+    await sos_handlers.sos_contact_save(
+        update, cast(CallbackContext[Any, Any, Any, Any], ContextStub())
+    )
 
     update_alert = make_update(
         effective_user=SimpleNamespace(id=1, first_name="Ivan")


### PR DESCRIPTION
## Summary
- ensure tests use ContextStub implementing CallbackContext for sos_contact_save

## Testing
- `ruff check services/api/app tests/test_sos_contact.py`
- `pytest tests/test_sos_contact.py`


------
https://chatgpt.com/codex/tasks/task_e_68aeb9f1c5e0832ab803da0724bd08b2