### PR TITLE
[deps] Ignore missing alembic and reportlab types

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -9,3 +9,9 @@ ignore_missing_imports = True
 
 [mypy-diabetes_sdk.*]
 ignore_missing_imports = True
+
+[mypy-alembic.*]
+ignore_missing_imports = True
+
+[mypy-reportlab.*]
+ignore_missing_imports = True

--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -6,7 +6,7 @@ from logging.config import fileConfig
 from urllib.parse import quote_plus
 from pathlib import Path
 
-from alembic import context
+from alembic import context  # type: ignore[import-not-found]
 from sqlalchemy import create_engine, pool  # используем create_engine — без set_main_option
 
 # Загружаем .env: сначала корень, затем сервисный (сервисный перекрывает)

--- a/services/api/alembic/versions/02857aa7fc3e_squashed_initial.py
+++ b/services/api/alembic/versions/02857aa7fc3e_squashed_initial.py
@@ -7,7 +7,7 @@ Create Date: 2025-08-07 09:15:17.518654
 """
 from typing import Sequence, Union
 
-from alembic import op
+from alembic import op  # type: ignore[import-not-found]
 import sqlalchemy as sa
 
 

--- a/services/api/alembic/versions/20250812_add_org_id_to_reminders.py
+++ b/services/api/alembic/versions/20250812_add_org_id_to_reminders.py
@@ -7,7 +7,7 @@ Create Date: 2025-08-12 00:00:00.000000
 """
 from typing import Sequence, Union
 
-from alembic import op
+from alembic import op  # type: ignore[import-not-found]
 import sqlalchemy as sa
 
 

--- a/services/api/alembic/versions/20250813_add_org_id_to_users.py
+++ b/services/api/alembic/versions/20250813_add_org_id_to_users.py
@@ -7,7 +7,7 @@ Create Date: 2025-08-13 00:00:00.000000
 """
 from typing import Sequence, Union
 
-from alembic import op
+from alembic import op  # type: ignore[import-not-found]
 import sqlalchemy as sa
 
 

--- a/services/api/alembic/versions/20250814_add_org_id_to_profiles.py
+++ b/services/api/alembic/versions/20250814_add_org_id_to_profiles.py
@@ -7,7 +7,7 @@ Create Date: 2025-08-14 00:00:00.000000
 """
 from typing import Sequence, Union
 
-from alembic import op
+from alembic import op  # type: ignore[import-not-found]
 import sqlalchemy as sa
 
 

--- a/services/api/alembic/versions/20250815_add_org_id_to_entries.py
+++ b/services/api/alembic/versions/20250815_add_org_id_to_entries.py
@@ -7,7 +7,7 @@ Create Date: 2025-08-15 00:00:00.000000
 """
 from typing import Sequence, Union
 
-from alembic import op
+from alembic import op  # type: ignore[import-not-found]
 import sqlalchemy as sa
 
 

--- a/services/api/alembic/versions/20250816_add_org_id_to_alerts.py
+++ b/services/api/alembic/versions/20250816_add_org_id_to_alerts.py
@@ -7,7 +7,7 @@ Create Date: 2025-08-16 00:00:00.000000
 """
 from typing import Sequence, Union
 
-from alembic import op
+from alembic import op  # type: ignore[import-not-found]
 import sqlalchemy as sa
 
 

--- a/services/api/alembic/versions/20250816a_expand_alembic_version_len.py
+++ b/services/api/alembic/versions/20250816a_expand_alembic_version_len.py
@@ -1,6 +1,6 @@
 """Expand alembic_version.version_num to VARCHAR(255)."""
 
-from alembic import op
+from alembic import op  # type: ignore[import-not-found]
 
 # NB: новая ревизия ВСТАВЛЯЕТСЯ между 20250816 и 20250817
 revision = "20250816a_expand_alembic_version_len"

--- a/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
+++ b/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
@@ -7,7 +7,7 @@ Create Date: 2025-08-17 00:00:00.000000
 """
 from typing import Sequence, Union
 
-from alembic import op
+from alembic import op  # type: ignore[import-not-found]
 import sqlalchemy as sa
 
 

--- a/services/api/app/diabetes/services/reporting.py
+++ b/services/api/app/diabetes/services/reporting.py
@@ -8,12 +8,12 @@ from datetime import datetime
 from typing import Iterable, Protocol, Sequence, cast
 
 import matplotlib.pyplot as plt
-from reportlab.lib.pagesizes import A4
-from reportlab.lib.units import mm
-from reportlab.lib.utils import ImageReader
-from reportlab.pdfbase import pdfmetrics
-from reportlab.pdfbase.ttfonts import TTFont, TTFError
-from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import A4  # type: ignore[import-not-found]
+from reportlab.lib.units import mm  # type: ignore[import-not-found]
+from reportlab.lib.utils import ImageReader  # type: ignore[import-not-found]
+from reportlab.pdfbase import pdfmetrics  # type: ignore[import-not-found]
+from reportlab.pdfbase.ttfonts import TTFont, TTFError  # type: ignore[import-not-found]
+from reportlab.pdfgen import canvas  # type: ignore[import-not-found]
 
 from services.api.app.config import settings
 

--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -7,8 +7,8 @@ import re
 from datetime import datetime, time, timedelta
 from urllib.request import urlopen
 
-from reportlab.pdfbase.pdfmetrics import stringWidth
-from reportlab.lib.units import mm
+from reportlab.pdfbase.pdfmetrics import stringWidth  # type: ignore[import-not-found]
+from reportlab.lib.units import mm  # type: ignore[import-not-found]
 
 
 def clean_markdown(text: str) -> str:

--- a/services/api/app/requirements-dev.txt
+++ b/services/api/app/requirements-dev.txt
@@ -3,3 +3,4 @@ pre-commit
 pytest-cov
 mypy
 playwright
+types-reportlab

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,10 +5,10 @@ import io
 import time
 import logging
 from datetime import timedelta
-from reportlab.pdfbase import pdfmetrics
-from reportlab.pdfbase.ttfonts import TTFont
-from reportlab.pdfbase.pdfmetrics import stringWidth
-from reportlab.lib.units import mm
+from reportlab.pdfbase import pdfmetrics  # type: ignore[import-not-found]
+from reportlab.pdfbase.ttfonts import TTFont  # type: ignore[import-not-found]
+from reportlab.pdfbase.pdfmetrics import stringWidth  # type: ignore[import-not-found]
+from reportlab.lib.units import mm  # type: ignore[import-not-found]
 
 import pytest
 


### PR DESCRIPTION
## Summary
- silence mypy missing-import errors for alembic and reportlab
- document reportlab typing stub in requirements-dev

## Testing
- `ruff check services/api/app tests`
- `pytest tests`
- `mypy services/api/alembic/env.py services/api/alembic/versions/*.py services/api/app/diabetes/utils/helpers.py services/api/app/diabetes/services/reporting.py tests/test_utils.py` *(fails: No overload variant of "int" matches argument type "object" etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aec09a17c4832a9138d7fd72998533