### PR TITLE
[reminders] Use ReminderSchema for reminder creation

### DIFF
--- a/services/webapp/ui/src/api/mock-server.ts
+++ b/services/webapp/ui/src/api/mock-server.ts
@@ -66,29 +66,29 @@ export const mockApi = {
 
   async createReminder(reminder: any) {
     console.log('[MockAPI] Creating reminder:', reminder);
-    
+
     // Determine kind based on payload data
     let kind: "at_time" | "every" | "after_event" = "at_time";
     if (reminder.time) {
       kind = "at_time";
-    } else if (reminder.interval_hours || reminder.interval_minutes) {
+    } else if (reminder.intervalMinutes || reminder.intervalHours) {
       kind = "every";
-    } else if (reminder.minutes_after) {
+    } else if (reminder.minutesAfter) {
       kind = "after_event";
     }
-    
+
     const newReminder = {
       id: nextId++,
-      telegramId: reminder.telegram_id,
+      telegramId: reminder.telegramId,
       type: reminder.type,
       title: reminder.title || null,
       kind,
       time: reminder.time || null,
-      intervalMinutes: reminder.interval_minutes || (reminder.interval_hours ? Math.round(reminder.interval_hours * 60) : null),
-      minutesAfter: reminder.minutes_after || null,
-      daysOfWeek: reminder.days_of_week || null,
-      isEnabled: reminder.is_enabled,
-      nextAt: reminder.next_at || null,
+      intervalMinutes: reminder.intervalMinutes || (reminder.intervalHours ? Math.round(reminder.intervalHours * 60) : null),
+      minutesAfter: reminder.minutesAfter || null,
+      daysOfWeek: reminder.daysOfWeek ? Array.from(reminder.daysOfWeek) : null,
+      isEnabled: reminder.isEnabled,
+      nextAt: reminder.nextAt || null,
     };
     mockReminders.push(newReminder);
     saveToStorage(mockReminders);
@@ -103,22 +103,26 @@ export const mockApi = {
       let kind: "at_time" | "every" | "after_event" = mockReminders[index].kind;
       if (reminder.time) {
         kind = "at_time";
-      } else if (reminder.interval_hours || reminder.interval_minutes) {
+      } else if (reminder.intervalMinutes || reminder.intervalHours) {
         kind = "every";
-      } else if (reminder.minutes_after) {
+      } else if (reminder.minutesAfter) {
         kind = "after_event";
       }
-      
+
       const updated = {
         ...mockReminders[index],
-        type: reminder.type || mockReminders[index].type,
+        type: reminder.type ?? mockReminders[index].type,
         kind,
-        time: reminder.time || null,
-        intervalMinutes: reminder.interval_hours ? Math.round(reminder.interval_hours * 60) : (reminder.interval_minutes || null),
-        minutesAfter: reminder.minutes_after || null,
-        isEnabled: reminder.is_enabled !== undefined ? reminder.is_enabled : mockReminders[index].isEnabled,
-        title: reminder.title || mockReminders[index].title,
-        daysOfWeek: reminder.days_of_week || mockReminders[index].daysOfWeek,
+        time: reminder.time ?? null,
+        intervalMinutes: reminder.intervalHours
+          ? Math.round(reminder.intervalHours * 60)
+          : reminder.intervalMinutes ?? mockReminders[index].intervalMinutes,
+        minutesAfter: reminder.minutesAfter ?? mockReminders[index].minutesAfter,
+        isEnabled: reminder.isEnabled !== undefined ? reminder.isEnabled : mockReminders[index].isEnabled,
+        title: reminder.title ?? mockReminders[index].title,
+        daysOfWeek: reminder.daysOfWeek
+          ? Array.from(reminder.daysOfWeek)
+          : mockReminders[index].daysOfWeek,
       };
       mockReminders[index] = updated;
       saveToStorage(mockReminders);

--- a/services/webapp/ui/src/features/reminders/components/Templates.tsx
+++ b/services/webapp/ui/src/features/reminders/components/Templates.tsx
@@ -39,13 +39,13 @@ export function Templates({
   
   const create = async (dto: any) => {
     try {
-      const payload = buildReminderPayload(dto);
-      
+      const reminder = buildReminderPayload(dto);
+
       try {
-        await api.remindersPost(payload);
+        await api.remindersPost({ reminder });
       } catch (apiError) {
         console.warn("Backend API failed, using mock API:", apiError);
-        await mockApi.createReminder(payload);
+        await mockApi.createReminder(reminder);
       }
       
       toast.success("Напоминание создано из шаблона");

--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -59,16 +59,16 @@ export default function RemindersCreate() {
     
     setLoading(true);
     try {
-      const payload = buildReminderPayload({ ...form, telegramId });
-      console.log("Payload being sent:", payload);
-      
+      const reminder = buildReminderPayload({ ...form, telegramId });
+      console.log("Payload being sent:", reminder);
+
       try {
         // Пробуем основной API
-        await api.remindersPost(payload);
+        await api.remindersPost({ reminder });
       } catch (apiError) {
         console.warn("Backend API failed, using mock API:", apiError);
         // Fallback на mock API
-        await mockApi.createReminder(payload);
+        await mockApi.createReminder(reminder);
       }
       
       toast.success("Напоминание успешно создано");


### PR DESCRIPTION
## Summary
- build `ReminderSchema` payload with camelCase fields
- post reminders via `{ reminder }` body and adjust mock server

## Testing
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any, etc.)*
- `pnpm --filter ./services/webapp/ui test` *(fails: No test files found)*
- `pytest` *(fails: unrecognized arguments: --cov=...)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68afe06bc560832a9a9c10b3a565e196