### PR TITLE
[tests] cover initData fallback and invalid profile values

### DIFF
--- a/services/webapp/ui/src/hooks/useTelegram.ts
+++ b/services/webapp/ui/src/hooks/useTelegram.ts
@@ -74,6 +74,7 @@ export const useTelegram = (
   const [colorScheme, setScheme] = useState<Scheme>("light");
   const mainClickRef = useRef<(() => void) | null>(null);
   const backClickRef = useRef<(() => void) | null>(null);
+  const initData = useMemo(() => tg?.initData ?? getDevInitData() ?? "", [tg]);
 
   // Конвертация hex в HSL
   const hexToHsl = useCallback((hex: string): string => {
@@ -289,7 +290,7 @@ export const useTelegram = (
     tg,
     isReady,
     user,
-    initData: tg?.initData,
+    initData,
     colorScheme,
     sendData,
     showMainButton,

--- a/services/webapp/ui/tests/useTelegramInitData.test.ts
+++ b/services/webapp/ui/tests/useTelegramInitData.test.ts
@@ -1,0 +1,33 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTelegram } from '../src/hooks/useTelegram';
+
+describe('useTelegram initData fallback', () => {
+  const saved = 'query=1&user=%7B%22id%22%3A1%7D';
+
+  beforeEach(() => {
+    (window as any).Telegram = {
+      WebApp: {
+        initDataUnsafe: {},
+        ready: vi.fn(),
+        expand: vi.fn(),
+        onEvent: vi.fn(),
+        offEvent: vi.fn(),
+      },
+    };
+    localStorage.setItem('tg_init_data', saved);
+  });
+
+  afterEach(() => {
+    delete (window as any).Telegram;
+    localStorage.clear();
+  });
+
+  it('returns initData from localStorage when tg.initData missing', async () => {
+    const { result } = renderHook(() => useTelegram(false));
+    await waitFor(() => {
+      expect(result.current.isReady).toBe(true);
+    });
+    expect(result.current.initData).toBe(saved);
+  });
+});

--- a/tests/test_profiles_api.py
+++ b/tests/test_profiles_api.py
@@ -71,3 +71,31 @@ def test_profiles_post_invalid_values_returns_422(
         resp = client.post("/api/profiles", json=payload)
     assert resp.status_code == 422
     engine.dispose()
+
+
+def test_profiles_post_invalid_icr_cf_returns_422(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    payload = {
+        "telegramId": 777,
+        "icr": 0,
+        "cf": -1,
+        "target": 5.0,
+        "low": 4.0,
+        "high": 6.0,
+    }
+    with TestClient(app) as client:
+        resp = client.post("/api/profiles", json=payload)
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "invalid profile values"
+    engine.dispose()


### PR DESCRIPTION
## Summary
- return saved initData when Telegram WebApp data is missing
- test useTelegram hook initData fallback
- add backend test for invalid icr/cf profile values

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b0874ce004832a8ad85da1d96dc3c2