### PR TITLE
[reminders] Evaluate webapp config at runtime

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -163,7 +163,7 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
     if active_count > limit:
         header += " ⚠️"
 
-    webapp_enabled: bool = bool(config.settings.public_origin)
+    webapp_enabled: bool = bool(config.get_settings().public_origin)
     add_button = (
         InlineKeyboardButton(
             "➕ Добавить",

--- a/tests/services/test_gpt_client_service.py
+++ b/tests/services/test_gpt_client_service.py
@@ -6,7 +6,6 @@ from typing import Any
 import pytest
 from openai import OpenAIError
 
-from services.api.app.config import settings
 from services.api.app.diabetes.services import gpt_client
 
 
@@ -26,7 +25,8 @@ async def test_send_message_missing_assistant_id(
         )
     )
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
-    monkeypatch.setattr(settings, "openai_assistant_id", "")
+    cfg = gpt_client.config.get_settings()
+    monkeypatch.setattr(cfg, "openai_assistant_id", "")
 
     with caplog.at_level(logging.ERROR):
         with pytest.raises(RuntimeError):
@@ -57,7 +57,8 @@ async def test_send_message_run_error_retry(
         )
     )
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
-    monkeypatch.setattr(settings, "openai_assistant_id", "asst")
+    cfg = gpt_client.config.get_settings()
+    monkeypatch.setattr(cfg, "openai_assistant_id", "asst")
 
     with caplog.at_level(logging.DEBUG):
         for _ in range(2):
@@ -99,7 +100,8 @@ async def test_send_message_cleanup_warning(
         ),
     )
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
-    monkeypatch.setattr(settings, "openai_assistant_id", "asst")
+    cfg = gpt_client.config.get_settings()
+    monkeypatch.setattr(cfg, "openai_assistant_id", "asst")
 
     def fake_remove(_: str) -> None:
         raise OSError("nope")

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -294,13 +294,13 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
         edit_btn = row[0]
         assert edit_btn.text == "✏️"
         assert edit_btn.web_app is not None
-        assert edit_btn.web_app.url == config.build_ui_url(
+        assert edit_btn.web_app.url == handlers.config.build_ui_url(
             f"/reminders?id={rem_id}"
         )
     add_btn = markup.inline_keyboard[-1][0]
     assert add_btn.text == "➕ Добавить"
     assert add_btn.web_app is not None
-    assert add_btn.web_app.url == config.build_ui_url("/reminders/new")
+    assert add_btn.web_app.url == handlers.config.build_ui_url("/reminders/new")
 
 
 def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -381,7 +381,7 @@ def test_render_reminders_no_entries_webapp(monkeypatch: pytest.MonkeyPatch) -> 
     assert [btn.text for btn in add_row] == ["➕ Добавить"]
     add_btn = add_row[0]
     assert add_btn.web_app is not None
-    assert add_btn.web_app.url == config.build_ui_url("/reminders/new")
+    assert add_btn.web_app.url == handlers.config.build_ui_url("/reminders/new")
 
 
 def test_render_reminders_runtime_public_origin(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -389,8 +389,6 @@ def test_render_reminders_runtime_public_origin(monkeypatch: pytest.MonkeyPatch)
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     handlers.SessionLocal = TestSession
-    import services.api.app.config as config
-
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
@@ -412,10 +410,10 @@ def test_render_reminders_runtime_public_origin(monkeypatch: pytest.MonkeyPatch)
     first_row = markup.inline_keyboard[0]
     edit_btn = first_row[0]
     assert edit_btn.web_app is not None
-    assert edit_btn.web_app.url == config.build_ui_url("/reminders?id=1")
+    assert edit_btn.web_app.url == handlers.config.build_ui_url("/reminders?id=1")
     add_btn = markup.inline_keyboard[1][0]
     assert add_btn.web_app is not None
-    assert add_btn.web_app.url == config.build_ui_url("/reminders/new")
+    assert add_btn.web_app.url == handlers.config.build_ui_url("/reminders/new")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Avoid cached config when rendering reminders so UI buttons reflect current PUBLIC_ORIGIN
- Update reminder tests to build URLs with live config and adjust OpenAI client tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b01451c3d8832aabb4a06bc06038c1