### PR TITLE
tests: return helper objects with typing

### DIFF
--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -67,18 +67,23 @@ def make_user(user_id: int) -> MagicMock:
     return user
 
 
-def make_update(**kwargs: Any) -> MagicMock:
+def make_update(**kwargs: Any) -> Update:
     update = MagicMock(spec=Update)
     for key, value in kwargs.items():
         setattr(update, key, value)
-    return update
+    return cast(Update, update)
 
 
-def make_context(**kwargs: Any) -> MagicMock:
+def make_context(
+    **kwargs: Any,
+) -> CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]:
     context = MagicMock(spec=CallbackContext)
     for key, value in kwargs.items():
         setattr(context, key, value)
-    return context
+    return cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        context,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -1,7 +1,7 @@
 import json
 from datetime import time, timedelta
 from types import TracebackType
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -69,18 +69,23 @@ def make_user(user_id: int) -> MagicMock:
     return user
 
 
-def make_update(**kwargs: Any) -> MagicMock:
+def make_update(**kwargs: Any) -> Update:
     update = MagicMock(spec=Update)
     for key, value in kwargs.items():
         setattr(update, key, value)
-    return update
+    return cast(Update, update)
 
 
-def make_context(**kwargs: Any) -> MagicMock:
+def make_context(
+    **kwargs: Any,
+) -> CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]:
     context = MagicMock(spec=CallbackContext)
     for key, value in kwargs.items():
         setattr(context, key, value)
-    return context
+    return cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        context,
+    )
 
 
 @pytest.mark.asyncio
@@ -95,7 +100,9 @@ async def test_add_reminder_fewer_args(reminder_handlers: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_reminder_sugar_invalid_time(reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_add_reminder_sugar_invalid_time(
+    reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
     message = DummyMessage()
     update = make_update(message=message, effective_user=make_user(1))
     context = make_context(args=["sugar", "ab:cd"])
@@ -110,7 +117,9 @@ async def test_add_reminder_sugar_invalid_time(reminder_handlers: Any, monkeypat
 
 
 @pytest.mark.asyncio
-async def test_add_reminder_sugar_non_numeric_interval(reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_add_reminder_sugar_non_numeric_interval(
+    reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
     message = DummyMessage()
     update = make_update(message=message, effective_user=make_user(1))
     context = make_context(args=["sugar", "abc"])
@@ -136,7 +145,9 @@ async def test_add_reminder_unknown_type(reminder_handlers: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_reminder_valid_type(reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_add_reminder_valid_type(
+    reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
     message = DummyMessage()
     update = make_update(message=message, effective_user=make_user(1))
     context = make_context(args=["sugar", "2"], job_queue=None)

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -140,18 +140,23 @@ def make_user(user_id: int) -> MagicMock:
     return user
 
 
-def make_update(**kwargs: Any) -> MagicMock:
+def make_update(**kwargs: Any) -> Update:
     update = MagicMock(spec=Update)
     for key, value in kwargs.items():
         setattr(update, key, value)
-    return update
+    return cast(Update, update)
 
 
-def make_context(**kwargs: Any) -> MagicMock:
+def make_context(
+    **kwargs: Any,
+) -> CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]:
     context = MagicMock(spec=CallbackContext)
     for key, value in kwargs.items():
         setattr(context, key, value)
-    return context
+    return cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        context,
+    )
 
 
 def test_schedule_reminder_replaces_existing_job() -> None:


### PR DESCRIPTION
## Summary
- return typed `Update` and `CallbackContext` objects from test helpers
- align helper return annotations for reminders and commit-failure tests

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68aec5d8ded4832a9ac6d40be5bb10f8