### PR TITLE
[ui] fix SDK runtime import extension

### DIFF
--- a/scripts/gen_ts_sdk.sh
+++ b/scripts/gen_ts_sdk.sh
@@ -33,3 +33,11 @@ JSON
 ( cd "$OUT_DIR" && { find apis models -type f | sort; echo index.ts; echo runtime.ts; } > .openapi-generator/FILES )
 
 rm -rf "$TMP_DIR"
+
+# Fix imports of SDK runtime to include the `.ts` extension in UI code.
+# Vite's ESM resolver requires explicit extensions when the runtime is
+# generated as a single `runtime.ts` file instead of a directory.
+if [ ! -d "$ROOT_DIR/libs/ts-sdk/runtime" ] && [ -f "$ROOT_DIR/libs/ts-sdk/runtime.ts" ]; then
+  find "$ROOT_DIR/services/webapp/ui/src" -type f -name "*.ts*" \
+    -exec sed -i "s|from ['\"]@sdk/runtime['\"]|from '@sdk/runtime.ts'|g" {} +
+fi

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,5 @@
 import { RemindersApi } from '@sdk';
-import { Configuration, ResponseError } from '@sdk/runtime';
+import { Configuration, ResponseError } from '@sdk/runtime.ts';
 import {
   instanceOfReminderSchema as instanceOfReminder,
   type ReminderSchema as Reminder,


### PR DESCRIPTION
## Summary
- ensure UI imports use `@sdk/runtime.ts`
- auto-fix SDK runtime imports during TS SDK generation

## Testing
- `npm run build`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aecd37a5a8832a82aa7cb58da1d204