### PR TITLE
webapp: use Link for reminder navigation

### DIFF
--- a/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { useRemindersApi } from "../api/reminders";
 import { formatNextAt } from "../../../shared/datetime";
 import { useTelegram } from "@/hooks/useTelegram";
@@ -305,12 +306,12 @@ export default function RemindersList({
                     >
                       {r.isEnabled ? "Вкл." : "Выкл."}
                     </button>
-                    <a 
-                      href={`/reminders/${r.id}/edit`} 
+                    <Link
+                      to={`${r.id}/edit`}
                       className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-all duration-200"
                     >
                       ✏️
-                    </a>
+                    </Link>
                     <button 
                       onClick={() => remove(r)} 
                       className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-destructive/10 hover:text-destructive hover:border-destructive/20 transition-all duration-200"
@@ -331,12 +332,12 @@ export default function RemindersList({
             <span className="text-2xl">⏰</span>
           </div>
           <p className="text-muted-foreground">Пока нет напоминаний</p>
-          <a 
-            href="/reminders/new" 
+          <Link
+            to="new"
             className="inline-flex items-center gap-2 mt-4 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
           >
             + Добавить первое напоминание
-          </a>
+          </Link>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- use react-router Link for reminder edit and creation
- ensure relative links keep /ui basename

## Testing
- `pytest -q` *(fails: async plugin missing)*
- `mypy --strict .`
- `ruff check .`
- `pnpm --dir services/webapp/ui lint` *(fails: ESLint errors)*
- `pnpm --dir services/webapp/ui test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68af1393f8e8832aaae4046805b95403