### PR TITLE
[reminders] Add fallback buttons for reminders

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -161,23 +161,22 @@ def _render_reminders(
     if active_count > limit:
         header += " ⚠️"
 
-    public_origin = config.settings.public_origin
-    add_button_row: list[InlineKeyboardButton] | None = None
-    if public_origin:
-        add_button_row = [
-            InlineKeyboardButton(
-                "➕ Добавить",
-                web_app=WebAppInfo(config.build_ui_url("/reminders/new")),
-            )
-        ]
+    webapp_enabled = bool(config.settings.public_origin)
+    add_button = (
+        InlineKeyboardButton(
+            "➕ Добавить",
+            web_app=WebAppInfo(config.build_ui_url("/reminders/new")),
+        )
+        if webapp_enabled
+        else InlineKeyboardButton("➕ Добавить", callback_data="rem_add")
+    )
+    add_button_row: list[InlineKeyboardButton] = [add_button]
     if not rems:
-        text = header
-
-        if add_button_row is not None:
-            text += "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
-            return text, InlineKeyboardMarkup([add_button_row])
-        text += "\nУ вас нет напоминаний. Отправьте /addreminder."
-        return text, None
+        text = (
+            header
+            + "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
+        )
+        return text, InlineKeyboardMarkup([add_button_row])
 
     by_time: list[tuple[str, list[InlineKeyboardButton]]] = []
     by_interval: list[tuple[str, list[InlineKeyboardButton]]] = []
@@ -190,13 +189,18 @@ def _render_reminders(
         line = f"{r.id}. {title}"
         status_icon = "🔔" if r.is_enabled else "🔕"
         row: list[InlineKeyboardButton] = []
-        if add_button_row is not None:
+        if webapp_enabled:
             row.append(
                 InlineKeyboardButton(
                     "✏️",
-                    web_app=WebAppInfo(
-                        config.build_ui_url(f"/reminders?id={r.id}")
-                    ),
+                    web_app=WebAppInfo(config.build_ui_url(f"/reminders?id={r.id}")),
+                )
+            )
+        else:
+            row.append(
+                InlineKeyboardButton(
+                    "✏️",
+                    callback_data=f"rem_edit:{r.id}",
                 )
             )
         row.extend(
@@ -231,8 +235,7 @@ def _render_reminders(
     extend("⏱ Интервал", by_interval)
     extend("📸 Триггер-фото", by_photo)
 
-    if add_button_row is not None:
-        buttons.append(add_button_row)
+    buttons.append(add_button_row)
     text = header + "\n" + "\n".join(lines)
     return text, InlineKeyboardMarkup(buttons)
 


### PR DESCRIPTION
## Summary
- show pencil and add buttons even without webapp
- cover reminder rendering for both webapp and fallback buttons

## Testing
- `python -m pytest tests/test_reminders.py::test_render_reminders_formatting tests/test_reminders.py::test_render_reminders_no_webapp tests/test_reminders.py::test_render_reminders_no_entries_no_webapp tests/test_reminders.py::test_render_reminders_runtime_public_origin -q --cov-fail-under=0`
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py`
- `ruff check services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py`


------
https://chatgpt.com/codex/tasks/task_e_68b004fa6cdc832a90ea8ddeda501a78