### PR TITLE
[config] add settings reload helpers

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -77,6 +77,20 @@ class Settings(BaseSettings):
 settings = Settings()
 
 
+def get_settings() -> Settings:
+    """Return the current application settings."""
+
+    return settings
+
+
+def reload_settings() -> Settings:
+    """Reload settings from the environment and return them."""
+
+    global settings
+    settings = Settings()
+    return settings
+
+
 def get_db_password() -> Optional[str]:
     """Return the database password from the environment.
 

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -59,8 +59,9 @@ def menu_keyboard() -> ReplyKeyboardMarkup:
     """
     from services.api.app import config
 
-    config.settings = config.Settings()
-    webapp_enabled = bool(config.settings.public_origin)
+    config.reload_settings()
+    settings = config.get_settings()
+    webapp_enabled = bool(settings.public_origin)
     profile_button = (
         KeyboardButton(
             PROFILE_BUTTON_TEXT,
@@ -153,8 +154,9 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
 
     from services.api.app import config
 
-    config.settings = config.Settings()
-    if not config.settings.public_origin:
+    config.reload_settings()
+    settings = config.get_settings()
+    if not settings.public_origin:
         return None
 
     return InlineKeyboardButton(

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -1,0 +1,16 @@
+import pytest
+
+import services.api.app.config as config
+
+
+def test_reload_settings_reflects_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
+    config.reload_settings()
+    assert config.get_settings().public_origin == ""
+
+    monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.com")
+    config.reload_settings()
+    assert config.get_settings().public_origin == "https://example.com"
+
+    monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
+    config.reload_settings()


### PR DESCRIPTION
## Summary
- add `get_settings` and `reload_settings` helpers to central config
- refresh settings in menu/timezone keyboards via new helpers
- test that settings reload picks up environment changes

## Testing
- `pytest -q --cov` *(fails: 13 failed, 671 passed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b002860de4832a8ca756678b236cd8