### PR TITLE
[ui] handle missing Telegram init data

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/reminders.ts
+++ b/services/webapp/ui/src/features/reminders/api/reminders.ts
@@ -2,10 +2,10 @@ import { Configuration } from "@sdk/runtime.ts";
 import { RemindersApi } from "@sdk/apis";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 
-export function makeRemindersApi(initData: string) {
+export function makeRemindersApi(initData: string | null) {
   const cfg = new Configuration({
     basePath: "",
-    headers: { "X-Telegram-Init-Data": initData },
+    headers: initData ? { "X-Telegram-Init-Data": initData } : undefined,
   });
   return new RemindersApi(cfg);
 }

--- a/services/webapp/ui/src/features/reminders/hooks/usePlan.ts
+++ b/services/webapp/ui/src/features/reminders/hooks/usePlan.ts
@@ -1,11 +1,11 @@
 import { Configuration } from '@sdk/runtime.ts';
 import { DefaultApi } from "@sdk/apis";
 
-export async function getPlanLimit(userId: number, initData: string): Promise<number> {
+export async function getPlanLimit(userId: number, initData: string | null): Promise<number> {
   try {
     const cfg = new Configuration({
       basePath: "",
-      headers: { "X-Telegram-Init-Data": initData }
+      headers: initData ? { "X-Telegram-Init-Data": initData } : undefined,
     });
     const api = new DefaultApi(cfg);
     const res = await api.remindersGetRaw({ telegramId: userId });

--- a/services/webapp/ui/src/hooks/useTelegramInitData.ts
+++ b/services/webapp/ui/src/hooks/useTelegramInitData.ts
@@ -1,5 +1,7 @@
-import { useMemo } from "react";
-
-export function useTelegramInitData() {
-  return useMemo(() => localStorage.getItem("tg_init_data") || "", []);
+export function useTelegramInitData(): string | null {
+  try {
+    return localStorage.getItem("tg_init_data");
+  } catch {
+    return null;
+  }
 }

--- a/services/webapp/ui/src/shared/telegram.ts
+++ b/services/webapp/ui/src/shared/telegram.ts
@@ -1,6 +1,7 @@
-export function getTelegramUserId(initData: string): number {
+export function getTelegramUserId(initData: string | null): number {
   // initData = 'query_id=...&user=%7B...%7D&...'
   try {
+    if (!initData) return 0;
     const params = new URLSearchParams(initData);
     const raw = params.get("user");
     if (!raw) return 0;

--- a/services/webapp/ui/tests/mockApi.test.tsx
+++ b/services/webapp/ui/tests/mockApi.test.tsx
@@ -19,7 +19,7 @@ vi.mock('../src/hooks/useTelegram', () => ({
   useTelegram: () => ({ user: { id: 1 }, sendData: vi.fn() })
 }));
 vi.mock('../src/hooks/useTelegramInitData', () => ({
-  useTelegramInitData: () => ({})
+  useTelegramInitData: () => null
 }));
 vi.mock('../src/shared/toast', () => ({
   useToast: () => ({ success: vi.fn(), error: toastError })
@@ -38,7 +38,7 @@ vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn()
 }));
 vi.mock('../src/features/reminders/hooks/usePlan', () => ({
-  getPlanLimit: () => Promise.resolve(5)
+  getPlanLimit: (_userId: number, _initData: string | null) => Promise.resolve(5)
 }));
 
 describe('mockApi not used in production', () => {

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -17,7 +17,7 @@ vi.mock('../src/hooks/useTelegram', () => ({
 }));
 
 vi.mock('../src/hooks/useTelegramInitData', () => ({
-  useTelegramInitData: () => '',
+  useTelegramInitData: () => null,
 }));
 
 vi.mock('react-router-dom', () => ({

--- a/services/webapp/ui/tests/useTelegramInitData.test.ts
+++ b/services/webapp/ui/tests/useTelegramInitData.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
+
+describe('useTelegramInitData', () => {
+  it('returns null when localStorage is inaccessible', () => {
+    const original = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(useTelegramInitData()).toBeNull();
+
+    if (original) {
+      Object.defineProperty(globalThis, 'localStorage', original);
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (globalThis as any).localStorage;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- make telegram init data hook return `null` when localStorage is unavailable
- propagate optional init data through helper functions and API clients
- test Telegram init data hook with missing localStorage

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pytest -q` *(fails: async plugin missing)*
- `mypy --strict .` *(fails: interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b087418e7c832a87dc7ff06953c92d