### PR TITLE
[ui] handle missing Telegram init data

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/reminders.ts
+++ b/services/webapp/ui/src/features/reminders/api/reminders.ts
@@ -2,10 +2,14 @@ import { Configuration } from "@sdk/runtime.ts";
 import { RemindersApi } from "@sdk/apis";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 
-export function makeRemindersApi(initData: string) {
+export function makeRemindersApi(initData: string | null) {
+  const headers: Record<string, string> = {};
+  if (initData) {
+    headers["X-Telegram-Init-Data"] = initData;
+  }
   const cfg = new Configuration({
     basePath: "",
-    headers: { "X-Telegram-Init-Data": initData },
+    headers,
   });
   return new RemindersApi(cfg);
 }

--- a/services/webapp/ui/src/features/reminders/hooks/usePlan.ts
+++ b/services/webapp/ui/src/features/reminders/hooks/usePlan.ts
@@ -1,11 +1,15 @@
 import { Configuration } from '@sdk/runtime.ts';
 import { DefaultApi } from "@sdk/apis";
 
-export async function getPlanLimit(userId: number, initData: string): Promise<number> {
+export async function getPlanLimit(userId: number, initData: string | null): Promise<number> {
   try {
+    const headers: Record<string, string> = {};
+    if (initData) {
+      headers["X-Telegram-Init-Data"] = initData;
+    }
     const cfg = new Configuration({
       basePath: "",
-      headers: { "X-Telegram-Init-Data": initData }
+      headers,
     });
     const api = new DefaultApi(cfg);
     const res = await api.remindersGetRaw({ telegramId: userId });

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -29,7 +29,14 @@ const Profile = () => {
   const handleSave = async () => {
     let telegramId = user?.id;
     if (!telegramId) {
-      const userStr = new URLSearchParams(initData || "").get("user");
+      let userStr: string | null = null;
+      if (initData) {
+        try {
+          userStr = new URLSearchParams(initData).get("user");
+        } catch (e) {
+          console.error("[Profile] failed to parse initData:", e);
+        }
+      }
       if (userStr) {
         try {
           const parsed = JSON.parse(userStr);

--- a/services/webapp/ui/src/shared/telegram.ts
+++ b/services/webapp/ui/src/shared/telegram.ts
@@ -1,5 +1,6 @@
-export function getTelegramUserId(initData: string): number {
+export function getTelegramUserId(initData: string | null): number {
   // initData = 'query_id=...&user=%7B...%7D&...'
+  if (!initData) return 0;
   try {
     const params = new URLSearchParams(initData);
     const raw = params.get("user");

--- a/services/webapp/ui/tests/mockApi.test.tsx
+++ b/services/webapp/ui/tests/mockApi.test.tsx
@@ -19,7 +19,7 @@ vi.mock('../src/hooks/useTelegram', () => ({
   useTelegram: () => ({ user: { id: 1 }, sendData: vi.fn() })
 }));
 vi.mock('../src/hooks/useTelegramInitData', () => ({
-  useTelegramInitData: () => ({})
+  useTelegramInitData: () => null,
 }));
 vi.mock('../src/shared/toast', () => ({
   useToast: () => ({ success: vi.fn(), error: toastError })

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -38,7 +38,7 @@ describe('Profile page', () => {
   });
 
   it('blocks save without telegramId and shows toast', () => {
-    useTelegramInitData.mockReturnValue('');
+    useTelegramInitData.mockReturnValue(null);
     const { getByText } = render(<Profile />);
     fireEvent.click(getByText('Сохранить настройки'));
     expect(saveProfile).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- allow getTelegramUserId to accept null and default to 0
- send X-Telegram-Init-Data header only when present
- guard Profile page URLSearchParams usage when init data missing
- adjust plan limit fetch and tests for nullable init data

## Testing
- `pnpm lint` *(fails: Unexpected any in existing files)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b08c640b5c832aa7d9cc7efe9d3231