### PR TITLE
[scripts] Add fix script for ts sdk runtime imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,10 @@ repos:
     rev: v0.6.2
     hooks:
       - id: ruff
+  - repo: local
+    hooks:
+      - id: fix-sdk-runtime
+        name: Fix TS SDK runtime imports
+        entry: bash scripts/fix-sdk-runtime.sh
+        language: system
+        pass_filenames: false

--- a/scripts/fix-sdk-runtime.sh
+++ b/scripts/fix-sdk-runtime.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+find . -type f -name "*.ts*" -exec sed -i "s|from '@sdk/runtime'|from '@sdk/runtime.ts'|g" {} +
+find . -type f -name "*.ts*" -exec sed -i 's|from "../../../../libs/ts-sdk/runtime"|from "../../../../libs/ts-sdk/runtime.ts"|g' {} +

--- a/src/features/reminders/api/reminders.ts
+++ b/src/features/reminders/api/reminders.ts
@@ -1,4 +1,4 @@
-import { Configuration } from "../../../../libs/ts-sdk/runtime";
+import { Configuration } from "../../../../libs/ts-sdk/runtime.ts";
 import { DefaultApi } from "../../../../libs/ts-sdk/apis";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 

--- a/src/features/reminders/hooks/usePlan.ts
+++ b/src/features/reminders/hooks/usePlan.ts
@@ -1,4 +1,4 @@
-import { Configuration } from "../../../../libs/ts-sdk/runtime";
+import { Configuration } from "../../../../libs/ts-sdk/runtime.ts";
 import { DefaultApi } from "../../../../libs/ts-sdk/apis";
 
 export async function getPlanLimit(userId: number, initData: string): Promise<number> {


### PR DESCRIPTION
## Summary
- add script to convert runtime imports to runtime.ts
- run fix script during pre-commit
- update reminders imports to use runtime.ts

## Testing
- `pre-commit run --files scripts/fix-sdk-runtime.sh .pre-commit-config.yaml src/features/reminders/api/reminders.ts src/features/reminders/hooks/usePlan.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aee2b67db0832a9ffad002c0adc6ab