### PR TITLE
[webapp] handle reminder save response

### DIFF
--- a/libs/ts-sdk/models/RemindersPost200Response.ts
+++ b/libs/ts-sdk/models/RemindersPost200Response.ts
@@ -20,24 +20,26 @@ import { mapValues } from '../runtime';
  */
 export interface RemindersPost200Response {
     /**
-     * 
+     *
      * @type {string}
      * @memberof RemindersPost200Response
      */
-    status?: string;
+    status: string;
     /**
-     * 
+     *
      * @type {number}
      * @memberof RemindersPost200Response
      */
-    id?: number;
+    id: number;
 }
 
 /**
  * Check if a given object implements the RemindersPost200Response interface.
  */
-export function instanceOfRemindersPost200Response(value: object): value is RemindersPost200Response {
-    return true;
+export function instanceOfRemindersPost200Response(
+    value: object,
+): value is RemindersPost200Response {
+    return 'status' in value && 'id' in value;
 }
 
 export function RemindersPost200ResponseFromJSON(json: any): RemindersPost200Response {
@@ -50,8 +52,8 @@ export function RemindersPost200ResponseFromJSONTyped(json: any, ignoreDiscrimin
     }
     return {
         
-        'status': json['status'] == null ? undefined : json['status'],
-        'id': json['id'] == null ? undefined : json['id'],
+        status: json['status'],
+        id: json['id'],
     };
 }
 

--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,5 +1,5 @@
 
-import { Reminder } from '@sdk';
+import { Reminder, RemindersPost200Response } from '@sdk';
 import { http } from './http';
 import { mockApi } from './mock-server';
 
@@ -37,26 +37,36 @@ export async function getReminder(
   }
 }
 
-export async function createReminder(reminder: Reminder) {
+export async function createReminder(
+  reminder: Reminder,
+): Promise<RemindersPost200Response> {
   try {
     if (isDevelopment) {
       console.log('[API] Using mock server for createReminder');
       return await mockApi.createReminder(reminder);
     }
-    return await http.post<Reminder>('/reminders', reminder);
+    return await http.post<RemindersPost200Response>(
+      '/reminders',
+      reminder,
+    );
   } catch (error) {
     console.error('Failed to create reminder:', error);
     throw new Error('Не удалось создать напоминание');
   }
 }
 
-export async function updateReminder(reminder: Reminder) {
+export async function updateReminder(
+  reminder: Reminder,
+): Promise<RemindersPost200Response> {
   try {
     if (isDevelopment) {
       console.log('[API] Using mock server for updateReminder');
       return await mockApi.updateReminder(reminder);
     }
-    return await http.patch<Reminder>('/reminders', reminder);
+    return await http.patch<RemindersPost200Response>(
+      '/reminders',
+      reminder,
+    );
   } catch (error) {
     console.error('Failed to update reminder:', error);
     throw new Error('Не удалось обновить напоминание');

--- a/services/webapp/ui/src/reminders/CreateReminder.tsx
+++ b/services/webapp/ui/src/reminders/CreateReminder.tsx
@@ -133,7 +133,7 @@ export default function CreateReminder() {
       const res = editing
         ? await updateReminder(payload)
         : await createReminder(payload);
-      const rid = editing ? editing.id : res?.id;
+      const rid = editing ? editing.id : res.id;
       const hours = interval != null ? interval / 60 : undefined;
       const value =
         hours != null && Number.isInteger(hours) ? `${hours}h` : time;


### PR DESCRIPTION
## Summary
- align reminder creation/update APIs with `{status, id}` backend response
- adjust SDK type for reminder save response
- use returned id when saving reminders

## Testing
- `pnpm typecheck`
- `pnpm test` *(fails: No test files found)*
- `pytest -q --cov` *(fails: 13 failed, 8 errors)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68af31536270832abf2f202af3af73c7