### PR TITLE
tests: reload reminder handlers after config changes

### DIFF
--- a/tests/services/test_gpt_client_service.py
+++ b/tests/services/test_gpt_client_service.py
@@ -30,7 +30,6 @@ async def test_send_message_missing_assistant_id(
     )
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
     monkeypatch.setattr(settings, "openai_assistant_id", "")
-    monkeypatch.setattr(gpt_client.config, "get_settings", lambda: settings)
 
     with caplog.at_level(logging.ERROR):
         with pytest.raises(RuntimeError):

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -4,7 +4,7 @@ import services.api.app.config as config
 
 
 def test_reload_settings_reflects_environment(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("PUBLIC_ORIGIN", "", raising=False)
+    monkeypatch.setenv("PUBLIC_ORIGIN", "")
     config.reload_settings()
     assert config.get_settings().public_origin == ""
 
@@ -12,5 +12,5 @@ def test_reload_settings_reflects_environment(monkeypatch: pytest.MonkeyPatch) -
     config.reload_settings()
     assert config.get_settings().public_origin == "https://example.com"
 
-    monkeypatch.setenv("PUBLIC_ORIGIN", "", raising=False)
+    monkeypatch.setenv("PUBLIC_ORIGIN", "")
     config.reload_settings()

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -38,8 +38,8 @@ def test_menu_keyboard_webapp_urls(
 
 def test_menu_keyboard_webapp_reloads_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     """``menu_keyboard`` should reflect environment changes at runtime."""
-    monkeypatch.setenv("PUBLIC_ORIGIN", "", raising=False)
-    monkeypatch.setenv("UI_BASE_URL", "", raising=False)
+    monkeypatch.setenv("PUBLIC_ORIGIN", "")
+    monkeypatch.setenv("UI_BASE_URL", "")
     config.reload_settings()
     buttons = [btn for row in ui.menu_keyboard().keyboard for btn in row]
     profile_btn = next(b for b in buttons if b.text == ui.PROFILE_BUTTON_TEXT)

--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -275,8 +275,8 @@ def test_build_ui_url(
 
 
 def test_build_ui_url_without_origin(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("PUBLIC_ORIGIN", "", raising=False)
-    monkeypatch.setenv("UI_BASE_URL", "", raising=False)
+    monkeypatch.setenv("PUBLIC_ORIGIN", "")
+    monkeypatch.setenv("UI_BASE_URL", "")
     config = importlib.import_module("services.api.app.config")
     importlib.reload(config)
     with pytest.raises(RuntimeError, match="PUBLIC_ORIGIN not configured"):

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -243,12 +243,13 @@ def test_render_reminders_formatting(monkeypatch: pytest.MonkeyPatch) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    handlers.SessionLocal = TestSession
     monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.org")
     monkeypatch.setenv("UI_BASE_URL", "/ui")
     import services.api.app.config as config
 
     importlib.reload(config)
+    importlib.reload(handlers)
+    handlers.SessionLocal = TestSession
     monkeypatch.setattr(handlers, "_limit_for", lambda u: 1)
     # Make _describe deterministic and include status icon to test strikethrough
     monkeypatch.setattr(
@@ -307,12 +308,13 @@ def test_render_reminders_no_webapp(monkeypatch: pytest.MonkeyPatch) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    handlers.SessionLocal = TestSession
-    monkeypatch.setenv("PUBLIC_ORIGIN", "", raising=False)
-    monkeypatch.setenv("UI_BASE_URL", "", raising=False)
+    monkeypatch.setenv("PUBLIC_ORIGIN", "")
+    monkeypatch.setenv("UI_BASE_URL", "")
     import services.api.app.config as config
 
     importlib.reload(config)
+    importlib.reload(handlers)
+    handlers.SessionLocal = TestSession
     settings = config.get_settings()
     monkeypatch.setattr(settings, "public_origin", "")
     with TestSession() as session:
@@ -340,12 +342,13 @@ def test_render_reminders_no_entries_no_webapp(monkeypatch: pytest.MonkeyPatch) 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    handlers.SessionLocal = TestSession
-    monkeypatch.setenv("PUBLIC_ORIGIN", "", raising=False)
-    monkeypatch.setenv("UI_BASE_URL", "", raising=False)
+    monkeypatch.setenv("PUBLIC_ORIGIN", "")
+    monkeypatch.setenv("UI_BASE_URL", "")
     import services.api.app.config as config
 
     importlib.reload(config)
+    importlib.reload(handlers)
+    handlers.SessionLocal = TestSession
     settings = config.get_settings()
     monkeypatch.setattr(settings, "public_origin", "")
     with TestSession() as session:
@@ -366,12 +369,13 @@ def test_render_reminders_no_entries_webapp(monkeypatch: pytest.MonkeyPatch) -> 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    handlers.SessionLocal = TestSession
     monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.org")
     monkeypatch.setenv("UI_BASE_URL", "/ui")
     import services.api.app.config as config
 
     importlib.reload(config)
+    importlib.reload(handlers)
+    handlers.SessionLocal = TestSession
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
         session.commit()

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -7,8 +7,8 @@ import services.api.app.diabetes.utils.ui as ui
 
 def test_timezone_button_webapp_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     """Should not build button when PUBLIC_ORIGIN and UI_BASE_URL are unset."""
-    monkeypatch.setenv("PUBLIC_ORIGIN", "", raising=False)
-    monkeypatch.setenv("UI_BASE_URL", "", raising=False)
+    monkeypatch.setenv("PUBLIC_ORIGIN", "")
+    monkeypatch.setenv("UI_BASE_URL", "")
     config.reload_settings()
 
     assert ui.build_timezone_webapp_button() is None


### PR DESCRIPTION
## Summary
- reload reminder handler module when tests change environment settings
- update tests to use MonkeyPatch.setenv without deprecated `raising`
- simplify gpt client service test setup

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b04ca370c4832aad4476070a71d758