### PR TITLE
[alembic] Add quiet time to profiles

### DIFF
--- a/services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py
+++ b/services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py
@@ -1,0 +1,37 @@
+"""add quiet_start and quiet_end to profiles"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250828_add_quiet_time"
+down_revision: Union[str, None] = "1188e4de1729"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "profiles",
+        sa.Column(
+            "quiet_start",
+            sa.Time(),
+            nullable=False,
+            server_default=sa.text("'23:00:00'"),
+        ),
+    )
+    op.add_column(
+        "profiles",
+        sa.Column(
+            "quiet_end",
+            sa.Time(),
+            nullable=False,
+            server_default=sa.text("'07:00:00'"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("profiles", "quiet_start")
+    op.drop_column("profiles", "quiet_end")


### PR DESCRIPTION
## Summary
- add `quiet_start` and `quiet_end` fields to profiles with defaults

## Testing
- `alembic upgrade head` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: Missing type parameters for generic type "dict")*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b0ba6533e8832aa429fb965f5db0f0