### PR TITLE
[py-sdk] document multipart handling

### DIFF
--- a/libs/py-sdk/diabetes_sdk/rest.py
+++ b/libs/py-sdk/diabetes_sdk/rest.py
@@ -126,7 +126,10 @@ class RESTClientObject:
 
         :param method: http request method
         :param url: http request url
-        :param headers: http request headers
+        :param headers: http request headers. When ``Content-Type`` is
+                        ``multipart/form-data``, any existing entry is
+                        removed so ``urllib3`` can generate the correct
+                        boundary.
         :param body: request json body, for `application/json`
         :param post_params: request parameters for
                             ``application/x-www-form-urlencoded`` or

--- a/libs/py-sdk/test/test_rest_multipart.py
+++ b/libs/py-sdk/test/test_rest_multipart.py
@@ -112,3 +112,17 @@ def test_multipart_invalid_string() -> None:
                 "invalid",
             ),
         )
+
+
+def test_multipart_invalid_bytes() -> None:
+    client = _client()
+    with pytest.raises(ApiValueError):
+        client.request(
+            "POST",
+            "http://example.com",
+            headers={"Content-Type": "multipart/form-data"},
+            post_params=cast(
+                Mapping[str, object] | Iterable[tuple[str, object]] | None,
+                b"invalid",
+            ),
+        )


### PR DESCRIPTION
## Summary
- clarify multipart Content-Type handling in REST client docstring
- test multipart error path for byte-string post params

## Testing
- `pytest libs/py-sdk/test/test_rest_multipart.py -q --cov=libs/py-sdk/diabetes_sdk --cov-fail-under=0`
- `mypy --strict libs/py-sdk/diabetes_sdk/rest.py libs/py-sdk/test/test_rest_multipart.py`
- `ruff check libs/py-sdk/diabetes_sdk/rest.py libs/py-sdk/test/test_rest_multipart.py`


------
https://chatgpt.com/codex/tasks/task_e_68aec037a0b8832aaa0fa9c54509dbb1