### PR TITLE
[webapp] test localStorage fallback for useTelegramInitData

### DIFF
--- a/services/webapp/ui/tests/useTelegramInitData.localStorage.test.ts
+++ b/services/webapp/ui/tests/useTelegramInitData.localStorage.test.ts
@@ -1,0 +1,26 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
+
+describe('useTelegramInitData localStorage absence', () => {
+  const original = globalThis.localStorage;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: original,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('returns null when localStorage.getItem throws', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: { getItem: () => { throw new Error('boom'); } },
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useTelegramInitData());
+
+    expect(result.current).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add test ensuring useTelegramInitData returns null when localStorage access fails

## Testing
- `pnpm --filter ./services/webapp/ui exec eslint tests/useTelegramInitData.localStorage.test.ts`
- `pnpm --filter ./services/webapp/ui test tests/useTelegramInitData.localStorage.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b08c94c5b8832a95fac6a99623b02d