### PR TITLE
tests: adjust profile API validation expectations

### DIFF
--- a/tests/test_profiles_api.py
+++ b/tests/test_profiles_api.py
@@ -74,7 +74,7 @@ def test_profiles_post_invalid_values_returns_422(
     engine.dispose()
 
 
-def test_profiles_post_invalid_icr_cf_returns_422(
+def test_profiles_post_invalid_icr_returns_422(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     app = FastAPI()
@@ -90,6 +90,34 @@ def test_profiles_post_invalid_icr_cf_returns_422(
     payload = {
         "telegramId": 777,
         "icr": 0,
+        "cf": 1.0,
+        "target": 5.0,
+        "low": 4.0,
+        "high": 6.0,
+    }
+    with TestClient(app) as client:
+        resp = client.post("/api/profiles", json=payload)
+    assert resp.status_code == 422
+    assert resp.json() == {"detail": "icr must be greater than 0"}
+    engine.dispose()
+
+
+def test_profiles_post_invalid_cf_returns_422(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    payload = {
+        "telegramId": 777,
+        "icr": 1.0,
         "cf": -1,
         "target": 5.0,
         "low": 4.0,
@@ -98,5 +126,5 @@ def test_profiles_post_invalid_icr_cf_returns_422(
     with TestClient(app) as client:
         resp = client.post("/api/profiles", json=payload)
     assert resp.status_code == 422
-    assert resp.json()["detail"] == "invalid profile values"
+    assert resp.json() == {"detail": "cf must be greater than 0"}
     engine.dispose()


### PR DESCRIPTION
## Summary
- split profile API invalid-value test into dedicated checks for ICR and CF
- assert explicit validation error messages returned by the endpoint

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b08f8a3ac0832aaea5e232ecf996a4