### PR TITLE
[webapp] send reminder data to bot

### DIFF
--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -3,9 +3,15 @@ import { useNavigate } from "react-router-dom";
 import { useRemindersApi } from "../api/reminders"; // ваш хук, возвращающий DefaultApi
 import { DayOfWeekPicker } from "../components/DayOfWeekPicker";
 import { DaysPresets } from "../components/DaysPresets";
-import { buildReminderPayload, ReminderFormValues, ScheduleKind, ReminderType } from "../api/buildPayload";
+import {
+  buildReminderPayload,
+  ReminderFormValues,
+  ScheduleKind,
+  ReminderType,
+} from "../api/buildPayload";
 import { validate, hasErrors } from "../logic/validate";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
+import { useTelegram } from "../../../hooks/useTelegram";
 import { getTelegramUserId } from "../../../shared/telegram";
 import { mockApi } from "../../../api/mock-server";
 import { useToast } from "../../../shared/toast";
@@ -27,9 +33,21 @@ const KIND_OPTIONS: { value: ScheduleKind; label: string }[] = [
   { value: "after_event", label: "После события" },
 ];
 
+const BOT_TYPE_MAP: Record<ReminderType, string> = {
+  sugar: "sugar",
+  insulin_short: "insulin_short",
+  insulin_long: "long_insulin",
+  after_meal: "xe_after",
+  meal: "meal",
+  sensor_change: "sensor_change",
+  injection_site: "injection_site",
+  custom: "custom",
+};
+
 export default function RemindersCreate() {
   const api = useRemindersApi();
   const initData = useTelegramInitData();
+  const { sendData } = useTelegram();
   const telegramId = useMemo(() => getTelegramUserId(initData), [initData]);
   const nav = useNavigate();
   const toast = useToast();
@@ -46,31 +64,57 @@ export default function RemindersCreate() {
   const errors = validate(form);
   const formHasErrors = hasErrors(errors);
 
-  const onChange = <K extends keyof ReminderFormValues>(k: K, v: ReminderFormValues[K]) =>
-    setForm((s) => ({ ...s, [k]: v }));
+  const onChange = <K extends keyof ReminderFormValues>(
+    k: K,
+    v: ReminderFormValues[K],
+  ) => setForm((s) => ({ ...s, [k]: v }));
 
-  const presetsTime = ["07:30","12:30","22:00"];
-  const presetsEvery = [60,120,180,1440];
-  const presetsAfter = [90,120,150];
+  const presetsTime = ["07:30", "12:30", "22:00"];
+  const presetsEvery = [60, 120, 180, 1440];
+  const presetsAfter = [90, 120, 150];
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (formHasErrors) return;
-    
+
     setLoading(true);
     try {
       const reminder = buildReminderPayload({ ...form, telegramId });
       console.log("Payload being sent:", reminder);
 
+      let rid: number | undefined;
       try {
         // Пробуем основной API
-        await api.remindersPost({ reminder });
+        const res = await api.remindersPost({ reminder });
+        rid = res?.id;
       } catch (apiError) {
         console.warn("Backend API failed, using mock API:", apiError);
         // Fallback на mock API
-        await mockApi.createReminder(reminder);
+        const res = await mockApi.createReminder(reminder);
+        rid = (res as any)?.id;
       }
-      
+
+      if (rid) {
+        let value: string | undefined;
+        if (form.kind === "at_time" && form.time) {
+          value = form.time;
+        } else if (form.kind === "every" && form.intervalMinutes) {
+          value =
+            form.intervalMinutes % 60 === 0
+              ? `${form.intervalMinutes / 60}h`
+              : String(form.intervalMinutes);
+        } else if (form.kind === "after_event" && form.minutesAfter) {
+          value =
+            form.minutesAfter % 60 === 0
+              ? `${form.minutesAfter / 60}h`
+              : String(form.minutesAfter);
+        }
+        const type = BOT_TYPE_MAP[reminder.type];
+        if (value) {
+          sendData({ id: rid, type, value });
+        }
+      }
+
       toast.success("Напоминание успешно создано");
       nav("/reminders");
     } catch (err) {
@@ -81,52 +125,78 @@ export default function RemindersCreate() {
     }
   }
 
-  // switchKind: фиксируем type и поля расписания  
+  // switchKind: фиксируем type и поля расписания
   const switchKind = (k: ScheduleKind) =>
-    setForm(s => {
-      const base = { ...s, kind: k, time: undefined, intervalMinutes: undefined, minutesAfter: undefined };
+    setForm((s) => {
+      const base = {
+        ...s,
+        kind: k,
+        time: undefined,
+        intervalMinutes: undefined,
+        minutesAfter: undefined,
+      };
       if (k === "at_time") base.time = "07:30";
       if (k === "every") base.intervalMinutes = 60;
-      if (k === "after_event") { base.minutesAfter = 120; base.type = "after_meal"; }
+      if (k === "after_event") {
+        base.minutesAfter = 120;
+        base.type = "after_meal";
+      }
       return base;
     });
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
       <div className="container mx-auto px-4 py-6">
-        <form className="max-w-xl mx-auto space-y-6 medical-card animate-slide-up" onSubmit={onSubmit}>
-          <h1 className="text-xl font-semibold text-foreground">Добавить напоминание</h1>
+        <form
+          className="max-w-xl mx-auto space-y-6 medical-card animate-slide-up"
+          onSubmit={onSubmit}
+        >
+          <h1 className="text-xl font-semibold text-foreground">
+            Добавить напоминание
+          </h1>
 
           {/* Тип */}
           <div>
-            <label className="block text-sm font-medium text-foreground mb-2">Тип</label>
+            <label className="block text-sm font-medium text-foreground mb-2">
+              Тип
+            </label>
             <select
               className="medical-input"
               value={form.kind === "after_event" ? "after_meal" : form.type}
               onChange={(e) => onChange("type", e.target.value as ReminderType)}
               disabled={form.kind === "after_event"}
             >
-              {TYPE_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+              {TYPE_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
             </select>
             {form.kind === "after_event" && (
               <p className="text-xs text-muted-foreground mt-1">
-                Это напоминание сработает <strong className="text-foreground">после записи приёма пищи</strong> в разделе «История».
+                Это напоминание сработает{" "}
+                <strong className="text-foreground">
+                  после записи приёма пищи
+                </strong>{" "}
+                в разделе «История».
               </p>
             )}
           </div>
 
           {/* Режим */}
           <div>
-            <label className="block text-sm font-medium text-foreground mb-2">Режим</label>
+            <label className="block text-sm font-medium text-foreground mb-2">
+              Режим
+            </label>
             <div className="flex gap-2">
               {KIND_OPTIONS.map((o) => (
                 <button
-                  type="button" 
+                  type="button"
                   key={o.value}
                   onClick={() => switchKind(o.value)}
                   className={`px-3 py-2 rounded-lg border transition-all duration-200 ${
-                    form.kind === o.value 
-                      ? "bg-primary text-primary-foreground border-primary shadow-soft" 
+                    form.kind === o.value
+                      ? "bg-primary text-primary-foreground border-primary shadow-soft"
                       : "border-border bg-background text-foreground hover:bg-secondary"
                   }`}
                 >
@@ -139,7 +209,9 @@ export default function RemindersCreate() {
           {/* Условные поля */}
           {form.kind === "at_time" && (
             <div className="space-y-3">
-              <label className="block text-sm font-medium text-foreground">Время (HH:MM)</label>
+              <label className="block text-sm font-medium text-foreground">
+                Время (HH:MM)
+              </label>
               <input
                 type="time"
                 className={`medical-input ${errors.time ? "border-destructive focus:border-destructive" : ""}`}
@@ -151,10 +223,10 @@ export default function RemindersCreate() {
               )}
               <div className="flex gap-2 flex-wrap">
                 {presetsTime.map((t) => (
-                  <button 
-                    key={t} 
-                    type="button" 
-                    className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-colors" 
+                  <button
+                    key={t}
+                    type="button"
+                    className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-colors"
                     onClick={() => onChange("time", t)}
                   >
                     {t}
@@ -166,23 +238,29 @@ export default function RemindersCreate() {
 
           {form.kind === "every" && (
             <div className="space-y-3">
-              <label className="block text-sm font-medium text-foreground">Интервал (мин)</label>
+              <label className="block text-sm font-medium text-foreground">
+                Интервал (мин)
+              </label>
               <input
-                type="number" 
+                type="number"
                 min={1}
                 className={`medical-input ${errors.intervalMinutes ? "border-destructive focus:border-destructive" : ""}`}
                 value={form.intervalMinutes ?? ""}
-                onChange={(e) => onChange("intervalMinutes", Number(e.target.value || 0))}
+                onChange={(e) =>
+                  onChange("intervalMinutes", Number(e.target.value || 0))
+                }
               />
               {errors.intervalMinutes && (
-                <p className="text-xs text-destructive mt-1">{errors.intervalMinutes}</p>
+                <p className="text-xs text-destructive mt-1">
+                  {errors.intervalMinutes}
+                </p>
               )}
               <div className="flex gap-2 flex-wrap">
                 {presetsEvery.map((m) => (
-                  <button 
-                    key={m} 
-                    type="button" 
-                    className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-colors" 
+                  <button
+                    key={m}
+                    type="button"
+                    className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-colors"
                     onClick={() => onChange("intervalMinutes", m)}
                   >
                     {m} мин
@@ -194,23 +272,29 @@ export default function RemindersCreate() {
 
           {form.kind === "after_event" && (
             <div className="space-y-3">
-              <label className="block text-sm font-medium text-foreground">Задержка после еды (мин)</label>
+              <label className="block text-sm font-medium text-foreground">
+                Задержка после еды (мин)
+              </label>
               <input
-                type="number" 
+                type="number"
                 min={1}
                 className={`medical-input ${errors.minutesAfter ? "border-destructive focus:border-destructive" : ""}`}
                 value={form.minutesAfter ?? ""}
-                onChange={(e) => onChange("minutesAfter", Number(e.target.value || 0))}
+                onChange={(e) =>
+                  onChange("minutesAfter", Number(e.target.value || 0))
+                }
               />
               {errors.minutesAfter && (
-                <p className="text-xs text-destructive mt-1">{errors.minutesAfter}</p>
+                <p className="text-xs text-destructive mt-1">
+                  {errors.minutesAfter}
+                </p>
               )}
               <div className="flex gap-2 flex-wrap">
                 {presetsAfter.map((m) => (
-                  <button 
-                    key={m} 
-                    type="button" 
-                    className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-colors" 
+                  <button
+                    key={m}
+                    type="button"
+                    className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-colors"
                     onClick={() => onChange("minutesAfter", m)}
                   >
                     {m} мин
@@ -222,16 +306,26 @@ export default function RemindersCreate() {
 
           {/* Дни недели */}
           <div>
-            <label className="block text-sm font-medium text-foreground mb-2">Дни недели (опционально)</label>
+            <label className="block text-sm font-medium text-foreground mb-2">
+              Дни недели (опционально)
+            </label>
             <div className="space-y-3">
-              <DaysPresets value={form.daysOfWeek} onChange={(v) => onChange("daysOfWeek", v)} />
-              <DayOfWeekPicker value={form.daysOfWeek} onChange={(v) => onChange("daysOfWeek", v)} />
+              <DaysPresets
+                value={form.daysOfWeek}
+                onChange={(v) => onChange("daysOfWeek", v)}
+              />
+              <DayOfWeekPicker
+                value={form.daysOfWeek}
+                onChange={(v) => onChange("daysOfWeek", v)}
+              />
             </div>
           </div>
 
           {/* Название (необяз.) */}
           <div>
-            <label className="block text-sm font-medium text-foreground mb-2">Название (если пусто — автогенерация)</label>
+            <label className="block text-sm font-medium text-foreground mb-2">
+              Название (если пусто — автогенерация)
+            </label>
             <input
               className="medical-input"
               value={form.title ?? ""}
@@ -251,8 +345,8 @@ export default function RemindersCreate() {
             <span className="text-foreground">Включено</span>
           </label>
 
-          <button 
-            disabled={loading || formHasErrors} 
+          <button
+            disabled={loading || formHasErrors}
             className="w-full bg-primary text-primary-foreground rounded-xl py-3 shadow-soft hover:shadow-medium hover:bg-primary/90 disabled:opacity-50 transition-all duration-200"
           >
             {loading ? "Сохранение…" : "Сохранить"}


### PR DESCRIPTION
## Summary
- use Telegram hook to send reminder data
- map frontend reminder type values to ones bot expects
- send reminder schedule info to Telegram after creating reminder

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: many tests failing)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`
- `pnpm --filter ./services/webapp/ui lint` *(fails: 20 errors, 9 warnings)*
- `pnpm --filter ./services/webapp/ui typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b0079bbf34832a876b1e43ccc418e0