### PR TITLE
[reminders] Always include add/edit buttons with webapp fallback

### DIFF
--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -249,6 +249,7 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     import services.api.app.config as config
 
     importlib.reload(config)
+    handlers.config = config
     monkeypatch.setattr(handlers, "_limit_for", lambda u: 1)
     # Make _describe deterministic and include status icon to test strikethrough
     monkeypatch.setattr(
@@ -289,9 +290,16 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "📸 Триггер-фото" in text
     assert "2. <s>🔕title2</s>" in text
     assert markup.inline_keyboard
-    add_btn = next(btn for row in markup.inline_keyboard for btn in row if btn.text == "➕ Добавить")
+    first_row = markup.inline_keyboard[0]
+    assert [btn.text for btn in first_row] == ["✏️", "🗑️", "🔔"]
+    edit_btn = first_row[0]
+    assert edit_btn.web_app is not None
+    assert edit_btn.web_app.url == handlers.config.build_ui_url("/reminders?id=1")
+    add_btn = next(
+        btn for row in markup.inline_keyboard for btn in row if btn.text == "➕ Добавить"
+    )
     assert add_btn.web_app is not None
-    assert add_btn.web_app.url == config.build_ui_url("/reminders/new")
+    assert add_btn.web_app.url == handlers.config.build_ui_url("/reminders/new")
 
 
 def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -299,11 +307,7 @@ def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
-    monkeypatch.delenv("UI_BASE_URL", raising=False)
-    import services.api.app.config as config
-
-    importlib.reload(config)
+    monkeypatch.setattr(handlers.config.settings, "public_origin", "")
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
@@ -312,11 +316,18 @@ def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
         text, markup = handlers._render_reminders(session, 1)
     assert markup is not None
     assert "Нажмите кнопку" not in text
-    assert len(markup.inline_keyboard) == 1
+    assert len(markup.inline_keyboard) == 2
     first_row = markup.inline_keyboard[0]
-    texts = [btn.text for btn in first_row]
-    assert texts == ["🗑️", "🔔"]
+    assert [btn.text for btn in first_row] == ["✏️", "🗑️", "🔔"]
     assert all(btn.web_app is None for btn in first_row)
+    edit_btn = first_row[0]
+    assert edit_btn.callback_data == "rem_edit:1"
+    add_row = markup.inline_keyboard[1]
+    assert len(add_row) == 1
+    add_btn = add_row[0]
+    assert add_btn.text == "➕ Добавить"
+    assert add_btn.callback_data == "rem_add"
+    assert add_btn.web_app is None
 
 
 def test_render_reminders_no_entries_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -324,18 +335,20 @@ def test_render_reminders_no_entries_no_webapp(monkeypatch: pytest.MonkeyPatch) 
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
-    monkeypatch.delenv("UI_BASE_URL", raising=False)
-    import services.api.app.config as config
-
-    importlib.reload(config)
+    monkeypatch.setattr(handlers.config.settings, "public_origin", "")
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.commit()
     with TestSession() as session:
         text, markup = handlers._render_reminders(session, 1)
     assert "У вас нет напоминаний" in text
-    assert markup is None
+    assert "Нажмите кнопку" in text
+    assert markup is not None
+    assert len(markup.inline_keyboard) == 1
+    add_btn = markup.inline_keyboard[0][0]
+    assert add_btn.text == "➕ Добавить"
+    assert add_btn.callback_data == "rem_add"
+    assert add_btn.web_app is None
 
 
 def test_render_reminders_runtime_public_origin(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -343,26 +356,33 @@ def test_render_reminders_runtime_public_origin(monkeypatch: pytest.MonkeyPatch)
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    import services.api.app.config as config
-
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
         session.commit()
 
-    monkeypatch.setattr(config.settings, "public_origin", "")
+    monkeypatch.setattr(handlers.config.settings, "public_origin", "")
     with TestSession() as session:
         _, markup = handlers._render_reminders(session, 1)
     assert markup is not None
-    assert not any(btn.text == "➕ Добавить" for row in markup.inline_keyboard for btn in row)
+    first_row = markup.inline_keyboard[0]
+    edit_btn = first_row[0]
+    assert edit_btn.callback_data == "rem_edit:1"
+    add_btn = markup.inline_keyboard[1][0]
+    assert add_btn.callback_data == "rem_add"
+    assert add_btn.web_app is None
 
-    monkeypatch.setattr(config.settings, "public_origin", "https://example.org")
+    monkeypatch.setattr(handlers.config.settings, "public_origin", "https://example.org")
     with TestSession() as session:
         _, markup = handlers._render_reminders(session, 1)
     assert markup is not None
-    add_btn = next(btn for row in markup.inline_keyboard for btn in row if btn.text == "➕ Добавить")
+    first_row = markup.inline_keyboard[0]
+    edit_btn = first_row[0]
+    assert edit_btn.web_app is not None
+    assert edit_btn.web_app.url == handlers.config.build_ui_url("/reminders?id=1")
+    add_btn = markup.inline_keyboard[1][0]
     assert add_btn.web_app is not None
-    assert add_btn.web_app.url == config.build_ui_url("/reminders/new")
+    assert add_btn.web_app.url == handlers.config.build_ui_url("/reminders/new")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Always render add and edit buttons for reminders
- Provide callback fallbacks when webapp is disabled
- Test reminder list for new controls

## Testing
- `ruff check services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py`
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py`
- `pytest -q` *(fails: AttributeError in gpt_client, various openai_utils assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68b0067a6ee8832a891c5b1a0003bbdf