### PR TITLE
[webapp] fix reminders api import path

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,5 @@
 import { RemindersApi } from '@sdk';
-import { Configuration, ResponseError } from '@sdk/runtime.ts';
+import { Configuration, ResponseError } from '@sdk';
 import {
   instanceOfReminderSchema as instanceOfReminder,
   type ReminderSchema as Reminder,


### PR DESCRIPTION
## Summary
- update reminders API to import Configuration and ResponseError from `@sdk`

## Testing
- `npm test` in `services/webapp/ui`


------
https://chatgpt.com/codex/tasks/task_e_68aef27b1d8c832abb9b9a180f993f0d