### PR TITLE
[utils] Refresh config in timezone button

### DIFF
--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -150,10 +150,14 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
         Button instance when ``PUBLIC_ORIGIN`` is set and valid, otherwise ``None``.
     """
 
-    if not config.settings.public_origin:
+    import importlib
+
+    config_module = importlib.import_module("services.api.app.config")
+    fresh_config = importlib.reload(config_module)
+    if not fresh_config.settings.public_origin:
         return None
 
     return InlineKeyboardButton(
         "Определить автоматически",
-        web_app=WebAppInfo(config.build_ui_url("/timezone")),
+        web_app=WebAppInfo(fresh_config.build_ui_url("/timezone")),
     )

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -1,4 +1,3 @@
-import importlib
 from urllib.parse import urlparse
 
 import pytest
@@ -6,15 +5,23 @@ import pytest
 import services.api.app.diabetes.utils.ui as ui
 
 
-def test_timezone_button_webapp_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Timezone button should open webapp path for timezone detection."""
+def test_timezone_button_webapp_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Button should be returned when PUBLIC_ORIGIN is configured."""
+
     monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.com")
     monkeypatch.setenv("UI_BASE_URL", "/ui")
-    import services.api.app.config as config
-    importlib.reload(config)
 
     button = ui.build_timezone_webapp_button()
     assert button is not None
     web_app = button.web_app
     assert web_app is not None
     assert urlparse(web_app.url).path == "/ui/timezone"
+
+
+def test_timezone_button_webapp_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No button is built when PUBLIC_ORIGIN is missing."""
+
+    monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
+
+    button = ui.build_timezone_webapp_button()
+    assert button is None


### PR DESCRIPTION
## Summary
- reload config before creating timezone detection WebApp button
- cover timezone WebApp button for configured and missing PUBLIC_ORIGIN

## Testing
- `pytest -q` *(fails: module services.api.app.config not in sys.modules, assertion errors in unrelated tests)*
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68afe4ecf2fc832a84365e1cb17702fa