### PR TITLE
[tests] ensure history view test resets public origin

### DIFF
--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -62,6 +62,7 @@ async def test_history_view_buttons(monkeypatch: pytest.MonkeyPatch) -> None:
     import services.api.app.diabetes.handlers.reporting_handlers as reporting_handlers
     import services.api.app.diabetes.handlers.router as router
     import services.api.app.diabetes.handlers.dose_calc as dose_calc
+    import services.api.app.config as config
 
     engine = create_engine(
         "sqlite:///:memory:",
@@ -74,6 +75,7 @@ async def test_history_view_buttons(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(reporting_handlers, "SessionLocal", TestSession)
     monkeypatch.setattr(router, "SessionLocal", TestSession)
     monkeypatch.setattr(dose_calc, "SessionLocal", TestSession)
+    monkeypatch.setattr(config.settings, "public_origin", "")
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))


### PR DESCRIPTION
## Summary
- fix history view buttons test to avoid leftover public_origin settings

## Testing
- `pytest -q`
- `mypy --strict tests/test_handlers_history_edit.py`
- `ruff check tests/test_handlers_history_edit.py`


------
https://chatgpt.com/codex/tasks/task_e_68b077811bd0832a960db56b9174fc0a