### PR TITLE
[profile] surface profile validation errors

### DIFF
--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -46,7 +46,10 @@ def _validate_profile(data: ProfileSchema) -> None:
 
 
 async def save_profile(data: ProfileSchema) -> None:
-    _validate_profile(data)
+    try:
+        _validate_profile(data)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
 
     def _save(session: SessionProtocol) -> None:
         user = cast(User | None, session.get(User, data.telegramId))

--- a/tests/test_profiles_api.py
+++ b/tests/test_profiles_api.py
@@ -44,3 +44,30 @@ def test_profiles_post_creates_user_for_missing_telegram_id(
         resp = client.post("/api/profiles", json=payload)
     assert resp.status_code == 200
     engine.dispose()
+
+
+def test_profiles_post_invalid_values_returns_422(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    payload = {
+        "telegramId": 777,
+        "icr": 1.0,
+        "cf": 1.0,
+        "target": 5.0,
+        "low": 6.0,
+        "high": 5.0,
+    }
+    with TestClient(app) as client:
+        resp = client.post("/api/profiles", json=payload)
+    assert resp.status_code == 422
+    engine.dispose()


### PR DESCRIPTION
## Summary
- return 422 with details when profile validation fails
- add regression test for invalid profile values

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*


------
https://chatgpt.com/codex/tasks/task_e_68b082b6b344832a8dbc8bf81b9537f1