### PR TITLE
[handlers] refresh settings in profile view and reminders

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -218,8 +218,9 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     user_id = user.id
     profile = fetch_profile(api, ApiException, user_id)
 
+    settings = config.get_settings()
     webapp_button: list[InlineKeyboardButton] | None = None
-    if config.settings.public_origin:
+    if settings.public_origin:
         webapp_button = [
             InlineKeyboardButton(
                 "📝 Заполнить форму",
@@ -502,13 +503,13 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
         await sos_handlers.sos_contact_start(update, context)
         return
-    from services.api.app import config as app_config
 
-    origin = app_config.settings.public_origin
+    settings = config.get_settings()
+    origin = settings.public_origin
     if action == "add" and origin:
         button = InlineKeyboardButton(
             "📝 Новое",
-            web_app=WebAppInfo(app_config.build_ui_url("/reminders")),
+            web_app=WebAppInfo(config.build_ui_url("/reminders")),
         )
         keyboard = InlineKeyboardMarkup([[button]])
         await q_message.reply_text("Создать напоминание:", reply_markup=keyboard)

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -155,7 +155,8 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
     if active_count > limit:
         header += " ⚠️"
 
-    webapp_enabled: bool = bool(config.settings.public_origin)
+    settings = config.get_settings()
+    webapp_enabled: bool = bool(settings.public_origin)
     add_button = (
         InlineKeyboardButton(
             "➕ Добавить",


### PR DESCRIPTION
## Summary
- refresh configuration in `profile_view` on each call
- use refreshed settings when rendering reminder actions

## Testing
- `pytest -q --cov` *(fails: tests/services/test_gpt_client_service.py::test_send_message_missing_assistant_id, tests/test_reminders.py::test_render_reminders_formatting, tests/test_reminders.py::test_reminders_list_renders_output[None], coverage < 85%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b011cf2a54832a864a52d0389a67f6