### PR TITLE
[webapp] validate telegram id before profile save

### DIFF
--- a/services/webapp/ui/src/hooks/useTelegram.ts
+++ b/services/webapp/ui/src/hooks/useTelegram.ts
@@ -192,7 +192,11 @@ export const useTelegram = (
           } catch (e) {
             console.error("[TG] failed to parse dev user:", e);
           }
+        } else {
+          console.warn("[TG] initData does not contain user field");
         }
+      } else {
+        console.warn("[TG] no initData found in localStorage or env");
       }
 
       // If no user from initData, create fallback test user

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -6,11 +6,13 @@ import { useToast } from "@/hooks/use-toast";
 import MedicalButton from "@/components/MedicalButton";
 import { saveProfile } from "@/api/profile";
 import { useTelegram } from "@/hooks/useTelegram";
+import { useTelegramInitData } from "@/hooks/useTelegramInitData";
 
 const Profile = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
-  const { user, initData } = useTelegram();
+  const { user } = useTelegram();
+  const initData = useTelegramInitData();
 
   const [profile, setProfile] = useState({
     icr: "12",
@@ -27,8 +29,16 @@ const Profile = () => {
   const handleSave = async () => {
     let telegramId = user?.id;
     if (!telegramId) {
-      const userStr = new URLSearchParams(initData ?? "").get("user");
-      telegramId = userStr ? JSON.parse(userStr).id : undefined;
+      const userStr = new URLSearchParams(initData || "").get("user");
+      if (userStr) {
+        try {
+          telegramId = JSON.parse(userStr).id;
+        } catch (e) {
+          console.error("[Profile] failed to parse initData user:", e);
+        }
+      } else {
+        console.warn("[Profile] no user field in initData");
+      }
     }
 
     if (!telegramId) {

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+const toast = vi.fn();
+
+vi.mock('../src/api/profile', () => ({
+  saveProfile: vi.fn(),
+}));
+
+vi.mock('../src/hooks/use-toast', () => ({
+  useToast: () => ({ toast }),
+}));
+
+vi.mock('../src/hooks/useTelegram', () => ({
+  useTelegram: () => ({ user: null }),
+}));
+
+vi.mock('../src/hooks/useTelegramInitData', () => ({
+  useTelegramInitData: () => '',
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+import Profile from '../src/pages/Profile';
+import { saveProfile } from '../src/api/profile';
+
+describe('Profile page', () => {
+  it('blocks save without telegramId and shows toast', () => {
+    const { getByText } = render(<Profile />);
+    fireEvent.click(getByText('Сохранить настройки'));
+    expect(saveProfile).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Ошибка',
+        description: 'Не удалось определить пользователя',
+        variant: 'destructive',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- guard profile save when telegram ID is missing, using initData fallback
- log missing or malformed initData in useTelegram
- add test for missing telegram ID handling

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any, other lint errors)*
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q tests/test_telegram_auth.py` *(fails: Required test coverage of 85% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68b082b696c8832aa460f77d53a4984a