### PR TITLE
[utils] fetch OpenAI settings at runtime

### DIFF
--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -59,34 +59,34 @@ def get_openai_client() -> OpenAI:
     mutated, keeping proxy settings local to the OpenAI client.
     """
 
-    if not config.settings.openai_api_key:
+    settings = config.get_settings()
+    if not settings.openai_api_key:
         message = "OPENAI_API_KEY is not set"
         logger.error("[OpenAI] %s", message)
         raise RuntimeError(message)
 
-    http_client = _build_http_client(config.settings.openai_proxy, False)
-    client = OpenAI(api_key=config.settings.openai_api_key, http_client=http_client)
+    http_client = _build_http_client(settings.openai_proxy, False)
+    client = OpenAI(api_key=settings.openai_api_key, http_client=http_client)
 
-    if config.settings.openai_assistant_id:
-        logger.info("[OpenAI] Using assistant: %s", config.settings.openai_assistant_id)
+    if settings.openai_assistant_id:
+        logger.info("[OpenAI] Using assistant: %s", settings.openai_assistant_id)
     return client
 
 
 def get_async_openai_client() -> AsyncOpenAI:
     """Return a configured asynchronous OpenAI client."""
 
-    if not config.settings.openai_api_key:
+    settings = config.get_settings()
+    if not settings.openai_api_key:
         message = "OPENAI_API_KEY is not set"
         logger.error("[OpenAI] %s", message)
         raise RuntimeError(message)
 
-    http_client = _build_http_client(config.settings.openai_proxy, True)
-    client = AsyncOpenAI(
-        api_key=config.settings.openai_api_key, http_client=http_client
-    )
+    http_client = _build_http_client(settings.openai_proxy, True)
+    client = AsyncOpenAI(api_key=settings.openai_api_key, http_client=http_client)
 
-    if config.settings.openai_assistant_id:
-        logger.info("[OpenAI] Using assistant: %s", config.settings.openai_assistant_id)
+    if settings.openai_assistant_id:
+        logger.info("[OpenAI] Using assistant: %s", settings.openai_assistant_id)
     return client
 
 


### PR DESCRIPTION
## Summary
- retrieve OpenAI credentials via `config.get_settings()` at call time
- adapt OpenAI utility tests to supply settings through `config.get_settings`

## Testing
- `pytest tests/test_openai_utils.py -q --cov-fail-under=0`
- `pytest tests/test_gpt_client.py -q --cov-fail-under=0`
- `mypy --strict .`
- `ruff check .`
- `pytest -q --maxfail=1` *(fails: AttributeError in tests/services/test_gpt_client_service.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b007747c4c832ab3ba5b8fdb5477b9