### PR TITLE
[webapp] Add usePlan hook and tests

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,4 @@
-import { RemindersApi } from '@sdk';
-import { Configuration, ResponseError } from '@sdk/runtime.ts';
+import { RemindersApi, Configuration, ResponseError } from '@sdk';
 import {
   instanceOfReminderSchema as instanceOfReminder,
   type ReminderSchema as Reminder,

--- a/services/webapp/ui/src/features/reminders/hooks/usePlan.test.ts
+++ b/services/webapp/ui/src/features/reminders/hooks/usePlan.test.ts
@@ -1,0 +1,63 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockProfilesGet = vi.hoisted(() => vi.fn());
+
+vi.mock(
+  "@sdk",
+  () => {
+    class ProfilesApi {
+      profilesGet = mockProfilesGet;
+    }
+    class Configuration {}
+    return { ProfilesApi, Configuration };
+  },
+  { virtual: true },
+);
+
+vi.mock("@/lib/tgFetch", () => ({ tgFetch: vi.fn() }), { virtual: true });
+vi.mock("@/api/base", () => ({ API_BASE: "" }), { virtual: true });
+
+import { usePlan } from "./usePlan";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("usePlan", () => {
+  beforeEach(() => {
+    mockProfilesGet.mockReset();
+  });
+
+  it("returns plan on success", async () => {
+    mockProfilesGet.mockResolvedValueOnce({ plan: "pro" });
+    const { result } = renderHook(() => usePlan(1), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe("pro");
+  });
+
+  it("handles error state", async () => {
+    const error = new Error("fail");
+    mockProfilesGet.mockRejectedValueOnce(error);
+    const { result } = renderHook(() => usePlan(1), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.error).toBe(error));
+  });
+
+  it("shows loading initially", async () => {
+    mockProfilesGet.mockResolvedValueOnce({ plan: "free" });
+    const { result } = renderHook(() => usePlan(1), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/services/webapp/ui/src/features/reminders/hooks/usePlan.ts
+++ b/services/webapp/ui/src/features/reminders/hooks/usePlan.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { ProfilesApi, Configuration } from "@sdk";
+import { tgFetch } from "@/lib/tgFetch";
+import { API_BASE } from "@/api/base";
+
+const api = new ProfilesApi(
+  new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
+);
+
+export function usePlan(telegramId: number) {
+  return useQuery({
+    queryKey: ["plan", telegramId],
+    queryFn: async () => {
+      const profile: any = await api.profilesGet({ telegramId });
+      return profile?.plan as string;
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- import Reminders API helpers from `@sdk`
- add `usePlan` React Query hook and tests covering success, error and loading states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef27f16e8832abeae4fe91bc54709