### PR TITLE
[webapp] Fix RemindersApi base path

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/reminders.ts
+++ b/services/webapp/ui/src/features/reminders/api/reminders.ts
@@ -8,7 +8,7 @@ export function makeRemindersApi(initData: string | null) {
     headers["X-Telegram-Init-Data"] = initData;
   }
   const cfg = new Configuration({
-    basePath: "",
+    basePath: "/api",
     headers,
   });
   return new RemindersApi(cfg);

--- a/services/webapp/ui/tests/reminders.api.test.ts
+++ b/services/webapp/ui/tests/reminders.api.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { makeRemindersApi } from '../src/features/reminders/api/reminders';
+import { ReminderType } from '@sdk/models/ReminderType';
+
+describe('RemindersApi', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('posts to /api/reminders and parses JSON', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', mockFetch);
+
+    const api = makeRemindersApi(null);
+    const result = await api.remindersPost({
+      reminder: { telegramId: 1, type: ReminderType.Sugar },
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/reminders',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(result).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure RemindersApi uses `/api` base path
- test remindersPost hits `/api/reminders` and parses JSON

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: unexpected any errors in existing files)*
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q` *(fails: async plugin missing, many tests)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b12251586c832ab8337d19647c9e7a