### PR TITLE
[reminders] Pass runtime settings to reminder rendering

### DIFF
--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -323,12 +323,10 @@ async def test_reminders_command_renders_list(
 
     monkeypatch.setattr(reminder_handlers, "SessionLocal", lambda: DummySessionCtx())
 
-    keyboard = InlineKeyboardMarkup(
-        [[InlineKeyboardButton("btn", callback_data="1")]]
-    )
+    keyboard = InlineKeyboardMarkup([[InlineKeyboardButton("btn", callback_data="1")]])
 
     def fake_render(
-        session: Session, user_id: int
+        session: Session, user_id: int, settings: Any
     ) -> tuple[str, InlineKeyboardMarkup | None]:
         assert session is session_obj
         assert user_id == 1


### PR DESCRIPTION
## Summary
- pass runtime settings into reminder list rendering
- support dynamic UI links and add tests for settings propagation

## Testing
- `ruff check services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py tests/test_register_handlers.py`
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py tests/test_register_handlers.py`
- `pytest -q` *(fails: KeyboardInterrupt during test run)*

------
https://chatgpt.com/codex/tasks/task_e_68b0076d3f68832abb58e984b491680e