### PR TITLE
[config] Refine log level parsing

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Optional
+from typing import Optional, SupportsInt
 
 from pydantic import Field, field_validator
 
@@ -57,13 +57,20 @@ class Settings(BaseSettings):
 
     @field_validator("log_level", mode="before")
     @classmethod
-    def parse_log_level(cls, v: object) -> int:  # pragma: no cover - simple parsing
-        if isinstance(v, str) and v.lower() in {"1", "true", "debug"}:
-            return logging.DEBUG
-        try:
-            return int(v)  # type: ignore[return-value]
-        except (TypeError, ValueError):
-            return logging.INFO
+    def parse_log_level(cls, v: str | SupportsInt) -> int:  # pragma: no cover - simple parsing
+        if isinstance(v, str):
+            if v.lower() in {"1", "true", "debug"}:
+                return logging.DEBUG
+            try:
+                return int(v)
+            except ValueError as exc:
+                raise ValueError(f"Invalid log level: {v}") from exc
+        if isinstance(v, SupportsInt):
+            try:
+                return int(v)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"Invalid log level: {v}") from exc
+        raise TypeError(f"Unsupported type for log level: {type(v).__name__}")
 
 
 # Instantiate settings for external use


### PR DESCRIPTION
## Summary
- narrow `parse_log_level` input to `str | SupportsInt`
- raise errors for invalid or unsupported log level types

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68aec09dcd14832a9cce376da9d0b9ba