### PR TITLE
[reminders] use SDK alias for reminders API

### DIFF
--- a/src/features/reminders/api/reminders.ts
+++ b/src/features/reminders/api/reminders.ts
@@ -1,5 +1,5 @@
-import { Configuration } from "../../../../libs/ts-sdk/runtime.ts";
-import { DefaultApi } from "../../../../libs/ts-sdk/apis";
+import { Configuration } from "@sdk/runtime.ts";
+import { DefaultApi } from "@sdk/apis";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 
 export function makeRemindersApi(initData: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@sdk/*": ["libs/ts-sdk/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- use `@sdk` path alias in reminders API
- add `tsconfig` path mapping for `@sdk`

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aee724385c832a8f0ddcde64c4d4d8