### PR TITLE
[webapp] use Configuration for ProfilesApi

### DIFF
--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,6 +1,11 @@
-import { ProfilesApi, ProfileSchema } from '@sdk';
+import { Configuration, ProfilesApi, ProfileSchema } from '@sdk';
 
-const api = new ProfilesApi({ basePath: '/api' });
+const api = new ProfilesApi(
+  new Configuration({
+    basePath: '/api',
+    // apiKey: localStorage.getItem('token') ?? undefined,
+  }),
+);
 
 export async function saveProfile(profile: ProfileSchema) {
   try {


### PR DESCRIPTION
## Summary
- use `Configuration` when instantiating `ProfilesApi`
- prepare for auth headers via the configuration object

## Testing
- `pytest -q --cov` *(fails: async plugin missing, coverage 50 < 85)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b073d46c8c832aadf56171ec1a3abc