### PR TITLE
[workflow] use script for ts sdk generation

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -1,4 +1,4 @@
-name: Generate SDKs
+name: Generate TS SDK
 
 on:
   push:
@@ -26,12 +26,13 @@ jobs:
           node-version: "20"
           cache: pnpm
       - run: pnpm install
-      - name: Generate SDKs
-        run: pnpm run generate:sdk
-      - name: Commit SDKs
+      - name: Install OpenAPI Generator CLI
+        run: pnpm add --global @openapitools/openapi-generator-cli
+      - name: Generate TS SDK
+        run: bash scripts/gen_ts_sdk.sh
+      - name: Commit TS SDK
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: 'chore: regenerate SDKs'
+          commit_message: 'chore: regenerate TS SDK'
           file_pattern: |
             libs/ts-sdk/**
-            libs/py-sdk/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,8 +34,10 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r services/api/app/requirements-dev.txt
-      - name: Generate SDK
-        run: pnpm run generate:sdk
+      - name: Install OpenAPI Generator CLI
+        run: pnpm add --global @openapitools/openapi-generator-cli
+      - name: Generate TS SDK
+        run: bash scripts/gen_ts_sdk.sh
       - name: Build webapp UI
         run: pnpm --filter services/webapp/ui run build
       - name: Type-check webapp UI

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev":       "pnpm --filter ./services/webapp/ui dev",
     "build":     "pnpm --filter ./services/webapp/ui build",
     "preview":   "pnpm --filter ./services/webapp/ui preview",
-    "generate:sdk": "pnpm dlx @openapitools/openapi-generator-cli generate -i libs/contracts/openapi.yaml -g typescript-fetch -o libs/ts-sdk -p useSingleRequestParameter=true && pnpm dlx @openapitools/openapi-generator-cli generate -i libs/contracts/openapi.yaml -g python -o libs/py-sdk -p packageName=diabetes_sdk,modelPropertyNaming=camelCase,snakeCaseIfNeed=false"
+    "generate:sdk": "bash scripts/gen_ts_sdk.sh"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Summary
- call `bash scripts/gen_ts_sdk.sh` for SDK generation
- update workflows to install OpenAPI generator and run the new script

## Testing
- `pytest -q --cov=services.api.app.diabetes --cov-report=term-missing --cov-report=xml --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aed1d8dd28832a9508ba49ec2289cb