### PR TITLE
[utils] refresh settings before building timezone button

### DIFF
--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -151,10 +151,9 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
         Button instance when ``PUBLIC_ORIGIN`` is set and valid, otherwise ``None``.
     """
 
-    from importlib import reload
     from services.api.app import config
 
-    reload(config)
+    config.settings = config.Settings()
     if not config.settings.public_origin:
         return None
 

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 
 import pytest
+from telegram import InlineKeyboardButton
 
 import services.api.app.diabetes.utils.ui as ui
 
@@ -22,7 +23,7 @@ def test_timezone_button_webapp_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("UI_BASE_URL", "/ui")
 
     button = ui.build_timezone_webapp_button()
-    assert button is not None
+    assert isinstance(button, InlineKeyboardButton)
     web_app = button.web_app
     assert web_app is not None
     assert urlparse(web_app.url).path == "/ui/timezone"


### PR DESCRIPTION
## Summary
- refresh settings before building timezone WebApp button
- verify timezone button returns InlineKeyboardButton when PUBLIC_ORIGIN is set

## Testing
- `pytest -q --cov` *(fails: tests for OpenAI utils and reminders)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68affe7c8e70832abd025db51b5a80b1