### PR TITLE
[bot] Add emojis to command menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Fixed missing role in AuthMiddleware causing 403 on authorized `/api/reminders` requests.
 - Changed `/api/reminders`: returns `200` with an empty list instead of `404` when no reminders exist.
 - Changed `/api/stats`: now returns default stats (or `204`) instead of `404` when no data is available.
+- Enhanced bot command menu with emojis for easier navigation.

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -21,15 +21,15 @@ logger = logging.getLogger(__name__)
 TELEGRAM_TOKEN = settings.telegram_token
 
 commands = [
-    BotCommand("start", "Запустить бота"),
-    BotCommand("menu", "Главное меню"),
-    BotCommand("profile", "Мой профиль"),
-    BotCommand("report", "Отчёт"),
-    BotCommand("history", "История записей"),
-    BotCommand("sugar", "Расчёт сахара"),
-    BotCommand("gpt", "Чат с GPT"),
-    BotCommand("reminders", "Список напоминаний"),
-    BotCommand("help", "Справка"),
+    BotCommand("start", "🚀 Запустить бота"),
+    BotCommand("menu", "📋 Главное меню"),
+    BotCommand("profile", "👤 Мой профиль"),
+    BotCommand("report", "📊 Отчёт"),
+    BotCommand("history", "📚 История записей"),
+    BotCommand("sugar", "🩸 Расчёт сахара"),
+    BotCommand("gpt", "🤖 Чат с GPT"),
+    BotCommand("reminders", "⏰ Список напоминаний"),
+    BotCommand("help", "❓ Справка"),
 ]
 
 

--- a/tests/test_bot_commands_emoji.py
+++ b/tests/test_bot_commands_emoji.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import services.bot.main as main
+
+
+def test_commands_include_emojis() -> None:
+    """Command descriptions include emojis for better UX."""
+    expected = [
+        ("start", "🚀 Запустить бота"),
+        ("menu", "📋 Главное меню"),
+        ("profile", "👤 Мой профиль"),
+        ("report", "📊 Отчёт"),
+        ("history", "📚 История записей"),
+        ("sugar", "🩸 Расчёт сахара"),
+        ("gpt", "🤖 Чат с GPT"),
+        ("reminders", "⏰ Список напоминаний"),
+        ("help", "❓ Справка"),
+    ]
+    assert [(c.command, c.description) for c in main.commands] == expected


### PR DESCRIPTION
## Summary
- add emojis to Telegram command descriptions for a friendlier menu
- document menu enhancement in changelog
- test that all commands include emojis

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b06ad0f1a4832a833f2a91aa8f902f