### PR TITLE
[webapp] Use navigate for reminders links

### DIFF
--- a/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import type { ReminderSchema } from "@sdk";
 import { useRemindersApi } from "../api/reminders";
 import { formatNextAt } from "../../../shared/datetime";
@@ -56,7 +56,7 @@ function scheduleLine(r: ReminderDto) {
   return TYPE_LABEL[r.type] || "Напоминание";
 }
 
-export default function RemindersList({ 
+export default function RemindersList({
   onCountChange, 
   planLimit 
 }: { 
@@ -66,6 +66,7 @@ export default function RemindersList({
   const api = useRemindersApi();
   const { user } = useTelegram();
   const initData = useTelegramInitData();
+  const navigate = useNavigate();
   const { toast } = useToast();
   const [items, setItems] = useState<ReminderDto[]>([]);
   const [loading, setLoading] = useState(false);
@@ -320,12 +321,13 @@ export default function RemindersList({
                     >
                       {r.isEnabled ? "Вкл." : "Выкл."}
                     </button>
-                    <Link
-                      to={`/reminders/${r.id}/edit`}
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/reminders/${r.id}/edit`)}
                       className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-all duration-200"
                     >
                       ✏️
-                    </Link>
+                    </button>
                     <button 
                       onClick={() => remove(r)} 
                       className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-destructive/10 hover:text-destructive hover:border-destructive/20 transition-all duration-200"
@@ -346,12 +348,13 @@ export default function RemindersList({
             <span className="text-2xl">⏰</span>
           </div>
           <p className="text-muted-foreground">Пока нет напоминаний</p>
-          <Link
-            to="/reminders/new"
+          <button
+            type="button"
+            onClick={() => navigate('/reminders/new')}
             className="inline-flex items-center gap-2 mt-4 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
           >
             + Добавить первое напоминание
-          </Link>
+          </button>
         </div>
       )}
     </div>

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -1,6 +1,6 @@
 import RemindersList from '../features/reminders/pages/RemindersList'
 import { MedicalHeader } from '@/components/MedicalHeader'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { useTelegram } from '@/hooks/useTelegram'
 import { useState, useEffect } from 'react'
 import { getPlanLimit } from '../features/reminders/hooks/usePlan'
@@ -24,13 +24,14 @@ export default function Reminders() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
       <MedicalHeader title={`Напоминания ${quotaBadge}`} showBack onBack={() => navigate('/')}>
-        <Link
-          to="/reminders/new"
+        <button
+          type="button"
+          onClick={() => navigate('/reminders/new')}
           className="px-4 py-2 bg-primary text-primary-foreground rounded-lg shadow-soft hover:shadow-medium hover:bg-primary/90 transition-all duration-200"
         >
           + Добавить
-        </Link>
-        </MedicalHeader>
+        </button>
+      </MedicalHeader>
 
       <main className="container mx-auto px-4 py-6">
         <RemindersList onCountChange={setReminderCount} planLimit={planLimit} />


### PR DESCRIPTION
## Summary
- avoid full page reload in Telegram by replacing Reminders links with programmatic navigation

## Testing
- `pytest -q` *(fails: import of telegram module hangs, KeyboardInterrupt)*
- `mypy --strict .` *(fails: Interrupted)*
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01d4b2944832a857f1eb3321a45e1