### PR TITLE
[config] add update_settings helper

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -1,17 +1,26 @@
-"""Application configuration via Pydantic settings."""
+"""Application configuration via Pydantic settings.
+
+The module exposes a shared :data:`settings` instance. Use
+:func:`update_settings` to replace it with a new :class:`Settings` object so
+that all imports observe the same configuration. Call
+:func:`reload_settings` to rebuild ``settings`` from the current environment.
+Avoid mutating attributes directly.
+"""
 
 from __future__ import annotations
 
 import logging
 import os
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import Field, field_validator
 
 try:  # pragma: no cover - import guard
     from pydantic_settings import BaseSettings, SettingsConfigDict
 except ModuleNotFoundError as exc:  # pragma: no cover - executed at import time
-    raise ImportError("`pydantic-settings` is required. Install it with `pip install pydantic-settings`.") from exc
+    raise ImportError(
+        "`pydantic-settings` is required. Install it with `pip install pydantic-settings`."
+    ) from exc
 
 
 logger = logging.getLogger(__name__)
@@ -52,14 +61,18 @@ class Settings(BaseSettings):
     ui_base_url: str = Field(default="/ui", alias="UI_BASE_URL")
     api_url: Optional[str] = Field(default=None, alias="API_URL")
     openai_api_key: Optional[str] = Field(default=None, alias="OPENAI_API_KEY")
-    openai_assistant_id: Optional[str] = Field(default=None, alias="OPENAI_ASSISTANT_ID")
+    openai_assistant_id: Optional[str] = Field(
+        default=None, alias="OPENAI_ASSISTANT_ID"
+    )
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
     font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
     telegram_token: Optional[str] = Field(default=None, alias="TELEGRAM_TOKEN")
 
     @field_validator("log_level", mode="before")
     @classmethod
-    def parse_log_level(cls, v: int | str | None) -> int:  # pragma: no cover - simple parsing
+    def parse_log_level(
+        cls, v: int | str | None
+    ) -> int:  # pragma: no cover - simple parsing
         if isinstance(v, str):
             v_lower = v.lower()
             if v_lower in {"1", "true", "debug"}:
@@ -83,12 +96,29 @@ def get_settings() -> Settings:
     return settings
 
 
+def update_settings(**kwargs: Any) -> Settings:
+    """Replace ``settings`` with a new instance built from ``kwargs``.
+
+    Parameters
+    ----------
+    **kwargs
+        Values overriding those loaded from the environment.
+
+    Returns
+    -------
+    Settings
+        The newly created settings object.
+    """
+
+    global settings
+    settings = Settings().model_copy(update=kwargs)
+    return settings
+
+
 def reload_settings() -> Settings:
     """Reload settings from the environment and return them."""
 
-    global settings
-    settings = Settings()
-    return settings
+    return update_settings()
 
 
 def get_db_password() -> Optional[str]:

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -14,3 +14,17 @@ def test_reload_settings_reflects_environment(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
     config.reload_settings()
+
+
+def test_update_settings_replaces_global_instance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PUBLIC_ORIGIN", "https://env")
+    config.reload_settings()
+    new = config.update_settings(public_origin="https://example.org")
+    assert new is config.get_settings()
+    assert new.public_origin == "https://example.org"
+    config.reload_settings()
+    assert config.get_settings().public_origin == "https://env"
+    monkeypatch.undo()
+    config.reload_settings()

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -87,7 +87,9 @@ async def test_profile_command_and_view(
         session.commit()
 
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=123)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=123))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=args, user_data={}),
@@ -144,7 +146,9 @@ async def test_profile_command_and_view(
     ],
 )
 @pytest.mark.asyncio
-async def test_profile_command_invalid_values(monkeypatch: pytest.MonkeyPatch, args: Any, expected_attr: str) -> None:
+async def test_profile_command_invalid_values(
+    monkeypatch: pytest.MonkeyPatch, args: Any, expected_attr: str
+) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
@@ -158,7 +162,9 @@ async def test_profile_command_invalid_values(monkeypatch: pytest.MonkeyPatch, a
     monkeypatch.setattr(handlers, "post_profile", post_profile_mock)
 
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=args, user_data={}),
@@ -181,7 +187,9 @@ async def test_profile_command_help(monkeypatch: pytest.MonkeyPatch) -> None:
     from services.api.app.diabetes.handlers import profile as handlers
 
     help_msg = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=help_msg, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=help_msg, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=["help"], user_data={}),
@@ -192,7 +200,9 @@ async def test_profile_command_help(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_profile_command_view_existing_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_profile_command_view_existing_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
@@ -210,7 +220,9 @@ async def test_profile_command_view_existing_profile(monkeypatch: pytest.MonkeyP
         session.commit()
 
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=[], user_data={}),
@@ -251,7 +263,9 @@ async def test_profile_view_preserves_user_data(
         session.commit()
 
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"thread_id": "tid", "foo": "bar"}),
@@ -275,13 +289,15 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     import services.api.app.diabetes.handlers.profile as handlers
 
     import services.api.app.config as config
-    monkeypatch.setattr(config.settings, "public_origin", "https://example.com")
-    monkeypatch.setattr(config.settings, "ui_base_url", "")
+
+    config.update_settings(public_origin="https://example.com", ui_base_url="")
     monkeypatch.setattr(handlers, "get_api", lambda: (object(), Exception, None))
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: None)
 
     msg = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
@@ -296,6 +312,8 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     assert button.web_app is not None
     assert urlparse(button.web_app.url).path == "/profile"
 
+    config.reload_settings()
+
 
 @pytest.mark.asyncio
 async def test_profile_view_existing_profile_shows_webapp_button(
@@ -305,15 +323,17 @@ async def test_profile_view_existing_profile_shows_webapp_button(
     import services.api.app.diabetes.handlers.profile as handlers
 
     import services.api.app.config as config
-    monkeypatch.setattr(config.settings, "public_origin", "https://example.com")
-    monkeypatch.setattr(config.settings, "ui_base_url", "")
+
+    config.update_settings(public_origin="https://example.com", ui_base_url="")
 
     profile = SimpleNamespace(icr=1, cf=1, target=1, low=1, high=1)
     monkeypatch.setattr(handlers, "get_api", lambda: (object(), Exception, None))
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: profile)
 
     msg = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
@@ -326,3 +346,5 @@ async def test_profile_view_existing_profile_shows_webapp_button(
     assert button.text == "📝 Заполнить форму"
     assert button.web_app is not None
     assert urlparse(button.web_app.url).path == "/profile"
+
+    config.reload_settings()


### PR DESCRIPTION
## Summary
- add `update_settings` helper to swap global config in tests or runtime
- advise against attribute monkeypatching in config docstring
- update tests to refresh settings via helper

## Testing
- `ruff check services/api/app/config.py tests/test_config_reload.py tests/test_handlers_profile.py tests/test_reminders.py`
- `mypy --strict tests/test_config_reload.py tests/test_handlers_profile.py tests/test_reminders.py services/api/app/config.py`
- `pytest -q --override-ini addopts='' tests/test_config_reload.py tests/test_handlers_profile.py tests/test_reminders.py::test_render_reminders_formatting tests/test_reminders.py::test_render_reminders_no_entries_webapp tests/test_reminders.py::test_render_reminders_runtime_public_origin`


------
https://chatgpt.com/codex/tasks/task_e_68b01454ed5c832a80ff1c55919f71ee