### PR TITLE
[webapp] fix reminders links

### DIFF
--- a/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
@@ -321,7 +321,7 @@ export default function RemindersList({
                       {r.isEnabled ? "Вкл." : "Выкл."}
                     </button>
                     <Link
-                      to={`${r.id}/edit`}
+                      to={`/reminders/${r.id}/edit`}
                       className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-all duration-200"
                     >
                       ✏️
@@ -347,7 +347,7 @@ export default function RemindersList({
           </div>
           <p className="text-muted-foreground">Пока нет напоминаний</p>
           <Link
-            to="new"
+            to="/reminders/new"
             className="inline-flex items-center gap-2 mt-4 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
           >
             + Добавить первое напоминание

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -25,7 +25,7 @@ export default function Reminders() {
     <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
       <MedicalHeader title={`Напоминания ${quotaBadge}`} showBack onBack={() => navigate('/')}>
         <Link
-          to="new"
+          to="/reminders/new"
           className="px-4 py-2 bg-primary text-primary-foreground rounded-lg shadow-soft hover:shadow-medium hover:bg-primary/90 transition-all duration-200"
         >
           + Добавить

--- a/tests/test_ui_reminders_smoke.py
+++ b/tests/test_ui_reminders_smoke.py
@@ -19,3 +19,12 @@ def test_reminders_new_page_smoke() -> None:
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]
         assert "<html" in resp.text.lower()
+
+
+def test_reminders_edit_page_smoke() -> None:
+    with TestClient(app) as client:
+        base = config.settings.ui_base_url.rstrip("/")
+        resp = client.get(f"{base}/reminders/1/edit")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        assert "<html" in resp.text.lower()


### PR DESCRIPTION
## Summary
- fix reminders add/edit links to use absolute paths
- cover `/reminders/1/edit` route with smoke test

## Testing
- `pnpm --filter ./services/webapp/ui test` *(fails: No test files found)*
- `pytest -q --ignore=tests/test_reminders.py --ignore=tests/services/test_gpt_client_service.py`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b01e1160e0832a8809f72d16d58c9e