### PR TITLE
[tests] rely on internal config loading for reminder handlers

### DIFF
--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -32,7 +32,6 @@ def reminder_handlers(monkeypatch: pytest.MonkeyPatch) -> Any:
         "services.api.app.diabetes.handlers.reminder_handlers",
     )
     importlib.reload(handlers)
-    handlers.config = config
     return handlers
 
 


### PR DESCRIPTION
## Summary
- stop overriding `handlers.config` in `reminder_handlers` fixture so tests use internal `config.get_settings()`

## Testing
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'runs')*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b0077a48c0832aaf02f52bc3b490aa