### PR TITLE
webapp: guard mock API usage by environment

### DIFF
--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -44,6 +44,7 @@ export default function RemindersCreate() {
   );
   const nav = useNavigate();
   const toast = useToast();
+  const isDev = process.env.NODE_ENV === "development";
 
   const [form, setForm] = useState<ReminderFormValues>({
     telegramId,
@@ -81,10 +82,14 @@ export default function RemindersCreate() {
         const res = await api.remindersPost({ reminder });
         rid = res?.id;
       } catch (apiError) {
-        console.warn("Backend API failed, using mock API:", apiError);
-        // Fallback на mock API
-        const res = await mockApi.createReminder(reminder);
-        rid = (res as any)?.id;
+        if (isDev) {
+          console.warn("Backend API failed, using mock API:", apiError);
+          // Fallback на mock API
+          const res = await mockApi.createReminder(reminder);
+          rid = (res as any)?.id;
+        } else {
+          throw apiError;
+        }
       }
 
       if (rid) {

--- a/services/webapp/ui/tests/mockApi.test.tsx
+++ b/services/webapp/ui/tests/mockApi.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const remindersGet = vi.fn();
+const remindersPost = vi.fn();
+const mockGetReminders = vi.fn();
+const mockCreateReminder = vi.fn();
+const toast = vi.fn();
+const toastError = vi.fn();
+
+vi.mock('../src/features/reminders/api/reminders', () => ({
+  useRemindersApi: () => ({ remindersGet, remindersPost })
+}));
+vi.mock('../src/hooks/use-toast', () => ({
+  useToast: () => ({ toast })
+}));
+vi.mock('../src/hooks/useTelegram', () => ({
+  useTelegram: () => ({ user: { id: 1 }, sendData: vi.fn() })
+}));
+vi.mock('../src/hooks/useTelegramInitData', () => ({
+  useTelegramInitData: () => ({})
+}));
+vi.mock('../src/shared/toast', () => ({
+  useToast: () => ({ success: vi.fn(), error: toastError })
+}));
+vi.mock('../src/api/mock-server', () => ({
+  mockApi: { getReminders: mockGetReminders, createReminder: mockCreateReminder }
+}));
+vi.mock('../src/features/reminders/api/buildPayload', () => ({
+  buildReminderPayload: (x: any) => x
+}));
+vi.mock('../src/features/reminders/logic/validate', () => ({
+  validate: () => ({}),
+  hasErrors: () => false
+}));
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn()
+}));
+vi.mock('../src/features/reminders/hooks/usePlan', () => ({
+  getPlanLimit: () => Promise.resolve(5)
+}));
+
+describe('mockApi not used in production', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    remindersGet.mockReset();
+    remindersPost.mockReset();
+    mockGetReminders.mockReset();
+    mockCreateReminder.mockReset();
+    toast.mockReset();
+    toastError.mockReset();
+  });
+
+  it('RemindersList uses toast and not mockApi in production', async () => {
+    remindersGet.mockRejectedValue(new Error('fail'));
+    const { default: RemindersList } = await import('../src/features/reminders/pages/RemindersList');
+    vi.stubEnv('NODE_ENV', 'production');
+    render(<RemindersList planLimit={5} />);
+    await waitFor(() => {
+      expect(remindersGet).toHaveBeenCalled();
+    });
+    expect(mockGetReminders).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalled();
+  });
+
+  it('RemindersCreate uses toast and not mockApi in production', async () => {
+    remindersPost.mockRejectedValue(new Error('fail'));
+    const { default: RemindersCreate } = await import('../src/features/reminders/pages/RemindersCreate');
+    vi.stubEnv('NODE_ENV', 'production');
+    const { container } = render(<RemindersCreate />);
+    const form = container.querySelector('form')!;
+    fireEvent.submit(form);
+    await waitFor(() => {
+      expect(remindersPost).toHaveBeenCalled();
+    });
+    expect(mockCreateReminder).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Guard mock API calls behind development-only checks in reminder pages
- Notify on API failures in production instead of using mock server
- Add tests ensuring mock API stays unused in production mode

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b0710a1718832aa48c2777c8c3dcf1