### PR TITLE
[webapp] use camelCase reminder payload

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/buildPayload.test.ts
+++ b/services/webapp/ui/src/features/reminders/api/buildPayload.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, vi } from 'vitest';
+import { buildReminderPayload } from './buildPayload';
+import { Configuration } from '@sdk/runtime.ts';
+import { RemindersApi } from '@sdk/apis';
+import { mockApi } from '../../../api/mock-server';
+
+describe('reminders api', () => {
+  test('builds camelCase payload and posts without mock fallback', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+    // @ts-expect-error - override global fetch for test
+    global.fetch = fetchMock;
+
+    const createReminderSpy = vi.spyOn(mockApi, 'createReminder').mockResolvedValue({});
+
+    const cfg = new Configuration({ basePath: '', fetchApi: fetchMock });
+    const api = new RemindersApi(cfg);
+
+    const form = {
+      telegramId: 1,
+      type: 'sugar',
+      kind: 'at_time' as const,
+      time: '07:30',
+      isEnabled: true,
+    };
+
+    const payload = buildReminderPayload(form);
+    expect(payload).toEqual({
+      telegramId: 1,
+      type: 'sugar',
+      isEnabled: true,
+      time: '07:30',
+    });
+
+    try {
+      await api.remindersPost({ reminder: payload });
+    } catch (err) {
+      await mockApi.createReminder(payload);
+    }
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0][0]).toBe('/reminders');
+    const body = fetchMock.mock.calls[0][1]?.body as string;
+    expect(body).toContain('"telegramId"');
+    expect(createReminderSpy).not.toHaveBeenCalled();
+  });
+});

--- a/services/webapp/ui/src/features/reminders/api/buildPayload.ts
+++ b/services/webapp/ui/src/features/reminders/api/buildPayload.ts
@@ -42,18 +42,18 @@ export function buildReminderPayload(v: ReminderFormValues) {
   }
 
   const base = {
-    telegram_id: values.telegramId,
+    telegramId: values.telegramId,
     type: values.type,
-    is_enabled: values.isEnabled ?? true,
+    isEnabled: values.isEnabled ?? true,
   };
-  
-  // Backend only supports one of: time, interval_minutes, minutes_after
+
+  // Backend only supports one of: time, intervalMinutes, minutesAfter
   if (values.kind === "at_time" && values.time) {
     return { ...base, time: values.time };
   } else if (values.kind === "every" && values.intervalMinutes) {
-    return { ...base, interval_minutes: values.intervalMinutes };
+    return { ...base, intervalMinutes: values.intervalMinutes };
   } else if (values.kind === "after_event" && values.minutesAfter) {
-    return { ...base, minutes_after: values.minutesAfter };
+    return { ...base, minutesAfter: values.minutesAfter };
   }
   
   return base;

--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -64,7 +64,7 @@ export default function RemindersCreate() {
       
       try {
         // Пробуем основной API
-        await api.remindersPost(payload);
+        await api.remindersPost({ reminder: payload });
       } catch (apiError) {
         console.warn("Backend API failed, using mock API:", apiError);
         // Fallback на mock API


### PR DESCRIPTION
## Summary
- wrap reminders payload under `reminder` when calling API
- send camelCase fields when building reminder payload
- test posting reminders without mock fallback

## Testing
- `pnpm -F vite_react_shadcn_ts lint` *(fails: Unexpected any ...)*
- `pnpm -F vite_react_shadcn_ts exec eslint src/features/reminders/api/buildPayload.ts src/features/reminders/pages/RemindersCreate.tsx src/features/reminders/api/buildPayload.test.ts`
- `pnpm -F vite_react_shadcn_ts typecheck`
- `pnpm -F vite_react_shadcn_ts test`
- `pnpm -F vite_react_shadcn_ts build`
- `pytest -q` *(fails: async def functions are not natively supported, many failures)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68af65f03d7c832aa397cda3e4a160af