### PR TITLE
[webapp] Remove runtime alias

### DIFF
--- a/services/webapp/ui/tsconfig.app.json
+++ b/services/webapp/ui/tsconfig.app.json
@@ -24,7 +24,6 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@sdk/runtime": ["../../../libs/ts-sdk/runtime.ts"],
       "@sdk": ["../../../libs/ts-sdk"],
       "@sdk/*": ["../../../libs/ts-sdk/*"]
     }

--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -8,7 +8,6 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@sdk/runtime": ["../../../libs/ts-sdk/runtime.ts"],
       "@sdk": ["../../../libs/ts-sdk"],
       "@sdk/*": ["../../../libs/ts-sdk/*"]
     },

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -81,13 +81,6 @@ export default defineConfig(async ({ mode, command }) => {
     plugins,
     resolve: {
       alias: [
-        {
-          find: '@sdk/runtime',
-          replacement: path.resolve(
-            __dirname,
-            '../../../libs/ts-sdk/runtime.ts',
-          ),
-        },
         { find: '@sdk', replacement: path.resolve(__dirname, '../../../libs/ts-sdk') },
         { find: '@', replacement: path.resolve(__dirname, './src') },
       ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,13 +7,6 @@ export default defineConfig({
   },
   resolve: {
     alias: [
-      {
-        find: '@sdk/runtime',
-        replacement: path.resolve(
-          __dirname,
-          './libs/ts-sdk/runtime.ts',
-        ),
-      },
       { find: '@sdk', replacement: path.resolve(__dirname, './libs/ts-sdk') },
       { find: '@', replacement: path.resolve(__dirname, './services/webapp/ui/src') },
     ],


### PR DESCRIPTION
## Summary
- clean up UI runtime alias so imports use `@sdk` + `.ts`

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(interrupted: no output)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68aed1d8de6c832a9efd870c305614bc