### PR TITLE
[webapp] Use localStorage fallback for initData

### DIFF
--- a/services/webapp/ui/src/hooks/useTelegram.ts
+++ b/services/webapp/ui/src/hooks/useTelegram.ts
@@ -48,7 +48,7 @@ interface TelegramWebApp {
   themeParams?: ThemeParams;
   user?: TelegramUser;
   initDataUnsafe?: { user?: TelegramUser };
-  initData?: string;
+  initData?: string | null;
   setBackgroundColor?: (color: string) => void;
   setHeaderColor?: (color: string) => void;
   onEvent?: (eventType: string, handler: () => void) => void;
@@ -74,7 +74,10 @@ export const useTelegram = (
   const [colorScheme, setScheme] = useState<Scheme>("light");
   const mainClickRef = useRef<(() => void) | null>(null);
   const backClickRef = useRef<(() => void) | null>(null);
-  const initData = useMemo(() => tg?.initData ?? getDevInitData() ?? "", [tg]);
+  const initData = useMemo<string | null>(
+    () => tg?.initData ?? localStorage.getItem("tg_init_data") ?? null,
+    [tg],
+  );
 
   // Конвертация hex в HSL
   const hexToHsl = useCallback((hex: string): string => {

--- a/services/webapp/ui/tests/useTelegramInitData.test.ts
+++ b/services/webapp/ui/tests/useTelegramInitData.test.ts
@@ -30,4 +30,13 @@ describe('useTelegram initData fallback', () => {
     });
     expect(result.current.initData).toBe(saved);
   });
+
+  it('returns null when initData is absent in tg and localStorage', async () => {
+    localStorage.removeItem('tg_init_data');
+    const { result } = renderHook(() => useTelegram(false));
+    await waitFor(() => {
+      expect(result.current.isReady).toBe(true);
+    });
+    expect(result.current.initData).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- read Telegram `initData` from `localStorage` when `tg.initData` missing
- return `initData` as `string | null`
- cover localStorage fallback with tests

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: tests/test_profiles_api.py::test_profiles_post_invalid_icr_cf_returns_422)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b089e03b60832a953b2f2fe5c1d312