### PR TITLE
[config] ensure dynamic settings access

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -108,12 +108,16 @@ def build_ui_url(path: str) -> str:
 
     Slashes are normalized and ``settings.public_origin`` must be configured.
     ``settings.ui_base_url`` is stripped of leading and trailing slashes.
+
+    The function retrieves the current settings via :func:`get_settings` to
+    ensure runtime updates are respected.
     """
 
-    if not settings.public_origin:
+    cfg = get_settings()
+    if not cfg.public_origin:
         raise RuntimeError("PUBLIC_ORIGIN not configured")
-    origin = settings.public_origin.rstrip("/")
-    base = settings.ui_base_url.strip("/")
+    origin = cfg.public_origin.rstrip("/")
+    base = cfg.ui_base_url.strip("/")
     rel = path.lstrip("/")
     if base:
         return f"{origin}/{base}/{rel}"

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -219,7 +219,8 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     profile = fetch_profile(api, ApiException, user_id)
 
     webapp_button: list[InlineKeyboardButton] | None = None
-    if config.settings.public_origin:
+    current_settings = config.get_settings()
+    if current_settings.public_origin:
         webapp_button = [
             InlineKeyboardButton(
                 "📝 Заполнить форму",
@@ -504,7 +505,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         return
     from services.api.app import config as app_config
 
-    origin = app_config.settings.public_origin
+    origin = app_config.get_settings().public_origin
     if action == "add" and origin:
         button = InlineKeyboardButton(
             "📝 Новое",

--- a/tests/services/test_gpt_client_service.py
+++ b/tests/services/test_gpt_client_service.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 from openai import OpenAIError
 
-from services.api.app.config import settings
+from services.api.app import config
 from services.api.app.diabetes.services import gpt_client
 
 
@@ -26,7 +26,8 @@ async def test_send_message_missing_assistant_id(
         )
     )
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
-    monkeypatch.setattr(settings, "openai_assistant_id", "")
+    cfg = config.get_settings()
+    monkeypatch.setattr(cfg, "openai_assistant_id", "")
 
     with caplog.at_level(logging.ERROR):
         with pytest.raises(RuntimeError):
@@ -57,7 +58,8 @@ async def test_send_message_run_error_retry(
         )
     )
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
-    monkeypatch.setattr(settings, "openai_assistant_id", "asst")
+    cfg = config.get_settings()
+    monkeypatch.setattr(cfg, "openai_assistant_id", "asst")
 
     with caplog.at_level(logging.DEBUG):
         for _ in range(2):
@@ -99,7 +101,8 @@ async def test_send_message_cleanup_warning(
         ),
     )
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
-    monkeypatch.setattr(settings, "openai_assistant_id", "asst")
+    cfg = config.get_settings()
+    monkeypatch.setattr(cfg, "openai_assistant_id", "asst")
 
     def fake_remove(_: str) -> None:
         raise OSError("nope")

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -275,8 +275,9 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     import services.api.app.diabetes.handlers.profile as handlers
 
     import services.api.app.config as config
-    monkeypatch.setattr(config.settings, "public_origin", "https://example.com")
-    monkeypatch.setattr(config.settings, "ui_base_url", "")
+    cfg = config.get_settings()
+    monkeypatch.setattr(cfg, "public_origin", "https://example.com")
+    monkeypatch.setattr(cfg, "ui_base_url", "")
     monkeypatch.setattr(handlers, "get_api", lambda: (object(), Exception, None))
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: None)
 
@@ -305,8 +306,9 @@ async def test_profile_view_existing_profile_shows_webapp_button(
     import services.api.app.diabetes.handlers.profile as handlers
 
     import services.api.app.config as config
-    monkeypatch.setattr(config.settings, "public_origin", "https://example.com")
-    monkeypatch.setattr(config.settings, "ui_base_url", "")
+    cfg = config.get_settings()
+    monkeypatch.setattr(cfg, "public_origin", "https://example.com")
+    monkeypatch.setattr(cfg, "ui_base_url", "")
 
     profile = SimpleNamespace(icr=1, cf=1, target=1, low=1, high=1)
     monkeypatch.setattr(handlers, "get_api", lambda: (object(), Exception, None))

--- a/tests/test_ui_reminders_smoke.py
+++ b/tests/test_ui_reminders_smoke.py
@@ -6,7 +6,7 @@ from services.api.app.main import app
 
 def test_reminders_page_smoke() -> None:
     with TestClient(app) as client:
-        base = config.settings.ui_base_url.rstrip("/")
+        base = config.get_settings().ui_base_url.rstrip("/")
         resp = client.get(f"{base}/reminders")
         assert resp.status_code == 200
         assert "<html" in resp.text.lower()
@@ -14,7 +14,7 @@ def test_reminders_page_smoke() -> None:
 
 def test_reminders_new_page_smoke() -> None:
     with TestClient(app) as client:
-        base = config.settings.ui_base_url.rstrip("/")
+        base = config.get_settings().ui_base_url.rstrip("/")
         resp = client.get(f"{base}/reminders/new")
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]


### PR DESCRIPTION
## Summary
- fetch settings dynamically in `build_ui_url`
- avoid stale `config.settings` by using `config.get_settings()` in handlers and tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b016ccf554832a8c2f8a3a8958f9fd