### PR TITLE
[services] Include field name in profile validation errors

### DIFF
--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -38,7 +38,7 @@ def _validate_profile(data: ProfileSchema) -> None:
     }
     for name, value in required.items():
         if value is None:
-            raise ValueError("field is required")  # pragma: no cover
+            raise ValueError(f"{name} is required")  # pragma: no cover
         if value <= 0:
             raise ValueError(f"{name} must be greater than 0")  # pragma: no cover
 

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -62,8 +62,15 @@ def test_validate_profile_rejects_invalid_values(
     assert str(exc.value) == message
 
 
-@pytest.mark.parametrize("field", ["icr", "low", "high"])
-def test_validate_profile_rejects_missing_fields(field: str) -> None:
+@pytest.mark.parametrize(
+    "field,message",
+    [
+        ("icr", "ratio is required"),
+        ("low", "target is required"),
+        ("high", "target is required"),
+    ],
+)
+def test_validate_profile_rejects_missing_fields(field: str, message: str) -> None:
     kwargs = {
         "telegramId": 1,
         "icr": 1.0,
@@ -74,7 +81,7 @@ def test_validate_profile_rejects_missing_fields(field: str) -> None:
     data = ProfileSchema(**kwargs)
     with pytest.raises(ValueError) as exc:
         _validate_profile(data)
-    assert str(exc.value) == "field is required"
+    assert str(exc.value) == message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- include field names in profile validation error messages
- adjust profile validation tests for new error messages

## Testing
- `pytest tests/test_profile_validation.py::test_validate_profile_rejects_missing_fields -q` *(fails: Coverage failure: total of 24 is less than fail-under=85)*
- `mypy --strict services/api/app/services/profile.py tests/test_profile_validation.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b133480e00832abe308dbf32511f85