### PR TITLE
[config] add UI URL builder and migrate webapp links

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -221,13 +221,13 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     profile = fetch_profile(api, ApiException, user_id)
 
     if not profile:
-        if config.get_webapp_url():
+        if config.settings.public_origin:
             keyboard = InlineKeyboardMarkup(
                 [
                     [
                         InlineKeyboardButton(
                             "📝 Заполнить форму",
-                            web_app=WebAppInfo(reminder_handlers.build_webapp_url("/profile")),
+                            web_app=WebAppInfo(config.build_ui_url("/profile")),
                         )
                     ]
                 ]
@@ -258,13 +258,13 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         [InlineKeyboardButton("🌐 Часовой пояс", callback_data="profile_timezone")],
         [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
     ]
-    if config.get_webapp_url():
+    if config.settings.public_origin:
         rows.insert(
             1,
             [
                 InlineKeyboardButton(
                     "📝 Заполнить форму",
-                    web_app=WebAppInfo(reminder_handlers.build_webapp_url("/profile")),
+                    web_app=WebAppInfo(config.build_ui_url("/profile")),
                 )
             ],
         )
@@ -510,10 +510,10 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
         await sos_handlers.sos_contact_start(update, context)
         return
-    if action == "add" and config.get_webapp_url():
+    if action == "add" and config.settings.public_origin:
         button = InlineKeyboardButton(
             "📝 Новое",
-            web_app=WebAppInfo(reminder_handlers.build_webapp_url("/reminders")),
+            web_app=WebAppInfo(config.build_ui_url("/reminders")),
         )
         keyboard = InlineKeyboardMarkup([[button]])
         await q_message.reply_text("Создать напоминание:", reply_markup=keyboard)

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -15,7 +15,6 @@ from telegram import (
     WebAppInfo,
 )
 from services.api.app import config
-from services.api.app.diabetes.handlers import reminder_handlers
 
 PROFILE_BUTTON_TEXT = "📄 Мой профиль"
 REMINDERS_BUTTON_TEXT = "⏰ Напоминания"
@@ -57,25 +56,24 @@ __all__ = (
 def menu_keyboard() -> ReplyKeyboardMarkup:
     """Build the main menu keyboard.
 
-    ``config.get_webapp_url()`` is read at call time to determine whether
-    WebApp buttons should be used for profile and reminders.
+    WebApp buttons are used only when ``PUBLIC_ORIGIN`` is configured.
     """
 
-    webapp_url = config.get_webapp_url()
+    webapp_enabled = bool(config.settings.public_origin)
     profile_button = (
         KeyboardButton(
             PROFILE_BUTTON_TEXT,
-            web_app=WebAppInfo(reminder_handlers.build_webapp_url("/profile")),
+            web_app=WebAppInfo(config.build_ui_url("/profile")),
         )
-        if webapp_url
+        if webapp_enabled
         else KeyboardButton(PROFILE_BUTTON_TEXT)
     )
     reminders_button = (
         KeyboardButton(
             REMINDERS_BUTTON_TEXT,
-            web_app=WebAppInfo(reminder_handlers.build_webapp_url("/reminders")),
+            web_app=WebAppInfo(config.build_ui_url("/reminders")),
         )
-        if webapp_url
+        if webapp_enabled
         else KeyboardButton(REMINDERS_BUTTON_TEXT)
     )
     return ReplyKeyboardMarkup(
@@ -149,14 +147,13 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
     Returns
     -------
     InlineKeyboardButton | None
-        Button instance when ``WEBAPP_URL`` is set and valid, otherwise ``None``.
+        Button instance when ``PUBLIC_ORIGIN`` is set and valid, otherwise ``None``.
     """
 
-    webapp_url = config.get_webapp_url()
-    if not webapp_url:
+    if not config.settings.public_origin:
         return None
 
     return InlineKeyboardButton(
         "Определить автоматически",
-        web_app=WebAppInfo(f"{webapp_url}/timezone"),
+        web_app=WebAppInfo(config.build_ui_url("/timezone")),
     )

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -28,7 +28,8 @@ async def test_post_init_sets_chat_menu_button(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Chat menu button is always set to default."""
-    monkeypatch.setenv("WEBAPP_URL", "https://app.example")
+    monkeypatch.setenv("PUBLIC_ORIGIN", "https://app.example")
+    monkeypatch.setenv("UI_BASE_URL", "/ui")
     main = _reload_main()
     bot = SimpleNamespace(
         set_my_commands=AsyncMock(),
@@ -48,8 +49,9 @@ async def test_post_init_sets_chat_menu_button(
 async def test_post_init_skips_chat_menu_button_without_url(
     monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-    """Default menu is used when WEBAPP_URL is missing."""
-    monkeypatch.delenv("WEBAPP_URL", raising=False)
+    """Default menu is used when PUBLIC_ORIGIN is missing."""
+    monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
+    monkeypatch.delenv("UI_BASE_URL", raising=False)
     main = _reload_main()
     bot = SimpleNamespace(
         set_my_commands=AsyncMock(),

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -2,6 +2,7 @@ import warnings
 from contextlib import contextmanager
 
 import pytest
+import importlib
 from types import SimpleNamespace
 from typing import Any, Iterator, cast
 from sqlalchemy import create_engine
@@ -259,7 +260,10 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     from urllib.parse import urlparse
     import services.api.app.diabetes.handlers.profile as handlers
 
-    monkeypatch.setenv("WEBAPP_URL", "https://example.com")
+    monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.com")
+    monkeypatch.setenv("UI_BASE_URL", "")
+    import services.api.app.config as config
+    importlib.reload(config)
     monkeypatch.setattr(handlers, "get_api", lambda: (object(), Exception, None))
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: None)
 

--- a/tests/test_menu_button.py
+++ b/tests/test_menu_button.py
@@ -14,7 +14,8 @@ def _reload_config() -> None:
 @pytest.mark.asyncio
 async def test_post_init_sets_default_menu(monkeypatch: pytest.MonkeyPatch) -> None:
     base_url = "https://example.com"
-    monkeypatch.setenv("WEBAPP_URL", base_url)
+    monkeypatch.setenv("PUBLIC_ORIGIN", base_url)
+    monkeypatch.setenv("UI_BASE_URL", "/ui")
     _reload_config()
     import services.api.app.menu_button as menu_button
 

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -1,24 +1,28 @@
 from urllib.parse import urlparse
 
+import importlib
 import pytest
 
 import services.api.app.diabetes.utils.ui as ui
 
 
 @pytest.mark.parametrize(
-    "base_url",
+    "origin, ui_base",
     [
-        "https://example.com",
-        "https://example.com/",
-        "https://example.com/ui",
-        "https://example.com/ui/",
+        ("https://example.com", ""),
+        ("https://example.com/", ""),
+        ("https://example.com", "/ui"),
+        ("https://example.com/", "/ui/"),
     ],
 )
 def test_menu_keyboard_webapp_urls(
-    monkeypatch: pytest.MonkeyPatch, base_url: str
+    monkeypatch: pytest.MonkeyPatch, origin: str, ui_base: str
 ) -> None:
     """Menu buttons should open webapp paths for profile and reminders."""
-    monkeypatch.setenv("WEBAPP_URL", base_url)
+    monkeypatch.setenv("PUBLIC_ORIGIN", origin)
+    monkeypatch.setenv("UI_BASE_URL", ui_base)
+    import services.api.app.config as config
+    importlib.reload(config)
 
     buttons = [btn for row in ui.menu_keyboard().keyboard for btn in row]
     profile_btn = next(b for b in buttons if b.text == ui.PROFILE_BUTTON_TEXT)

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -1,4 +1,5 @@
 import pytest
+import importlib
 from datetime import time
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -228,7 +229,10 @@ async def test_profile_security_add_delete_calls_handlers(
 
     monkeypatch.setattr(reminder_handlers, "delete_reminder", fake_del)
 
-    monkeypatch.setenv("WEBAPP_URL", "http://example")
+    monkeypatch.setenv("PUBLIC_ORIGIN", "http://example")
+    monkeypatch.setenv("UI_BASE_URL", "")
+    import services.api.app.config as config
+    importlib.reload(config)
     query_add = DummyQuery(DummyMessage(), "profile_security:add")
     update_add = cast(
         Any,

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 from typing import Any, Callable, cast
 
 import pytest
+import importlib
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -248,7 +249,10 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.setenv("WEBAPP_URL", "https://example.org")
+    monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.org")
+    monkeypatch.setenv("UI_BASE_URL", "/ui")
+    import services.api.app.config as config
+    importlib.reload(config)
     monkeypatch.setattr(handlers, "_limit_for", lambda u: 1)
     # Make _describe deterministic and include status icon to test strikethrough
     monkeypatch.setattr(
@@ -306,7 +310,10 @@ def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.delenv("WEBAPP_URL", raising=False)
+    monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
+    monkeypatch.delenv("UI_BASE_URL", raising=False)
+    import services.api.app.config as config
+    importlib.reload(config)
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.add(
@@ -331,7 +338,10 @@ def test_render_reminders_no_entries_no_webapp(monkeypatch: pytest.MonkeyPatch) 
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.delenv("WEBAPP_URL", raising=False)
+    monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
+    monkeypatch.delenv("UI_BASE_URL", raising=False)
+    import services.api.app.config as config
+    importlib.reload(config)
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.commit()

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -1,15 +1,20 @@
-import pytest
+import importlib
 from urllib.parse import urlparse
+
+import pytest
 
 import services.api.app.diabetes.utils.ui as ui
 
 
 def test_timezone_button_webapp_url(monkeypatch: pytest.MonkeyPatch) -> None:
     """Timezone button should open webapp path for timezone detection."""
-    monkeypatch.setenv("WEBAPP_URL", "https://example.com")
+    monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.com")
+    monkeypatch.setenv("UI_BASE_URL", "/ui")
+    import services.api.app.config as config
+    importlib.reload(config)
 
     button = ui.build_timezone_webapp_button()
     assert button is not None
     web_app = button.web_app
     assert web_app is not None
-    assert urlparse(web_app.url).path == "/timezone"
+    assert urlparse(web_app.url).path == "/ui/timezone"


### PR DESCRIPTION
## Summary
- add PUBLIC_ORIGIN/UI_BASE_URL settings and build_ui_url helper
- use build_ui_url for reminder, profile and menu WebApp links
- adjust tests for new env vars and URL builder

## Testing
- `pytest tests/test_menu_keyboard_webapp.py tests/test_reminder_handlers.py tests/test_profile_security.py tests/test_timezone_button_webapp.py tests/test_handlers_profile.py tests/test_reminders.py tests/test_menu_button.py tests/test_chat_menu_button.py -q` *(fails: Coverage failure: total of 25 is less than fail-under=85)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68af1af06f28832a83994f936d9b582b