### PR TITLE
[webapp] Use ProfilesApi for profile saving

### DIFF
--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,10 +1,10 @@
-import { DefaultApi, Profile } from '@sdk';
+import { ProfilesApi, ProfileSchema } from '@sdk';
 
-const api = new DefaultApi({ basePath: '/api' });
+const api = new ProfilesApi({ basePath: '/api' });
 
-export async function saveProfile(profile: Profile) {
+export async function saveProfile(profile: ProfileSchema) {
   try {
-    return await api.profilesPost({ profile });
+    return await api.profilesPost({ profileSchema: profile });
   } catch (error) {
     console.error('Failed to save profile:', error);
     if (error instanceof Error) {


### PR DESCRIPTION
## Summary
- replace deprecated DefaultApi usage with ProfilesApi and ProfileSchema
- adjust saveProfile to submit `profileSchema` payload

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test` *(fails: No test files found)*
- `pnpm --filter ./services/webapp/ui lint` *(fails: lint errors in unrelated files)*
- `pnpm --filter ./services/webapp/ui typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b065a27e1c832abb14ee93cfdcd17b