### PR TITLE
[reminders] fix runtime import paths

### DIFF
--- a/src/features/reminders/api/reminders.ts
+++ b/src/features/reminders/api/reminders.ts
@@ -1,4 +1,4 @@
-import { Configuration } from "../../../../libs/ts-sdk/runtime";
+import { Configuration } from "../../../../libs/ts-sdk/runtime.ts";
 import { DefaultApi } from "../../../../libs/ts-sdk/apis";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 

--- a/src/features/reminders/hooks/usePlan.ts
+++ b/src/features/reminders/hooks/usePlan.ts
@@ -1,4 +1,4 @@
-import { Configuration } from "../../../../libs/ts-sdk/runtime";
+import { Configuration } from "../../../../libs/ts-sdk/runtime.ts";
 import { DefaultApi } from "../../../../libs/ts-sdk/apis";
 
 export async function getPlanLimit(userId: number, initData: string): Promise<number> {


### PR DESCRIPTION
## Summary
- fix ts-sdk runtime import path in reminders modules

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install --no-save vitest` *(fails: ERESOLVE could not resolve)*
- `ruff check services/api/app tests`
- `pytest tests` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68aee2a65710832ab576cac3ffb104fe