### PR TITLE
tests: add explicit annotations

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,14 +3,14 @@ from typing import Any
 from tests.telegram_stubs import CallbackContext, Update
 
 
-def make_update(**kwargs: Any) -> None:
+def make_update(**kwargs: Any) -> Update:
     update = Update()
     for key, value in kwargs.items():
         setattr(update, key, value)
     return update
 
 
-def make_context(**kwargs: Any) -> None:
+def make_context(**kwargs: Any) -> CallbackContext:
     ctx = CallbackContext()
     for key, value in kwargs.items():
         setattr(ctx, key, value)

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -183,7 +183,7 @@ async def test_three_alerts_notify(monkeypatch: pytest.MonkeyPatch) -> None:
 
     update = make_update(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
     context = cast(AlertContext, ContextStub(bot=DummyBot()))
-    async def fake_get_coords_and_link() -> None:
+    async def fake_get_coords_and_link() -> tuple[str, str]:
         return ("0,0", "link")
 
     monkeypatch.setattr(handlers, "get_coords_and_link", fake_get_coords_and_link)
@@ -231,7 +231,7 @@ async def test_alert_message_without_coords(monkeypatch: pytest.MonkeyPatch) -> 
     update = make_update(effective_user=SimpleNamespace(id=1, first_name="Ivan"))
     context = cast(AlertContext, ContextStub(bot=DummyBot()))
 
-    async def fake_get_coords_and_link() -> None:
+    async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
         return None, None
 
     monkeypatch.setattr(handlers, "get_coords_and_link", fake_get_coords_and_link)

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -5,12 +5,12 @@ from fastapi.testclient import TestClient
 from services.api.app.middleware.auth import AuthMiddleware
 
 
-def create_app() -> None:
+def create_app() -> FastAPI:
     app = FastAPI()
     app.add_middleware(AuthMiddleware)
 
     @app.get("/whoami")
-    async def whoami(request: Request) -> None:
+    async def whoami(request: Request) -> dict[str, int]:
         return {"user_id": request.state.user_id}
 
     return app

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,12 +2,13 @@
 
 import importlib
 import sys
+from types import ModuleType
 
 import pytest
 from typing import Any
 
 
-def _reload(module: str) -> None:
+def _reload(module: str) -> ModuleType:
     if module in sys.modules:
         del sys.modules[module]
     return importlib.import_module(module)

--- a/tests/test_db_reinit.py
+++ b/tests/test_db_reinit.py
@@ -1,11 +1,12 @@
 import importlib
 import sys
-
-import pytest
+from types import ModuleType
 from typing import Any
 
+import pytest
 
-def _reload(module: str) -> None:
+
+def _reload(module: str) -> ModuleType:
     if module in sys.modules:
         del sys.modules[module]
     return importlib.import_module(module)
@@ -35,7 +36,7 @@ def test_init_db_recreates_engine_on_url_change(monkeypatch: Any, attr: Any, ori
 
     created = []
 
-    def fake_create_engine(url: Any) -> None:
+    def fake_create_engine(url: Any) -> DummyEngine:
         engine = DummyEngine(url)
         created.append(engine)
         return engine

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -13,7 +13,7 @@ import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F40
 from services.api.app.diabetes.handlers import dose_handlers
 
 
-def _find_handler(fallbacks: Any, regex: str) -> None:
+def _find_handler(fallbacks: Any, regex: str) -> MessageHandler:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -15,7 +15,7 @@ def test_get_client_thread_safe(monkeypatch: Any) -> None:
     fake_client = object()
     call_count = 0
 
-    def fake_get_openai_client() -> None:
+    def fake_get_openai_client() -> Any:
         nonlocal call_count
         time.sleep(0.01)
         call_count += 1
@@ -100,7 +100,7 @@ async def test_send_message_empty_string_preserved(tmp_path: Any, monkeypatch: A
 
     captured = {}
 
-    def fake_files_create(file: Any, purpose: Any) -> None:
+    def fake_files_create(file: Any, purpose: Any) -> SimpleNamespace:
         return SimpleNamespace(id="f1")
 
     def fake_messages_create(*, thread_id: Any, role: Any, content: Any) -> None:

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -15,7 +15,7 @@ from services.api.app.diabetes import gpt_command_parser  # noqa: E402
 
 @pytest.mark.asyncio
 async def test_parse_command_timeout_non_blocking(monkeypatch: Any) -> None:
-    def slow_create(*args: Any, **kwargs: Any) -> None:
+    def slow_create(*args: Any, **kwargs: Any) -> Any:
         time.sleep(1)
 
         class FakeResponse:
@@ -69,7 +69,7 @@ async def test_parse_command_with_explanatory_text(monkeypatch: Any) -> None:
             )
         ]
 
-    def create(*args: Any, **kwargs: Any) -> None:
+    def create(*args: Any, **kwargs: Any) -> Any:
         return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
@@ -97,7 +97,7 @@ async def test_parse_command_with_array_response(monkeypatch: Any) -> None:
             )
         ]
 
-    def create(*args: Any, **kwargs: Any) -> None:
+    def create(*args: Any, **kwargs: Any) -> Any:
         return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
@@ -125,7 +125,7 @@ async def test_parse_command_with_scalar_response(monkeypatch: Any) -> None:
             )
         ]
 
-    def create(*args: Any, **kwargs: Any) -> None:
+    def create(*args: Any, **kwargs: Any) -> Any:
         return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
@@ -157,7 +157,7 @@ async def test_parse_command_with_invalid_schema(monkeypatch: Any, caplog: Any) 
             )
         ]
 
-    def create(*args: Any, **kwargs: Any) -> None:
+    def create(*args: Any, **kwargs: Any) -> Any:
         return FakeResponse()
 
     fake_client = SimpleNamespace(
@@ -182,7 +182,7 @@ async def test_parse_command_with_missing_content(monkeypatch: Any, caplog: Any)
     class FakeResponse:
         choices = [type("Choice", (), {"message": type("Msg", (), {})()})]
 
-    def create(*args: Any, **kwargs: Any) -> None:
+    def create(*args: Any, **kwargs: Any) -> Any:
         return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
@@ -212,7 +212,7 @@ async def test_parse_command_with_non_string_content(monkeypatch: Any, caplog: A
             )
         ]
 
-    def create(*args: Any, **kwargs: Any) -> None:
+    def create(*args: Any, **kwargs: Any) -> Any:
         return FakeResponse()
     fake_client = SimpleNamespace(
         chat=SimpleNamespace(
@@ -304,7 +304,7 @@ async def test_parse_command_with_multiple_jsons(monkeypatch: Any) -> None:
             )
         ]
 
-    def create(*args: Any, **kwargs: Any) -> None:
+    def create(*args: Any, **kwargs: Any) -> Any:
         return FakeResponse()
 
     fake_client = SimpleNamespace(
@@ -341,7 +341,7 @@ async def test_parse_command_with_malformed_json(monkeypatch: Any, caplog: Any) 
             )
         ]
 
-    def create(*args: Any, **kwargs: Any) -> None:
+    def create(*args: Any, **kwargs: Any) -> Any:
         return FakeResponse()
 
     fake_client = SimpleNamespace(

--- a/tests/test_handlers_freeform_numbers.py
+++ b/tests/test_handlers_freeform_numbers.py
@@ -1,11 +1,11 @@
 import re
 
 
-def parse_values(text: str) -> None:
+def parse_values(text: str) -> dict[str, float]:
     parts = dict(
         re.findall(r"(\w+)\s*=\s*(-?\d+(?:[.,]\d+)?)(?=\s|$)", text)
     )
-    result = {}
+    result: dict[str, float] = {}
     if "xe" in parts:
         result["xe"] = float(parts["xe"].replace(",", "."))
     if "carbs" in parts:

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -65,7 +65,7 @@ session = DummySession()
 async def test_photo_flow_saves_entry(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Any
 ) -> None:
-    async def fake_parse_command(text: str) -> None:
+    async def fake_parse_command(text: str) -> dict[str, Any]:
         return {"action": "add_entry", "fields": {}, "entry_date": None, "time": None}
 
     monkeypatch.setattr(dose_handlers, "parse_command", fake_parse_command)
@@ -84,7 +84,7 @@ async def test_photo_flow_saves_entry(
 
     monkeypatch.chdir(tmp_path)
 
-    async def fake_get_file(file_id: str) -> None:
+    async def fake_get_file(file_id: str) -> Any:
         class File:
             async def download_to_drive(self, path: str) -> None:
                 Path(path).write_bytes(b"img")
@@ -98,7 +98,7 @@ async def test_photo_flow_saves_entry(
         thread_id = "tid"
         id = "runid"
 
-    async def fake_send_message(**kwargs: Any) -> None:
+    async def fake_send_message(**kwargs: Any) -> Run:
         return Run()
 
     class DummyClient:

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -108,7 +108,7 @@ async def test_report_period_callback_week(
 
     class DummyDateTime(dt.datetime):
         @classmethod
-        def now(cls, tz: dt.tzinfo | None = None) -> None:
+        def now(cls, tz: dt.tzinfo | None = None) -> dt.datetime:
             return fixed_now
 
     fixed_now = DummyDateTime(2024, 1, 10, tzinfo=dt.timezone.utc)

--- a/tests/test_history_view_async.py
+++ b/tests/test_history_view_async.py
@@ -18,26 +18,26 @@ class DummyMessage:
 async def test_history_view_does_not_block_event_loop(monkeypatch: Any) -> None:
     """The database query is executed in a thread and doesn't block."""
 
-    def slow_session() -> None:
+    def slow_session() -> Any:
         class FakeSession:
-            def __enter__(self) -> None:
+            def __enter__(self) -> Any:
                 return self
 
             def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
                 pass
 
-            def query(self, *args: Any, **kwargs: Any) -> None:
+            def query(self, *args: Any, **kwargs: Any) -> Any:
                 class Q:
-                    def filter(self, *args: Any, **kwargs: Any) -> None:
+                    def filter(self, *args: Any, **kwargs: Any) -> Any:
                         return self
 
-                    def order_by(self, *args: Any, **kwargs: Any) -> None:
+                    def order_by(self, *args: Any, **kwargs: Any) -> Any:
                         return self
 
-                    def limit(self, *args: Any, **kwargs: Any) -> None:
+                    def limit(self, *args: Any, **kwargs: Any) -> Any:
                         return self
 
-                    def all(self) -> None:
+                    def all(self) -> list[Any]:
                         time.sleep(0.5)  # Blocking call executed in to_thread
                         return []
 

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -23,7 +23,7 @@ class DummyMessage:
         self.kwargs.append(kwargs)
 
 
-def _get_menu_handler(fallbacks: Any) -> None:
+def _get_menu_handler(fallbacks: Any) -> CommandHandler:
     return next(
         h
         for h in fallbacks

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -18,7 +18,7 @@ from services.api.app.diabetes.handlers import (
 )
 
 
-def _find_handler(fallbacks: Any, regex: str) -> None:
+def _find_handler(fallbacks: Any, regex: str) -> MessageHandler:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
             filt = getattr(h, "filters", None)

--- a/tests/test_render_entry.py
+++ b/tests/test_render_entry.py
@@ -1,11 +1,11 @@
 import datetime
 from types import SimpleNamespace
-
-from services.api.app.diabetes.handlers.reporting_handlers import render_entry
 from typing import Any
 
+from services.api.app.diabetes.handlers.reporting_handlers import render_entry
 
-def make_entry(**kwargs: Any) -> None:
+
+def make_entry(**kwargs: Any) -> SimpleNamespace:
     defaults = dict(
         event_time=datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
         sugar_before=5.5,

--- a/tests/test_run_db.py
+++ b/tests/test_run_db.py
@@ -16,14 +16,14 @@ async def test_run_db_sqlite_in_memory(monkeypatch: Any) -> None:
 
     called = False
 
-    async def fake_to_thread(fn: Any, *args: Any, **kwargs: Any) -> None:
+    async def fake_to_thread(fn: Any, *args: Any, **kwargs: Any) -> Any:
         nonlocal called
         called = True
         return fn(*args, **kwargs)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
 
-    def work(session: Any) -> None:
+    def work(session: Any) -> int:
         return 42
 
     result = await run_db(work, sessionmaker=Session)
@@ -36,28 +36,28 @@ async def test_run_db_postgres(monkeypatch: Any) -> None:
     dummy_engine = SimpleNamespace(url=SimpleNamespace(drivername="postgresql", database="db"))
 
     class DummySession:
-        def get_bind(self) -> None:
+        def get_bind(self) -> Any:
             return dummy_engine
 
-        def __enter__(self) -> None:
+        def __enter__(self) -> "DummySession":
             return self
 
         def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
             pass
 
-    def dummy_sessionmaker() -> None:
+    def dummy_sessionmaker() -> DummySession:
         return DummySession()
 
     called = False
 
-    async def fake_to_thread(fn: Any, *args: Any, **kwargs: Any) -> None:
+    async def fake_to_thread(fn: Any, *args: Any, **kwargs: Any) -> Any:
         nonlocal called
         called = True
         return fn(*args, **kwargs)
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
 
-    def work(session: Any) -> None:
+    def work(session: Any) -> int:
         return 42
 
     result = await run_db(work, sessionmaker=dummy_sessionmaker)
@@ -69,7 +69,7 @@ async def test_run_db_postgres(monkeypatch: Any) -> None:
 async def test_run_db_without_engine() -> None:
     Session = sessionmaker()
 
-    def work(session: Any) -> None:
+    def work(session: Any) -> int:
         return 42
 
     with pytest.raises(RuntimeError, match="init_db"):

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -32,7 +32,7 @@ class DummyMessage:
 
 
 @pytest.fixture
-def test_session(monkeypatch: Any) -> None:
+def test_session(monkeypatch: Any) -> sessionmaker[Any]:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -85,7 +85,7 @@ async def test_alert_notifies_user_and_contact(test_session: Any, monkeypatch: A
     context: AlertContext = ContextStub(bot=cast(Bot, SimpleNamespace()))
     send_mock = AsyncMock()
     monkeypatch.setattr(context.bot, "send_message", send_mock, raising=False)
-    async def fake_get_coords_and_link() -> None:
+    async def fake_get_coords_and_link() -> tuple[str, str]:
         return ("0,0", "link")
 
     monkeypatch.setattr(alert_handlers, "get_coords_and_link", fake_get_coords_and_link)
@@ -124,7 +124,7 @@ async def test_alert_skips_phone_contact(test_session: Any, monkeypatch: Any) ->
     send_mock = AsyncMock()
     monkeypatch.setattr(context.bot, "send_message", send_mock, raising=False)
 
-    async def fake_get_coords_and_link() -> None:
+    async def fake_get_coords_and_link() -> tuple[str, str]:
         return ("0,0", "link")
 
     monkeypatch.setattr(alert_handlers, "get_coords_and_link", fake_get_coords_and_link)

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -13,7 +13,7 @@ import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F40
 from services.api.app.diabetes.handlers import dose_handlers
 
 
-def _filter_pattern_equals(h: Any, regex: str) -> None:
+def _filter_pattern_equals(h: Any, regex: str) -> bool:
     filt = getattr(h, "filters", None)
     pattern = getattr(filt, "pattern", None)
     return isinstance(pattern, Pattern) and pattern.pattern == regex

--- a/tests/test_webapp_history.py
+++ b/tests/test_webapp_history.py
@@ -12,14 +12,14 @@ from services.api.app.diabetes.services import db
 from typing import Any
 
 
-def setup_db(monkeypatch: Any) -> None:
+def setup_db(monkeypatch: Any) -> sessionmaker[Any]:
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
     )
     Session = sessionmaker(bind=engine)
     db.Base.metadata.create_all(bind=engine)
 
-    async def run_db_wrapper(fn: Any, *args: Any, **kwargs: Any) -> None:
+    async def run_db_wrapper(fn: Any, *args: Any, **kwargs: Any) -> Any:
         return await db.run_db(fn, *args, sessionmaker=Session, **kwargs)
 
     monkeypatch.setattr(server, "run_db", run_db_wrapper)
@@ -65,7 +65,7 @@ async def test_history_concurrent_writes(monkeypatch: Any) -> None:
         for i in range(5)
     ]
 
-    async def post_record(rec: dict) -> None:
+    async def post_record(rec: dict[str, Any]) -> None:
         async with AsyncClient(app=server.app, base_url="http://test") as ac:
             resp = await ac.post("/api/history", json=rec)
             assert resp.status_code == 200

--- a/tests/test_webapp_server_startup.py
+++ b/tests/test_webapp_server_startup.py
@@ -12,7 +12,7 @@ def test_app_import_without_ui(monkeypatch: pytest.MonkeyPatch) -> None:
     ui_dir = ui_dist.parent
     original_exists = Path.exists
 
-    def fake_exists(self: Path) -> None:  # noqa: ANN001
+    def fake_exists(self: Path) -> bool:  # noqa: ANN001
         if self == ui_dist:
             return False
         if self == ui_dir:

--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -13,14 +13,14 @@ from services.api.app.diabetes.services import db
 from typing import Any
 
 
-def setup_db(monkeypatch: Any) -> None:
+def setup_db(monkeypatch: Any) -> sessionmaker[Any]:
     engine = create_engine(
         "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
     )
     Session = sessionmaker(bind=engine)
     db.Base.metadata.create_all(bind=engine)
 
-    async def run_db_wrapper(fn: Any, *args: Any, **kwargs: Any) -> None:
+    async def run_db_wrapper(fn: Any, *args: Any, **kwargs: Any) -> Any:
         return await db.run_db(fn, *args, sessionmaker=Session, **kwargs)
 
     monkeypatch.setattr(server, "run_db", run_db_wrapper)


### PR DESCRIPTION
## Summary
- add return types for test helpers
- type test utilities for Telegram objects
- annotate async test helpers for clarity

## Testing
- `pre-commit run --files tests/helpers.py tests/test_alerts.py tests/test_auth_middleware.py tests/test_config.py tests/test_db_reinit.py tests/test_dose_conv_photo_fallback.py tests/test_gpt_client.py tests/test_gpt_command_parser.py tests/test_handlers_freeform_numbers.py tests/test_handlers_photo_sugar_save.py tests/test_handlers_report_request.py tests/test_history_view_async.py tests/test_menu_fallbacks.py tests/test_photo_fallbacks.py tests/test_render_entry.py tests/test_run_db.py tests/test_sos_contact.py tests/test_sugar_exit.py tests/test_webapp_history.py tests/test_webapp_server_startup.py tests/test_webapp_timezone.py`
- `pytest tests` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68aec099f0cc832ab33a1d055b879e64