### PR TITLE
[db] Type remaining SQLAlchemy models

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -17,8 +17,6 @@ import logging
 from pathlib import Path
 from typing import Any, cast
 
-from typing import Any, cast
-
 from telegram import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
@@ -42,7 +40,6 @@ from services.api.app.diabetes.services.repository import commit
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from openai import OpenAIError
-from typing import Any
 
 
 logger = logging.getLogger(__name__)
@@ -204,9 +201,9 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         if profile is None:
             profile = Profile(telegram_id=user_id)
             session.add(profile)
-        cast(Any, profile).icr = icr
-        cast(Any, profile).cf = cf
-        cast(Any, profile).target_bg = target
+        profile.icr = icr
+        profile.cf = cf
+        profile.target_bg = target
         if not commit(session):
             await message.reply_text("⚠️ Не удалось сохранить профиль.")
             return ConversationHandler.END

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -3,7 +3,6 @@
 
 from sqlalchemy import (
     create_engine,
-    Column,
     Integer,
     BigInteger,
     String,
@@ -100,54 +99,62 @@ class User(Base):
 class Profile(Base):
     __tablename__ = "profiles"
 
-    telegram_id = Column(
-        BigInteger,
-        ForeignKey("users.telegram_id"),
-        primary_key=True,
+    telegram_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
     )
-    icr = Column(Float)  # г углеводов на 1 Е инсулина
-    cf = Column(Float)  # коэффициент коррекции
-    target_bg = Column(Float)  # целевой сахар
-    low_threshold = Column(Float)  # нижний порог сахара
-    high_threshold = Column(Float)  # верхний порог сахара
-    sos_contact = Column(String)  # контакт для экстренной связи
-    sos_alerts_enabled = Column(Boolean, default=True)
-    quiet_start = Column(Time)  # начало тихого режима
-    quiet_end = Column(Time)  # конец тихого режима
-    org_id = Column(Integer)
-    user = relationship("User")
+    icr: Mapped[float | None] = mapped_column(Float)  # г углеводов на 1 Е инсулина
+    cf: Mapped[float | None] = mapped_column(Float)  # коэффициент коррекции
+    target_bg: Mapped[float | None] = mapped_column(Float)  # целевой сахар
+    low_threshold: Mapped[float | None] = mapped_column(Float)  # нижний порог сахара
+    high_threshold: Mapped[float | None] = mapped_column(Float)  # верхний порог сахара
+    sos_contact: Mapped[str | None] = mapped_column(String)  # контакт для экстренной связи
+    sos_alerts_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    quiet_start: Mapped[datetime.time | None] = mapped_column(Time)  # начало тихого режима
+    quiet_end: Mapped[datetime.time | None] = mapped_column(Time)  # конец тихого режима
+    org_id: Mapped[int | None] = mapped_column(Integer)
+    user: Mapped[User] = relationship("User")
 
 
 class Entry(Base):
     __tablename__ = "entries"
 
-    id = Column(Integer, primary_key=True, index=True)
-    telegram_id = Column(BigInteger, ForeignKey("users.telegram_id"))
-    org_id = Column(Integer)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    telegram_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id")
+    )
+    org_id: Mapped[int | None] = mapped_column(Integer)
 
-    event_time = Column(TIMESTAMP(timezone=True), nullable=False)  # время приёма
-    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now())
-    updated_at = Column(TIMESTAMP(timezone=True), onupdate=func.now())
+    event_time: Mapped[datetime.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )  # время приёма
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime.datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), onupdate=func.now()
+    )
 
-    photo_path = Column(String)
-    carbs_g = Column(Float)
-    xe = Column(Float)
-    sugar_before = Column(Float)
-    dose = Column(Float)
-    gpt_summary = Column(Text)
+    photo_path: Mapped[str | None] = mapped_column(String)
+    carbs_g: Mapped[float | None] = mapped_column(Float)
+    xe: Mapped[float | None] = mapped_column(Float)
+    sugar_before: Mapped[float | None] = mapped_column(Float)
+    dose: Mapped[float | None] = mapped_column(Float)
+    gpt_summary: Mapped[str | None] = mapped_column(Text)
 
 
 class Alert(Base):
     __tablename__ = "alerts"
 
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(BigInteger, ForeignKey("users.telegram_id"))
-    org_id = Column(Integer)
-    sugar = Column(Float)
-    type = Column(String)
-    ts = Column(TIMESTAMP(timezone=True), server_default=func.now())
-    resolved = Column(Boolean, default=False)
-    user = relationship("User")
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"))
+    org_id: Mapped[int | None] = mapped_column(Integer)
+    sugar: Mapped[float | None] = mapped_column(Float)
+    type: Mapped[str] = mapped_column(String)
+    ts: Mapped[datetime.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now()
+    )
+    resolved: Mapped[bool] = mapped_column(Boolean, default=False)
+    user: Mapped[User] = relationship("User")
 
 
 class Reminder(Base):
@@ -185,22 +192,22 @@ class ReminderLog(Base):
 class Timezone(Base):
     __tablename__ = "timezones"
 
-    id = Column(Integer, primary_key=True, index=True)
-    tz = Column(String, nullable=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    tz: Mapped[str] = mapped_column(String, nullable=False)
 
 
 class HistoryRecord(Base):
     __tablename__ = "history_records"
 
-    id = Column(String, primary_key=True, index=True)
-    date = Column(String, nullable=False)
-    time = Column(String, nullable=False)
-    sugar = Column(Float)
-    carbs = Column(Float)
-    bread_units = Column(Float)
-    insulin = Column(Float)
-    notes = Column(Text)
-    type = Column(String, nullable=False)
+    id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
+    date: Mapped[str] = mapped_column(String, nullable=False)
+    time: Mapped[str] = mapped_column(String, nullable=False)
+    sugar: Mapped[float | None] = mapped_column(Float)
+    carbs: Mapped[float | None] = mapped_column(Float)
+    bread_units: Mapped[float | None] = mapped_column(Float)
+    insulin: Mapped[float | None] = mapped_column(Float)
+    notes: Mapped[str | None] = mapped_column(Text)
+    type: Mapped[str] = mapped_column(String, nullable=False)
 
 
 # ────────────────────── инициализация ────────────────────────


### PR DESCRIPTION
## Summary
- replace remaining Column definitions with typed `Mapped` `mapped_column` in `db.py`
- remove casts and assign to typed profile fields directly during onboarding

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: async def functions are not natively supported)*
- `python -m mypy services/api/app/services/profile.py`
- `python -m mypy services/api/app/diabetes/handlers/onboarding_handlers.py` *(fails: Return value expected, union-attr, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aecdc333f0832a84b19388d3456523