### PR TITLE
[webapp] restrict ts-sdk imports

### DIFF
--- a/services/webapp/ui/eslint.config.js
+++ b/services/webapp/ui/eslint.config.js
@@ -27,7 +27,7 @@ export default tseslint.config(
       "no-restricted-imports": [
         "error",
         {
-          patterns: ["../libs/ts-sdk", "../libs/ts-sdk/*"],
+          patterns: ["**/libs/ts-sdk/**"],
         },
       ],
     },

--- a/services/webapp/ui/src/api/history.api.test.ts
+++ b/services/webapp/ui/src/api/history.api.test.ts
@@ -40,7 +40,7 @@ describe('getHistory', () => {
 
   it('throws on invalid history item', async () => {
     mockHistoryGet.mockResolvedValueOnce([
-      { id: '1', time: '12:00', type: 'meal' } as any,
+      { id: '1', time: '12:00', type: 'meal' } as unknown,
     ]);
     await expect(getHistory()).rejects.toThrow(
       'Некорректная запись истории',

--- a/services/webapp/ui/src/api/reminders.api.test.ts
+++ b/services/webapp/ui/src/api/reminders.api.test.ts
@@ -79,7 +79,7 @@ describe('getReminder', () => {
 
   it('passes signal to API', async () => {
     const controller = new AbortController();
-    mockRemindersIdGet.mockResolvedValueOnce({} as any);
+    mockRemindersIdGet.mockResolvedValueOnce({} as unknown);
     mockInstanceOfReminder.mockReturnValueOnce(true);
     await getReminder(1, 1, controller.signal);
     expect(mockRemindersIdGet).toHaveBeenCalledWith(
@@ -108,7 +108,7 @@ describe('getReminders', () => {
   });
 
   it('throws on invalid API response', async () => {
-    mockRemindersGet.mockResolvedValueOnce([{} as any]);
+    mockRemindersGet.mockResolvedValueOnce([{} as unknown]);
     mockInstanceOfReminder.mockReturnValueOnce(false);
     await expect(getReminders(1)).rejects.toThrow('Некорректный ответ API');
   });
@@ -130,8 +130,8 @@ describe('getReminders', () => {
 
 describe('createReminder', () => {
   it('returns API response on success', async () => {
-    const reminder = { id: 1 } as any;
-    const apiResponse = { ok: true } as any;
+    const reminder = { id: 1 } as unknown;
+    const apiResponse = { ok: true } as unknown;
     mockRemindersPost.mockResolvedValueOnce(apiResponse);
     await expect(createReminder(reminder)).resolves.toBe(apiResponse);
     expect(mockRemindersPost).toHaveBeenCalledWith({ reminder });
@@ -140,14 +140,14 @@ describe('createReminder', () => {
   it('rethrows API errors', async () => {
     const error = new Error('api error');
     mockRemindersPost.mockRejectedValueOnce(error);
-    await expect(createReminder({} as any)).rejects.toBe(error);
+    await expect(createReminder({} as unknown)).rejects.toBe(error);
   });
 });
 
 describe('updateReminder', () => {
   it('returns API response on success', async () => {
-    const reminder = { id: 1 } as any;
-    const apiResponse = { ok: true } as any;
+    const reminder = { id: 1 } as unknown;
+    const apiResponse = { ok: true } as unknown;
     mockRemindersPatch.mockResolvedValueOnce(apiResponse);
     await expect(updateReminder(reminder)).resolves.toBe(apiResponse);
     expect(mockRemindersPatch).toHaveBeenCalledWith({ reminder });
@@ -156,13 +156,13 @@ describe('updateReminder', () => {
   it('rethrows API errors', async () => {
     const error = new Error('api error');
     mockRemindersPatch.mockRejectedValueOnce(error);
-    await expect(updateReminder({} as any)).rejects.toBe(error);
+    await expect(updateReminder({} as unknown)).rejects.toBe(error);
   });
 });
 
 describe('deleteReminder', () => {
   it('returns API response on success', async () => {
-    const apiResponse = { ok: true } as any;
+    const apiResponse = { ok: true } as unknown;
     mockRemindersDelete.mockResolvedValueOnce(apiResponse);
     await expect(deleteReminder(1, 2)).resolves.toBe(apiResponse);
     expect(mockRemindersDelete).toHaveBeenCalledWith({ telegramId: 1, id: 2 });

--- a/services/webapp/ui/src/hooks/use-mobile.test.tsx
+++ b/services/webapp/ui/src/hooks/use-mobile.test.tsx
@@ -10,13 +10,14 @@ describe("useIsMobile", () => {
       result = useIsMobile();
       return null;
     };
-    const originalWindow = (global as any).window;
+    const globalWithWindow = global as { window?: unknown };
+    const originalWindow = globalWithWindow.window;
     // @ts-expect-error simulate absence of window
-    delete (global as any).window;
+    delete globalWithWindow.window;
     act(() => {
       TestRenderer.create(<TestComponent />);
     });
-    (global as any).window = originalWindow;
+    globalWithWindow.window = originalWindow;
     expect(result).toBe(false);
   });
 });

--- a/services/webapp/ui/src/hooks/use-telegram.test.tsx
+++ b/services/webapp/ui/src/hooks/use-telegram.test.tsx
@@ -13,15 +13,17 @@ vi.mock("../lib/telegram-theme", () => ({
 }));
 
 describe("useTelegram start_param", () => {
+  const win = window as Record<string, unknown>;
+
   afterEach(() => {
-    delete (window as any).Telegram;
-    delete (window as any).tgWebAppStartParam;
+    delete win.Telegram;
+    delete win.tgWebAppStartParam;
     window.history.pushState({}, "", "/");
     navigate.mockReset();
   });
 
   it("navigates to reminders when start_param is reminders", async () => {
-    (window as any).Telegram = {
+    win.Telegram = {
       WebApp: {
         initDataUnsafe: { user: { id: 1 }, start_param: "reminders" },
         initData: "",
@@ -45,7 +47,7 @@ describe("useTelegram start_param", () => {
   });
 
   it("navigates to reminders when tgWebAppStartParam is reminders", async () => {
-    (window as any).Telegram = {
+    win.Telegram = {
       WebApp: {
         initDataUnsafe: { user: { id: 1 } },
         initData: "",
@@ -55,7 +57,7 @@ describe("useTelegram start_param", () => {
         offEvent: vi.fn(),
       },
     };
-    (window as any).tgWebAppStartParam = "reminders";
+    win.tgWebAppStartParam = "reminders";
 
     const TestComponent = () => {
       useTelegram();
@@ -70,7 +72,7 @@ describe("useTelegram start_param", () => {
   });
 
   it("navigates to reminders when query param tgWebAppStartParam is reminders", async () => {
-    (window as any).Telegram = {
+    win.Telegram = {
       WebApp: {
         initDataUnsafe: { user: { id: 1 } },
         initData: "",

--- a/services/webapp/ui/src/lib/tgFetch.ts
+++ b/services/webapp/ui/src/lib/tgFetch.ts
@@ -36,7 +36,10 @@ export async function tgFetch(input: RequestInfo | URL, init: RequestInit = {}):
   let signal: AbortSignal = controller.signal
   if (init.signal) {
     if (typeof AbortSignal.any === 'function') {
-      signal = (AbortSignal as any).any([controller.signal, init.signal])
+      const AbortSignalAny = AbortSignal as unknown as {
+        any(signals: readonly AbortSignal[]): AbortSignal
+      }
+      signal = AbortSignalAny.any([controller.signal, init.signal])
     } else {
       if (init.signal.aborted) controller.abort()
       else init.signal.addEventListener('abort', () => controller.abort(), { once: true })

--- a/services/webapp/ui/src/main.tsx
+++ b/services/webapp/ui/src/main.tsx
@@ -14,7 +14,8 @@ const tgStartParam = new URLSearchParams(window.location.search).get(
   'tgWebAppStartParam',
 )
 if (tgStartParam) {
-  (window as any).tgWebAppStartParam = tgStartParam
+  const win = window as { tgWebAppStartParam?: string }
+  win.tgWebAppStartParam = tgStartParam
 }
 
 const rootElement = document.getElementById('root')


### PR DESCRIPTION
## Summary
- use a glob pattern to ban imports from libs/ts-sdk
- replace `any` assertions with `unknown` or typed helpers so lint passes

## Testing
- `npm run lint`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aef5f7a154832a9456b7bc14b06eb2