### PR TITLE
[handlers] Accept sessionmaker via kwargs

### DIFF
--- a/services/api/app/diabetes/handlers/db.py
+++ b/services/api/app/diabetes/handlers/db.py
@@ -21,12 +21,12 @@ R = TypeVar("R")
 async def run_db(
     fn: Callable[Concatenate[Session, P], R],
     *args: P.args,
-    sessionmaker: sessionmaker[Session] = SessionLocal,
     **kwargs: P.kwargs,
 ) -> R:
     """Proxy to :func:`services.api.app.diabetes.services.db.run_db` with types."""
 
-    return await _run_db(fn, *args, sessionmaker=sessionmaker, **kwargs)
+    session_factory: sessionmaker[Session] = kwargs.pop("sessionmaker", SessionLocal)
+    return await _run_db(fn, *args, sessionmaker=session_factory, **kwargs)
 
 
 __all__ = ["SessionLocal", "run_db"]


### PR DESCRIPTION
## Summary
- accept `sessionmaker` via `kwargs` in handler `run_db`

## Testing
- `ruff check services/api/app tests`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68aec09a96e8832ab9633dd748db5b05