### PR TITLE
[handlers] Use config.get_settings for reminders

### DIFF
--- a/tests/services/test_gpt_client_service.py
+++ b/tests/services/test_gpt_client_service.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 from openai import OpenAIError
 
-from services.api.app.config import settings
+import services.api.app.config as config
 from services.api.app.diabetes.services import gpt_client
 
 
@@ -26,7 +26,8 @@ async def test_send_message_missing_assistant_id(
         )
     )
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
-    monkeypatch.setattr(settings, "openai_assistant_id", "")
+    fake_settings = config.Settings(OPENAI_ASSISTANT_ID="")
+    monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
 
     with caplog.at_level(logging.ERROR):
         with pytest.raises(RuntimeError):
@@ -57,7 +58,8 @@ async def test_send_message_run_error_retry(
         )
     )
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
-    monkeypatch.setattr(settings, "openai_assistant_id", "asst")
+    fake_settings = config.Settings(OPENAI_ASSISTANT_ID="asst")
+    monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
 
     with caplog.at_level(logging.DEBUG):
         for _ in range(2):
@@ -99,7 +101,8 @@ async def test_send_message_cleanup_warning(
         ),
     )
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
-    monkeypatch.setattr(settings, "openai_assistant_id", "asst")
+    fake_settings = config.Settings(OPENAI_ASSISTANT_ID="asst")
+    monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
 
     def fake_remove(_: str) -> None:
         raise OSError("nope")


### PR DESCRIPTION
## Summary
- refactor reminder rendering to use config.get_settings and shared settings for URL building
- adjust tests to patch config.get_settings and reload handler config

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b00c7b9498832ab3f888b9b930109e