### PR TITLE
[gpt_client] use config accessor for settings

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -18,7 +18,7 @@ from openai.types.beta.threads import (
     TextContentBlockParam,
 )
 
-from services.api.app.config import settings
+from services.api.app import config
 from services.api.app.diabetes.utils.openai_utils import (
     get_async_openai_client,
     get_openai_client,
@@ -175,6 +175,7 @@ async def send_message(
         logger.exception("[OpenAI] Failed to create message: %s", exc)
         raise
 
+    settings = config.get_settings()
     if not settings.openai_assistant_id:
         message = "OPENAI_ASSISTANT_ID is not set"
         logger.error("[OpenAI] %s", message)

--- a/tests/services/test_gpt_client_service.py
+++ b/tests/services/test_gpt_client_service.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 from openai import OpenAIError
 
-from services.api.app.config import settings
+from services.api.app.config import Settings, settings
 from services.api.app.diabetes.services import gpt_client
 
 


### PR DESCRIPTION
## Summary
- fetch OpenAI settings through `config.get_settings`
- fix test to patch `gpt_client.config.get_settings`

## Testing
- `pytest -q --cov` *(fails: tests/test_reminders.py::test_render_reminders_formatting, tests/test_reminders.py::test_render_reminders_no_webapp, tests/test_reminders.py::test_render_reminders_no_entries_no_webapp, tests/test_reminders.py::test_render_reminders_no_entries_webapp, tests/test_reminders.py::test_render_reminders_runtime_public_origin)*
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b04a53eac0832aacfb3950d8d52b53