### PR TITLE
[reminders] use @sdk alias for plan hook

### DIFF
--- a/services/webapp/ui/tsconfig.json
+++ b/services/webapp/ui/tsconfig.json
@@ -7,7 +7,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@sdk/*": ["/workspace/saharlight-ux/libs/ts-sdk/*"],
+      "@sdk/*": ["../../../libs/ts-sdk/*"],
       "@/*": ["./src/*"]
     },
     "noImplicitAny": false,

--- a/src/features/reminders/hooks/usePlan.ts
+++ b/src/features/reminders/hooks/usePlan.ts
@@ -1,5 +1,5 @@
-import { Configuration } from "../../../../libs/ts-sdk/runtime.ts";
-import { DefaultApi } from "../../../../libs/ts-sdk/apis";
+import { Configuration } from "@sdk/runtime";
+import { DefaultApi } from "@sdk/apis";
 
 export async function getPlanLimit(userId: number, initData: string): Promise<number> {
   try {


### PR DESCRIPTION
## Summary
- replace relative SDK imports in usePlan hook with `@sdk` alias
- map `@sdk/*` to local `libs/ts-sdk` in webapp tsconfig

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aef02b8418832aa89d187361eb4222