### PR TITLE
[reminders] Update runtime import extension

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/reminders.ts
+++ b/services/webapp/ui/src/features/reminders/api/reminders.ts
@@ -1,4 +1,4 @@
-import { Configuration } from "@sdk/runtime";
+import { Configuration } from "@sdk/runtime.ts";
 import { DefaultApi } from "@sdk/apis";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 


### PR DESCRIPTION
## Summary
- fix reminders API runtime import to include `.ts` extension

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68aee2a0098c832a92f72f534e36a6ec