### PR TITLE
[handlers] Expose profile handlers at package level

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -1,0 +1,27 @@
+"""Convenience re-exports for public handler callables."""
+
+from .profile.conversation import (
+    profile_command,
+    profile_view,
+    profile_cancel,
+    profile_back,
+    profile_security,
+    profile_timezone,
+    profile_edit,
+    profile_conv,
+    profile_webapp_save,
+    profile_webapp_handler,
+)
+
+__all__ = [
+    "profile_command",
+    "profile_view",
+    "profile_cancel",
+    "profile_back",
+    "profile_security",
+    "profile_timezone",
+    "profile_edit",
+    "profile_conv",
+    "profile_webapp_save",
+    "profile_webapp_handler",
+]

--- a/services/api/app/diabetes/handlers/profile/__init__.py
+++ b/services/api/app/diabetes/handlers/profile/__init__.py
@@ -1,6 +1,25 @@
 """Expose profile conversation handlers and helpers."""
 
 from . import conversation as _conversation
+from .conversation import (
+    PROFILE_ICR,
+    PROFILE_CF,
+    PROFILE_TARGET,
+    PROFILE_LOW,
+    PROFILE_HIGH,
+    PROFILE_TZ,
+    back_keyboard,
+    profile_command,
+    profile_view,
+    profile_cancel,
+    profile_back,
+    profile_security,
+    profile_timezone,
+    profile_edit,
+    profile_conv,
+    profile_webapp_save,
+    profile_webapp_handler,
+)
 from .api import get_api, save_profile, set_timezone, fetch_profile, post_profile
 from .validation import parse_profile_args
 
@@ -12,6 +31,32 @@ _conversation.set_timezone = set_timezone
 _conversation.fetch_profile = fetch_profile
 _conversation.post_profile = post_profile
 _conversation.parse_profile_args = parse_profile_args
+
+__all__ = [
+    "PROFILE_ICR",
+    "PROFILE_CF",
+    "PROFILE_TARGET",
+    "PROFILE_LOW",
+    "PROFILE_HIGH",
+    "PROFILE_TZ",
+    "back_keyboard",
+    "profile_command",
+    "profile_view",
+    "profile_cancel",
+    "profile_back",
+    "profile_security",
+    "profile_timezone",
+    "profile_edit",
+    "profile_conv",
+    "profile_webapp_save",
+    "profile_webapp_handler",
+    "get_api",
+    "save_profile",
+    "set_timezone",
+    "fetch_profile",
+    "post_profile",
+    "parse_profile_args",
+]
 
 # Re-export the conversation module as the package itself
 import sys as _sys


### PR DESCRIPTION
## Summary
- export profile-related handler functions at package level for direct imports
- provide explicit re-exports in profile package for MyPy visibility

## Testing
- `python - <<'PY'
from services.api.app.diabetes.handlers import profile_view, profile_command
print(profile_view.__name__, profile_command.__name__)
PY`
- `mypy tests/test_handlers_profile.py` *(fails: numerous existing typing issues; no "module has no attribute" errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aecdc48054832aadd54c2ae5cebec5