### PR TITLE
[services] Handle optional profile fields

### DIFF
--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -3,18 +3,18 @@ from __future__ import annotations
 from typing import Optional
 from datetime import time
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
 
 class ProfileSchema(BaseModel):
     telegramId: int = Field(
         alias="telegramId", validation_alias=AliasChoices("telegramId", "telegram_id")
     )
-    icr: float
-    cf: float
-    target: float
-    low: float
-    high: float
+    icr: Optional[float] = None
+    cf: Optional[float] = None
+    target: Optional[float] = None
+    low: Optional[float] = None
+    high: Optional[float] = None
     quietStart: time = Field(
         default=time(23, 0),
         alias="quietStart",
@@ -38,3 +38,9 @@ class ProfileSchema(BaseModel):
     )
 
     model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="after")
+    def compute_target(self) -> "ProfileSchema":
+        if self.target is None and self.low is not None and self.high is not None:
+            self.target = (self.low + self.high) / 2
+        return self

--- a/tests/test_profile_optional_fields.py
+++ b/tests/test_profile_optional_fields.py
@@ -1,0 +1,32 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from services.api.app.diabetes.services.db import Base, User
+from services.api.app.schemas.profile import ProfileSchema
+from services.api.app.services import profile as profile_service
+
+
+@pytest.mark.asyncio
+async def test_save_profile_saves_computed_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.commit()
+    data = ProfileSchema(
+        telegramId=1,
+        icr=1.0,
+        cf=2.0,
+        low=4.0,
+        high=6.0,
+    )
+    await profile_service.save_profile(data)
+    prof = await profile_service.get_profile(1)
+    assert prof is not None
+    assert prof.target_bg == 5.0
+    engine.dispose()

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -7,16 +7,16 @@ from services.api.app.schemas.profile import ProfileSchema
 from services.api.app.services.profile import _validate_profile
 
 
-def test_validate_profile_allows_target_between_limits() -> None:
+def test_validate_profile_allows_computed_target() -> None:
     data = ProfileSchema(
         telegramId=1,
         icr=1.0,
         cf=1.0,
-        target=5.0,
         low=4.0,
-        high=7.0,
+        high=6.0,
     )
     _validate_profile(data)
+    assert data.target == 5.0
 
 
 @pytest.mark.parametrize("target", [3.0, 8.0])
@@ -64,6 +64,22 @@ def test_validate_profile_rejects_invalid_values(
     with pytest.raises(ValueError) as exc:
         _validate_profile(data)
     assert str(exc.value) == message
+
+
+@pytest.mark.parametrize("field", ["icr", "cf", "low", "high"])
+def test_validate_profile_rejects_missing_fields(field: str) -> None:
+    kwargs = {
+        "telegramId": 1,
+        "icr": 1.0,
+        "cf": 1.0,
+        "low": 4.0,
+        "high": 7.0,
+    }
+    kwargs.pop(field)
+    data = ProfileSchema(**kwargs)
+    with pytest.raises(ValueError) as exc:
+        _validate_profile(data)
+    assert str(exc.value) == "field is required"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- support optional icr/cf/target/low/high in ProfileSchema
- validate optional profile values and persist computed target
- add tests for computed target and missing field handling

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0953db128832a848d71b86048c755