### PR TITLE
[profile] Update profile help for WebApp

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -55,7 +55,10 @@ from services.api.app.diabetes.utils.ui import (  # noqa: E402
     back_keyboard as _back_keyboard,
     menu_keyboard,
 )
-from services.api.app.diabetes.services.repository import CommitError, commit  # noqa: E402
+from services.api.app.diabetes.services.repository import (  # noqa: E402
+    CommitError,
+    commit,
+)
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers  # noqa: E402
 
 from .api import (  # noqa: E402
@@ -79,7 +82,9 @@ MSG_LOW_GT0 = "Нижний порог должен быть больше 0."
 MSG_HIGH_GT_LOW = "Верхний порог должен быть больше нижнего и больше 0."
 
 
-PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(6)
+PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(
+    6
+)
 END: int = ConversationHandler.END
 
 
@@ -108,9 +113,21 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         if callable(end_conv):
             end_conv(update, context, END)
         else:
-            chat_id = getattr(update.effective_chat, "id", None) if sugar_conv.per_chat else None
-            user_id = getattr(update.effective_user, "id", None) if sugar_conv.per_user else None
-            msg_id = getattr(update.effective_message, "message_id", None) if sugar_conv.per_message else None
+            chat_id = (
+                getattr(update.effective_chat, "id", None)
+                if sugar_conv.per_chat
+                else None
+            )
+            user_id = (
+                getattr(update.effective_user, "id", None)
+                if sugar_conv.per_user
+                else None
+            )
+            msg_id = (
+                getattr(update.effective_message, "message_id", None)
+                if sugar_conv.per_message
+                else None
+            )
             key = cast(
                 tuple[int | str, ...],
                 tuple(i for i in (chat_id, user_id, msg_id) if i is not None),
@@ -121,10 +138,8 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 logger.warning("sugar_conv lacks _update_state method")
 
     help_text = (
-        "❗ Формат команды:\n"
-        "/profile <ИКХ г/ед.> <КЧ ммоль/л> <целевой ммоль/л> <низкий ммоль/л> <высокий ммоль/л>\n"
-        "или /profile icr=<ИКХ> cf=<КЧ> target=<целевой> low=<низкий> high=<высокий>\n"
-        "Пример: /profile 10 2 6 4 9 — ИКХ 10 г/ед., КЧ 2 ммоль/л, целевой 6 ммоль/л, низкий 4 ммоль/л, высокий 9 ммоль/л"
+        "Настройки профиля доступны в приложении. "
+        "Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
     )
 
     if len(args) == 1 and args[0].lower() == "help":
@@ -147,7 +162,9 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         low = float(values["low"].replace(",", "."))
         high = float(values["high"].replace(",", "."))
     except ValueError:
-        await message.reply_text("❗ Пожалуйста, введите корректные числа. Справка: /profile help")
+        await message.reply_text(
+            "❗ Пожалуйста, введите корректные числа. Справка: /profile help"
+        )
         return END
 
     if icr <= 0:
@@ -223,10 +240,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if settings.public_origin:
         webapp_button = [
             InlineKeyboardButton(
-
-
                 "🌐 Открыть профиль в WebApp",
-
                 web_app=WebAppInfo(config.build_ui_url("/profile")),
             )
         ]
@@ -234,13 +248,10 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if not profile:
         text = (
             "Ваш профиль пока не настроен.\n\n"
-            "Чтобы настроить профиль, введите команду:\n"
-            "/profile <ИКХ г/ед.> <КЧ ммоль/л> <целевой ммоль/л> <низкий ммоль/л> <высокий ммоль/л>\n"
-            "или /profile icr=<ИКХ> cf=<КЧ> target=<целевой> low=<низкий> high=<высокий>\n"
-            "Пример: /profile 10 2 6 4 9 — ИКХ 10 г/ед., КЧ 2 ммоль/л, целевой 6 ммоль/л, "
-            "низкий 4 ммоль/л, высокий 9 ммоль/л"
+            "Настройки профиля доступны в приложении."
         )
         if webapp_button is not None:
+            text += " Нажмите кнопку ниже, чтобы открыть и обновить данные."
             keyboard = InlineKeyboardMarkup([webapp_button])
             await message.reply_text(text, parse_mode="Markdown", reply_markup=keyboard)
         else:
@@ -371,11 +382,15 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     button = build_timezone_webapp_button()
     if button:
         keyboard = InlineKeyboardMarkup([[button]])
-        await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
+        await message.reply_text(
+            "Можно определить автоматически:", reply_markup=keyboard
+        )
     return PROFILE_TZ
 
 
-async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def profile_timezone_save(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     """Save user timezone from input."""
     message = update.message
     if message is None:
@@ -400,7 +415,9 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
         button = build_timezone_webapp_button()
         if button:
             keyboard = InlineKeyboardMarkup([[button]])
-            await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
+            await message.reply_text(
+                "Можно определить автоматически:", reply_markup=keyboard
+            )
         return PROFILE_TZ
     user = update.effective_user
     if user is None:
@@ -428,7 +445,9 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
     return END
 
 
-def _security_db(session: Session, user_id: int, action: str | None) -> dict[str, object]:
+def _security_db(
+    session: Session, user_id: int, action: str | None
+) -> dict[str, object]:
     profile = session.get(Profile, user_id)
     user = session.get(User, user_id)
     if not profile:
@@ -462,13 +481,22 @@ def _security_db(session: Session, user_id: int, action: str | None) -> dict[str
     if changed:
         try:
             commit(session)
-            alert = session.query(Alert).filter_by(user_id=user_id).order_by(Alert.ts.desc()).first()
+            alert = (
+                session.query(Alert)
+                .filter_by(user_id=user_id)
+                .order_by(Alert.ts.desc())
+                .first()
+            )
             alert_sugar = alert.sugar if alert else None
         except CommitError:
             commit_ok = False
 
     rems = session.query(Reminder).filter_by(telegram_id=user_id).all()
-    rem_text = "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems) if rems else "нет"
+    rem_text = (
+        "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems)
+        if rems
+        else "нет"
+    )
     return {
         "found": True,
         "commit_ok": commit_ok,
@@ -552,12 +580,20 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton("Низкий -0.5", callback_data="profile_security:low_dec"),
-                InlineKeyboardButton("Низкий +0.5", callback_data="profile_security:low_inc"),
+                InlineKeyboardButton(
+                    "Низкий -0.5", callback_data="profile_security:low_dec"
+                ),
+                InlineKeyboardButton(
+                    "Низкий +0.5", callback_data="profile_security:low_inc"
+                ),
             ],
             [
-                InlineKeyboardButton("Высокий -0.5", callback_data="profile_security:high_dec"),
-                InlineKeyboardButton("Высокий +0.5", callback_data="profile_security:high_inc"),
+                InlineKeyboardButton(
+                    "Высокий -0.5", callback_data="profile_security:high_dec"
+                ),
+                InlineKeyboardButton(
+                    "Высокий +0.5", callback_data="profile_security:high_inc"
+                ),
             ],
             [
                 InlineKeyboardButton(
@@ -565,9 +601,15 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     callback_data="profile_security:toggle_sos",
                 )
             ],
-            [InlineKeyboardButton("SOS контакт", callback_data="profile_security:sos_contact")],
             [
-                InlineKeyboardButton("➕ Добавить", callback_data="profile_security:add"),
+                InlineKeyboardButton(
+                    "SOS контакт", callback_data="profile_security:sos_contact"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    "➕ Добавить", callback_data="profile_security:add"
+                ),
                 InlineKeyboardButton("🗑 Удалить", callback_data="profile_security:del"),
             ],
             [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
@@ -682,7 +724,9 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     try:
         target = float(text)
     except ValueError:
-        await message.reply_text("Введите целевой сахар числом.", reply_markup=back_keyboard)
+        await message.reply_text(
+            "Введите целевой сахар числом.", reply_markup=back_keyboard
+        )
         return PROFILE_TARGET
     if target <= 0:
         await message.reply_text(MSG_TARGET_GT0, reply_markup=back_keyboard)
@@ -718,7 +762,9 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     try:
         low = float(text)
     except ValueError:
-        await message.reply_text("Введите нижний порог числом.", reply_markup=back_keyboard)
+        await message.reply_text(
+            "Введите нижний порог числом.", reply_markup=back_keyboard
+        )
         return PROFILE_LOW
     if low <= 0:
         await message.reply_text(MSG_LOW_GT0, reply_markup=back_keyboard)
@@ -754,7 +800,9 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     try:
         high = float(text)
     except ValueError:
-        await message.reply_text("Введите верхний порог числом.", reply_markup=back_keyboard)
+        await message.reply_text(
+            "Введите верхний порог числом.", reply_markup=back_keyboard
+        )
         return PROFILE_HIGH
     low = user_data.get("profile_low")
     if high <= 0 or low is None or high <= low:
@@ -768,7 +816,9 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     target = user_data.pop("profile_target", None)
     user_data.pop("profile_low", None)
     if icr is None or cf is None or target is None:
-        await message.reply_text("⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново.")
+        await message.reply_text(
+            "⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново."
+        )
         return END
     user = update.effective_user
     if user is None:
@@ -831,11 +881,15 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return END
 
 
-async def _profile_edit_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def _profile_edit_entry(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     return await profile_edit(update, context)
 
 
-async def _profile_timezone_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def _profile_timezone_entry(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     return await profile_timezone(update, context)
 
 
@@ -843,12 +897,16 @@ profile_conv = ConversationHandler(
     entry_points=[
         CommandHandler("profile", profile_command),
         CallbackQueryNoWarnHandler(_profile_edit_entry, pattern="^profile_edit$"),
-        CallbackQueryNoWarnHandler(_profile_timezone_entry, pattern="^profile_timezone$"),
+        CallbackQueryNoWarnHandler(
+            _profile_timezone_entry, pattern="^profile_timezone$"
+        ),
     ],
     states={
         PROFILE_ICR: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_icr)],
         PROFILE_CF: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_cf)],
-        PROFILE_TARGET: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)],
+        PROFILE_TARGET: [
+            MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)
+        ],
         PROFILE_LOW: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_low)],
         PROFILE_HIGH: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_high)],
         PROFILE_TZ: [
@@ -870,7 +928,9 @@ profile_conv = ConversationHandler(
 )
 
 
-profile_webapp_handler = MessageHandler(filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save)
+profile_webapp_handler = MessageHandler(
+    filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save
+)
 
 
 __all__ = [

--- a/tests/services/test_gpt_client_service.py
+++ b/tests/services/test_gpt_client_service.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 from openai import OpenAIError
 
-from services.api.app.config import Settings, settings
+from services.api.app.config import settings
 from services.api.app.diabetes.services import gpt_client
 
 

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -87,7 +87,9 @@ async def test_profile_command_and_view(
         session.commit()
 
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=123)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=123))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=args, user_data={}),
@@ -144,7 +146,9 @@ async def test_profile_command_and_view(
     ],
 )
 @pytest.mark.asyncio
-async def test_profile_command_invalid_values(monkeypatch: pytest.MonkeyPatch, args: Any, expected_attr: str) -> None:
+async def test_profile_command_invalid_values(
+    monkeypatch: pytest.MonkeyPatch, args: Any, expected_attr: str
+) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
@@ -158,7 +162,9 @@ async def test_profile_command_invalid_values(monkeypatch: pytest.MonkeyPatch, a
     monkeypatch.setattr(handlers, "post_profile", post_profile_mock)
 
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=args, user_data={}),
@@ -181,18 +187,22 @@ async def test_profile_command_help(monkeypatch: pytest.MonkeyPatch) -> None:
     from services.api.app.diabetes.handlers import profile as handlers
 
     help_msg = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=help_msg, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=help_msg, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=["help"], user_data={}),
     )
     result = await handlers.profile_command(update, context)
     assert result == handlers.END
-    assert "Формат команды" in help_msg.texts[0]
+    assert "Настройки профиля доступны" in help_msg.texts[0]
 
 
 @pytest.mark.asyncio
-async def test_profile_command_view_existing_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_profile_command_view_existing_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
@@ -210,7 +220,9 @@ async def test_profile_command_view_existing_profile(monkeypatch: pytest.MonkeyP
         session.commit()
 
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(args=[], user_data={}),
@@ -251,7 +263,9 @@ async def test_profile_view_preserves_user_data(
         session.commit()
 
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"thread_id": "tid", "foo": "bar"}),
@@ -282,7 +296,9 @@ async def test_profile_view_missing_profile_shows_webapp_button(
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: None)
 
     msg = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
@@ -317,7 +333,9 @@ async def test_profile_view_existing_profile_shows_webapp_button(
     monkeypatch.setattr(handlers, "fetch_profile", lambda api, exc, user_id: profile)
 
     msg = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),

--- a/tests/test_profile_conversation_help.py
+++ b/tests/test_profile_conversation_help.py
@@ -30,5 +30,4 @@ async def test_profile_command_help(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(conv, "get_api", lambda: (None, Exception, object))
     result = await conv.profile_command(update, context)
     assert result == conv.END
-    assert message.texts and "Формат команды" in message.texts[0]
-
+    assert message.texts and "Настройки профиля доступны" in message.texts[0]


### PR DESCRIPTION
## Summary
- mention in `/profile` help that editing now happens via the WebApp
- show WebApp prompt instead of legacy commands when profile is missing
- adjust tests and remove unused import for lint

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b05d575cac832aba31b449ae9ed044