### PR TITLE
[handlers] Make reminders list final message

### DIFF
--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -77,9 +77,7 @@ class DummyBot:
     async def send_message(self, chat_id: int | str, text: str, **kwargs: Any) -> None:
         self.messages.append((chat_id, text, kwargs))
 
-    async def answer_callback_query(
-        self, callback_query_id: str, text: str | None = None, **kwargs: Any
-    ) -> None:
+    async def answer_callback_query(self, callback_query_id: str, text: str | None = None, **kwargs: Any) -> None:
         self.cb_answers.append((callback_query_id, text))
 
 
@@ -174,11 +172,7 @@ def test_schedule_reminder_replaces_existing_job() -> None:
     handlers.SessionLocal = TestSession
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="Europe/Moscow"))
-        session.add(
-            Reminder(
-                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
-            )
-        )
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
         session.commit()
     job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
     with TestSession() as session:
@@ -210,9 +204,7 @@ def test_schedule_with_next_interval(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(handlers, "datetime", DummyDatetime)
     user = DbUser(telegram_id=1, thread_id="t", timezone="Europe/Moscow")
-    rem = Reminder(
-        telegram_id=1, type="sugar", interval_hours=2, is_enabled=True, user=user
-    )
+    rem = Reminder(telegram_id=1, type="sugar", interval_hours=2, is_enabled=True, user=user)
     icon, schedule = handlers._schedule_with_next(rem)
     assert icon == "⏱"
     assert schedule == "каждые 2 ч (next 12:00)"
@@ -222,9 +214,7 @@ def test_schedule_with_next_invalid_timezone_logs_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     user = DbUser(telegram_id=1, thread_id="t", timezone="Invalid/Zone")
-    rem = Reminder(
-        telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user
-    )
+    rem = Reminder(telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user)
     with caplog.at_level(logging.WARNING):
         icon, schedule = handlers._schedule_with_next(rem)
     assert icon == "⏰"
@@ -235,9 +225,7 @@ def test_schedule_reminder_invalid_timezone_logs_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     user = DbUser(telegram_id=1, thread_id="t", timezone="Bad/Zone")
-    rem = Reminder(
-        id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user
-    )
+    rem = Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user)
     job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
     with caplog.at_level(logging.WARNING):
         handlers.schedule_reminder(rem, job_queue)
@@ -259,6 +247,7 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.org")
     monkeypatch.setenv("UI_BASE_URL", "/ui")
     import services.api.app.config as config
+
     importlib.reload(config)
     monkeypatch.setattr(handlers, "_limit_for", lambda u: 1)
     # Make _describe deterministic and include status icon to test strikethrough
@@ -272,9 +261,7 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.add_all(
             [
-                Reminder(
-                    id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
-                ),
+                Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True),
                 Reminder(
                     id=2,
                     telegram_id=1,
@@ -302,12 +289,7 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "📸 Триггер-фото" in text
     assert "2. <s>🔕title2</s>" in text
     assert markup.inline_keyboard
-    add_btn = next(
-        btn
-        for row in markup.inline_keyboard
-        for btn in row
-        if btn.text == "➕ Добавить"
-    )
+    add_btn = next(btn for row in markup.inline_keyboard for btn in row if btn.text == "➕ Добавить")
     assert add_btn.web_app is not None
     assert add_btn.web_app.url == config.build_ui_url("/reminders/new")
 
@@ -320,14 +302,11 @@ def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
     monkeypatch.delenv("UI_BASE_URL", raising=False)
     import services.api.app.config as config
+
     importlib.reload(config)
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
-        session.add(
-            Reminder(
-                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
-            )
-        )
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
         session.commit()
     with TestSession() as session:
         text, markup = handlers._render_reminders(session, 1)
@@ -348,6 +327,7 @@ def test_render_reminders_no_entries_no_webapp(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
     monkeypatch.delenv("UI_BASE_URL", raising=False)
     import services.api.app.config as config
+
     importlib.reload(config)
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
@@ -367,33 +347,20 @@ def test_render_reminders_runtime_public_origin(monkeypatch: pytest.MonkeyPatch)
 
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
-        session.add(
-            Reminder(
-                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
-            )
-        )
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
         session.commit()
 
     monkeypatch.setattr(config.settings, "public_origin", "")
     with TestSession() as session:
         _, markup = handlers._render_reminders(session, 1)
     assert markup is not None
-    assert not any(
-        btn.text == "➕ Добавить"
-        for row in markup.inline_keyboard
-        for btn in row
-    )
+    assert not any(btn.text == "➕ Добавить" for row in markup.inline_keyboard for btn in row)
 
     monkeypatch.setattr(config.settings, "public_origin", "https://example.org")
     with TestSession() as session:
         _, markup = handlers._render_reminders(session, 1)
     assert markup is not None
-    add_btn = next(
-        btn
-        for row in markup.inline_keyboard
-        for btn in row
-        if btn.text == "➕ Добавить"
-    )
+    add_btn = next(btn for row in markup.inline_keyboard for btn in row if btn.text == "➕ Добавить")
     assert add_btn.web_app is not None
     assert add_btn.web_app.url == config.build_ui_url("/reminders/new")
 
@@ -419,9 +386,7 @@ async def test_reminders_list_renders_output(
 
     monkeypatch.setattr(handlers, "SessionLocal", lambda: DummySessionCtx())
 
-    def fake_render(
-        session: Session, user_id: int
-    ) -> tuple[str, InlineKeyboardMarkup | None]:
+    def fake_render(session: Session, user_id: int) -> tuple[str, InlineKeyboardMarkup | None]:
         assert session is session_obj
         assert user_id == 1
         return "rendered", keyboard
@@ -440,8 +405,8 @@ async def test_reminders_list_renders_output(
 
     await handlers.reminders_list(update, context)
 
-    assert captured[0][0] == "rendered"
-    kwargs = captured[0][1]
+    assert captured[-1][0] == "rendered"
+    kwargs = captured[-1][1]
     assert kwargs.get("parse_mode") == "HTML"
     if keyboard is not None:
         assert kwargs.get("reply_markup") is keyboard
@@ -466,9 +431,7 @@ async def test_reminders_list_shows_menu_keyboard(
 
     monkeypatch.setattr(handlers, "SessionLocal", lambda: DummySessionCtx())
 
-    def fake_render(
-        session: Session, user_id: int
-    ) -> tuple[str, InlineKeyboardMarkup | None]:
+    def fake_render(session: Session, user_id: int) -> tuple[str, InlineKeyboardMarkup | None]:
         return "rendered", None
 
     monkeypatch.setattr(handlers, "_render_reminders", fake_render)
@@ -489,8 +452,9 @@ async def test_reminders_list_shows_menu_keyboard(
     await handlers.reminders_list(update, context)
 
     assert len(captured) == 2
-    second_kwargs = captured[1][1]
-    assert second_kwargs.get("reply_markup") is sentinel_markup
+    first_text, first_kwargs = captured[0]
+    assert first_text == "📋 Выберите действие:"
+    assert first_kwargs.get("reply_markup") is sentinel_markup
 
 
 @pytest.mark.asyncio
@@ -503,11 +467,7 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
-        session.add(
-            Reminder(
-                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
-            )
-        )
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
         session.commit()
 
     job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
@@ -894,9 +854,7 @@ def client(
         yield test_client
 
 
-def test_empty_returns_200(
-    client: TestClient, session_factory: sessionmaker[Session]
-) -> None:
+def test_empty_returns_200(client: TestClient, session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -905,10 +863,7 @@ def test_empty_returns_200(
     assert resp.json() == []
 
 
-def test_nonempty_returns_list(
-    client: TestClient, session_factory: sessionmaker[Session]
-) -> None:
-
+def test_nonempty_returns_list(client: TestClient, session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(
@@ -945,9 +900,7 @@ def test_nonempty_returns_list(
     ]
 
 
-def test_get_single_reminder(
-    client: TestClient, session_factory: sessionmaker[Session]
-) -> None:
+def test_get_single_reminder(client: TestClient, session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(
@@ -990,9 +943,7 @@ def test_real_404(client: TestClient) -> None:
     assert resp.json() == []
 
 
-def test_get_single_reminder_not_found(
-    client: TestClient, session_factory: sessionmaker[Session]
-) -> None:
+def test_get_single_reminder_not_found(client: TestClient, session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -1001,9 +952,7 @@ def test_get_single_reminder_not_found(
     assert resp.json() == {"detail": "reminder not found"}
 
 
-def test_post_reminder_forbidden(
-    client: TestClient, session_factory: sessionmaker[Session]
-) -> None:
+def test_post_reminder_forbidden(client: TestClient, session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -1018,9 +967,7 @@ def test_post_reminder_forbidden(
     fastapi_app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
 
 
-def test_patch_reminder_forbidden(
-    client: TestClient, session_factory: sessionmaker[Session]
-) -> None:
+def test_patch_reminder_forbidden(client: TestClient, session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(


### PR DESCRIPTION
## Summary
- ensure `reminders_list` sends the list last and optionally shows menu prompt first
- adjust reminder list tests for new order

## Testing
- `pytest -q` *(fails: AttributeError in gpt_client_service, openai_utils assertions, reminder formatting assertions)*
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py`
- `ruff check services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0028b5980832a86205b017e6d2b0a