### PR TITLE
[webapp] fix telegram init path

### DIFF
--- a/services/webapp/ui/public/timezone.html
+++ b/services/webapp/ui/public/timezone.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
     <title>Часовой пояс</title>
-    <script type="module" src="/telegram-init.js"></script>
+    <script type="module" src="%BASE_URL%telegram-init.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -31,7 +31,7 @@ function telegramInitPlugin(): Plugin {
 
     // Резолв только для статического импорта init (если где-то используется)
     resolveId(id, importer) {
-      if (id === 'telegram-init.js' || id === '/ui/telegram-init.js') {
+      if (id === 'telegram-init.js' || id === '/ui/telegram-init.js' || id === '/telegram-init.js') {
         return telegramInitPath
       }
       // динамический импорт темы из init оставляем внешним модулем


### PR DESCRIPTION
## Summary
- honor VITE_BASE_URL when loading telegram-init in timezone page
- allow `/telegram-init.js` in Vite telegramInitPlugin

## Testing
- `npm run build`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b12e43da74832a8351caea0c3309eb