### PR TITLE
[services] refine profile validation

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -15,7 +15,10 @@ router.include_router(reminders_router)
 
 @router.post("/profiles", operation_id="profilesPost", tags=["profiles"])
 async def profiles_post(data: ProfileSchema) -> ProfileSchema:
-    await save_profile(data)
+    try:
+        await save_profile(data)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     return data
 
 

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -29,15 +29,18 @@ async def set_timezone(telegram_id: int, tz: str) -> None:  # pragma: no cover
 
 def _validate_profile(data: ProfileSchema) -> None:
     """Validate business rules for a patient profile."""
-    if (
-        data.icr <= 0
-        or data.cf <= 0
-        or data.target <= 0
-        or data.low <= 0
-        or data.high <= 0
-        or data.low >= data.high
-    ):
-        raise ValueError("invalid profile values")  # pragma: no cover
+    if data.icr <= 0:
+        raise ValueError("icr must be greater than 0")  # pragma: no cover
+    if data.cf <= 0:
+        raise ValueError("cf must be greater than 0")  # pragma: no cover
+    if data.target <= 0:
+        raise ValueError("target must be greater than 0")  # pragma: no cover
+    if data.low <= 0:
+        raise ValueError("low must be greater than 0")  # pragma: no cover
+    if data.high <= 0:
+        raise ValueError("high must be greater than 0")  # pragma: no cover
+    if data.low >= data.high:
+        raise ValueError("low must be less than high")  # pragma: no cover
 
     if not (data.low < data.target < data.high):
         raise ValueError("target must be between low and high")  # pragma: no cover
@@ -46,10 +49,7 @@ def _validate_profile(data: ProfileSchema) -> None:
 
 
 async def save_profile(data: ProfileSchema) -> None:
-    try:
-        _validate_profile(data)
-    except ValueError as e:
-        raise HTTPException(status_code=422, detail=str(e))
+    _validate_profile(data)
 
     def _save(session: SessionProtocol) -> None:
         user = cast(User | None, session.get(User, data.telegramId))

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -34,6 +34,37 @@ def test_validate_profile_rejects_target_outside_limits(target: Any) -> None:
     assert str(exc.value) == "target must be between low and high"
 
 
+@pytest.mark.parametrize(
+    "field,value,message",
+    [
+        ("icr", 0.0, "icr must be greater than 0"),
+        ("cf", 0.0, "cf must be greater than 0"),
+        ("target", 0.0, "target must be greater than 0"),
+        ("low", 0.0, "low must be greater than 0"),
+        ("high", 0.0, "high must be greater than 0"),
+        ("low_high", (5.0, 4.0), "low must be less than high"),
+    ],
+)
+def test_validate_profile_rejects_invalid_values(
+    field: str, value: Any, message: str
+) -> None:
+    kwargs = {
+        "telegramId": 1,
+        "icr": 1.0,
+        "cf": 1.0,
+        "target": 5.0,
+        "low": 4.0,
+        "high": 7.0,
+    }
+    if field == "low_high":
+        kwargs["low"], kwargs["high"] = value
+    else:
+        kwargs[field] = value
+    data = ProfileSchema(**kwargs)
+    with pytest.raises(ValueError) as exc:
+        _validate_profile(data)
+    assert str(exc.value) == message
+
 
 @pytest.mark.parametrize(
     "field,value",
@@ -51,4 +82,3 @@ def test_profile_rejects_malformed_quiet_times(field: str, value: str) -> None:
     kwargs[field] = value
     with pytest.raises(ValidationError):
         ProfileSchema(**kwargs)
-

--- a/tests/test_profiles_api.py
+++ b/tests/test_profiles_api.py
@@ -70,4 +70,5 @@ def test_profiles_post_invalid_values_returns_422(
     with TestClient(app) as client:
         resp = client.post("/api/profiles", json=payload)
     assert resp.status_code == 422
+    assert resp.json() == {"detail": "low must be less than high"}
     engine.dispose()


### PR DESCRIPTION
## Summary
- replace generic profile validation with specific field checks
- surface profile validation errors as 422 from profiles API
- test profile validation and API error messaging

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0874a8cb4832aa0382f9780752d9d