### PR TITLE
[handlers] Add WebApp profile button

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -223,24 +223,25 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if settings.public_origin:
         webapp_button = [
             InlineKeyboardButton(
-                "📝 Заполнить форму",
+                "Открыть профиль",
                 web_app=WebAppInfo(config.build_ui_url("/profile")),
             )
         ]
 
     if not profile:
+        text = (
+            "Ваш профиль пока не настроен.\n\n"
+            "Чтобы настроить профиль, введите команду:\n"
+            "/profile <ИКХ г/ед.> <КЧ ммоль/л> <целевой ммоль/л> <низкий ммоль/л> <высокий ммоль/л>\n"
+            "или /profile icr=<ИКХ> cf=<КЧ> target=<целевой> low=<низкий> high=<высокий>\n"
+            "Пример: /profile 10 2 6 4 9 — ИКХ 10 г/ед., КЧ 2 ммоль/л, целевой 6 ммоль/л, "
+            "низкий 4 ммоль/л, высокий 9 ммоль/л"
+        )
         if webapp_button is not None:
             keyboard = InlineKeyboardMarkup([webapp_button])
-            await message.reply_text("Ваш профиль пока не настроен.", reply_markup=keyboard)
+            await message.reply_text(text, parse_mode="Markdown", reply_markup=keyboard)
         else:
-            await message.reply_text(
-                "Ваш профиль пока не настроен.\n\n"
-                "Чтобы настроить профиль, введите команду:\n"
-                "/profile <ИКХ г/ед.> <КЧ ммоль/л> <целевой ммоль/л> <низкий ммоль/л> <высокий ммоль/л>\n"
-                "или /profile icr=<ИКХ> cf=<КЧ> target=<целевой> low=<низкий> high=<высокий>\n"
-                "Пример: /profile 10 2 6 4 9 — ИКХ 10 г/ед., КЧ 2 ммоль/л, целевой 6 ммоль/л, низкий 4 ммоль/л, высокий 9 ммоль/л",
-                parse_mode="Markdown",
-            )
+            await message.reply_text(text, parse_mode="Markdown")
         return
 
     msg = (
@@ -458,12 +459,7 @@ def _security_db(session: Session, user_id: int, action: str | None) -> dict[str
     if changed:
         try:
             commit(session)
-            alert = (
-                session.query(Alert)
-                .filter_by(user_id=user_id)
-                .order_by(Alert.ts.desc())
-                .first()
-            )
+            alert = session.query(Alert).filter_by(user_id=user_id).order_by(Alert.ts.desc()).first()
             alert_sugar = alert.sugar if alert else None
         except CommitError:
             commit_ok = False

--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -18,7 +18,7 @@ from openai.types.beta.threads import (
     TextContentBlockParam,
 )
 
-from services.api.app import config
+from services.api.app.config import settings
 from services.api.app.diabetes.utils.openai_utils import (
     get_async_openai_client,
     get_openai_client,
@@ -121,7 +121,6 @@ async def send_message(
 
     >>> await send_message(thread_id="abc", image_path="/tmp/photo.jpg")
     """
-    settings = config.get_settings()
     if content is None and image_path is None:
         raise ValueError("Either 'content' or 'image_path' must be provided")
 

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -275,6 +275,7 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     import services.api.app.diabetes.handlers.profile as handlers
 
     import services.api.app.config as config
+
     monkeypatch.setattr(config.settings, "public_origin", "https://example.com")
     monkeypatch.setattr(config.settings, "ui_base_url", "")
     monkeypatch.setattr(handlers, "get_api", lambda: (object(), Exception, None))
@@ -292,7 +293,7 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     assert msg.texts[0].startswith("Ваш профиль пока не настроен.")
     markup = msg.markups[0]
     button = markup.inline_keyboard[0][0]
-    assert button.text == "📝 Заполнить форму"
+    assert button.text == "Открыть профиль"
     assert button.web_app is not None
     assert urlparse(button.web_app.url).path == "/profile"
 
@@ -305,6 +306,7 @@ async def test_profile_view_existing_profile_shows_webapp_button(
     import services.api.app.diabetes.handlers.profile as handlers
 
     import services.api.app.config as config
+
     monkeypatch.setattr(config.settings, "public_origin", "https://example.com")
     monkeypatch.setattr(config.settings, "ui_base_url", "")
 
@@ -323,6 +325,6 @@ async def test_profile_view_existing_profile_shows_webapp_button(
 
     markup = msg.markups[0]
     button = markup.inline_keyboard[1][0]
-    assert button.text == "📝 Заполнить форму"
+    assert button.text == "Открыть профиль"
     assert button.web_app is not None
     assert urlparse(button.web_app.url).path == "/profile"


### PR DESCRIPTION
## Summary
- Use simple "Открыть профиль" label for WebApp profile button and keep inline instructions
- Import global settings in gpt client so missing assistant ID triggers a clear error
- Adjust profile handler tests for the new button label

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b01a1cc044832aba0ab9edef30ec37