### PR TITLE
refactor: alias context user data

### DIFF
--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -68,13 +68,13 @@ async def photo_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
 async def sugar_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Prompt user for current sugar level."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
         return
-    context.user_data.pop("pending_entry", None)
-    context.user_data["pending_entry"] = {
+    user_data.pop("pending_entry", None)
+    user_data["pending_entry"] = {
         "telegram_id": user.id,
         "event_time": datetime.datetime.now(datetime.timezone.utc),
     }
@@ -90,7 +90,7 @@ async def sugar_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
 async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Store the provided sugar level to the diary."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
@@ -107,7 +107,7 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     if sugar < 0:
         await message.reply_text("Сахар не может быть отрицательным.")
         return SUGAR_VAL
-    entry_data: dict[str, Any] = context.user_data.pop("pending_entry", None) or {
+    entry_data: dict[str, Any] = user_data.pop("pending_entry", None) or {
         "telegram_id": user.id,
         "event_time": datetime.datetime.now(datetime.timezone.utc),
     }
@@ -130,13 +130,13 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Entry point for dose calculation conversation."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     message: Message = update.message
     if message is None:
         return
-    context.user_data.pop("pending_entry", None)
-    context.user_data.pop("edit_id", None)
-    context.user_data.pop("dose_method", None)
+    user_data.pop("pending_entry", None)
+    user_data.pop("edit_id", None)
+    user_data.pop("dose_method", None)
     await message.reply_text(
         "💉 Как рассчитать дозу? Выберите метод:",
         reply_markup=dose_keyboard,
@@ -146,7 +146,7 @@ async def dose_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_method_choice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle method selection for dose calculation."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     message: Message = update.message
     if message is None:
         return
@@ -154,11 +154,11 @@ async def dose_method_choice(update: Update, context: ContextTypes.DEFAULT_TYPE)
     if "назад" in text:
         return await dose_cancel(update, context)
     if "углев" in text:
-        context.user_data["dose_method"] = "carbs"
+        user_data["dose_method"] = "carbs"
         await message.reply_text("Введите количество углеводов (г).")
         return DOSE_CARBS
     if "xe" in text or "хе" in text:
-        context.user_data["dose_method"] = "xe"
+        user_data["dose_method"] = "xe"
         await message.reply_text("Введите количество ХЕ.")
         return DOSE_XE
     await message.reply_text(
@@ -170,7 +170,7 @@ async def dose_method_choice(update: Update, context: ContextTypes.DEFAULT_TYPE)
 
 async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Capture XE amount from user."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
@@ -184,7 +184,7 @@ async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     if xe < 0:
         await message.reply_text("Количество ХЕ не может быть отрицательным.")
         return DOSE_XE
-    context.user_data["pending_entry"] = {
+    user_data["pending_entry"] = {
         "telegram_id": user.id,
         "event_time": datetime.datetime.now(datetime.timezone.utc),
         "xe": xe,
@@ -195,7 +195,7 @@ async def dose_xe(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Capture carbohydrates in grams."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
@@ -211,7 +211,7 @@ async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
             "Количество углеводов не может быть отрицательным."
         )
         return DOSE_CARBS
-    context.user_data["pending_entry"] = {
+    user_data["pending_entry"] = {
         "telegram_id": user.id,
         "event_time": datetime.datetime.now(datetime.timezone.utc),
         "carbs_g": carbs,
@@ -222,7 +222,7 @@ async def dose_carbs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Finalize dose calculation after receiving sugar level."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
@@ -237,7 +237,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         await message.reply_text("Сахар не может быть отрицательным.")
         return DOSE_SUGAR
 
-    entry: dict[str, Any] = context.user_data.get("pending_entry", {})
+    entry: dict[str, Any] = user_data.get("pending_entry", {})
     entry["sugar_before"] = sugar
     xe = entry.get("xe")
     carbs_g = entry.get("carbs_g")
@@ -246,7 +246,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
             "Не указаны углеводы или ХЕ. Расчёт невозможен.",
             reply_markup=menu_keyboard,
         )
-        context.user_data.pop("pending_entry", None)
+        user_data.pop("pending_entry", None)
         return ConversationHandler.END
     if carbs_g is None and xe is not None:
         carbs_g = xe * 12
@@ -261,7 +261,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
             "Профиль не настроен. Установите коэффициенты через /profile.",
             reply_markup=menu_keyboard,
         )
-        context.user_data.pop("pending_entry", None)
+        user_data.pop("pending_entry", None)
         return ConversationHandler.END
 
     patient = PatientProfile(
@@ -272,7 +272,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     dose = calc_bolus(carbs_g, sugar, patient)
     entry["dose"] = dose
 
-    context.user_data["pending_entry"] = entry
+    user_data["pending_entry"] = entry
 
     xe_info = f", ХЕ: {xe}" if xe is not None else ""
     await message.reply_text(
@@ -290,13 +290,13 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def dose_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Cancel dose calculation conversation."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     message: Message = update.message
     if message is None:
         return
     await message.reply_text("Отменено.", reply_markup=menu_keyboard)
-    context.user_data.pop("pending_entry", None)
-    context.user_data.pop("dose_method", None)
+    user_data.pop("pending_entry", None)
+    user_data.pop("dose_method", None)
     chat_data = getattr(context, "chat_data", None)
     if chat_data is not None:
         chat_data.pop("sugar_active", None)
@@ -319,7 +319,7 @@ def _cancel_then(
 
 async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle freeform text commands for adding diary entries."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
@@ -328,10 +328,10 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     user_id = user.id
     logger.info("FREEFORM raw='%s'  user=%s", _sanitize(raw_text), user_id)
 
-    if context.user_data.get("awaiting_report_date"):
+    if user_data.get("awaiting_report_date"):
         text = message.text.strip().lower()
         if "назад" in text or text == "/cancel":
-            context.user_data.pop("awaiting_report_date", None)
+            user_data.pop("awaiting_report_date", None)
             await message.reply_text(
                 "📋 Выберите действие:", reply_markup=menu_keyboard
             )
@@ -346,12 +346,12 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             )
             return
         await send_report(update, context, date_from, "указанный период")
-        context.user_data.pop("awaiting_report_date", None)
+        user_data.pop("awaiting_report_date", None)
         return
 
-    pending_entry: dict[str, Any] | None = context.user_data.get("pending_entry")
-    pending_fields = context.user_data.get("pending_fields")
-    edit_id = context.user_data.get("edit_id")
+    pending_entry: dict[str, Any] | None = user_data.get("pending_entry")
+    pending_fields = user_data.get("pending_fields")
+    edit_id = user_data.get("edit_id")
     if pending_entry is not None and edit_id is None and pending_fields:
         field = pending_fields[0]
         text = update.message.text.strip().replace(",", ".")
@@ -422,8 +422,8 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         sugar = pending_entry.get("sugar_before")
         if sugar is not None:
             await check_alert(update, context, sugar)
-        context.user_data.pop("pending_entry", None)
-        context.user_data.pop("pending_fields", None)
+        user_data.pop("pending_entry", None)
+        user_data.pop("pending_fields", None)
         xe = pending_entry.get("xe")
         dose = pending_entry.get("dose")
         xe_info = f", ХЕ {xe}" if xe is not None else ""
@@ -474,7 +474,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                         "Профиль не настроен. Установите коэффициенты через /profile.",
                         reply_markup=menu_keyboard,
                     )
-                    context.user_data.pop("pending_entry", None)
+                    user_data.pop("pending_entry", None)
                     return
                 patient = PatientProfile(
                     icr=profile.icr,
@@ -483,7 +483,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 )
                 dose = calc_bolus(carbs_g, sugar, patient)
                 entry["dose"] = dose
-                context.user_data["pending_entry"] = entry
+                user_data["pending_entry"] = entry
                 xe_info = f", ХЕ: {xe}" if xe is not None else ""
                 await update.message.reply_text(
                     text=(
@@ -574,8 +574,8 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             reply_markup=confirm_keyboard(),
         )
         return
-    if "edit_id" in context.user_data:
-        field = context.user_data.get("edit_field")
+    if "edit_id" in user_data:
+        field = user_data.get("edit_field")
         text = update.message.text.strip().replace(",", ".")
         try:
             value = float(text)
@@ -596,7 +596,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     "Доза инсулина не может быть отрицательной."
                 )
             return
-        edit_id = context.user_data.get("edit_id")
+        edit_id = user_data.get("edit_id")
         def db_update(session: Session) -> tuple[str, Entry | None]:
             assert edit_id is not None
             entry = session.get(Entry, edit_id)
@@ -618,7 +618,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         if status == "missing":
             await update.message.reply_text("Запись уже удалена.")
             for key in ("edit_id", "edit_field", "edit_entry", "edit_query"):
-                context.user_data.pop(key, None)
+                user_data.pop(key, None)
             return
         if status == "fail" or entry is None:
             await update.message.reply_text("⚠️ Не удалось обновить запись.")
@@ -626,7 +626,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         if field == "sugar":
             await check_alert(update, context, value)
         render_text = render_entry(entry)
-        edit_info = context.user_data.get("edit_entry", {})
+        edit_info = user_data.get("edit_entry", {})
         assert edit_id is not None
         markup = InlineKeyboardMarkup(
             [
@@ -647,11 +647,11 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             parse_mode="HTML",
             reply_markup=markup,
         )
-        query = context.user_data.get("edit_query")
+        query = user_data.get("edit_query")
         if query:
             await query.answer("Изменено")
         for key in ("edit_id", "edit_field", "edit_entry", "edit_query"):
-            context.user_data.pop(key, None)
+            user_data.pop(key, None)
         return
 
     try:
@@ -716,8 +716,8 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 reply_markup=menu_keyboard,
             )
             return
-        context.user_data["pending_entry"] = entry_data
-        context.user_data["pending_fields"] = missing
+        user_data["pending_entry"] = entry_data
+        user_data["pending_fields"] = missing
         next_field = missing[0]
         if next_field == "sugar":
             await update.message.reply_text("Введите уровень сахара (ммоль/л).")
@@ -780,8 +780,8 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             event_dt = datetime.datetime.now(datetime.timezone.utc)
     else:
         event_dt = datetime.datetime.now(datetime.timezone.utc)
-    context.user_data.pop("pending_entry", None)
-    context.user_data["pending_entry"] = {
+    user_data.pop("pending_entry", None)
+    user_data["pending_entry"] = {
         "telegram_id": user_id,
         "event_time": event_dt,
         "xe": fields.get("xe"),
@@ -809,7 +809,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
 async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Placeholder GPT chat handler."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     message: Message = update.message
     if message is None:
         return
@@ -822,7 +822,7 @@ async def photo_handler(
     demo: bool = False,
 ) -> int:
     """Process food photos and trigger nutrition analysis."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     message: Message | None = update.message or (
         update.callback_query.message if update.callback_query else None
     )
@@ -831,18 +831,18 @@ async def photo_handler(
         return
     user_id = user.id
 
-    if context.user_data.get(WAITING_GPT_FLAG):
+    if user_data.get(WAITING_GPT_FLAG):
         await message.reply_text("⏳ Уже обрабатываю фото, подождите…")
         return ConversationHandler.END
-    context.user_data[WAITING_GPT_FLAG] = True
+    user_data[WAITING_GPT_FLAG] = True
 
-    file_path = context.user_data.pop("__file_path", None)
+    file_path = user_data.pop("__file_path", None)
     if not file_path:
         try:
             photo = message.photo[-1]
         except (AttributeError, IndexError, TypeError):
             await message.reply_text("❗ Файл не распознан как изображение.")
-            context.user_data.pop(WAITING_GPT_FLAG, None)
+            user_data.pop(WAITING_GPT_FLAG, None)
             return ConversationHandler.END
 
         os.makedirs("photos", exist_ok=True)
@@ -853,13 +853,13 @@ async def photo_handler(
         except OSError as exc:
             logging.exception("[PHOTO] Failed to save photo: %s", exc)
             await message.reply_text("⚠️ Не удалось сохранить фото. Попробуйте ещё раз.")
-            context.user_data.pop(WAITING_GPT_FLAG, None)
+            user_data.pop(WAITING_GPT_FLAG, None)
             return ConversationHandler.END
 
     logger.info("[PHOTO] Saved to %s", file_path)
 
     try:
-        thread_id = context.user_data.get("thread_id")
+        thread_id = user_data.get("thread_id")
         if not thread_id:
             with SessionLocal() as session:
                 user = session.get(User, user_id)
@@ -873,7 +873,7 @@ async def photo_handler(
                             "⚠️ Не удалось сохранить данные пользователя."
                         )
                         return ConversationHandler.END
-            context.user_data["thread_id"] = thread_id
+            user_data["thread_id"] = thread_id
 
         run = await send_message(
             thread_id=thread_id,
@@ -1021,14 +1021,14 @@ async def photo_handler(
             )
             return ConversationHandler.END
 
-        pending_entry: dict[str, Any] = context.user_data.get("pending_entry") or {
+        pending_entry: dict[str, Any] = user_data.get("pending_entry") or {
             "telegram_id": user_id,
             "event_time": datetime.datetime.now(datetime.timezone.utc),
         }
         pending_entry.update(
             {"carbs_g": carbs_g, "xe": xe, "photo_path": file_path}
         )
-        context.user_data["pending_entry"] = pending_entry
+        user_data["pending_entry"] = pending_entry
         if status_message and hasattr(status_message, "delete"):
             try:
                 await status_message.delete()
@@ -1066,14 +1066,14 @@ async def photo_handler(
         logging.exception("[PHOTO] Telegram error: %s", exc)
         return ConversationHandler.END
     finally:
-        context.user_data.pop(WAITING_GPT_FLAG, None)
+        user_data.pop(WAITING_GPT_FLAG, None)
 
 
 async def doc_handler(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> int:
     """Handle images sent as documents."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     message: Message = update.message
     user = update.effective_user
     if message is None or user is None:
@@ -1094,7 +1094,7 @@ async def doc_handler(
     file = await context.bot.get_file(document.file_id)
     await file.download_to_drive(path)
 
-    context.user_data["__file_path"] = path
+    user_data["__file_path"] = path
     message.photo = []
     return await photo_handler(update, context)
 

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -539,7 +539,7 @@ async def profile_edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
 
 async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle ICR input."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     raw_text = update.message.text.strip()
     if "назад" in raw_text.lower():
         return await profile_cancel(update, context)
@@ -552,7 +552,7 @@ async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     if icr <= 0:
         await update.message.reply_text("ИКХ должен быть больше 0.", reply_markup=back_keyboard)
         return PROFILE_ICR
-    context.user_data["profile_icr"] = icr
+    user_data["profile_icr"] = icr
     await update.message.reply_text(
         "Введите коэффициент чувствительности (КЧ) ммоль/л — на сколько ммоль/л 1 ед. инсулина снижает сахар:",
         reply_markup=back_keyboard,
@@ -562,7 +562,7 @@ async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
 async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle CF input."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     raw_text = update.message.text.strip()
     if "назад" in raw_text.lower():
         await update.message.reply_text(
@@ -579,7 +579,7 @@ async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     if cf <= 0:
         await update.message.reply_text("КЧ должен быть больше 0.", reply_markup=back_keyboard)
         return PROFILE_CF
-    context.user_data["profile_cf"] = cf
+    user_data["profile_cf"] = cf
     await update.message.reply_text(
         "Введите целевой уровень сахара (ммоль/л) — к какому значению вы стремитесь:",
         reply_markup=back_keyboard,
@@ -589,7 +589,7 @@ async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle target BG input."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     raw_text = update.message.text.strip()
     if "назад" in raw_text.lower():
         await update.message.reply_text(
@@ -610,7 +610,7 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             "Целевой сахар должен быть больше 0.", reply_markup=back_keyboard
         )
         return PROFILE_TARGET
-    context.user_data["profile_target"] = target
+    user_data["profile_target"] = target
     await update.message.reply_text(
         "Введите нижний порог сахара (ммоль/л) — ниже него бот предупредит о гипогликемии:",
         reply_markup=back_keyboard,
@@ -620,7 +620,7 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle low threshold input."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     raw_text = update.message.text.strip()
     if "назад" in raw_text.lower():
         await update.message.reply_text(
@@ -641,7 +641,7 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
             "Нижний порог должен быть больше 0.", reply_markup=back_keyboard
         )
         return PROFILE_LOW
-    context.user_data["profile_low"] = low
+    user_data["profile_low"] = low
     await update.message.reply_text(
         "Введите верхний порог сахара (ммоль/л) — выше него бот предупредит о гипергликемии:",
         reply_markup=back_keyboard,
@@ -649,7 +649,7 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     return PROFILE_HIGH
 async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle high threshold input and save profile."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     raw_text = update.message.text.strip()
     if "назад" in raw_text.lower():
         await update.message.reply_text(
@@ -665,17 +665,17 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
             "Введите верхний порог числом.", reply_markup=back_keyboard
         )
         return PROFILE_HIGH
-    low = context.user_data.get("profile_low")
+    low = user_data.get("profile_low")
     if high <= 0 or low is None or high <= low:
         await update.message.reply_text(
             "Верхний порог должен быть больше нижнего и больше 0.",
             reply_markup=back_keyboard,
         )
         return PROFILE_HIGH
-    icr = context.user_data.pop("profile_icr", None)
-    cf = context.user_data.pop("profile_cf", None)
-    target = context.user_data.pop("profile_target", None)
-    context.user_data.pop("profile_low", None)
+    icr = user_data.pop("profile_icr", None)
+    cf = user_data.pop("profile_cf", None)
+    target = user_data.pop("profile_target", None)
+    user_data.pop("profile_low", None)
     if icr is None or cf is None or target is None:
         await update.message.reply_text(
             "⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново."

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle inline button callbacks for pending entries and history actions."""
-    context.user_data: dict[str, Any] = context.user_data or {}
+    user_data = context.user_data
     query = update.callback_query
     await query.answer()
     data = query.data or ""
@@ -25,7 +25,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         return
 
     if data == "confirm_entry":
-        entry_data: dict[str, Any] | None = context.user_data.pop("pending_entry", None)
+        entry_data: dict[str, Any] | None = user_data.pop("pending_entry", None)
         if not entry_data:
             await query.edit_message_text("❗ Нет данных для сохранения.")
             return
@@ -47,11 +47,11 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             reminder_handlers.schedule_after_meal(update.effective_user.id, job_queue)
         return
     elif data == "edit_entry":
-        entry_data: dict[str, Any] | None = context.user_data.get("pending_entry")
+        entry_data: dict[str, Any] | None = user_data.get("pending_entry")
         if not entry_data:
             await query.edit_message_text("❗ Нет данных для редактирования.")
             return
-        context.user_data["edit_id"] = None
+        user_data["edit_id"] = None
         await query.edit_message_text(
             "Отправьте новое сообщение в формате:\n"
             "`сахар=<ммоль/л>  xe=<ХЕ>  carbs=<г>  dose=<ед>`\n"
@@ -60,7 +60,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         )
         return
     elif data == "cancel_entry":
-        context.user_data.pop("pending_entry", None)
+        user_data.pop("pending_entry", None)
         await query.edit_message_text("❌ Запись отменена.")
         await query.message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
         return
@@ -90,7 +90,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 await query.edit_message_text("❌ Запись удалена.")
                 return
             if action == "edit":
-                context.user_data["edit_entry"] = {
+                user_data["edit_entry"] = {
                     "id": entry.id,
                     "chat_id": query.message.chat_id,
                     "message_id": query.message.message_id,
@@ -124,9 +124,9 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             logger.warning("Invalid edit_field data: %s", data)
             await query.edit_message_text("Некорректные данные для редактирования.")
             return
-        context.user_data["edit_id"] = entry_id
-        context.user_data["edit_field"] = field
-        context.user_data["edit_query"] = query
+        user_data["edit_id"] = entry_id
+        user_data["edit_field"] = field
+        user_data["edit_query"] = query
         prompts: dict[str, str] = {
             "sugar": "Введите уровень сахара (ммоль/л).",
             "xe": "Введите количество ХЕ.",


### PR DESCRIPTION
## Summary
- stop reassigning context.user_data in dose handlers
- refactor profile conversation handlers to mutate user_data
- update router callback handler to use local user_data variable

## Testing
- `ruff check services/api/app tests`
- `pytest tests/` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68aeea35c818832a821ca7bd0c9662f9