### PR TITLE
[reminders] ensure edit and add buttons default

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -155,18 +155,16 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
     if active_count > limit:
         header += " ⚠️"
 
-    webapp_enabled = bool(config.settings.public_origin)
-    if webapp_enabled:
-        add_button_row = [
-            InlineKeyboardButton(
-                "➕ Добавить",
-                web_app=WebAppInfo(config.build_ui_url("/reminders/new")),
-            )
-        ]
-    else:
-        add_button_row = [
-            InlineKeyboardButton("➕ Добавить", callback_data="rem_add")
-        ]
+    webapp_enabled: bool = bool(config.settings.public_origin)
+    add_button = (
+        InlineKeyboardButton(
+            "➕ Добавить",
+            web_app=WebAppInfo(config.build_ui_url("/reminders/new")),
+        )
+        if webapp_enabled
+        else InlineKeyboardButton("➕ Добавить", callback_data="rem_add")
+    )
+    add_button_row = [add_button]
     if not rems:
         text = (
             header


### PR DESCRIPTION
## Summary
- handle absence of webapp by falling back to callbacks for edit/add buttons
- always include add reminder button row
- extend reminder list tests for default controls

## Testing
- `pytest -q` *(fails: many tests require async plugin and coverage setup)*
- `pytest tests/test_reminders.py -q --no-cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b00a81dce0832a9c2a2584ed7e51c2