### PR TITLE
[ui] fix sdk runtime import

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,5 @@
 import { RemindersApi } from '@sdk';
-import { Configuration, ResponseError } from '@sdk/runtime.ts';
+import { Configuration, ResponseError } from '@sdk/runtime';
 import {
   instanceOfReminderSchema as instanceOfReminder,
   type ReminderSchema as Reminder,


### PR DESCRIPTION
## Summary
- import `Configuration` and `ResponseError` from `@sdk/runtime` rather than `@sdk/runtime.ts`

## Testing
- `npm run build`
- `pytest -q --cov` *(fails: unrecognized arguments: --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=85 --cov)*
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68aec0a60e34832ab2459a1705118a39