### PR TITLE
[webapp] use ReminderSchema for reminders

### DIFF
--- a/services/webapp/ui/src/api/reminders.ts
+++ b/services/webapp/ui/src/api/reminders.ts
@@ -1,18 +1,22 @@
 
-import { Reminder } from '@sdk';
+import type { ReminderSchema } from '@sdk';
 import { http } from './http';
 import { mockApi } from './mock-server';
 
 // Определяем, находимся ли мы в режиме разработки
 const isDevelopment = import.meta.env.DEV;
 
-export async function getReminders(telegramId: number): Promise<Reminder[]> {
+export async function getReminders(
+  telegramId: number,
+): Promise<ReminderSchema[]> {
   try {
     if (isDevelopment) {
       console.log('[API] Using mock server for getReminders');
       return await mockApi.getReminders(telegramId);
     }
-    return await http.get<Reminder[]>(`/reminders?telegramId=${telegramId}`);
+    return await http.get<ReminderSchema[]>(
+      `/reminders?telegramId=${telegramId}`,
+    );
   } catch (error) {
     console.error('[API] Failed to fetch reminders:', error);
     throw new Error('Не удалось загрузить напоминания');
@@ -22,13 +26,13 @@ export async function getReminders(telegramId: number): Promise<Reminder[]> {
 export async function getReminder(
   telegramId: number,
   id: number,
-): Promise<Reminder> {
+): Promise<ReminderSchema> {
   try {
     if (isDevelopment) {
       console.log('[API] Using mock server for getReminder');
       return await mockApi.getReminder(telegramId, id);
     }
-    return await http.get<Reminder>(
+    return await http.get<ReminderSchema>(
       `/reminders/${id}?telegramId=${telegramId}`,
     );
   } catch (error) {
@@ -37,26 +41,26 @@ export async function getReminder(
   }
 }
 
-export async function createReminder(reminder: Reminder) {
+export async function createReminder(reminder: ReminderSchema) {
   try {
     if (isDevelopment) {
       console.log('[API] Using mock server for createReminder');
       return await mockApi.createReminder(reminder);
     }
-    return await http.post<Reminder>('/reminders', reminder);
+    return await http.post<ReminderSchema>('/reminders', reminder);
   } catch (error) {
     console.error('Failed to create reminder:', error);
     throw new Error('Не удалось создать напоминание');
   }
 }
 
-export async function updateReminder(reminder: Reminder) {
+export async function updateReminder(reminder: ReminderSchema) {
   try {
     if (isDevelopment) {
       console.log('[API] Using mock server for updateReminder');
       return await mockApi.updateReminder(reminder);
     }
-    return await http.patch<Reminder>('/reminders', reminder);
+    return await http.patch<ReminderSchema>('/reminders', reminder);
   } catch (error) {
     console.error('Failed to update reminder:', error);
     throw new Error('Не удалось обновить напоминание');


### PR DESCRIPTION
## Summary
- switch reminder API to ReminderSchema
- build full ReminderSchema when toggling reminders

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: many lint errors)*
- `pnpm --filter ./services/webapp/ui test` *(fails: No test files found)*
- `pytest -q` *(fails: coverage plugin missing)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68afe06d8618832aa247cee2ff9f6759