### PR TITLE
config: use get_settings for UI URL

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -106,10 +106,13 @@ def get_db_password() -> Optional[str]:
 def build_ui_url(path: str) -> str:
     """Return an absolute UI URL for ``path``.
 
-    Slashes are normalized and ``settings.public_origin`` must be configured.
-    ``settings.ui_base_url`` is stripped of leading and trailing slashes.
+    The function fetches the latest settings via :func:`get_settings` to avoid
+    using a stale ``Settings`` instance. ``public_origin`` must be configured
+    and ``ui_base_url`` is normalized by stripping leading and trailing
+    slashes.
     """
 
+    settings = get_settings()
     if not settings.public_origin:
         raise RuntimeError("PUBLIC_ORIGIN not configured")
     origin = settings.public_origin.rstrip("/")

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -275,8 +275,9 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     import services.api.app.diabetes.handlers.profile as handlers
 
     import services.api.app.config as config
-    monkeypatch.setattr(config.settings, "public_origin", "https://example.com")
-    monkeypatch.setattr(config.settings, "ui_base_url", "")
+    settings = config.get_settings()
+    monkeypatch.setattr(settings, "public_origin", "https://example.com")
+    monkeypatch.setattr(settings, "ui_base_url", "")
     monkeypatch.setattr(handlers, "get_api", lambda: (object(), Exception, None))
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: None)
 
@@ -305,8 +306,9 @@ async def test_profile_view_existing_profile_shows_webapp_button(
     import services.api.app.diabetes.handlers.profile as handlers
 
     import services.api.app.config as config
-    monkeypatch.setattr(config.settings, "public_origin", "https://example.com")
-    monkeypatch.setattr(config.settings, "ui_base_url", "")
+    settings = config.get_settings()
+    monkeypatch.setattr(settings, "public_origin", "https://example.com")
+    monkeypatch.setattr(settings, "ui_base_url", "")
 
     profile = SimpleNamespace(icr=1, cf=1, target=1, low=1, high=1)
     monkeypatch.setattr(handlers, "get_api", lambda: (object(), Exception, None))

--- a/tests/test_ui_reminders_smoke.py
+++ b/tests/test_ui_reminders_smoke.py
@@ -6,7 +6,7 @@ from services.api.app.main import app
 
 def test_reminders_page_smoke() -> None:
     with TestClient(app) as client:
-        base = config.settings.ui_base_url.rstrip("/")
+        base = config.get_settings().ui_base_url.rstrip("/")
         resp = client.get(f"{base}/reminders")
         assert resp.status_code == 200
         assert "<html" in resp.text.lower()
@@ -14,7 +14,7 @@ def test_reminders_page_smoke() -> None:
 
 def test_reminders_new_page_smoke() -> None:
     with TestClient(app) as client:
-        base = config.settings.ui_base_url.rstrip("/")
+        base = config.get_settings().ui_base_url.rstrip("/")
         resp = client.get(f"{base}/reminders/new")
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]


### PR DESCRIPTION
## Summary
- call `get_settings()` inside `build_ui_url` so updated `PUBLIC_ORIGIN` and `UI_BASE_URL` are used
- update tests to use `config.get_settings()` instead of touching `config.settings`

## Testing
- `ruff check .`
- `mypy --strict services/api/app/config.py tests/test_handlers_profile.py tests/test_ui_reminders_smoke.py`
- `pytest tests/test_config_reload.py tests/test_ui_reminders_smoke.py tests/test_handlers_profile.py::test_profile_view_missing_profile_shows_webapp_button tests/test_handlers_profile.py::test_profile_view_existing_profile_shows_webapp_button tests/test_reminders.py::test_render_reminders_runtime_public_origin -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b01a6d2184832a9f0a59fee005315c