### PR TITLE
[webapp] use relative sdk path in tsconfig

### DIFF
--- a/services/webapp/ui/tsconfig.app.json
+++ b/services/webapp/ui/tsconfig.app.json
@@ -23,7 +23,7 @@
 
     "baseUrl": ".",
     "paths": {
-      "@sdk/*": ["/workspace/saharlight-ux/libs/ts-sdk/*"],
+      "@sdk/*": ["../../../libs/ts-sdk/*"],
       "@/*": ["./src/*"]
     }
   },


### PR DESCRIPTION
## Summary
- replace absolute @sdk/* path with relative path in tsconfig.app.json
- ensure included SDK path uses relative form

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aef9b83fa4832aa9d85f693dee5fa2