### PR TITLE
[handlers] Guard sos contact save against missing text

### DIFF
--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -25,11 +25,11 @@ SOS_CONTACT, = range(1)
 
 async def sos_contact_start(
     update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+) -> int | None:
     """Prompt user to enter emergency contact."""
     message: Message = update.message
     if message is None:
-        return
+        return None
     await message.reply_text(
         "Введите контакт в Telegram (@username). Телефоны не поддерживаются.",
         reply_markup=back_keyboard,
@@ -46,12 +46,14 @@ def _is_valid_contact(text: str) -> bool:
 
 async def sos_contact_save(
     update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+) -> int | None:
     """Save provided contact to profile."""
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
-        return
+        return None
+    if message.text is None:
+        return None
     contact = message.text.strip()
     if not _is_valid_contact(contact):
         await message.reply_text(
@@ -63,7 +65,7 @@ async def sos_contact_save(
     user_id = user.id
     with SessionLocal() as session:
         profile = session.get(Profile, user_id)
-        if not profile:
+        if profile is None:
             profile = Profile(telegram_id=user_id)
             session.add(profile)
         profile.sos_contact = contact
@@ -83,11 +85,11 @@ async def sos_contact_save(
 
 async def sos_contact_cancel(
     update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+) -> int | None:
     """Cancel SOS contact input."""
     message: Message = update.message
     if message is None:
-        return
+        return None
     await message.reply_text("Отменено.", reply_markup=menu_keyboard)
     return ConversationHandler.END
 

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -100,22 +100,22 @@ class User(Base):
 class Profile(Base):
     __tablename__ = "profiles"
 
-    telegram_id = Column(
+    telegram_id: Mapped[int] = mapped_column(
         BigInteger,
         ForeignKey("users.telegram_id"),
         primary_key=True,
     )
-    icr = Column(Float)  # г углеводов на 1 Е инсулина
-    cf = Column(Float)  # коэффициент коррекции
-    target_bg = Column(Float)  # целевой сахар
-    low_threshold = Column(Float)  # нижний порог сахара
-    high_threshold = Column(Float)  # верхний порог сахара
-    sos_contact = Column(String)  # контакт для экстренной связи
-    sos_alerts_enabled = Column(Boolean, default=True)
-    quiet_start = Column(Time)  # начало тихого режима
-    quiet_end = Column(Time)  # конец тихого режима
-    org_id = Column(Integer)
-    user = relationship("User")
+    icr: Mapped[float | None] = mapped_column(Float)  # г углеводов на 1 Е инсулина
+    cf: Mapped[float | None] = mapped_column(Float)  # коэффициент коррекции
+    target_bg: Mapped[float | None] = mapped_column(Float)  # целевой сахар
+    low_threshold: Mapped[float | None] = mapped_column(Float)  # нижний порог сахара
+    high_threshold: Mapped[float | None] = mapped_column(Float)  # верхний порог сахара
+    sos_contact: Mapped[str | None] = mapped_column(String)  # контакт для экстренной связи
+    sos_alerts_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    quiet_start: Mapped[datetime.time | None] = mapped_column(Time)  # начало тихого режима
+    quiet_end: Mapped[datetime.time | None] = mapped_column(Time)  # конец тихого режима
+    org_id: Mapped[int | None] = mapped_column(Integer)
+    user: Mapped[User] = relationship("User")
 
 
 class Entry(Base):


### PR DESCRIPTION
## Summary
- prevent SOS contact handler from stripping missing text
- type annotate profile fields for better ORM runtime behavior

## Testing
- `ruff check services/api/app/diabetes/handlers/sos_handlers.py services/api/app/diabetes/services/db.py tests`
- `mypy --ignore-missing-imports --follow-imports=skip services/api/app/diabetes/handlers/sos_handlers.py services/api/app/diabetes/services/db.py`
- `pytest tests/` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68aecdc11bdc832a9f67b6e8df0461d5