### PR TITLE
[profile] unify icr cf fields

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -35,7 +35,6 @@ async def profiles_get(
         raise HTTPException(status_code=404, detail="profile not found")
 
     icr: float | None = profile.icr
-    cf: float | None = profile.cf
     target_bg: float | None = profile.target_bg
     low_threshold: float | None = profile.low_threshold
     high_threshold: float | None = profile.high_threshold
@@ -43,7 +42,6 @@ async def profiles_get(
     return ProfileSchema(
         telegramId=profile.telegram_id,
         icr=float(icr) if icr is not None else 0.0,
-        cf=float(cf) if cf is not None else 0.0,
         target=float(target_bg) if target_bg is not None else 0.0,
         low=float(low_threshold) if low_threshold is not None else 0.0,
         high=float(high_threshold) if high_threshold is not None else 0.0,

--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -11,8 +11,11 @@ class ProfileSchema(BaseModel):
     telegramId: int = Field(
         alias="telegramId", validation_alias=AliasChoices("telegramId", "telegram_id")
     )
-    icr: Optional[float] = Field(default=None, alias="icr")
-    cf: Optional[float] = None
+    ratio: Optional[float] = Field(
+        default=None,
+        alias="icr",
+        validation_alias=AliasChoices("icr", "cf"),
+    )
     target: Optional[float] = None
     low: Optional[float] = Field(
         default=None,

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -31,8 +31,7 @@ async def set_timezone(telegram_id: int, tz: str) -> None:  # pragma: no cover
 def _validate_profile(data: ProfileSchema) -> None:
     """Validate business rules for a patient profile."""
     required = {
-        "icr": data.icr,
-        "cf": data.cf,
+        "ratio": data.ratio,
         "target": data.target,
         "low": data.low,
         "high": data.high,
@@ -68,8 +67,8 @@ async def save_profile(data: ProfileSchema) -> None:
         profile_data = {
             "telegram_id": data.telegramId,
             "org_id": data.orgId,
-            "icr": data.icr,
-            "cf": data.cf,
+            "icr": data.ratio,
+            "cf": data.ratio,
             "target_bg": data.target,
             "low_threshold": data.low,
             "high_threshold": data.high,

--- a/tests/test_profile_aliases.py
+++ b/tests/test_profile_aliases.py
@@ -18,11 +18,11 @@ def _create_app() -> FastAPI:
 def test_profile_schema_accepts_aliases_and_computes_target() -> None:
     data = ProfileSchema(
         telegramId=1,
-        icr=1.0,
         cf=1.0,
         targetLow=4.0,
         targetHigh=6.0,
     )
+    assert data.ratio == 1.0
     assert data.low == 4.0
     assert data.high == 6.0
     assert data.target == 5.0
@@ -39,7 +39,6 @@ def test_profiles_post_alias_mismatch_returns_422(field: str, value: dict) -> No
     app = _create_app()
     payload = {
         "telegramId": 1,
-        "icr": 1.0,
         "cf": 1.0,
         **value,
     }

--- a/tests/test_profile_optional_fields.py
+++ b/tests/test_profile_optional_fields.py
@@ -21,7 +21,6 @@ async def test_save_profile_saves_computed_target(
     data = ProfileSchema(
         telegramId=1,
         icr=1.0,
-        cf=2.0,
         low=4.0,
         high=6.0,
     )

--- a/tests/test_profile_quiet_fields.py
+++ b/tests/test_profile_quiet_fields.py
@@ -20,7 +20,6 @@ async def test_save_profile_stores_quiet_fields(monkeypatch: pytest.MonkeyPatch)
     data = ProfileSchema(
         telegramId=1,
         icr=1.0,
-        cf=2.0,
         target=3.0,
         low=1.0,
         high=5.0,
@@ -47,7 +46,6 @@ async def test_save_profile_defaults_quiet_fields(monkeypatch: pytest.MonkeyPatc
     data = ProfileSchema(
         telegramId=2,
         icr=1.0,
-        cf=2.0,
         target=3.0,
         low=1.0,
         high=5.0,

--- a/tests/test_profile_sos_fields.py
+++ b/tests/test_profile_sos_fields.py
@@ -21,7 +21,6 @@ async def test_save_profile_stores_sos_fields(monkeypatch: pytest.MonkeyPatch) -
     data = ProfileSchema(
         telegramId=1,
         icr=1.0,
-        cf=2.0,
         target=3.0,
         low=1.0,
         high=5.0,
@@ -50,7 +49,6 @@ async def test_save_profile_defaults_sos_fields(
     data = ProfileSchema(
         telegramId=2,
         icr=1.0,
-        cf=2.0,
         target=3.0,
         low=1.0,
         high=5.0,
@@ -77,7 +75,6 @@ async def test_save_profile_persists_quiet_hours(
     data = ProfileSchema(
         telegramId=3,
         icr=1.0,
-        cf=2.0,
         target=3.0,
         low=1.0,
         high=5.0,
@@ -106,7 +103,6 @@ async def test_save_profile_defaults_quiet_hours(
     data = ProfileSchema(
         telegramId=4,
         icr=1.0,
-        cf=2.0,
         target=3.0,
         low=1.0,
         high=5.0,

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -11,7 +11,6 @@ def test_validate_profile_allows_computed_target() -> None:
     data = ProfileSchema(
         telegramId=1,
         icr=1.0,
-        cf=1.0,
         low=4.0,
         high=6.0,
     )
@@ -24,7 +23,6 @@ def test_validate_profile_rejects_target_outside_limits(target: Any) -> None:
     data = ProfileSchema(
         telegramId=1,
         icr=1.0,
-        cf=1.0,
         target=target,
         low=4.0,
         high=7.0,
@@ -37,8 +35,7 @@ def test_validate_profile_rejects_target_outside_limits(target: Any) -> None:
 @pytest.mark.parametrize(
     "field,value,message",
     [
-        ("icr", 0.0, "icr must be greater than 0"),
-        ("cf", 0.0, "cf must be greater than 0"),
+        ("icr", 0.0, "ratio must be greater than 0"),
         ("target", 0.0, "target must be greater than 0"),
         ("low", 0.0, "low must be greater than 0"),
         ("high", 0.0, "high must be greater than 0"),
@@ -51,7 +48,6 @@ def test_validate_profile_rejects_invalid_values(
     kwargs = {
         "telegramId": 1,
         "icr": 1.0,
-        "cf": 1.0,
         "target": 5.0,
         "low": 4.0,
         "high": 7.0,
@@ -66,12 +62,11 @@ def test_validate_profile_rejects_invalid_values(
     assert str(exc.value) == message
 
 
-@pytest.mark.parametrize("field", ["icr", "cf", "low", "high"])
+@pytest.mark.parametrize("field", ["icr", "low", "high"])
 def test_validate_profile_rejects_missing_fields(field: str) -> None:
     kwargs = {
         "telegramId": 1,
         "icr": 1.0,
-        "cf": 1.0,
         "low": 4.0,
         "high": 7.0,
     }
@@ -90,7 +85,6 @@ def test_profile_rejects_malformed_quiet_times(field: str, value: str) -> None:
     kwargs = {
         "telegramId": 1,
         "icr": 1.0,
-        "cf": 1.0,
         "target": 5.0,
         "low": 4.0,
         "high": 7.0,

--- a/tests/test_profiles_api.py
+++ b/tests/test_profiles_api.py
@@ -34,7 +34,6 @@ def test_profiles_post_creates_user_for_missing_telegram_id(
     payload = {
         "telegramId": 777,
         "icr": 1.0,
-        "cf": 1.0,
         "target": 5.0,
         "low": 4.0,
         "high": 6.0,
@@ -62,7 +61,6 @@ def test_profiles_post_invalid_values_returns_422(
     payload = {
         "telegramId": 777,
         "icr": 1.0,
-        "cf": 1.0,
         "target": 5.0,
         "low": 6.0,
         "high": 5.0,
@@ -71,7 +69,7 @@ def test_profiles_post_invalid_values_returns_422(
         resp = client.post("/api/profiles", json=payload)
     assert resp.status_code == 422
     body = resp.json()
-    assert body["detail"][0]["msg"].endswith("low must be less than high")
+    assert body["detail"].endswith("low must be less than high")
     engine.dispose()
 
 
@@ -91,7 +89,6 @@ def test_profiles_post_invalid_icr_returns_422(
     payload = {
         "telegramId": 777,
         "icr": 0,
-        "cf": 1.0,
         "target": 5.0,
         "low": 4.0,
         "high": 6.0,
@@ -99,11 +96,11 @@ def test_profiles_post_invalid_icr_returns_422(
     with TestClient(app) as client:
         resp = client.post("/api/profiles", json=payload)
     assert resp.status_code == 422
-    assert resp.json() == {"detail": "icr must be greater than 0"}
+    assert resp.json() == {"detail": "ratio must be greater than 0"}
     engine.dispose()
 
 
-def test_profiles_post_invalid_cf_returns_422(
+def test_profiles_post_invalid_cf_alias_returns_422(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     app = FastAPI()
@@ -118,7 +115,6 @@ def test_profiles_post_invalid_cf_returns_422(
     monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
     payload = {
         "telegramId": 777,
-        "icr": 1.0,
         "cf": -1,
         "target": 5.0,
         "low": 4.0,
@@ -127,7 +123,7 @@ def test_profiles_post_invalid_cf_returns_422(
     with TestClient(app) as client:
         resp = client.post("/api/profiles", json=payload)
     assert resp.status_code == 422
-    assert resp.json() == {"detail": "cf must be greater than 0"}
+    assert resp.json() == {"detail": "ratio must be greater than 0"}
     engine.dispose()
 
 
@@ -148,7 +144,6 @@ def test_profiles_post_updates_existing_profile(
         payload = {
             "telegramId": 777,
             "icr": 1.0,
-            "cf": 1.0,
             "target": 5.0,
             "low": 4.0,
             "high": 6.0,
@@ -159,8 +154,7 @@ def test_profiles_post_updates_existing_profile(
 
         update = {
             "telegramId": 777,
-            "icr": 2.0,
-            "cf": 1.5,
+            "cf": 2.0,
             "target": 6.0,
             "low": 5.0,
             "high": 7.0,


### PR DESCRIPTION
## Summary
- replace `icr`/`cf` pair with single `ratio` field using aliases
- update profile services and legacy API to use unified field
- adjust profile-related tests for the new schema

## Testing
- `pytest tests/test_profile_validation.py tests/test_profile_aliases.py tests/test_profile_optional_fields.py tests/test_profile_sos_fields.py tests/test_profile_quiet_fields.py tests/test_profiles_api.py -q` *(fails: Coverage failure: total of 25 is less than fail-under=85)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b1183aff10832a908f2ec4b701b469