### PR TITLE
[ui] Restrict ts-sdk relative imports

### DIFF
--- a/services/webapp/ui/eslint.config.js
+++ b/services/webapp/ui/eslint.config.js
@@ -24,6 +24,12 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
       "@typescript-eslint/no-unused-vars": "off",
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: ["../libs/ts-sdk", "../libs/ts-sdk/*"],
+        },
+      ],
     },
   }
 );

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,5 @@
 import { RemindersApi } from '@sdk';
-import { Configuration, ResponseError } from '@sdk/runtime.ts';
+import { Configuration, ResponseError } from '@sdk';
 import {
   instanceOfReminderSchema as instanceOfReminder,
   type ReminderSchema as Reminder,


### PR DESCRIPTION
## Summary
- enforce no-restricted-imports against ../libs/ts-sdk
- switch reminders API to use sdk exports instead of runtime file

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68aef280ec18832aa5ebd94193501be5