### PR TITLE
[webapp] add usePlan hook tests

### DIFF
--- a/services/webapp/ui/src/features/reminders/hooks/usePlan.test.ts
+++ b/services/webapp/ui/src/features/reminders/hooks/usePlan.test.ts
@@ -1,0 +1,60 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import React from "react";
+
+import { usePlan } from "./usePlan";
+
+const mockRemindersGet = vi.hoisted(() => vi.fn());
+
+vi.mock(
+  "@sdk",
+  () => {
+    class RemindersApi {
+      remindersGet = mockRemindersGet;
+    }
+    class Configuration {}
+    return { RemindersApi, Configuration };
+  },
+  { virtual: true },
+);
+
+function createWrapper() {
+  const queryClient = new QueryClient();
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("usePlan", () => {
+  afterEach(() => {
+    mockRemindersGet.mockReset();
+  });
+
+  it("is loading initially", () => {
+    mockRemindersGet.mockResolvedValueOnce([]);
+    const { result } = renderHook(() => usePlan(1), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns data on success", async () => {
+    const data = [{ id: 1 }];
+    mockRemindersGet.mockResolvedValueOnce(data);
+    const { result } = renderHook(() => usePlan(1), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(data);
+  });
+
+  it("returns error on failure", async () => {
+    const error = new Error("fail");
+    mockRemindersGet.mockRejectedValueOnce(error);
+    const { result } = renderHook(() => usePlan(1), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBe(error);
+  });
+});

--- a/services/webapp/ui/src/features/reminders/hooks/usePlan.ts
+++ b/services/webapp/ui/src/features/reminders/hooks/usePlan.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { RemindersApi, Configuration } from "@sdk";
+import { API_BASE } from "@/api/base";
+import { tgFetch } from "@/lib/tgFetch";
+
+const api = new RemindersApi(
+  new Configuration({ basePath: API_BASE, fetchApi: tgFetch }),
+);
+
+export function usePlan(telegramId: number) {
+  return useQuery({
+    queryKey: ["plan", telegramId],
+    queryFn: ({ signal }) => api.remindersGet({ telegramId }, { signal }),
+    retry: false,
+  });
+}


### PR DESCRIPTION
## Summary
- add usePlan hook using RemindersApi and react-query
- cover usePlan with tests for loading, success, and error states

## Testing
- `npm test`
- `pytest -q` *(fails: unrecognized arguments --cov=..., plugin missing)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aef5f5deb8832a8dd2a21edf33709f