### PR TITLE
[ui] add history webapp button

### DIFF
--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -78,10 +78,18 @@ def menu_keyboard() -> ReplyKeyboardMarkup:
         if webapp_enabled
         else KeyboardButton(REMINDERS_BUTTON_TEXT)
     )
+    history_button = (
+        KeyboardButton(
+            HISTORY_BUTTON_TEXT,
+            web_app=WebAppInfo(config.build_ui_url("/history")),
+        )
+        if webapp_enabled
+        else KeyboardButton(HISTORY_BUTTON_TEXT)
+    )
     return ReplyKeyboardMarkup(
         keyboard=[
             [KeyboardButton(PHOTO_BUTTON_TEXT), KeyboardButton(SUGAR_BUTTON_TEXT)],
-            [KeyboardButton(DOSE_BUTTON_TEXT), KeyboardButton(HISTORY_BUTTON_TEXT)],
+            [KeyboardButton(DOSE_BUTTON_TEXT), history_button],
             [KeyboardButton(REPORT_BUTTON_TEXT), profile_button],
             [KeyboardButton(QUICK_INPUT_BUTTON_TEXT), KeyboardButton(HELP_BUTTON_TEXT)],
             [reminders_button, KeyboardButton(SOS_BUTTON_TEXT)],

--- a/tests/services/test_gpt_client_service.py
+++ b/tests/services/test_gpt_client_service.py
@@ -22,11 +22,15 @@ async def test_send_message_missing_assistant_id(
 ) -> None:
     fake_client = SimpleNamespace(
         beta=SimpleNamespace(
-            threads=SimpleNamespace(messages=SimpleNamespace(create=lambda **_: None))
+            threads=SimpleNamespace(
+                messages=SimpleNamespace(create=lambda **_: None),
+                runs=SimpleNamespace(create=lambda **_: None),
+            )
         )
     )
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
     monkeypatch.setattr(settings, "openai_assistant_id", "")
+    monkeypatch.setattr(gpt_client.config, "get_settings", lambda: settings)
 
     with caplog.at_level(logging.ERROR):
         with pytest.raises(RuntimeError):

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -17,18 +17,21 @@ import services.api.app.diabetes.utils.ui as ui
 def test_menu_keyboard_webapp_urls(
     monkeypatch: pytest.MonkeyPatch, origin: str, ui_base: str
 ) -> None:
-    """Menu buttons should open webapp paths for profile and reminders."""
+    """Menu buttons should open webapp paths for profile, reminders and history."""
     monkeypatch.setenv("PUBLIC_ORIGIN", origin)
     monkeypatch.setenv("UI_BASE_URL", ui_base)
 
     buttons = [btn for row in ui.menu_keyboard().keyboard for btn in row]
     profile_btn = next(b for b in buttons if b.text == ui.PROFILE_BUTTON_TEXT)
     reminders_btn = next(b for b in buttons if b.text == ui.REMINDERS_BUTTON_TEXT)
+    history_btn = next(b for b in buttons if b.text == ui.HISTORY_BUTTON_TEXT)
 
     assert profile_btn.web_app is not None
     assert urlparse(profile_btn.web_app.url).path.endswith("/profile")
     assert reminders_btn.web_app is not None
     assert urlparse(reminders_btn.web_app.url).path.endswith("/reminders")
+    assert history_btn.web_app is not None
+    assert urlparse(history_btn.web_app.url).path.endswith("/history")
 
 
 def test_menu_keyboard_webapp_reloads_settings(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -38,15 +41,20 @@ def test_menu_keyboard_webapp_reloads_settings(monkeypatch: pytest.MonkeyPatch) 
     buttons = [btn for row in ui.menu_keyboard().keyboard for btn in row]
     profile_btn = next(b for b in buttons if b.text == ui.PROFILE_BUTTON_TEXT)
     reminders_btn = next(b for b in buttons if b.text == ui.REMINDERS_BUTTON_TEXT)
+    history_btn = next(b for b in buttons if b.text == ui.HISTORY_BUTTON_TEXT)
     assert profile_btn.web_app is None
     assert reminders_btn.web_app is None
+    assert history_btn.web_app is None
 
     monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.com")
     monkeypatch.setenv("UI_BASE_URL", "")
     buttons = [btn for row in ui.menu_keyboard().keyboard for btn in row]
     profile_btn = next(b for b in buttons if b.text == ui.PROFILE_BUTTON_TEXT)
     reminders_btn = next(b for b in buttons if b.text == ui.REMINDERS_BUTTON_TEXT)
+    history_btn = next(b for b in buttons if b.text == ui.HISTORY_BUTTON_TEXT)
     assert profile_btn.web_app is not None
     assert reminders_btn.web_app is not None
+    assert history_btn.web_app is not None
     assert urlparse(profile_btn.web_app.url).path.endswith("/profile")
     assert urlparse(reminders_btn.web_app.url).path.endswith("/reminders")
+    assert urlparse(history_btn.web_app.url).path.endswith("/history")


### PR DESCRIPTION
## Summary
- expose History as a WebApp button when UI origin is configured
- cover History button behavior in menu keyboard webapp tests
- stabilize gpt client tests by patching settings retrieval

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b01c66fb9c832ab337f5c2dfc2e9db