### PR TITLE
[reminders] Build add button row at runtime

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -161,9 +161,9 @@ def _render_reminders(
     if active_count > limit:
         header += " ⚠️"
 
-    webapp_enabled = bool(config.settings.public_origin)
-    add_button_row = None
-    if webapp_enabled:
+    public_origin = config.settings.public_origin
+    add_button_row: list[InlineKeyboardButton] | None = None
+    if public_origin:
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
@@ -173,7 +173,7 @@ def _render_reminders(
     if not rems:
         text = header
 
-        if webapp_enabled and add_button_row is not None:
+        if add_button_row is not None:
             text += "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
             return text, InlineKeyboardMarkup([add_button_row])
         text += "\nУ вас нет напоминаний. Отправьте /addreminder."
@@ -190,7 +190,7 @@ def _render_reminders(
         line = f"{r.id}. {title}"
         status_icon = "🔔" if r.is_enabled else "🔕"
         row: list[InlineKeyboardButton] = []
-        if webapp_enabled:
+        if add_button_row is not None:
             row.append(
                 InlineKeyboardButton(
                     "✏️",


### PR DESCRIPTION
## Summary
- Build reminder Add button row at runtime using latest `public_origin`
- Verify Add button URL via `config.build_ui_url` and public origin changes

## Testing
- `coverage run --source=services/api/app/diabetes/handlers -m pytest tests/test_reminders.py::test_render_reminders_formatting tests/test_reminders.py::test_render_reminders_no_webapp tests/test_reminders.py::test_render_reminders_no_entries_no_webapp tests/test_reminders.py::test_render_reminders_runtime_public_origin -q -o addopts=''`
- `coverage report --fail-under=85`
- `ruff check .`
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py`


------
https://chatgpt.com/codex/tasks/task_e_68afe4ebfc38832a816592778bd1fd3b