### PR TITLE
[handlers] remove duplicate alert jobs

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -66,6 +66,9 @@ def schedule_alert(
         "profile": profile,
         "first_name": first_name,
     }
+    for job in job_queue.get_jobs_by_name(f"alert_{user_id}"):
+        if job is not None:
+            job.schedule_removal()
     job_queue.run_once(
         alert_job,
         when=ALERT_REPEAT_DELAY,


### PR DESCRIPTION
## Summary
- clear existing alert jobs before scheduling new ones
- cover alert scheduling to ensure jobs aren't duplicated

## Testing
- ⚠️ `pytest tests/test_alert_handlers.py -k schedule_alert -q` (coverage threshold failure)
- ✅ `pytest tests/test_alert_handlers.py -k schedule_alert --no-cov -q`
- ✅ `mypy --strict services/api/app/diabetes/handlers/alert_handlers.py tests/test_alert_handlers.py`
- ✅ `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aeea2ed25c832a9d0c8ac47473fee6