### PR TITLE
[webapp] Use Telegram fallback id for reminders

### DIFF
--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -37,8 +37,11 @@ const KIND_OPTIONS: { value: ScheduleKind; label: string }[] = [
 export default function RemindersCreate() {
   const api = useRemindersApi();
   const initData = useTelegramInitData();
-  const { sendData } = useTelegram();
-  const telegramId = useMemo(() => getTelegramUserId(initData), [initData]);
+  const { sendData, user } = useTelegram();
+  const telegramId = useMemo(
+    () => getTelegramUserId(initData) || user?.id || 0,
+    [initData, user],
+  );
   const nav = useNavigate();
   const toast = useToast();
 

--- a/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
@@ -62,11 +62,14 @@ function mapToForm(reminder: ReminderSchema): ReminderFormValues {
 export default function RemindersEdit() {
   const api = useRemindersApi();
   const initData = useTelegramInitData();
-  const telegramId = useMemo(() => getTelegramUserId(initData), [initData]);
+  const { sendData, user } = useTelegram();
+  const telegramId = useMemo(
+    () => getTelegramUserId(initData) || user?.id || 0,
+    [initData, user],
+  );
   const { id } = useParams<{ id: string }>();
   const nav = useNavigate();
   const toast = useToast();
-  const { sendData } = useTelegram();
 
   const [form, setForm] = useState<ReminderFormValues | null>(null);
   const [saving, setSaving] = useState(false);

--- a/tests/services/test_gpt_client_service.py
+++ b/tests/services/test_gpt_client_service.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 from openai import OpenAIError
 
-from services.api.app.config import Settings, settings
+from services.api.app.config import settings
 from services.api.app.diabetes.services import gpt_client
 
 


### PR DESCRIPTION
## Summary
- use Telegram user id fallback when creating and editing reminders
- tidy test gpt client import to satisfy ruff

## Testing
- `pnpm exec vitest run ../../../tests/useTelegram.test.ts --root ../../..` (fails: Failed to resolve import "@testing-library/react")
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b05de79100832abf85e0a0d9a09b72