### PR TITLE
[reminders] pass settings to reminder rendering

### DIFF
--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -14,6 +14,7 @@ from telegram.ext import (
     JobQueue,
     MessageHandler,
 )
+from services.api.app.config import Settings
 from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import (
     CallbackQueryNoWarnHandler,
 )
@@ -328,7 +329,7 @@ async def test_reminders_command_renders_list(
     )
 
     def fake_render(
-        session: Session, user_id: int
+        session: Session, user_id: int, _settings: Settings
     ) -> tuple[str, InlineKeyboardMarkup | None]:
         assert session is session_obj
         assert user_id == 1


### PR DESCRIPTION
## Summary
- plumb `Settings` into `_render_reminders` and callers
- build UI URLs from passed settings instead of global config
- adapt reminder tests for new `settings` parameter

## Testing
- `pytest -q` *(fails: services/test_gpt_client_service.py::test_send_message_missing_assistant_id: AttributeError: 'types.SimpleNamespace' object has no attribute 'runs')*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b011919a10832a95e433a3260c7a3b