### PR TITLE
fix: refresh public origin in profile security

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -510,10 +510,13 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
         await sos_handlers.sos_contact_start(update, context)
         return
-    if action == "add" and config.settings.public_origin:
+    from services.api.app import config as app_config
+
+    origin = app_config.settings.public_origin
+    if action == "add" and origin:
         button = InlineKeyboardButton(
             "📝 Новое",
-            web_app=WebAppInfo(config.build_ui_url("/reminders")),
+            web_app=WebAppInfo(app_config.build_ui_url("/reminders")),
         )
         keyboard = InlineKeyboardMarkup([[button]])
         await q_message.reply_text("Создать напоминание:", reply_markup=keyboard)

--- a/tests/test_profile_security.py
+++ b/tests/test_profile_security.py
@@ -242,6 +242,14 @@ async def test_profile_security_add_delete_calls_handlers(
 
     await handlers.profile_security(update_add, context)
     assert query_add.message.texts[-1] == "Создать напоминание:"
+    markup = query_add.message.markups[-1]
+    button = markup.inline_keyboard[0][0]
+    assert button.web_app is not None
+    assert button.web_app.url == config.build_ui_url("/reminders")
+
+    monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
+    monkeypatch.delenv("UI_BASE_URL", raising=False)
+    importlib.reload(config)
 
     query_del = DummyQuery(DummyMessage(), "profile_security:del")
     update_del = cast(


### PR DESCRIPTION
## Summary
- always re-read PUBLIC_ORIGIN in profile_security and show add reminder button when available
- test add-action shows reminder button with correct link

## Testing
- `pytest -q` *(fails: ImportError module services.api.app.config not in sys.modules)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68afe4ea9244832ab88f4922e5b909e5