### PR TITLE
[handlers] Show profile when command has no args

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -86,7 +86,7 @@ END: int = ConversationHandler.END
 async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle ``/profile`` command.
 
-    * ``/profile`` → start step-by-step profile setup (conversation)
+    * ``/profile`` → display current profile
     * ``/profile help`` → show usage instructions
     * ``/profile <args>`` → set profile directly
     """
@@ -132,11 +132,8 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         return END
 
     if not args:
-        await message.reply_text(
-            "Введите коэффициент ИКХ (г/ед.) — сколько граммов углеводов покрывает 1 ед. быстрого инсулина:",
-            reply_markup=back_keyboard,
-        )
-        return PROFILE_ICR
+        await profile_view(update, context)
+        return END
 
     values = parse_profile_args(args)
     if values is None:

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -34,9 +33,11 @@ class DummyQuery:
 
 
 @pytest.mark.asyncio
-async def test_callback_router_cancel_entry_sends_menu() -> None:
-    os.environ["OPENAI_API_KEY"] = "test"
-    os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
+async def test_callback_router_cancel_entry_sends_menu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
     from services.api.app.diabetes.handlers import common_handlers
@@ -66,10 +67,10 @@ async def test_callback_router_cancel_entry_sends_menu() -> None:
 
 @pytest.mark.asyncio
 async def test_callback_router_invalid_entry_id(
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
 ) -> None:
-    os.environ["OPENAI_API_KEY"] = "test"
-    os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
 
@@ -89,10 +90,10 @@ async def test_callback_router_invalid_entry_id(
 
 @pytest.mark.asyncio
 async def test_callback_router_unknown_data(
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
 ) -> None:
-    os.environ["OPENAI_API_KEY"] = "test"
-    os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
 
@@ -111,9 +112,11 @@ async def test_callback_router_unknown_data(
 
 
 @pytest.mark.asyncio
-async def test_callback_router_ignores_reminder_action() -> None:
-    os.environ["OPENAI_API_KEY"] = "test"
-    os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
+async def test_callback_router_ignores_reminder_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
 

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -91,10 +91,8 @@ async def test_profile_command_no_local_session(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Profile command should not touch the local DB session."""
-    import os
-
-    os.environ["OPENAI_API_KEY"] = "test"
-    os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
 
     session_factory = MagicMock()
@@ -121,10 +119,8 @@ async def test_profile_command_no_local_session(
 async def test_callback_router_commit_failure(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    import os
-
-    os.environ["OPENAI_API_KEY"] = "test"
-    os.environ["OPENAI_ASSISTANT_ID"] = "asst_test"
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
 
     session = MagicMock()

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -84,7 +84,7 @@ async def test_profile_input_not_logged_as_sugar(
     )
     await sugar_handlers.sugar_start(sugar_update, sugar_context)
 
-    # Start profile conversation which should cancel sugar conversation
+    # Open profile view which should cancel sugar conversation
     prof_msg = DummyMessage("/profile")
     prof_update = cast(
         Update,
@@ -99,11 +99,11 @@ async def test_profile_input_not_logged_as_sugar(
         SimpleNamespace(args=[], user_data={}, chat_data=shared_chat_data),
     )
     result = await profile_handlers.profile_command(prof_update, prof_context)
-    assert result == profile_handlers.PROFILE_ICR
-    assert "ИКХ" in prof_msg.replies[0]
+    assert result == profile_handlers.END
+    assert "Ваш профиль" in prof_msg.replies[0]
     assert "sugar_active" not in shared_chat_data
 
-    # Send ICR value
+    # Attempt to send a value; sugar conversation should be inactive
     icr_msg = DummyMessage("10")
     icr_update = cast(
         Update,
@@ -117,9 +117,8 @@ async def test_profile_input_not_logged_as_sugar(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, chat_data=shared_chat_data),
     )
-    result_icr = await profile_handlers.profile_icr(icr_update, icr_context)
-    assert result_icr == profile_handlers.PROFILE_CF
-    assert "КЧ" in icr_msg.replies[0]
+    result_icr = await sugar_handlers.sugar_val(icr_update, icr_context)
+    assert result_icr == sugar_handlers.END
 
     # Ensure no sugar entry was written
     with TestSession() as session:


### PR DESCRIPTION
## Summary
- show current profile when `/profile` is called without arguments
- add coverage verifying profile output and conversation cancellation
- isolate environment-sensitive tests from leaking state

## Testing
- `pytest -q` *(fails: openai_utils and reminders test failures)*
- `mypy --strict tests/test_handlers_cancel_entry.py tests/test_handlers_commit_failures.py tests/test_handlers_profile.py`
- `ruff check tests/test_handlers_cancel_entry.py tests/test_handlers_commit_failures.py tests/test_handlers_profile.py`


------
https://chatgpt.com/codex/tasks/task_e_68b007d6a248832a982e59285e2ff74e