### PR TITLE
[reminders] Fetch plan limit from backend

### DIFF
--- a/src/features/reminders/hooks/usePlan.ts
+++ b/src/features/reminders/hooks/usePlan.ts
@@ -3,19 +3,21 @@ import { DefaultApi } from "../../../../libs/ts-sdk/apis";
 
 export async function getPlanLimit(userId: number, initData: string): Promise<number> {
   try {
-    // Для демо возвращаем статичные лимиты пока нет API роли
-    // TODO: Когда появится API для получения роли пользователя, заменить на реальный вызов
-    const limits: Record<string, number> = { 
-      free: 5, 
-      pro: 10,
-      premium: 20 
-    };
-    
-    // Временная логика определения роли по userId
-    // В реальном приложении здесь будет вызов API
-    const roleString = userId === 12345 ? "free" : "free";
-    
-    return limits[roleString] ?? 5;
+    const cfg = new Configuration({
+      basePath: "",
+      headers: { "X-Telegram-Init-Data": initData }
+    });
+    const api = new DefaultApi(cfg);
+    const res = await api.remindersGetRaw({ telegramId: userId });
+    const limitHeader =
+      res.raw.headers.get("X-Plan-Limit") ?? res.raw.headers.get("x-plan-limit");
+    if (limitHeader) {
+      const limit = parseInt(limitHeader, 10);
+      if (!isNaN(limit)) {
+        return limit;
+      }
+    }
+    return 5;
   } catch (error) {
     console.warn("Failed to get plan limit, defaulting to free tier:", error);
     return 5;


### PR DESCRIPTION
## Summary
- fetch reminder plan limit from backend via DefaultApi and init data
- fall back to free-tier limit when request fails

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeea37eb7c832a952c56b8e02b7750