### PR TITLE
[utils] refresh timezone webapp settings

### DIFF
--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -151,10 +151,9 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
         Button instance when ``PUBLIC_ORIGIN`` is set and valid, otherwise ``None``.
     """
 
-    from importlib import reload
     from services.api.app import config
 
-    reload(config)
+    config.settings = config.Settings()
     if not config.settings.public_origin:
         return None
 


### PR DESCRIPTION
## Summary
- refresh settings within `build_timezone_webapp_button`

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68affe7bff40832ab93517685c5d4b96