### PR TITLE
[handlers] use HistoryRecord in reporting

### DIFF
--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -11,7 +11,7 @@ from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import Session, sessionmaker
 
 os.environ.setdefault("DB_PASSWORD", "test")
-from services.api.app.diabetes.services.db import Base, User, Entry
+from services.api.app.diabetes.services.db import Base, User, HistoryRecord, Entry
 from services.api.app.diabetes.handlers import UserData
 import services.api.app.diabetes.handlers.gpt_handlers as gpt_handlers
 
@@ -83,22 +83,24 @@ async def test_history_view_buttons(monkeypatch: pytest.MonkeyPatch) -> None:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add_all(
             [
-                Entry(
+                HistoryRecord(
+                    id="1",
                     telegram_id=1,
-                    event_time=datetime.datetime(
-                        2024, 1, 1, tzinfo=datetime.timezone.utc
-                    ),
+                    date=datetime.date(2024, 1, 1),
+                    time=datetime.time(0, 0),
+                    type="meal",
                 ),
-                Entry(
+                HistoryRecord(
+                    id="2",
                     telegram_id=1,
-                    event_time=datetime.datetime(
-                        2024, 1, 2, tzinfo=datetime.timezone.utc
-                    ),
+                    date=datetime.date(2024, 1, 2),
+                    time=datetime.time(0, 0),
+                    type="meal",
                 ),
             ]
         )
         session.commit()
-        entry_ids = [e.id for e in session.query(Entry).all()]
+        entry_ids = [e.id for e in session.query(HistoryRecord).all()]
 
     message = DummyMessage()
     update = cast(
@@ -169,9 +171,12 @@ async def test_history_view_webapp_button(
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(
-            Entry(
+            HistoryRecord(
+                id="1",
                 telegram_id=1,
-                event_time=datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+                date=datetime.date(2024, 1, 1),
+                time=datetime.time(0, 0),
+                type="meal",
             )
         )
         session.commit()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -223,7 +223,7 @@ async def test_send_report_uses_gpt(monkeypatch: pytest.MonkeyPatch) -> None:
     os.environ.setdefault("DB_PASSWORD", "pwd")
 
     import services.api.app.diabetes.handlers.reporting_handlers as handlers
-    from services.api.app.diabetes.services.db import Base, Entry, User
+    from services.api.app.diabetes.services.db import Base, HistoryRecord, User
 
     engine = create_engine(
         "sqlite:///:memory:",
@@ -237,12 +237,15 @@ async def test_send_report_uses_gpt(monkeypatch: pytest.MonkeyPatch) -> None:
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="tid"))
         session.add(
-            Entry(
+            HistoryRecord(
+                id="1",
                 telegram_id=1,
-                event_time=datetime.datetime(2025, 7, 1, tzinfo=datetime.timezone.utc),
-                sugar_before=6.0,
-                carbs_g=30.0,
-                dose=5.0,
+                date=datetime.date(2025, 7, 1),
+                time=datetime.time(9, 0),
+                sugar=6.0,
+                carbs=30.0,
+                insulin=5.0,
+                type="meal",
             )
         )
         session.commit()


### PR DESCRIPTION
## Summary
- Fetch latest history records for diary view using `HistoryRecord` and adapt them for existing rendering
- Use same record adapter in report generation
- Update tests to seed and expect `HistoryRecord`

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b067e13310832aaf70897388f5fb3d