### PR TITLE
[webapp] validate telegram id type in profile

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -32,7 +32,8 @@ const Profile = () => {
       const userStr = new URLSearchParams(initData || "").get("user");
       if (userStr) {
         try {
-          telegramId = JSON.parse(userStr).id;
+          const parsed = JSON.parse(userStr);
+          telegramId = typeof parsed.id === "number" ? parsed.id : undefined;
         } catch (e) {
           console.error("[Profile] failed to parse initData user:", e);
         }
@@ -41,10 +42,10 @@ const Profile = () => {
       }
     }
 
-    if (!telegramId) {
+    if (typeof telegramId !== "number") {
       toast({
         title: "Ошибка",
-        description: "Не удалось определить пользователя",
+        description: "Некорректный ID пользователя",
         variant: "destructive",
       });
       return;


### PR DESCRIPTION
## Summary
- validate numeric user id parsed from initData
- guard profile save on invalid telegram id and test error case

## Testing
- `pnpm typecheck`
- `pnpm test`
- `pytest -q --cov` *(fails: async plugin required)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b087447c68832a9ced83e3075705ca