### PR TITLE
contracts: make target required

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -710,7 +710,7 @@ components:
       required:
       - telegramId
       - icr
-      - cf
+      - target
       - low
       - high
       title: ProfileSchema

--- a/libs/ts-sdk/models/ProfileSchema.ts
+++ b/libs/ts-sdk/models/ProfileSchema.ts
@@ -36,13 +36,13 @@ export interface ProfileSchema {
      * @type {number}
      * @memberof ProfileSchema
      */
-    cf: number;
+    cf?: number;
     /**
      * 
      * @type {number}
      * @memberof ProfileSchema
      */
-    target?: number;
+    target: number;
     /**
      * Alias `targetLow` accepted on input.
      * @type {number}
@@ -93,7 +93,7 @@ export interface ProfileSchema {
 export function instanceOfProfileSchema(value: object): value is ProfileSchema {
     if (!('telegramId' in value) || value['telegramId'] === undefined) return false;
     if (!('icr' in value) || value['icr'] === undefined) return false;
-    if (!('cf' in value) || value['cf'] === undefined) return false;
+    if (!('target' in value) || value['target'] === undefined) return false;
     if (!('low' in value) || value['low'] === undefined) return false;
     if (!('high' in value) || value['high'] === undefined) return false;
     return true;
@@ -111,8 +111,8 @@ export function ProfileSchemaFromJSONTyped(json: any, ignoreDiscriminator: boole
         
         'telegramId': json['telegramId'],
         'icr': json['icr'],
-        'cf': json['cf'],
-        'target': json['target'] == null ? undefined : json['target'],
+        'cf': json['cf'] == null ? undefined : json['cf'],
+        'target': json['target'],
         'low': json['low'],
         'high': json['high'],
         'quietStart': json['quietStart'] == null ? undefined : json['quietStart'],

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -4,11 +4,10 @@ import { getTelegramAuthHeaders } from '@/lib/telegram-auth';
 export async function saveProfile({
   telegramId,
   icr,
-  cf,
   target,
   low,
   high,
-}: ProfileSchema) {
+}: Pick<ProfileSchema, 'telegramId' | 'icr' | 'target' | 'low' | 'high'>) {
   const headers = {
     'Content-Type': 'application/json',
     ...getTelegramAuthHeaders(),
@@ -18,7 +17,7 @@ export async function saveProfile({
     const res = await fetch('/api/profiles', {
       method: 'POST',
       headers,
-      body: JSON.stringify({ telegramId, icr, cf, target, low, high }),
+      body: JSON.stringify({ telegramId, icr, target, low, high }),
     });
 
     const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- require `target` in `ProfileSchema` and drop `cf` from required
- regenerate TypeScript SDK
- send only supported fields in profile save API

## Testing
- `pytest -q --cov` *(fails: unrecognized arguments: --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=85 --cov)*
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui lint` *(fails: 19 errors, 9 warnings)*
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test`


------
https://chatgpt.com/codex/tasks/task_e_68b127d874a0832a8de4a7c3c8ffdd67