### PR TITLE
[reminders] Restore menu after reminders list

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -40,6 +40,7 @@ from services.api.app.diabetes.utils.helpers import (
     INVALID_TIME_MSG,
     parse_time_interval,
 )
+from services.api.app.diabetes.utils.ui import menu_keyboard
 from . import UserData
 
 run_db: Callable[..., Awaitable[object]] | None
@@ -353,6 +354,8 @@ async def reminders_list(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await message.reply_text(text, parse_mode="HTML", reply_markup=keyboard)
     else:
         await message.reply_text(text, parse_mode="HTML")
+
+    await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
 
 
 async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- show main menu after listing reminders
- ensure reminder listing sends menu keyboard

## Testing
- `pytest tests/test_reminders.py::test_reminders_list_renders_output tests/test_reminders.py::test_reminders_list_shows_menu_keyboard -q --cov --cov-fail-under=0`
- `ruff check .`
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py` *(fails: Interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68afde77d52c832a85d9c3cc846450a7