### PR TITLE
[utils] Refresh menu keyboard config

### DIFF
--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -14,7 +14,6 @@ from telegram import (
     KeyboardButton,
     WebAppInfo,
 )
-from services.api.app import config
 
 PROFILE_BUTTON_TEXT = "📄 Мой профиль"
 REMINDERS_BUTTON_TEXT = "⏰ Напоминания"
@@ -58,7 +57,9 @@ def menu_keyboard() -> ReplyKeyboardMarkup:
 
     WebApp buttons are used only when ``PUBLIC_ORIGIN`` is configured.
     """
+    from services.api.app import config
 
+    config.settings = config.Settings()
     webapp_enabled = bool(config.settings.public_origin)
     profile_button = (
         KeyboardButton(
@@ -150,6 +151,9 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
         Button instance when ``PUBLIC_ORIGIN`` is set and valid, otherwise ``None``.
     """
 
+    from services.api.app import config
+
+    config.settings = config.Settings()
     if not config.settings.public_origin:
         return None
 

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -1,6 +1,5 @@
 from urllib.parse import urlparse
 
-import importlib
 import pytest
 
 import services.api.app.diabetes.utils.ui as ui
@@ -21,8 +20,6 @@ def test_menu_keyboard_webapp_urls(
     """Menu buttons should open webapp paths for profile and reminders."""
     monkeypatch.setenv("PUBLIC_ORIGIN", origin)
     monkeypatch.setenv("UI_BASE_URL", ui_base)
-    import services.api.app.config as config
-    importlib.reload(config)
 
     buttons = [btn for row in ui.menu_keyboard().keyboard for btn in row]
     profile_btn = next(b for b in buttons if b.text == ui.PROFILE_BUTTON_TEXT)
@@ -31,4 +28,25 @@ def test_menu_keyboard_webapp_urls(
     assert profile_btn.web_app is not None
     assert urlparse(profile_btn.web_app.url).path.endswith("/profile")
     assert reminders_btn.web_app is not None
+    assert urlparse(reminders_btn.web_app.url).path.endswith("/reminders")
+
+
+def test_menu_keyboard_webapp_reloads_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``menu_keyboard`` should reflect environment changes at runtime."""
+    monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
+    monkeypatch.delenv("UI_BASE_URL", raising=False)
+    buttons = [btn for row in ui.menu_keyboard().keyboard for btn in row]
+    profile_btn = next(b for b in buttons if b.text == ui.PROFILE_BUTTON_TEXT)
+    reminders_btn = next(b for b in buttons if b.text == ui.REMINDERS_BUTTON_TEXT)
+    assert profile_btn.web_app is None
+    assert reminders_btn.web_app is None
+
+    monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.com")
+    monkeypatch.setenv("UI_BASE_URL", "")
+    buttons = [btn for row in ui.menu_keyboard().keyboard for btn in row]
+    profile_btn = next(b for b in buttons if b.text == ui.PROFILE_BUTTON_TEXT)
+    reminders_btn = next(b for b in buttons if b.text == ui.REMINDERS_BUTTON_TEXT)
+    assert profile_btn.web_app is not None
+    assert reminders_btn.web_app is not None
+    assert urlparse(profile_btn.web_app.url).path.endswith("/profile")
     assert urlparse(reminders_btn.web_app.url).path.endswith("/reminders")


### PR DESCRIPTION
## Summary
- Reload config settings inside `menu_keyboard` and timezone helper so UI buttons use the latest environment
- Extend `test_menu_keyboard_webapp` to validate URLs update after environment changes

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/test_menu_keyboard_webapp.py -q` *(fails: Coverage failure: total of 11 is less than fail-under=85)*
- `pytest tests/test_menu_keyboard_webapp.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68afe4e4665c832a803de74eeaa838dc