### PR TITLE
[webapp] use sdk runtime alias in reminders api

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,5 @@
 import { RemindersApi } from '@sdk';
-import { Configuration, ResponseError } from '@sdk/runtime.ts';
+import { Configuration, ResponseError } from '@sdk/runtime';
 import {
   instanceOfReminderSchema as instanceOfReminder,
   type ReminderSchema as Reminder,


### PR DESCRIPTION
## Summary
- use `@sdk/runtime` alias in reminders API

## Testing
- `npm run build`
- `make ci` *(fails: No rule to make target 'ci')*
- `pytest -q --cov` *(fails: unrecognized arguments: --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=85 --cov)*
- `mypy --strict services/webapp/ui/src/api/reminders.ts` *(fails: Invalid syntax)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68aec0a5cc40832ab3bf2111de8b1936