### PR TITLE
[webapp] handle missing localStorage in useTelegramInitData

### DIFF
--- a/services/webapp/ui/src/hooks/useTelegramInitData.ts
+++ b/services/webapp/ui/src/hooks/useTelegramInitData.ts
@@ -1,5 +1,11 @@
 import { useMemo } from "react";
 
-export function useTelegramInitData() {
-  return useMemo(() => localStorage.getItem("tg_init_data") || "", []);
+export function useTelegramInitData(): string | null {
+  return useMemo(() => {
+    try {
+      return globalThis.localStorage?.getItem("tg_init_data") ?? null;
+    } catch {
+      return null;
+    }
+  }, []);
 }

--- a/services/webapp/ui/tests/useTelegramInitData.localStorage.test.ts
+++ b/services/webapp/ui/tests/useTelegramInitData.localStorage.test.ts
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
+
+describe('useTelegramInitData when localStorage unavailable', () => {
+  const original = globalThis.localStorage;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: original,
+    });
+  });
+
+  it('returns null if localStorage.getItem throws', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: () => {
+          throw new Error('fail');
+        },
+      },
+    });
+    const { result } = renderHook(() => useTelegramInitData());
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null if localStorage is undefined', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: undefined,
+    });
+    const { result } = renderHook(() => useTelegramInitData());
+    expect(result.current).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure useTelegramInitData returns null when localStorage is unavailable
- add tests covering localStorage errors and absence

## Testing
- `pnpm --filter ./services/webapp/ui test tests/useTelegramInitData.localStorage.test.ts`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b08ae603a0832a8c0394b5551d40a4