### PR TITLE
[ui] use Link for adding reminders

### DIFF
--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -1,6 +1,6 @@
 import RemindersList from '../features/reminders/pages/RemindersList'
 import { MedicalHeader } from '@/components/MedicalHeader'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useTelegram } from '@/hooks/useTelegram'
 import { useState, useEffect } from 'react'
 import { getPlanLimit } from '../features/reminders/hooks/usePlan'
@@ -24,13 +24,13 @@ export default function Reminders() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
       <MedicalHeader title={`Напоминания ${quotaBadge}`} showBack onBack={() => navigate('/')}>
-        <a 
-          href="/reminders/new" 
+        <Link
+          to="new"
           className="px-4 py-2 bg-primary text-primary-foreground rounded-lg shadow-soft hover:shadow-medium hover:bg-primary/90 transition-all duration-200"
         >
           + Добавить
-        </a>
-      </MedicalHeader>
+        </Link>
+        </MedicalHeader>
 
       <main className="container mx-auto px-4 py-6">
         <RemindersList onCountChange={setReminderCount} planLimit={planLimit} />


### PR DESCRIPTION
## Summary
- replace anchor with React Router Link in reminders page

## Testing
- `pytest -q --cov` *(fails: KeyboardInterrupt while importing pypdf)*
- `mypy --strict services/webapp/ui/src/pages/Reminders.tsx` *(fails: Invalid character '🔔')*
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test` *(fails: No test files found)*
- `pnpm --filter ./services/webapp/ui lint` *(fails: ESLint reported errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af138e4a5c832a82682df0bd34d71d