### PR TITLE
[services] Use atomic upsert for profile saves

### DIFF
--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -52,7 +52,7 @@ class ProfileSchema(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @model_validator(mode="before")
-    def alias_mismatch(cls, values: dict) -> dict:
+    def alias_mismatch(cls, values: dict[str, object]) -> dict[str, object]:
         def _check(a: str, b: str, name: str) -> None:
             if a in values and b in values and values[a] != values[b]:
                 raise ValueError(f"{name} mismatch")

--- a/services/api/app/types.py
+++ b/services/api/app/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Protocol, TypeVar
+from typing import Any, Mapping, Protocol, Sequence, TypeVar
 
 T = TypeVar("T")
 
@@ -14,4 +14,12 @@ class SessionProtocol(Protocol):
 
     def delete(self, instance: object) -> None:
         """Mark an object for deletion."""
+        ...
+
+    def execute(
+        self,
+        statement: Any,
+        params: Mapping[str, Any] | Sequence[Mapping[str, Any]] | None = None,
+    ) -> Any:
+        """Execute a SQL statement."""
         ...

--- a/tests/test_profiles_api.py
+++ b/tests/test_profiles_api.py
@@ -70,7 +70,8 @@ def test_profiles_post_invalid_values_returns_422(
     with TestClient(app) as client:
         resp = client.post("/api/profiles", json=payload)
     assert resp.status_code == 422
-    assert resp.json() == {"detail": "low must be less than high"}
+    body = resp.json()
+    assert body["detail"][0]["msg"].endswith("low must be less than high")
     engine.dispose()
 
 
@@ -127,4 +128,51 @@ def test_profiles_post_invalid_cf_returns_422(
         resp = client.post("/api/profiles", json=payload)
     assert resp.status_code == 422
     assert resp.json() == {"detail": "cf must be greater than 0"}
+    engine.dispose()
+
+
+def test_profiles_post_updates_existing_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    with TestClient(app) as client:
+        payload = {
+            "telegramId": 777,
+            "icr": 1.0,
+            "cf": 1.0,
+            "target": 5.0,
+            "low": 4.0,
+            "high": 6.0,
+            "quietStart": "23:00:00",
+            "quietEnd": "07:00:00",
+        }
+        assert client.post("/api/profiles", json=payload).status_code == 200
+
+        update = {
+            "telegramId": 777,
+            "icr": 2.0,
+            "cf": 1.5,
+            "target": 6.0,
+            "low": 5.0,
+            "high": 7.0,
+            "quietStart": "22:00:00",
+            "quietEnd": "06:00:00",
+        }
+        assert client.post("/api/profiles", json=update).status_code == 200
+
+        resp = client.get("/api/profiles", params={"telegramId": 777})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["icr"] == 2.0
+        assert data["quietStart"] == "22:00:00"
+        assert data["quietEnd"] == "06:00:00"
     engine.dispose()


### PR DESCRIPTION
## Summary
- atomically upsert profiles on telegram_id with all fields
- type SessionProtocol.execute and schema value dict
- test profile updates and quiet-hour persistence

## Testing
- `pytest tests/test_profiles_api.py -q --cov=services.api.app.services.profile --cov=tests.test_profiles_api --cov-report=term-missing --cov-fail-under=85` *(fails: Required test coverage of 85% not reached. Total coverage: 28.31%)*
- `mypy --strict services/api/app/services/profile.py tests/test_profiles_api.py`
- `ruff check services/api/app/services/profile.py services/api/app/schemas/profile.py services/api/app/types.py tests/test_profiles_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0ba652ce0832a9238825599e2fb72