### PR TITLE
[onboarding][profile] Prompt for manual timezone when webapp unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ sudo apt install python3.12 python3.12-venv
 
 - обязательные значения: `TELEGRAM_TOKEN` (токен бота), `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
 - дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `VITE_API_URL`, `VITE_BASE_URL`, `UVICORN_WORKERS`
+- для появления кнопки «Определить автоматически» при выборе часового пояса нужно задать `PUBLIC_ORIGIN`
 - при необходимости настройте прокси для OpenAI через переменные окружения
 Переменная `VITE_API_URL` задаёт базовый URL API для WebApp и используется SDK‑клиентом.
 Пустое значение означает использование префикса `/api`.

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -385,6 +385,11 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         await message.reply_text(
             "Можно определить автоматически:", reply_markup=keyboard
         )
+    else:
+        await message.reply_text(
+            "Автоматическое определение недоступно, укажите часовой пояс вручную.",
+            reply_markup=back_keyboard,
+        )
     return PROFILE_TZ
 
 
@@ -417,6 +422,11 @@ async def profile_timezone_save(
             keyboard = InlineKeyboardMarkup([[button]])
             await message.reply_text(
                 "Можно определить автоматически:", reply_markup=keyboard
+            )
+        else:
+            await message.reply_text(
+                "Автоматическое определение недоступно, введите часовой пояс вручную.",
+                reply_markup=back_keyboard,
             )
         return PROFILE_TZ
     user = update.effective_user

--- a/tests/test_profile_conversation.py
+++ b/tests/test_profile_conversation.py
@@ -29,7 +29,7 @@ class DummyMessage:
 
 @pytest.mark.asyncio
 async def test_profile_timezone_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(handlers, "build_timezone_webapp_button", lambda: None)
+    monkeypatch.setenv("PUBLIC_ORIGIN", "")
     message = DummyMessage()
     query = SimpleNamespace(message=message, answer=AsyncMock())
     update = cast(Update, SimpleNamespace(callback_query=query))
@@ -40,6 +40,7 @@ async def test_profile_timezone_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
     state = await handlers.profile_timezone(update, context)
     assert state == handlers.PROFILE_TZ
     assert "Введите ваш часовой пояс" in message.replies[0]
+    assert any("вручную" in r.lower() for r in message.replies)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- show manual timezone instructions when PUBLIC_ORIGIN is unset
- document PUBLIC_ORIGIN requirement for "Определить автоматически" button
- test manual timezone prompt when webapp button is missing

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b07771dd68832a8617bca493df9a15