### PR TITLE
scripts: restrict fix-sdk-runtime scope

### DIFF
--- a/scripts/fix-sdk-runtime.sh
+++ b/scripts/fix-sdk-runtime.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# This script fixes SDK runtime imports by appending an explicit `.ts` extension.
+# Run from the repository root with a clean working tree so that only files under
+# `services/webapp/ui` and `libs/ts-sdk` are affected.
+
 # Replace SDK runtime imports to include explicit .ts extension.
-find . -type f -name "*.ts*" -exec sed -i "s|from '@sdk/runtime'|from '@sdk/runtime.ts'|g" {} +
+find services/webapp/ui libs/ts-sdk -type f -name "*.ts*" \
+  -exec sed -i "s|from '@sdk/runtime'|from '@sdk/runtime.ts'|g" {} +
 
 # Handle direct imports from libs/ts-sdk runtime regardless of path depth.
-find . -type f -name "*.ts*" -exec sed -i -E 's|from "(.*/)?libs/ts-sdk/runtime"|from "\1libs/ts-sdk/runtime.ts"|g' {} +
+find services/webapp/ui libs/ts-sdk -type f -name "*.ts*" \
+  -exec sed -i -E 's|from "(.*/)?libs/ts-sdk/runtime"|from "\1libs/ts-sdk/runtime.ts"|g' {} +


### PR DESCRIPTION
## Summary
- limit fix-sdk-runtime.sh to services/webapp/ui and libs/ts-sdk
- document safe usage at top of script

## Testing
- `pytest tests` *(fails: async def functions are not natively supported)*
- `./scripts/fix-sdk-runtime.sh` on clean clone (only files in services/webapp/ui affected)


------
https://chatgpt.com/codex/tasks/task_e_68aef9bbf528832a8f81de88937cea2c