### PR TITLE
[db] enforce FK on history records

### DIFF
--- a/services/api/alembic/versions/20250901_history_record_foreign_key.py
+++ b/services/api/alembic/versions/20250901_history_record_foreign_key.py
@@ -1,0 +1,51 @@
+"""add foreign key constraint to history_records.telegram_id"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20250901_history_record_foreign_key"
+down_revision: Union[str, Sequence[str], None] = (
+    "20250821_add_snooze_minutes_to_reminder_logs",
+    "20250828_add_quiet_time",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    op.alter_column(
+        "history_records",
+        "telegram_id",
+        existing_type=sa.BigInteger(),
+        nullable=False,
+    )
+
+    fks = inspector.get_foreign_keys("history_records")
+    has_fk = any(
+        fk["referred_table"] == "users" and fk["constrained_columns"] == ["telegram_id"]
+        for fk in fks
+    )
+    if not has_fk:
+        op.create_foreign_key(
+            "history_records_telegram_id_fkey",
+            "history_records",
+            "users",
+            ["telegram_id"],
+            ["telegram_id"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    fks = [fk["name"] for fk in inspector.get_foreign_keys("history_records")]
+    if "history_records_telegram_id_fkey" in fks:
+        op.drop_constraint(
+            "history_records_telegram_id_fkey", "history_records", type_="foreignkey"
+        )

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -299,7 +299,9 @@ class Timezone(Base):
 class HistoryRecord(Base):
     __tablename__ = "history_records"
     id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
-    telegram_id: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
+    telegram_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id"), index=True, nullable=False
+    )
     date: Mapped[date] = mapped_column(Date, nullable=False)
     time: Mapped[time] = mapped_column(Time, nullable=False)
     sugar: Mapped[Optional[float]] = mapped_column(Float)

--- a/tests/test_history_record_fk.py
+++ b/tests/test_history_record_fk.py
@@ -1,0 +1,45 @@
+from datetime import date, time
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.services import db
+
+
+def setup_db() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(dbapi_connection: Any, connection_record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    return SessionLocal
+
+
+def test_history_record_requires_existing_user() -> None:
+    SessionLocal = setup_db()
+
+    with SessionLocal() as session:
+        session.add(
+            db.HistoryRecord(
+                id="1",
+                telegram_id=999,
+                date=date.today(),
+                time=time(12, 0),
+                type="note",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()


### PR DESCRIPTION
## Summary
- add foreign key from history records to users
- check that history record insert fails for unknown user

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b127d86b24832a9cb50a79f287bd56