### PR TITLE
[webapp] handle missing telegram init data

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/reminders.ts
+++ b/services/webapp/ui/src/features/reminders/api/reminders.ts
@@ -2,10 +2,12 @@ import { Configuration } from "@sdk/runtime.ts";
 import { RemindersApi } from "@sdk/apis";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 
-export function makeRemindersApi(initData: string) {
+export function makeRemindersApi(initData: string | null) {
+  const headers: Record<string, string> = {};
+  if (initData !== null) headers["X-Telegram-Init-Data"] = initData;
   const cfg = new Configuration({
     basePath: "",
-    headers: { "X-Telegram-Init-Data": initData },
+    headers,
   });
   return new RemindersApi(cfg);
 }

--- a/services/webapp/ui/src/features/reminders/hooks/usePlan.ts
+++ b/services/webapp/ui/src/features/reminders/hooks/usePlan.ts
@@ -1,11 +1,13 @@
 import { Configuration } from '@sdk/runtime.ts';
 import { DefaultApi } from "@sdk/apis";
 
-export async function getPlanLimit(userId: number, initData: string): Promise<number> {
+export async function getPlanLimit(userId: number, initData: string | null): Promise<number> {
   try {
+    const headers: Record<string, string> = {};
+    if (initData !== null) headers["X-Telegram-Init-Data"] = initData;
     const cfg = new Configuration({
       basePath: "",
-      headers: { "X-Telegram-Init-Data": initData }
+      headers
     });
     const api = new DefaultApi(cfg);
     const res = await api.remindersGetRaw({ telegramId: userId });

--- a/services/webapp/ui/src/hooks/useTelegramInitData.ts
+++ b/services/webapp/ui/src/hooks/useTelegramInitData.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
 
 export function useTelegramInitData() {
-  return useMemo(() => localStorage.getItem("tg_init_data") || "", []);
+  return useMemo(() => localStorage.getItem("tg_init_data"), []);
 }

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -29,16 +29,20 @@ const Profile = () => {
   const handleSave = async () => {
     let telegramId = user?.id;
     if (!telegramId) {
-      const userStr = new URLSearchParams(initData || "").get("user");
-      if (userStr) {
-        try {
-          const parsed = JSON.parse(userStr);
-          telegramId = typeof parsed.id === "number" ? parsed.id : undefined;
-        } catch (e) {
-          console.error("[Profile] failed to parse initData user:", e);
+      if (initData) {
+        const userStr = new URLSearchParams(initData).get("user");
+        if (userStr) {
+          try {
+            const parsed = JSON.parse(userStr);
+            telegramId = typeof parsed.id === "number" ? parsed.id : undefined;
+          } catch (e) {
+            console.error("[Profile] failed to parse initData user:", e);
+          }
+        } else {
+          console.warn("[Profile] no user field in initData");
         }
       } else {
-        console.warn("[Profile] no user field in initData");
+        console.warn("[Profile] no initData");
       }
     }
 

--- a/services/webapp/ui/src/shared/telegram.ts
+++ b/services/webapp/ui/src/shared/telegram.ts
@@ -1,5 +1,6 @@
-export function getTelegramUserId(initData: string): number {
+export function getTelegramUserId(initData: string | null): number {
   // initData = 'query_id=...&user=%7B...%7D&...'
+  if (!initData) return 0;
   try {
     const params = new URLSearchParams(initData);
     const raw = params.get("user");

--- a/services/webapp/ui/tests/mockApi.test.tsx
+++ b/services/webapp/ui/tests/mockApi.test.tsx
@@ -19,7 +19,7 @@ vi.mock('../src/hooks/useTelegram', () => ({
   useTelegram: () => ({ user: { id: 1 }, sendData: vi.fn() })
 }));
 vi.mock('../src/hooks/useTelegramInitData', () => ({
-  useTelegramInitData: () => ({})
+  useTelegramInitData: () => null
 }));
 vi.mock('../src/shared/toast', () => ({
   useToast: () => ({ success: vi.fn(), error: toastError })
@@ -38,7 +38,7 @@ vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn()
 }));
 vi.mock('../src/features/reminders/hooks/usePlan', () => ({
-  getPlanLimit: () => Promise.resolve(5)
+  getPlanLimit: (_userId: number, _initData: string | null) => Promise.resolve(5)
 }));
 
 describe('mockApi not used in production', () => {

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -38,7 +38,7 @@ describe('Profile page', () => {
   });
 
   it('blocks save without telegramId and shows toast', () => {
-    useTelegramInitData.mockReturnValue('');
+    useTelegramInitData.mockReturnValue(null);
     const { getByText } = render(<Profile />);
     fireEvent.click(getByText('Сохранить настройки'));
     expect(saveProfile).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- handle null init data when parsing Telegram user
- pass init data header only when present
- adjust profile parsing and tests for nullable init data

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm --filter ./services/webapp/ui lint` *(fails: 19 errors, 9 warnings)*
- `pnpm test` *(fails: Missing script: test)*
- `pnpm --filter ./services/webapp/ui test`


------
https://chatgpt.com/codex/tasks/task_e_68b08ae31590832a838ce32c0b5f1a56