### PR TITLE
[webapp] Update reminders API payloads

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -22,16 +22,15 @@ export async function getReminders(telegramId: number): Promise<Reminder[]> {
 export async function getReminder(
   telegramId: number,
   id: number,
-): Promise<Reminder | null> {
+): Promise<Reminder> {
   try {
     if (isDevelopment) {
       console.log('[API] Using mock server for getReminder');
       return await mockApi.getReminder(telegramId, id);
     }
-    const data = await http.get<Reminder | Reminder[]>(
-      `/reminders?telegramId=${telegramId}&id=${id}`,
+    return await http.get<Reminder>(
+      `/reminders/${id}?telegramId=${telegramId}`,
     );
-    return Array.isArray(data) ? data[0] ?? null : data ?? null;
   } catch (error) {
     console.error('Failed to fetch reminder:', error);
     throw new Error('Не удалось загрузить напоминание');
@@ -44,7 +43,7 @@ export async function createReminder(reminder: Reminder) {
       console.log('[API] Using mock server for createReminder');
       return await mockApi.createReminder(reminder);
     }
-    return await http.post<Reminder>('/reminders', { reminder });
+    return await http.post<Reminder>('/reminders', reminder);
   } catch (error) {
     console.error('Failed to create reminder:', error);
     throw new Error('Не удалось создать напоминание');
@@ -57,7 +56,7 @@ export async function updateReminder(reminder: Reminder) {
       console.log('[API] Using mock server for updateReminder');
       return await mockApi.updateReminder(reminder);
     }
-    return await http.patch<Reminder>('/reminders', { reminder });
+    return await http.patch<Reminder>('/reminders', reminder);
   } catch (error) {
     console.error('Failed to update reminder:', error);
     throw new Error('Не удалось обновить напоминание');
@@ -70,7 +69,7 @@ export async function deleteReminder(telegramId: number, id: number) {
       console.log('[API] Using mock server for deleteReminder');
       return await mockApi.deleteReminder(telegramId, id);
     }
-    return await http.delete(`/reminders/${id}?telegramId=${telegramId}`);
+    return await http.delete(`/reminders?telegramId=${telegramId}&id=${id}`);
   } catch (error) {
     console.error('Failed to delete reminder:', error);
     throw new Error('Не удалось удалить напоминание');

--- a/services/webapp/ui/src/features/reminders/components/Templates.tsx
+++ b/services/webapp/ui/src/features/reminders/components/Templates.tsx
@@ -42,7 +42,7 @@ export function Templates({
       const payload = buildReminderPayload(dto);
       
       try {
-        await api.remindersPost({ reminder: payload });
+        await api.remindersPost(payload);
       } catch (apiError) {
         console.warn("Backend API failed, using mock API:", apiError);
         await mockApi.createReminder(payload);

--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -64,7 +64,7 @@ export default function RemindersCreate() {
       
       try {
         // Пробуем основной API
-        await api.remindersPost({ reminder: payload });
+        await api.remindersPost(payload);
       } catch (apiError) {
         console.warn("Backend API failed, using mock API:", apiError);
         // Fallback на mock API

--- a/services/webapp/ui/src/features/reminders/pages/RemindersList.bulk.ts
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersList.bulk.ts
@@ -5,12 +5,10 @@ export async function bulkToggle(api: any, items: any[], enable: boolean) {
   for (const r of items) {
     if (r.isEnabled !== enable) {
       try {
-        await api.remindersPatch({ 
-          reminder: { 
-            id: r.id, 
-            telegramId: r.telegramId, 
-            isEnabled: enable 
-          } 
+        await api.remindersPatch({
+          id: r.id,
+          telegramId: r.telegramId,
+          isEnabled: enable,
         });
         successCount++;
       } catch {

--- a/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
@@ -138,7 +138,7 @@ export default function RemindersList({
     setItems(optimistic);
     try {
       try {
-        await api.remindersPatch({ reminder: { telegramId: r.telegramId, id: r.id, isEnabled: !r.isEnabled } });
+        await api.remindersPatch({ telegramId: r.telegramId, id: r.id, isEnabled: !r.isEnabled });
       } catch (apiError) {
         console.warn("Backend API failed, using mock API:", apiError);
         await mockApi.updateReminder({ ...r, isEnabled: !r.isEnabled });


### PR DESCRIPTION
## Summary
- adjust reminders API functions to send raw payloads and new endpoints
- align reminder components with updated API

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any...)*
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2464d708832ab8f34a88c7de3ada