### PR TITLE
[api] use configured UI base URL

### DIFF
--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -19,8 +19,8 @@ JWT_EXPIRE_DAYS=7
 # Optional service URLs
 WEBAPP_URL=http://localhost:3000
 API_URL=http://localhost:8000
-# Base path for the web app; defaults to /ui/
-VITE_BASE_URL=/ui/
+# Base path for the web app; used by both frontend and backend. Defaults to /ui/
+UI_BASE_URL=/ui/
 # Optional base API URL for webapp; defaults to '/api'.
 # Leave empty to use the '/api' prefix; for an external API set a full URL without a trailing '/'.
 VITE_API_URL=/api

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -4,7 +4,6 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import time as dt_time
 import logging
-import os
 from pathlib import Path
 import sys
 from typing import cast
@@ -23,6 +22,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 # ────────── local ──────────
+from . import config
 from .diabetes.services.db import (
     HistoryRecord as HistoryRecordDB,
     Timezone as TimezoneDB,
@@ -79,7 +79,7 @@ UI_DIR = (
     else (BASE_DIR / "ui")
 )
 UI_DIR = UI_DIR.resolve()
-UI_BASE_URL = os.getenv("VITE_BASE_URL", "/ui/").rstrip("/")
+UI_BASE_URL = config.settings.ui_base_url.rstrip("/")
 
 
 # ────────── Schemas ──────────

--- a/tests/test_ui_reminders_smoke.py
+++ b/tests/test_ui_reminders_smoke.py
@@ -1,9 +1,21 @@
 from fastapi.testclient import TestClient
+
+from services.api.app import config
 from services.api.app.main import app
 
 
 def test_reminders_page_smoke() -> None:
     with TestClient(app) as client:
-        resp = client.get("/ui/reminders")
+        base = config.settings.ui_base_url.rstrip("/")
+        resp = client.get(f"{base}/reminders")
         assert resp.status_code == 200
+        assert "<html" in resp.text.lower()
+
+
+def test_reminders_new_page_smoke() -> None:
+    with TestClient(app) as client:
+        base = config.settings.ui_base_url.rstrip("/")
+        resp = client.get(f"{base}/reminders/new")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
         assert "<html" in resp.text.lower()


### PR DESCRIPTION
## Summary
- derive UI_BASE_URL from config.settings.ui_base_url
- document UI_BASE_URL in env example
- test that reminders pages are served for new reminders path

## Testing
- `pytest tests/test_ui_reminders_smoke.py::test_reminders_new_page_smoke -q` *(fails: Coverage failure: total of 9 is less than fail-under=85)*
- `mypy --strict services/api/app/main.py tests/test_ui_reminders_smoke.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68afde7b68d4832a9179044349ff98b0