### PR TITLE
[contracts] document profile aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Changed `/api/reminders`: returns `200` with an empty list instead of `404` when no reminders exist.
 - Changed `/api/stats`: now returns default stats (or `204`) instead of `404` when no data is available.
 - Enhanced bot command menu with emojis for easier navigation.
+- Updated `ProfileSchema`: field `target` is now optional and aliases `cf`, `targetLow`, `targetHigh` are documented.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ API контейнер запускает `uvicorn` напрямую как ко
 
 ## Генерация SDK
 
-Файл `libs/contracts/openapi.yaml` содержит спецификацию API. По нему генерируются SDK. Перед генерацией установите зависимости, чтобы workspace был доступен в UI:
+Файл `libs/contracts/openapi.yaml` содержит спецификацию API. По нему генерируются SDK. В `ProfileSchema` поле `target` теперь необязательное, а для совместимости доступны алиасы `cf`, `targetLow` и `targetHigh`. Перед генерацией установите зависимости, чтобы workspace был доступен в UI:
 
 ```bash
 pnpm install

--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -672,15 +672,18 @@ components:
         cf:
           type: number
           title: Cf
+          description: Alias `cf` for compatibility.
         target:
           type: number
           title: Target
         low:
           type: number
           title: Low
+          description: Alias `targetLow` accepted on input.
         high:
           type: number
           title: High
+          description: Alias `targetHigh` accepted on input.
         quietStart:
           type: string
           title: Quiet Start
@@ -708,7 +711,6 @@ components:
       - telegramId
       - icr
       - cf
-      - target
       - low
       - high
       title: ProfileSchema

--- a/libs/ts-sdk/models/ProfileSchema.ts
+++ b/libs/ts-sdk/models/ProfileSchema.ts
@@ -32,7 +32,7 @@ export interface ProfileSchema {
      */
     icr: number;
     /**
-     * 
+     * Alias `cf` for compatibility.
      * @type {number}
      * @memberof ProfileSchema
      */
@@ -42,15 +42,15 @@ export interface ProfileSchema {
      * @type {number}
      * @memberof ProfileSchema
      */
-    target: number;
+    target?: number;
     /**
-     * 
+     * Alias `targetLow` accepted on input.
      * @type {number}
      * @memberof ProfileSchema
      */
     low: number;
     /**
-     * 
+     * Alias `targetHigh` accepted on input.
      * @type {number}
      * @memberof ProfileSchema
      */
@@ -94,7 +94,6 @@ export function instanceOfProfileSchema(value: object): value is ProfileSchema {
     if (!('telegramId' in value) || value['telegramId'] === undefined) return false;
     if (!('icr' in value) || value['icr'] === undefined) return false;
     if (!('cf' in value) || value['cf'] === undefined) return false;
-    if (!('target' in value) || value['target'] === undefined) return false;
     if (!('low' in value) || value['low'] === undefined) return false;
     if (!('high' in value) || value['high'] === undefined) return false;
     return true;
@@ -113,7 +112,7 @@ export function ProfileSchemaFromJSONTyped(json: any, ignoreDiscriminator: boole
         'telegramId': json['telegramId'],
         'icr': json['icr'],
         'cf': json['cf'],
-        'target': json['target'],
+        'target': json['target'] == null ? undefined : json['target'],
         'low': json['low'],
         'high': json['high'],
         'quietStart': json['quietStart'] == null ? undefined : json['quietStart'],


### PR DESCRIPTION
## Summary
- describe `cf`, `targetLow`, `targetHigh` aliases in ProfileSchema and make `target` optional
- regenerate TypeScript SDK
- document updated contract in README and CHANGELOG

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b095532e70832a8a2103420236e1b6