### PR TITLE
[ui] use @sdk alias for ts-sdk runtime

### DIFF
--- a/services/webapp/ui/src/features/reminders/hooks/usePlan.ts
+++ b/services/webapp/ui/src/features/reminders/hooks/usePlan.ts
@@ -1,5 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
-import { RemindersApi, Configuration } from "@sdk";
+
+import { RemindersApi } from "@sdk";
+import { Configuration } from "@sdk/runtime";
 import { API_BASE } from "@/api/base";
 import { tgFetch } from "@/lib/tgFetch";
 


### PR DESCRIPTION
## Summary
- use @sdk alias to import Reminders API configuration

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef9b15630832ab676e34ca9602104