### PR TITLE
[ui] Validate profile inputs

### DIFF
--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { parseProfile } from '../src/pages/Profile';
+
+describe('parseProfile', () => {
+  it('returns parsed numbers for valid input', () => {
+    const result = parseProfile({ icr: '1', cf: '2', target: '3', low: '4', high: '5' });
+    expect(result).toEqual({ icr: 1, cf: 2, target: 3, low: 4, high: 5 });
+  });
+
+  it('returns null when any value is non-positive or invalid', () => {
+    expect(parseProfile({ icr: '0', cf: '2', target: '3', low: '4', high: '5' })).toBeNull();
+    expect(parseProfile({ icr: '1', cf: '-1', target: '3', low: '4', high: '5' })).toBeNull();
+    expect(parseProfile({ icr: 'a', cf: '2', target: '3', low: '4', high: '5' })).toBeNull();
+  });
+});

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -67,4 +67,25 @@ describe('Profile page', () => {
       }),
     );
   });
+
+  it('blocks save with invalid numeric input and shows toast', () => {
+    const validInitData = new URLSearchParams({
+      user: JSON.stringify({ id: 123 }),
+    }).toString();
+    useTelegramInitData.mockReturnValue(validInitData);
+
+    const { getByText, getByPlaceholderText } = render(<Profile />);
+    const icrInput = getByPlaceholderText('12');
+    fireEvent.change(icrInput, { target: { value: '-1' } });
+
+    fireEvent.click(getByText('Сохранить настройки'));
+    expect(saveProfile).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Ошибка',
+        description: 'Все значения должны быть положительными числами',
+        variant: 'destructive',
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- validate numeric profile fields before saving
- show toast when profile values are invalid
- add tests for profile validation helper and page behavior

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pytest` *(fails: unrecognized arguments --cov...)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b1334fbbb0832aaa4f133564ef16db