### PR TITLE
[reminders] Add webapp-aware reminder controls

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -155,23 +155,24 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
     if active_count > limit:
         header += " ⚠️"
 
-    public_origin = config.settings.public_origin
-    add_button_row: list[InlineKeyboardButton] | None = None
-    if public_origin:
+    webapp_enabled = bool(config.settings.public_origin)
+    if webapp_enabled:
         add_button_row = [
             InlineKeyboardButton(
                 "➕ Добавить",
                 web_app=WebAppInfo(config.build_ui_url("/reminders/new")),
             )
         ]
+    else:
+        add_button_row = [
+            InlineKeyboardButton("➕ Добавить", callback_data="rem_add")
+        ]
     if not rems:
-        text = header
-
-        if add_button_row is not None:
-            text += "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
-            return text, InlineKeyboardMarkup([add_button_row])
-        text += "\nУ вас нет напоминаний. Отправьте /addreminder."
-        return text, None
+        text = (
+            header
+            + "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
+        )
+        return text, InlineKeyboardMarkup([add_button_row])
 
     by_time: list[tuple[str, list[InlineKeyboardButton]]] = []
     by_interval: list[tuple[str, list[InlineKeyboardButton]]] = []
@@ -183,14 +184,19 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
             title = f"<s>{title}</s>"
         line = f"{r.id}. {title}"
         status_icon = "🔔" if r.is_enabled else "🔕"
-        row: list[InlineKeyboardButton] = []
-        if add_button_row is not None:
-            row.append(
-                InlineKeyboardButton(
-                    "✏️",
-                    web_app=WebAppInfo(config.build_ui_url(f"/reminders?id={r.id}")),
-                )
+        edit_button = (
+            InlineKeyboardButton(
+                "✏️",
+                web_app=WebAppInfo(
+                    config.build_ui_url(f"/reminders?id={r.id}")
+                ),
             )
+            if webapp_enabled
+            else InlineKeyboardButton(
+                "✏️", callback_data=f"rem_edit:{r.id}"
+            )
+        )
+        row: list[InlineKeyboardButton] = [edit_button]
         row.extend(
             [
                 InlineKeyboardButton("🗑️", callback_data=f"rem_del:{r.id}"),
@@ -221,8 +227,7 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
     extend("⏱ Интервал", by_interval)
     extend("📸 Триггер-фото", by_photo)
 
-    if add_button_row is not None:
-        buttons.append(add_button_row)
+    buttons.append(add_button_row)
     text = header + "\n" + "\n".join(lines)
     return text, InlineKeyboardMarkup(buttons)
 


### PR DESCRIPTION
## Summary
- always show add-reminder button, using webapp when public origin present or callback fallback otherwise
- add pencil edit control for each reminder with webapp or callback
- extend reminder list tests for new controls

## Testing
- `pytest -q` *(fails: openai client tests, reminder webapp tests)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b00627f52c832a8f61ce9aae7f9e4d