### PR TITLE
[webapp] Fix ts-sdk alias and Vite fs allow

### DIFF
--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url))
+const sdkPath = path.resolve(__dirname, '../../../libs/ts-sdk')
 
 export default defineConfig(async ({ mode }) => {
   const plugins = [react(), tsconfigPaths()]
@@ -21,10 +22,10 @@ export default defineConfig(async ({ mode }) => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),
-        '@sdk': path.resolve(__dirname, '../../..', 'libs/ts-sdk'),
+        '@sdk': sdkPath,
       },
     },
-    server: { host: '::', port: 8080 },
+    server: { host: '::', port: 8080, fs: { allow: [sdkPath] } },
     build: { outDir: 'dist' }, // Явно задаём dist (по умолчанию и так dist)
   }
 })


### PR DESCRIPTION
## Summary
- ensure '@sdk' alias points to root libs/ts-sdk and allow Vite server access

## Testing
- `npm run build`
- `npm run lint` *(fails: 14 errors)*


------
https://chatgpt.com/codex/tasks/task_e_68aee721c3b8832ab1d1222e819f2ab8