### PR TITLE
[ui] refactor menu keyboard builder

### DIFF
--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.utils.ui import build_menu_keyboard
 
 
 async def menu_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Display the main menu keyboard using ``menu_keyboard``."""
+    """Display the main menu keyboard."""
     await update.message.reply_text(
-        "📋 Выберите действие:", reply_markup=menu_keyboard
+        "📋 Выберите действие:", reply_markup=build_menu_keyboard()
     )
 
 
@@ -61,7 +61,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "⏰ Напоминания\n"
         "ℹ️ Помощь"
     )
-    await update.message.reply_text(text, reply_markup=menu_keyboard)
+    await update.message.reply_text(text, reply_markup=build_menu_keyboard())
 
 
 async def smart_input_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -76,7 +76,7 @@ async def smart_input_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
 
 __all__ = [
-    "menu_keyboard",
+    "build_menu_keyboard",
     "menu_command",
     "help_command",
     "smart_input_help",

--- a/services/api/app/diabetes/handlers/dose_handlers.py
+++ b/services/api/app/diabetes/handlers/dose_handlers.py
@@ -33,7 +33,12 @@ from services.api.app.diabetes.utils.functions import (
 )
 from services.api.app.diabetes.services.gpt_client import create_thread, send_message, _get_client
 from services.api.app.diabetes.gpt_command_parser import parse_command
-from services.api.app.diabetes.utils.ui import menu_keyboard, confirm_keyboard, dose_keyboard, sugar_keyboard
+from services.api.app.diabetes.utils.ui import (
+    build_menu_keyboard,
+    confirm_keyboard,
+    dose_keyboard,
+    sugar_keyboard,
+)
 from services.api.app.diabetes.services.repository import commit
 from .common_handlers import menu_command
 from .alert_handlers import check_alert
@@ -62,7 +67,7 @@ async def photo_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if message is None:
         return
     await message.reply_text(
-        "📸 Пришлите фото блюда для анализа.", reply_markup=menu_keyboard
+        "📸 Пришлите фото блюда для анализа.", reply_markup=build_menu_keyboard()
     )
 
 
@@ -121,7 +126,7 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     await check_alert(update, context, sugar)
     await message.reply_text(
         f"✅ Уровень сахара {sugar} ммоль/л сохранён.",
-        reply_markup=menu_keyboard,
+        reply_markup=build_menu_keyboard(),
     )
     if chat_data is not None:
         chat_data.pop("sugar_active", None)
@@ -244,7 +249,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     if carbs_g is None and xe is None:
         await message.reply_text(
             "Не указаны углеводы или ХЕ. Расчёт невозможен.",
-            reply_markup=menu_keyboard,
+            reply_markup=build_menu_keyboard(),
         )
         context.user_data.pop("pending_entry", None)
         return ConversationHandler.END
@@ -259,7 +264,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     if not profile or None in (profile.icr, profile.cf, profile.target_bg):
         await message.reply_text(
             "Профиль не настроен. Установите коэффициенты через /profile.",
-            reply_markup=menu_keyboard,
+            reply_markup=build_menu_keyboard(),
         )
         context.user_data.pop("pending_entry", None)
         return ConversationHandler.END
@@ -294,7 +299,7 @@ async def dose_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     message: Message = update.message
     if message is None:
         return
-    await message.reply_text("Отменено.", reply_markup=menu_keyboard)
+    await message.reply_text("Отменено.", reply_markup=build_menu_keyboard())
     context.user_data.pop("pending_entry", None)
     context.user_data.pop("dose_method", None)
     chat_data = getattr(context, "chat_data", None)
@@ -333,7 +338,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         if "назад" in text or text == "/cancel":
             context.user_data.pop("awaiting_report_date", None)
             await message.reply_text(
-                "📋 Выберите действие:", reply_markup=menu_keyboard
+                "📋 Выберите действие:", reply_markup=build_menu_keyboard()
             )
             return
         try:
@@ -431,7 +436,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         sugar_info = f"сахар {sugar} ммоль/л" if sugar is not None else "сахар —"
         await update.message.reply_text(
             f"✅ Запись сохранена: {sugar_info}{xe_info}{dose_info}",
-            reply_markup=menu_keyboard,
+            reply_markup=build_menu_keyboard(),
         )
         return
     if pending_entry is not None and edit_id is None:
@@ -472,7 +477,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 ):
                     await update.message.reply_text(
                         "Профиль не настроен. Установите коэффициенты через /profile.",
-                        reply_markup=menu_keyboard,
+                        reply_markup=build_menu_keyboard(),
                     )
                     context.user_data.pop("pending_entry", None)
                     return
@@ -713,7 +718,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 await check_alert(update, context, sugar)
             await update.message.reply_text(
                 f"✅ Запись сохранена: сахар {sugar} ммоль/л, ХЕ {xe}, доза {dose} Ед.",
-                reply_markup=menu_keyboard,
+                reply_markup=build_menu_keyboard(),
             )
             return
         context.user_data["pending_entry"] = entry_data
@@ -1017,7 +1022,7 @@ async def photo_handler(
                 f"Вот полный ответ Vision:\n<pre>{vision_text}</pre>\n"
                 "Введите /dose и укажите их вручную.",
                 parse_mode="HTML",
-                reply_markup=menu_keyboard,
+                reply_markup=build_menu_keyboard(),
             )
             return ConversationHandler.END
 
@@ -1046,7 +1051,7 @@ async def photo_handler(
         await message.reply_text(
             f"🍽️ На фото:\n{vision_text}\n\n"
             "Введите текущий сахар (ммоль/л) — и я рассчитаю дозу инсулина.",
-            reply_markup=menu_keyboard,
+            reply_markup=build_menu_keyboard(),
         )
         return PHOTO_SUGAR
 

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -34,7 +34,10 @@ from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import Cal
 
 from services.api.app.diabetes.services.db import User, Profile, Reminder
 from .db import SessionLocal
-from services.api.app.diabetes.utils.ui import menu_keyboard, build_timezone_webapp_button
+from services.api.app.diabetes.utils.ui import (
+    build_menu_keyboard,
+    build_timezone_webapp_button,
+)
 from services.api.app.diabetes.services.repository import commit
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -95,7 +98,8 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
                 " Рада видеть тебя. Надеюсь, у тебя сегодня всё отлично."
             )
             await message.reply_text(
-                f"{greeting}\n\n📋 Выберите действие:", reply_markup=menu_keyboard
+                f"{greeting}\n\n📋 Выберите действие:",
+                reply_markup=build_menu_keyboard(),
             )
             return ConversationHandler.END
 
@@ -391,7 +395,7 @@ async def onboarding_reminders(
     polls[poll_msg.poll.id] = user_id
 
     await query.message.reply_text(
-        "Готово! Спасибо за настройку.", reply_markup=menu_keyboard
+        "Готово! Спасибо за настройку.", reply_markup=build_menu_keyboard()
     )
     return ConversationHandler.END
 
@@ -413,7 +417,7 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 await query.message.reply_text(
 
                     "⚠️ Не удалось сохранить настройки.",
-                    reply_markup=menu_keyboard,
+                    reply_markup=build_menu_keyboard(),
 
                 )
                 return ConversationHandler.END
@@ -426,7 +430,7 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     context.bot_data.setdefault("onboarding_polls", {})[poll_msg.poll.id] = user_id
 
     await query.message.reply_text(
-        "Пропущено.", reply_markup=menu_keyboard
+        "Пропущено.", reply_markup=build_menu_keyboard()
     )
     return ConversationHandler.END
 

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -32,7 +32,7 @@ from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import (
 from services.api.app.diabetes.utils.ui import (
     build_timezone_webapp_button,
     back_keyboard,
-    menu_keyboard,
+    build_menu_keyboard,
 )
 from services.api.app.config import settings
 from services.api.app.diabetes.services.repository import commit
@@ -154,7 +154,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         f"• Низкий порог: {low} ммоль/л\n"
         f"• Высокий порог: {high} ммоль/л" + warning_msg,
         parse_mode="Markdown",
-        reply_markup=menu_keyboard,
+        reply_markup=build_menu_keyboard(),
     )
     return ConversationHandler.END
 
@@ -232,7 +232,7 @@ async def profile_webapp_save(
     if api is None:
         await update.effective_message.reply_text(
             "⚠️ Функции профиля недоступны. Установите пакет 'diabetes_sdk'.",
-            reply_markup=menu_keyboard,
+            reply_markup=build_menu_keyboard(),
         )
         return
     raw = update.effective_message.web_app_data.data
@@ -241,7 +241,7 @@ async def profile_webapp_save(
         data = json.loads(raw)
     except json.JSONDecodeError:
         await update.effective_message.reply_text(
-            error_msg, reply_markup=menu_keyboard
+            error_msg, reply_markup=build_menu_keyboard()
         )
         return
     if {
@@ -252,7 +252,7 @@ async def profile_webapp_save(
         "high",
     } - data.keys():
         await update.effective_message.reply_text(
-            error_msg, reply_markup=menu_keyboard
+            error_msg, reply_markup=build_menu_keyboard()
         )
         return
     try:
@@ -263,7 +263,7 @@ async def profile_webapp_save(
         high = float(str(data["high"]).replace(",", "."))
     except ValueError:
         await update.effective_message.reply_text(
-            error_msg, reply_markup=menu_keyboard
+            error_msg, reply_markup=build_menu_keyboard()
         )
         return
     user_id = update.effective_user.id
@@ -281,7 +281,7 @@ async def profile_webapp_save(
     if not ok:
         await update.effective_message.reply_text(
             err or "⚠️ Не удалось сохранить профиль.",
-            reply_markup=menu_keyboard,
+            reply_markup=build_menu_keyboard(),
         )
         return
     await update.effective_message.reply_text(
@@ -291,13 +291,13 @@ async def profile_webapp_save(
         f"• Целевой сахар: {target} ммоль/л\n"
         f"• Низкий порог: {low} ммоль/л\n"
         f"• Высокий порог: {high} ммоль/л",
-        reply_markup=menu_keyboard,
+        reply_markup=build_menu_keyboard(),
     )
 
 
 async def profile_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Cancel profile creation conversation."""
-    await update.message.reply_text("Отменено.", reply_markup=menu_keyboard)
+    await update.message.reply_text("Отменено.", reply_markup=build_menu_keyboard())
     return ConversationHandler.END
 
 
@@ -306,7 +306,9 @@ async def profile_back(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     query = update.callback_query
     await query.answer()
     await query.message.delete()
-    await query.message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
+    await query.message.reply_text(
+        "📋 Выберите действие:", reply_markup=build_menu_keyboard()
+    )
 async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Prompt user to enter timezone."""
     query = update.callback_query
@@ -354,17 +356,17 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
     )
     if not exists:
         await update.message.reply_text(
-            "Профиль не найден.", reply_markup=menu_keyboard
+            "Профиль не найден.", reply_markup=build_menu_keyboard()
         )
         return ConversationHandler.END
     if not ok:
         await update.message.reply_text(
             "⚠️ Не удалось обновить часовой пояс.",
-            reply_markup=menu_keyboard,
+            reply_markup=build_menu_keyboard(),
         )
         return ConversationHandler.END
     await update.message.reply_text(
-        "✅ Часовой пояс обновлён.", reply_markup=menu_keyboard
+        "✅ Часовой пояс обновлён.", reply_markup=build_menu_keyboard()
     )
     return ConversationHandler.END
 
@@ -462,7 +464,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if not result.get("commit_ok", True):
         await query.message.reply_text(
             "⚠️ Не удалось сохранить настройки.",
-            reply_markup=menu_keyboard,
+            reply_markup=build_menu_keyboard(),
         )
         return
     alert_sugar = result.get("alert_sugar")
@@ -712,7 +714,7 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         f"• Целевой сахар: {target} ммоль/л\n"
         f"• Низкий порог: {low} ммоль/л\n"
         f"• Высокий порог: {high} ммоль/л" + warning_msg,
-        reply_markup=menu_keyboard,
+        reply_markup=build_menu_keyboard(),
     )
     return ConversationHandler.END
 

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -28,7 +28,7 @@ from services.api.app.diabetes.services.gpt_client import (
 )
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.services.reporting import make_sugar_plot, generate_pdf_report
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.utils.ui import build_menu_keyboard
 
 LOW_SUGAR_THRESHOLD = 3.0
 HIGH_SUGAR_THRESHOLD = 13.0
@@ -163,7 +163,7 @@ async def report_period_callback(
     if data == "report_back":
         await query.message.delete()
         await query.message.reply_text(
-            "📋 Выберите действие:", reply_markup=menu_keyboard
+            "📋 Выберите действие:", reply_markup=build_menu_keyboard()
         )
         return
     period = data.split(":", 1)[1]

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from services.api.app.diabetes.services.db import Entry
 from .db import SessionLocal
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.utils.ui import build_menu_keyboard
 
 from services.api.app.diabetes.services.repository import commit
 
@@ -62,7 +62,9 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     elif data == "cancel_entry":
         context.user_data.pop("pending_entry", None)
         await query.edit_message_text("❌ Запись отменена.")
-        await query.message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
+        await query.message.reply_text(
+            "📋 Выберите действие:", reply_markup=build_menu_keyboard()
+        )
         return
     elif data.startswith("edit:") or data.startswith("del:"):
         action, entry_id = data.split(":", 1)

--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -15,7 +15,7 @@ from telegram.ext import (
 
 from services.api.app.diabetes.services.db import Profile
 from .db import SessionLocal
-from services.api.app.diabetes.utils.ui import back_keyboard, menu_keyboard
+from services.api.app.diabetes.utils.ui import back_keyboard, build_menu_keyboard
 from services.api.app.diabetes.services.repository import commit
 from . import dose_handlers
 from .dose_handlers import _cancel_then
@@ -72,13 +72,13 @@ async def sos_contact_save(
         if not commit(session):
             await message.reply_text(
                 "⚠️ Не удалось сохранить контакт.",
-                reply_markup=menu_keyboard,
+                reply_markup=build_menu_keyboard(),
             )
             return ConversationHandler.END
 
     await message.reply_text(
         "✅ Контакт для SOS сохранён.",
-        reply_markup=menu_keyboard,
+        reply_markup=build_menu_keyboard(),
     )
     return ConversationHandler.END
 
@@ -90,7 +90,7 @@ async def sos_contact_cancel(
     message: Message = update.message
     if message is None:
         return None
-    await message.reply_text("Отменено.", reply_markup=menu_keyboard)
+    await message.reply_text("Отменено.", reply_markup=build_menu_keyboard())
     return ConversationHandler.END
 
 

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -4,7 +4,11 @@ UI-компоненты бота «Diabet Buddy».
 Здесь живут все клавиатуры (Reply и Inline) и их генераторы.
 Импортируйте объекты напрямую:
 
-    from services.api.app.diabetes.utils.ui import menu_keyboard, dose_keyboard, confirm_keyboard
+    from services.api.app.diabetes.utils.ui import (
+        build_menu_keyboard,
+        dose_keyboard,
+        confirm_keyboard,
+    )
 """
 
 from telegram import (
@@ -17,7 +21,7 @@ from telegram import (
 from services.api.app.config import settings
 
 __all__ = (
-    "menu_keyboard",
+    "build_menu_keyboard",
     "dose_keyboard",
     "sugar_keyboard",
     "confirm_keyboard",
@@ -26,34 +30,42 @@ __all__ = (
 )
 
 # ─────────────── Reply-клавиатуры (отображаются на экране чата) ───────────────
-# Create WebApp buttons when WebApp is configured, fall back to text buttons otherwise
-profile_button = (
-    KeyboardButton(
-        "📄 Мой профиль", web_app=WebAppInfo(f"{settings.webapp_url}/profile")
-    )
-    if settings.webapp_url
-    else KeyboardButton("📄 Мой профиль")
-)
-reminders_button = (
-    KeyboardButton(
-        "⏰ Напоминания", web_app=WebAppInfo(f"{settings.webapp_url}/reminders")
-    )
-    if settings.webapp_url
-    else KeyboardButton("⏰ Напоминания")
-)
 
-menu_keyboard = ReplyKeyboardMarkup(
-    keyboard=[
-        [KeyboardButton("📷 Фото еды"), KeyboardButton("🩸 Уровень сахара")],
-        [KeyboardButton("💉 Доза инсулина"), KeyboardButton("📊 История")],
-        [KeyboardButton("📈 Отчёт"), profile_button],
-        [KeyboardButton("🕹 Быстрый ввод"), KeyboardButton("ℹ️ Помощь")],
-        [reminders_button, KeyboardButton("🆘 SOS контакт")],
-    ],
-    resize_keyboard=True,
-    one_time_keyboard=False,
-    input_field_placeholder="Выберите действие…",
-)
+
+def build_menu_keyboard() -> ReplyKeyboardMarkup:
+    """Create the main menu keyboard with optional WebApp buttons.
+
+    A fresh ``ReplyKeyboardMarkup`` is returned on each call so that the
+    ``WEBAPP_URL`` setting is read dynamically.
+    """
+
+    profile_button = (
+        KeyboardButton(
+            "📄 Мой профиль", web_app=WebAppInfo(f"{settings.webapp_url}/profile")
+        )
+        if settings.webapp_url
+        else KeyboardButton("📄 Мой профиль")
+    )
+    reminders_button = (
+        KeyboardButton(
+            "⏰ Напоминания", web_app=WebAppInfo(f"{settings.webapp_url}/reminders")
+        )
+        if settings.webapp_url
+        else KeyboardButton("⏰ Напоминания")
+    )
+
+    return ReplyKeyboardMarkup(
+        keyboard=[
+            [KeyboardButton("📷 Фото еды"), KeyboardButton("🩸 Уровень сахара")],
+            [KeyboardButton("💉 Доза инсулина"), KeyboardButton("📊 История")],
+            [KeyboardButton("📈 Отчёт"), profile_button],
+            [KeyboardButton("🕹 Быстрый ввод"), KeyboardButton("ℹ️ Помощь")],
+            [reminders_button, KeyboardButton("🆘 SOS контакт")],
+        ],
+        resize_keyboard=True,
+        one_time_keyboard=False,
+        input_field_placeholder="Выберите действие…",
+    )
 
 dose_keyboard = ReplyKeyboardMarkup(
     keyboard=[

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -76,7 +76,7 @@ async def test_entry_without_dose_has_no_unit(
     monkeypatch.setattr(dose_handlers, "SessionLocal", lambda: DummySession())
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
-    monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
+    monkeypatch.setattr(dose_handlers, "build_menu_keyboard", lambda: None)
 
     await dose_handlers.freeform_handler(update, context)
 
@@ -122,7 +122,7 @@ async def test_entry_without_sugar_has_placeholder(
     monkeypatch.setattr(dose_handlers, "SessionLocal", lambda: DummySession())
     monkeypatch.setattr(dose_handlers, "commit", lambda session: True)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
-    monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
+    monkeypatch.setattr(dose_handlers, "build_menu_keyboard", lambda: None)
 
     await dose_handlers.freeform_handler(update, context)
 

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -52,7 +52,7 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
     assert not query.edit_kwargs[0] or "reply_markup" not in query.edit_kwargs[0]
     assert len(query.message.replies) == 1
     text, kwargs = query.message.replies[0]
-    assert kwargs["reply_markup"] == common_handlers.menu_keyboard
+    assert kwargs["reply_markup"] == common_handlers.build_menu_keyboard()
     assert "pending_entry" not in context.user_data
 
 

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -153,7 +153,7 @@ async def test_photo_handler_preserves_file(
     monkeypatch.setattr(handlers, "send_message", fake_send_message)
     monkeypatch.setattr(handlers, "_get_client", lambda: DummyClient())
     monkeypatch.setattr(handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
-    monkeypatch.setattr(handlers, "menu_keyboard", None)
+    monkeypatch.setattr(handlers, "build_menu_keyboard", lambda: None)
     monkeypatch.setattr(
         handlers.os,
         "makedirs",
@@ -206,7 +206,7 @@ async def test_photo_then_freeform_calculates_dose(
     monkeypatch.setattr(handlers, "send_message", fake_send_message)
     monkeypatch.setattr(handlers, "_get_client", lambda: DummyClient())
     monkeypatch.setattr(handlers, "extract_nutrition_info", lambda text: (10.0, 1.0))
-    monkeypatch.setattr(handlers, "menu_keyboard", None)
+    monkeypatch.setattr(handlers, "build_menu_keyboard", lambda: None)
     monkeypatch.setattr(handlers, "confirm_keyboard", lambda: None)
 
     photo_msg = DummyMessage(photo=[DummyPhoto()])

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -70,7 +70,7 @@ async def test_photo_flow_saves_entry(
 
     monkeypatch.setattr(dose_handlers, "parse_command", fake_parse_command)
     monkeypatch.setattr(dose_handlers, "confirm_keyboard", lambda: None)
-    monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
+    monkeypatch.setattr(dose_handlers, "build_menu_keyboard", lambda: None)
 
     msg_start = DummyMessage("/dose")
     update_start = cast(

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 from telegram import InlineKeyboardMarkup
 from telegram.ext import ConversationHandler
 
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.utils.ui import build_menu_keyboard
 
 from services.api.app.diabetes.services.db import Base, User, Profile
 from tests.helpers import make_context, make_update
@@ -45,8 +45,9 @@ async def test_profile_command_and_view(monkeypatch: Any, args: Any, expected_ic
     update = make_update(message=message, effective_user=TgUser(id=123))
     context = make_context(args=args, user_data={})
 
+    menu_keyboard = build_menu_keyboard()
     await handlers.profile_command(update, context)
-    assert message.markups[0] is menu_keyboard
+    assert message.markups[0] == menu_keyboard
     assert f"• ИКХ: {expected_icr} г/ед." in message.texts[0]
     assert f"• КЧ: {expected_cf} ммоль/л" in message.texts[0]
     assert f"• Целевой сахар: {expected_target} ммоль/л" in message.texts[0]

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -77,7 +77,7 @@ async def test_photo_prompt_includes_dish_name(monkeypatch: Any, tmp_path: Any) 
 
     monkeypatch.setattr(dose_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(dose_handlers, "_get_client", lambda: DummyClient())
-    monkeypatch.setattr(dose_handlers, "menu_keyboard", None)
+    monkeypatch.setattr(dose_handlers, "build_menu_keyboard", lambda: None)
 
     msg_photo = DummyMessage(photo=[DummyPhoto()])
     update = make_update(message=msg_photo, effective_user=SimpleNamespace(id=1))

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -25,7 +25,7 @@ async def test_help_includes_new_features() -> None:
 
     await handlers.help_command(update, context)
 
-    assert message.kwargs[0]["reply_markup"] == handlers.menu_keyboard
+    assert message.kwargs[0]["reply_markup"] == handlers.build_menu_keyboard()
     text = message.replies[0]
     assert "🆕 Новые возможности:\n" in text
     assert "• ✨ Мастер настройки при первом запуске\n" in text

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -13,7 +13,8 @@ def test_menu_keyboard_webapp_urls(monkeypatch: Any) -> None:
     importlib.reload(config)
     importlib.reload(ui)
 
-    buttons = [btn for row in ui.menu_keyboard.keyboard for btn in row]
+    keyboard = ui.build_menu_keyboard()
+    buttons = [btn for row in keyboard.keyboard for btn in row]
     profile_btn = next(b for b in buttons if b.text == "📄 Мой профиль")
     reminders_btn = next(b for b in buttons if b.text == "⏰ Напоминания")
 

--- a/tests/test_onboarding_demo_photo_missing.py
+++ b/tests/test_onboarding_demo_photo_missing.py
@@ -43,7 +43,7 @@ async def test_onboarding_demo_photo_missing(monkeypatch: Any, caplog: Any) -> N
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
+    monkeypatch.setattr(onboarding, "build_menu_keyboard", lambda: "MK")
 
     message = DummyMessage()
     update = make_update(

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -63,7 +63,7 @@ async def test_onboarding_flow(monkeypatch: Any) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
-    monkeypatch.setattr(onboarding, "menu_keyboard", "MK")
+    monkeypatch.setattr(onboarding, "build_menu_keyboard", lambda: "MK")
 
     message = DummyMessage()
     update = make_update(

--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -4,7 +4,7 @@ from typing import cast
 
 from telegram.ext import ApplicationBuilder, MessageHandler, filters
 
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.utils.ui import build_menu_keyboard
 import services.api.app.diabetes.handlers.registration as handlers
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
@@ -14,6 +14,7 @@ def test_reminders_button_matches_regex() -> None:
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
+    menu_keyboard = build_menu_keyboard()
     button_texts = [btn.text for row in menu_keyboard.keyboard for btn in row]
     assert "⏰ Напоминания" in button_texts
 

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -18,7 +18,7 @@ import services.api.app.diabetes.handlers.sos_handlers as sos_handlers
 import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
 import services.api.app.diabetes.handlers.registration as handlers
 from services.api.app.diabetes.services.repository import commit
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.diabetes.utils.ui import build_menu_keyboard
 from tests.helpers import make_context, make_update
 
 
@@ -144,6 +144,7 @@ async def test_sos_contact_menu_button_starts_conv(monkeypatch: Any) -> None:
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
+    menu_keyboard = build_menu_keyboard()
     button_texts = [btn.text for row in menu_keyboard.keyboard for btn in row]
     assert "🆘 SOS контакт" in button_texts
 


### PR DESCRIPTION
## Summary
- build `build_menu_keyboard` to generate menu keyboards dynamically from settings
- replace static `menu_keyboard` imports across handlers with function calls
- update tests for new keyboard factory

## Testing
- `ruff check services/api/app tests`
- `pytest tests` *(fails: sqlalchemy.exc.IntegrityError & AttributeError in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aeea3609dc832aaaf396f7dfe40f46