### PR TITLE
[reminders] use full reminder schema when toggling

### DIFF
--- a/services/webapp/ui/src/features/reminders/pages/RemindersList.bulk.ts
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersList.bulk.ts
@@ -1,15 +1,24 @@
+import type { ReminderSchema } from "@sdk";
+
 export async function bulkToggle(api: any, items: any[], enable: boolean) {
   let successCount = 0;
   let errorCount = 0;
-  
+
   for (const r of items) {
     if (r.isEnabled !== enable) {
       try {
-        await api.remindersPatch({
-          id: r.id,
+        const reminder: ReminderSchema = {
           telegramId: r.telegramId,
+          id: r.id,
+          type: r.type,
+          kind: r.kind,
+          time: r.time ?? undefined,
+          intervalMinutes: r.intervalMinutes ?? undefined,
+          minutesAfter: r.minutesAfter ?? undefined,
+          daysOfWeek: r.daysOfWeek ?? undefined,
           isEnabled: enable,
-        });
+        };
+        await api.remindersPatch({ reminder });
         successCount++;
       } catch {
         // Ignore individual errors, count them for summary
@@ -17,6 +26,6 @@ export async function bulkToggle(api: any, items: any[], enable: boolean) {
       }
     }
   }
-  
+
   return { successCount, errorCount, totalChanged: successCount + errorCount };
 }

--- a/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
+import type { ReminderSchema } from "@sdk";
 import { useRemindersApi } from "../api/reminders";
 import { formatNextAt } from "../../../shared/datetime";
 import { useTelegram } from "@/hooks/useTelegram";
@@ -134,11 +135,24 @@ export default function RemindersList({
   }, [items, filter]);
 
   async function toggleEnabled(r: ReminderDto) {
-    const optimistic = items.map(x => x.id === r.id ? { ...x, isEnabled: !x.isEnabled } : x);
+    const optimistic = items.map(x =>
+      x.id === r.id ? { ...x, isEnabled: !x.isEnabled } : x
+    );
     setItems(optimistic);
     try {
       try {
-        await api.remindersPatch({ telegramId: r.telegramId, id: r.id, isEnabled: !r.isEnabled });
+        const reminder: ReminderSchema = {
+          telegramId: r.telegramId,
+          id: r.id,
+          type: r.type as any,
+          kind: r.kind,
+          time: r.time ?? undefined,
+          intervalMinutes: r.intervalMinutes ?? undefined,
+          minutesAfter: r.minutesAfter ?? undefined,
+          daysOfWeek: r.daysOfWeek ?? undefined,
+          isEnabled: !r.isEnabled,
+        };
+        await api.remindersPatch({ reminder });
       } catch (apiError) {
         console.warn("Backend API failed, using mock API:", apiError);
         await mockApi.updateReminder({ ...r, isEnabled: !r.isEnabled });


### PR DESCRIPTION
## Summary
- send ReminderSchema payload when toggling a reminder
- update bulk toggle to patch reminders with complete schema

## Testing
- `pytest -q --cov` *(fails: async plugin missing)*
- `mypy --strict .` *(fails: interrupted/too long)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68af65f325dc832a990bab14a6bd5637