### PR TITLE
[ui] Serialize profile POST body

### DIFF
--- a/services/webapp/ui/src/api/http.ts
+++ b/services/webapp/ui/src/api/http.ts
@@ -57,9 +57,17 @@ async function handleMockRequest<T>(path: string, init: RequestInit): Promise<T>
 export const http = {
   get: <T>(path: string) => request<T>(path),
   post: <T>(path: string, body: unknown) =>
-    request<T>(path, { method: 'POST', body: JSON.stringify(body) }),
+    request<T>(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
   patch: <T>(path: string, body: unknown) =>
-    request<T>(path, { method: 'PATCH', body: JSON.stringify(body) }),
+    request<T>(path, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
   delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
 };
 


### PR DESCRIPTION
## Summary
- Send profile updates as JSON with correct headers
- Ensure HTTP helper sets JSON headers for POST and PATCH

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict services/webapp/ui/src/api/profile.ts services/webapp/ui/src/api/http.ts` *(fails: Invalid syntax)*
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test`


------
https://chatgpt.com/codex/tasks/task_e_68b11e297a20832aa58c5b0cadb332d2