### PR TITLE
[services] Guard GPT client when assistant id missing

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -123,18 +123,20 @@ async def send_message(
     """
     if content is None and image_path is None:
         raise ValueError("Either 'content' or 'image_path' must be provided")
+
     settings = config.get_settings()
     if not settings.openai_assistant_id:
         message = "OPENAI_ASSISTANT_ID is not set"
         logger.error("[OpenAI] %s", message)
         raise RuntimeError(message)
 
+    client: OpenAI = _get_client()
+
     # 1. Подготовка контента
     text_block: TextContentBlockParam = {
         "type": "text",
         "text": content if content is not None else "Что изображено на фото?",
     }
-    client: OpenAI = _get_client()
     message_content: Iterable[
         ImageFileContentBlockParam | ImageURLContentBlockParam | TextContentBlockParam
     ]
@@ -195,6 +197,6 @@ async def send_message(
         message = "Run creation returned None"
         logger.error("[OpenAI] %s", message)
         raise RuntimeError(message)
-
-    logger.debug("[OpenAI] Run %s started (thread %s)", run.id, thread_id)
-    return run
+    else:
+        logger.debug("[OpenAI] Run %s started (thread %s)", run.id, thread_id)
+        return run

--- a/tests/services/test_gpt_client_service.py
+++ b/tests/services/test_gpt_client_service.py
@@ -63,11 +63,14 @@ async def test_send_message_run_none(
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
     monkeypatch.setattr(settings, "openai_assistant_id", "asst")
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.DEBUG):
         with pytest.raises(RuntimeError):
             await gpt_client.send_message(thread_id="t", content="hi")
 
     assert any("Run creation returned None" in r.message for r in caplog.records)
+    assert not any(
+        r.levelno == logging.DEBUG and "Run" in r.message for r in caplog.records
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fail fast if `OPENAI_ASSISTANT_ID` is unset before any OpenAI API calls
- Log run identifier only after run creation succeeds
- Test missing assistant id and run-None path for safe logging

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b06833bef4832a9748c97a5bce1877