### PR TITLE
[profile] Accept settings in get_api

### DIFF
--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -85,6 +85,7 @@ if TYPE_CHECKING:  # pragma: no cover - used only for type hints
 
 def get_api(
     sessionmaker: Callable[[], Session] = SessionLocal,
+    settings: config.Settings | None = None,
 ) -> tuple[object, type[Exception], type]:
     """Return API client, its exception type and profile model.
 
@@ -93,6 +94,7 @@ def get_api(
     lightweight local implementation is returned instead.  This ensures the
     rest of the code can operate without having to handle ``None`` values.
     """
+    settings = settings or config.get_settings()
     try:  # pragma: no cover - exercised in tests but flagged for clarity
         from diabetes_sdk.api.default_api import DefaultApi
         from diabetes_sdk.api_client import ApiClient
@@ -109,7 +111,7 @@ def get_api(
             "diabetes_sdk could not be initialized. Falling back to local profile API.",
         )
         return LocalProfileAPI(sessionmaker), Exception, LocalProfile
-    api = DefaultApi(ApiClient(Configuration(host=config.settings.api_url)))
+    api = DefaultApi(ApiClient(Configuration(host=settings.api_url)))
     return api, ApiException, ProfileModel
 
 

--- a/tests/test_profile_api_settings.py
+++ b/tests/test_profile_api_settings.py
@@ -1,0 +1,94 @@
+import sys
+import types
+
+import pytest
+
+from services.api.app import config
+from services.api.app.config import Settings
+from services.api.app.diabetes.handlers.profile.api import get_api
+
+
+def _setup_sdk(monkeypatch: pytest.MonkeyPatch) -> tuple[type, type, type]:
+    """Install dummy ``diabetes_sdk`` modules for testing."""
+
+    sdk = types.ModuleType("diabetes_sdk")
+    api_pkg = types.ModuleType("diabetes_sdk.api")
+    default_api_mod = types.ModuleType("diabetes_sdk.api.default_api")
+    client_mod = types.ModuleType("diabetes_sdk.api_client")
+    conf_mod = types.ModuleType("diabetes_sdk.configuration")
+    exc_mod = types.ModuleType("diabetes_sdk.exceptions")
+    models_pkg = types.ModuleType("diabetes_sdk.models")
+    profile_mod = types.ModuleType("diabetes_sdk.models.profile")
+
+    sdk.api = api_pkg
+    api_pkg.default_api = default_api_mod
+    sdk.api_client = client_mod
+    sdk.configuration = conf_mod
+    sdk.exceptions = exc_mod
+    sdk.models = models_pkg
+    models_pkg.profile = profile_mod
+
+    monkeypatch.setitem(sys.modules, "diabetes_sdk", sdk)
+    monkeypatch.setitem(sys.modules, "diabetes_sdk.api", api_pkg)
+    monkeypatch.setitem(sys.modules, "diabetes_sdk.api.default_api", default_api_mod)
+    monkeypatch.setitem(sys.modules, "diabetes_sdk.api_client", client_mod)
+    monkeypatch.setitem(sys.modules, "diabetes_sdk.configuration", conf_mod)
+    monkeypatch.setitem(sys.modules, "diabetes_sdk.exceptions", exc_mod)
+    monkeypatch.setitem(sys.modules, "diabetes_sdk.models", models_pkg)
+    monkeypatch.setitem(sys.modules, "diabetes_sdk.models.profile", profile_mod)
+
+    class DummyApi:
+        def __init__(self, client: object) -> None:
+            self.client = client
+
+    class DummyClient:
+        def __init__(self, cfg: object) -> None:
+            self.configuration = cfg
+
+    class DummyConfig:
+        def __init__(self, host: str | None = None) -> None:
+            self.host = host
+
+    class DummyExc(Exception):
+        pass
+
+    class DummyProfile:  # pragma: no cover - simple placeholder
+        pass
+
+    default_api_mod.DefaultApi = DummyApi
+    client_mod.ApiClient = DummyClient
+    conf_mod.Configuration = DummyConfig
+    exc_mod.ApiException = DummyExc
+    profile_mod.Profile = DummyProfile
+
+    return DummyApi, DummyExc, DummyProfile
+
+
+def test_get_api_accepts_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    DummyApi, DummyExc, DummyProfile = _setup_sdk(monkeypatch)
+
+    custom = Settings(API_URL="http://example.org")
+    api, exc, model = get_api(settings=custom)
+
+    assert isinstance(api, DummyApi)
+    assert exc is DummyExc
+    assert model is DummyProfile
+    assert api.client.configuration.host == "http://example.org"
+
+
+def test_get_api_uses_config_get_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    DummyApi, _, _ = _setup_sdk(monkeypatch)
+
+    called: list[None] = []
+
+    def fake_get_settings() -> Settings:
+        called.append(None)
+        return Settings(API_URL="http://test.local")
+
+    monkeypatch.setattr(config, "get_settings", fake_get_settings)
+
+    api, _, _ = get_api()
+
+    assert called
+    assert isinstance(api, DummyApi)
+    assert api.client.configuration.host == "http://test.local"


### PR DESCRIPTION
## Summary
- allow `get_api` to accept optional settings and use `config.get_settings`
- reference `settings.api_url` when creating SDK configuration
- add tests covering custom settings and config-based retrieval

## Testing
- `pytest -q --cov` *(fails: numerous tests and coverage below threshold)*
- `pytest tests/test_profile_api_settings.py -q` *(fails: coverage below fail-under=85)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b00771fb14832a8df53d6bed57ab78