### PR TITLE
[scripts] Improve SDK runtime fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,12 @@ API контейнер запускает `uvicorn` напрямую как ко
 Файл `libs/contracts/openapi.yaml` содержит спецификацию API. По нему генерируются SDK:
 
 ```bash
-npx @openapitools/openapi-generator-cli generate -i libs/contracts/openapi.yaml -g python -o libs/py-sdk
-npx @openapitools/openapi-generator-cli generate -i libs/contracts/openapi.yaml -g typescript-fetch -o libs/ts-sdk
+npm run generate:sdk
 ```
+
+Скрипт `generate:ts-sdk` запускает `scripts/fix-sdk-runtime.sh`, который заменяет импорты
+`from '@sdk/runtime'` и `from "...libs/ts-sdk/runtime"` на варианты с явным расширением
+`.ts`.
 
 ## Сервисный запуск
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "generate:py-sdk": "npx @openapitools/openapi-generator-cli generate -i libs/contracts/openapi.yaml -g python -o libs/py-sdk",
+    "generate:ts-sdk": "npx @openapitools/openapi-generator-cli generate -i libs/contracts/openapi.yaml -g typescript-fetch -o libs/ts-sdk && bash scripts/fix-sdk-runtime.sh",
+    "generate:sdk": "npm run generate:py-sdk && npm run generate:ts-sdk"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/fix-sdk-runtime.sh
+++ b/scripts/fix-sdk-runtime.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Replace SDK runtime imports to include explicit .ts extension.
 find . -type f -name "*.ts*" -exec sed -i "s|from '@sdk/runtime'|from '@sdk/runtime.ts'|g" {} +
-find . -type f -name "*.ts*" -exec sed -i 's|from "../../../../libs/ts-sdk/runtime"|from "../../../../libs/ts-sdk/runtime.ts"|g' {} +
+
+# Handle direct imports from libs/ts-sdk runtime regardless of path depth.
+find . -type f -name "*.ts*" -exec sed -i -E 's|from "(.*/)?libs/ts-sdk/runtime"|from "\1libs/ts-sdk/runtime.ts"|g' {} +


### PR DESCRIPTION
## Summary
- generalize fix-sdk-runtime script to rewrite any libs/ts-sdk runtime import
- expose SDK generation scripts running the fixer automatically
- document SDK generation workflow

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` *(fails: async def functions are not natively supported)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aee725d4f4832aa0594dbcb49af20d