### PR TITLE
[ci] check UI build logs for runtime

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,17 @@ jobs:
       - name: Generate SDK
         run: pnpm run generate:sdk
       - name: Build webapp UI
-        run: pnpm --filter services/webapp/ui run build
+        id: build-webapp-ui
+        run: pnpm --filter services/webapp/ui run build 2>&1 | tee ui-build.log
+        continue-on-error: true
+      - name: Check build logs for runtime resolution
+        run: |
+          if grep -Eq "Could not resolve .* @sdk/runtime" ui-build.log; then
+            echo "Check that libs/ts-sdk/runtime.ts exists and update imports to '@sdk/runtime.ts'."
+            exit 1
+          elif [ "${{ steps.build-webapp-ui.outcome }}" = "failure" ]; then
+            exit 1
+          fi
       - name: Type-check webapp UI
         working-directory: services/webapp/ui
         run: pnpm run typecheck


### PR DESCRIPTION
## Summary
- capture webapp build logs and scan for unresolved `@sdk/runtime`

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aed1da6f68832a94bf39d224fc9265