### PR TITLE
[config] refresh settings dynamically

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -74,7 +74,13 @@ class Settings(BaseSettings):
 
 
 # Instantiate settings for external use
-settings = Settings()
+def get_settings() -> Settings:
+    """Return current application settings."""
+
+    return Settings()
+
+
+settings = get_settings()
 
 
 def get_db_password() -> Optional[str]:
@@ -89,13 +95,14 @@ def get_db_password() -> Optional[str]:
     return os.environ.get("DB_PASSWORD")
 
 
-def build_ui_url(path: str) -> str:
+def build_ui_url(path: str, settings: Settings | None = None) -> str:
     """Return an absolute UI URL for ``path``.
 
     Slashes are normalized and ``settings.public_origin`` must be configured.
     ``settings.ui_base_url`` is stripped of leading and trailing slashes.
     """
 
+    settings = settings or get_settings()
     if not settings.public_origin:
         raise RuntimeError("PUBLIC_ORIGIN not configured")
     origin = settings.public_origin.rstrip("/")

--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -109,7 +109,8 @@ def get_api(
             "diabetes_sdk could not be initialized. Falling back to local profile API.",
         )
         return LocalProfileAPI(sessionmaker), Exception, LocalProfile
-    api = DefaultApi(ApiClient(Configuration(host=config.settings.api_url)))
+    settings = config.get_settings()
+    api = DefaultApi(ApiClient(Configuration(host=settings.api_url)))
     return api, ApiException, ProfileModel
 
 

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -222,11 +222,14 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     profile = fetch_profile(api, ApiException, user_id)
 
     webapp_button: list[InlineKeyboardButton] | None = None
-    if config.settings.public_origin:
+    settings = config.get_settings()
+    if settings.public_origin:
         webapp_button = [
             InlineKeyboardButton(
                 "📝 Заполнить форму",
-                web_app=WebAppInfo(config.build_ui_url("/profile")),
+                web_app=WebAppInfo(
+                    config.build_ui_url("/profile", settings=settings)
+                ),
             )
         ]
 
@@ -507,11 +510,14 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         return
     from services.api.app import config as app_config
 
-    origin = app_config.settings.public_origin
+    settings = app_config.get_settings()
+    origin = settings.public_origin
     if action == "add" and origin:
         button = InlineKeyboardButton(
             "📝 Новое",
-            web_app=WebAppInfo(app_config.build_ui_url("/reminders")),
+            web_app=WebAppInfo(
+                app_config.build_ui_url("/reminders", settings=settings)
+            ),
         )
         keyboard = InlineKeyboardMarkup([[button]])
         await q_message.reply_text("Создать напоминание:", reply_markup=keyboard)

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -59,12 +59,12 @@ def menu_keyboard() -> ReplyKeyboardMarkup:
     """
     from services.api.app import config
 
-    config.settings = config.Settings()
-    webapp_enabled = bool(config.settings.public_origin)
+    settings = config.get_settings()
+    webapp_enabled = bool(settings.public_origin)
     profile_button = (
         KeyboardButton(
             PROFILE_BUTTON_TEXT,
-            web_app=WebAppInfo(config.build_ui_url("/profile")),
+            web_app=WebAppInfo(config.build_ui_url("/profile", settings=settings)),
         )
         if webapp_enabled
         else KeyboardButton(PROFILE_BUTTON_TEXT)
@@ -72,7 +72,9 @@ def menu_keyboard() -> ReplyKeyboardMarkup:
     reminders_button = (
         KeyboardButton(
             REMINDERS_BUTTON_TEXT,
-            web_app=WebAppInfo(config.build_ui_url("/reminders")),
+            web_app=WebAppInfo(
+                config.build_ui_url("/reminders", settings=settings)
+            ),
         )
         if webapp_enabled
         else KeyboardButton(REMINDERS_BUTTON_TEXT)
@@ -153,11 +155,13 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
 
     from services.api.app import config
 
-    config.settings = config.Settings()
-    if not config.settings.public_origin:
+    settings = config.get_settings()
+    if not settings.public_origin:
         return None
 
     return InlineKeyboardButton(
         "Определить автоматически",
-        web_app=WebAppInfo(config.build_ui_url("/timezone")),
+        web_app=WebAppInfo(
+            config.build_ui_url("/timezone", settings=settings)
+        ),
     )

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -328,7 +328,7 @@ async def test_reminders_command_renders_list(
     )
 
     def fake_render(
-        session: Session, user_id: int
+        session: Session, user_id: int, settings: Any | None = None
     ) -> tuple[str, InlineKeyboardMarkup | None]:
         assert session is session_obj
         assert user_id == 1
@@ -336,11 +336,10 @@ async def test_reminders_command_renders_list(
 
     monkeypatch.setattr(reminder_handlers, "_render_reminders", fake_render)
 
-    captured: dict[str, Any] = {}
+    captured: list[tuple[str, dict[str, Any]]] = []
 
     async def fake_reply_text(text: str, **kwargs: Any) -> None:
-        captured["text"] = text
-        captured["kwargs"] = kwargs
+        captured.append((text, kwargs))
 
     message = MagicMock(spec=Message)
     message.reply_text = fake_reply_text
@@ -356,7 +355,7 @@ async def test_reminders_command_renders_list(
 
     await handler.callback(update, context)
 
-    assert captured["text"] == "rendered"
-    kwargs = captured["kwargs"]
+    assert captured and captured[0][0] == "rendered"
+    kwargs = captured[0][1]
     assert kwargs.get("reply_markup") is keyboard
     assert kwargs.get("parse_mode") == "HTML"

--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -26,13 +26,10 @@ from services.api.app.diabetes.services.repository import commit
 def reminder_handlers(monkeypatch: pytest.MonkeyPatch) -> Any:
     monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.com")
     monkeypatch.setenv("UI_BASE_URL", "/ui")
-    config = importlib.import_module("services.api.app.config")
-    importlib.reload(config)
     handlers = importlib.import_module(
         "services.api.app.diabetes.handlers.reminder_handlers",
     )
     importlib.reload(handlers)
-    handlers.config = config
     return handlers
 
 

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -374,7 +374,7 @@ def test_render_reminders_runtime_public_origin(monkeypatch: pytest.MonkeyPatch)
         )
         session.commit()
 
-    monkeypatch.setattr(config.settings, "public_origin", "")
+    monkeypatch.setenv("PUBLIC_ORIGIN", "")
     with TestSession() as session:
         _, markup = handlers._render_reminders(session, 1)
     assert markup is not None
@@ -384,7 +384,7 @@ def test_render_reminders_runtime_public_origin(monkeypatch: pytest.MonkeyPatch)
         for btn in row
     )
 
-    monkeypatch.setattr(config.settings, "public_origin", "https://example.org")
+    monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.org")
     with TestSession() as session:
         _, markup = handlers._render_reminders(session, 1)
     assert markup is not None
@@ -420,7 +420,7 @@ async def test_reminders_list_renders_output(
     monkeypatch.setattr(handlers, "SessionLocal", lambda: DummySessionCtx())
 
     def fake_render(
-        session: Session, user_id: int
+        session: Session, user_id: int, settings: Any | None = None
     ) -> tuple[str, InlineKeyboardMarkup | None]:
         assert session is session_obj
         assert user_id == 1
@@ -467,7 +467,7 @@ async def test_reminders_list_shows_menu_keyboard(
     monkeypatch.setattr(handlers, "SessionLocal", lambda: DummySessionCtx())
 
     def fake_render(
-        session: Session, user_id: int
+        session: Session, user_id: int, settings: Any | None = None
     ) -> tuple[str, InlineKeyboardMarkup | None]:
         return "rendered", None
 

--- a/tests/test_ui_reminders_smoke.py
+++ b/tests/test_ui_reminders_smoke.py
@@ -6,7 +6,7 @@ from services.api.app.main import app
 
 def test_reminders_page_smoke() -> None:
     with TestClient(app) as client:
-        base = config.settings.ui_base_url.rstrip("/")
+        base = config.get_settings().ui_base_url.rstrip("/")
         resp = client.get(f"{base}/reminders")
         assert resp.status_code == 200
         assert "<html" in resp.text.lower()
@@ -14,7 +14,7 @@ def test_reminders_page_smoke() -> None:
 
 def test_reminders_new_page_smoke() -> None:
     with TestClient(app) as client:
-        base = config.settings.ui_base_url.rstrip("/")
+        base = config.get_settings().ui_base_url.rstrip("/")
         resp = client.get(f"{base}/reminders/new")
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]


### PR DESCRIPTION
## Summary
- add `get_settings` helper so config reads environment on each call
- fetch runtime settings in reminder and profile handlers
- update UI helpers and tests to avoid mutating global config

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b0028861bc832aa0895375627fcd6a