### PR TITLE
[profile] simplify user data access

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -82,9 +82,7 @@ MSG_LOW_GT0 = "Нижний порог должен быть больше 0."
 MSG_HIGH_GT_LOW = "Верхний порог должен быть больше нижнего и больше 0."
 
 
-PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(
-    6
-)
+PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(6)
 END: int = ConversationHandler.END
 
 
@@ -113,21 +111,9 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         if callable(end_conv):
             end_conv(update, context, END)
         else:
-            chat_id = (
-                getattr(update.effective_chat, "id", None)
-                if sugar_conv.per_chat
-                else None
-            )
-            user_id = (
-                getattr(update.effective_user, "id", None)
-                if sugar_conv.per_user
-                else None
-            )
-            msg_id = (
-                getattr(update.effective_message, "message_id", None)
-                if sugar_conv.per_message
-                else None
-            )
+            chat_id = getattr(update.effective_chat, "id", None) if sugar_conv.per_chat else None
+            user_id = getattr(update.effective_user, "id", None) if sugar_conv.per_user else None
+            msg_id = getattr(update.effective_message, "message_id", None) if sugar_conv.per_message else None
             key = cast(
                 tuple[int | str, ...],
                 tuple(i for i in (chat_id, user_id, msg_id) if i is not None),
@@ -138,8 +124,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 logger.warning("sugar_conv lacks _update_state method")
 
     help_text = (
-        "Настройки профиля доступны в приложении. "
-        "Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
+        "Настройки профиля доступны в приложении. Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
     )
 
     if len(args) == 1 and args[0].lower() == "help":
@@ -162,9 +147,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         low = float(values["low"].replace(",", "."))
         high = float(values["high"].replace(",", "."))
     except ValueError:
-        await message.reply_text(
-            "❗ Пожалуйста, введите корректные числа. Справка: /profile help"
-        )
+        await message.reply_text("❗ Пожалуйста, введите корректные числа. Справка: /profile help")
         return END
 
     if icr <= 0:
@@ -246,10 +229,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         ]
 
     if not profile:
-        text = (
-            "Ваш профиль пока не настроен.\n\n"
-            "Настройки профиля доступны в приложении."
-        )
+        text = "Ваш профиль пока не настроен.\n\nНастройки профиля доступны в приложении."
         if webapp_button is not None:
             text += " Нажмите кнопку ниже, чтобы открыть и обновить данные."
             keyboard = InlineKeyboardMarkup([webapp_button])
@@ -382,9 +362,7 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     button = build_timezone_webapp_button()
     if button:
         keyboard = InlineKeyboardMarkup([[button]])
-        await message.reply_text(
-            "Можно определить автоматически:", reply_markup=keyboard
-        )
+        await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
     else:
         await message.reply_text(
             "Автоматическое определение недоступно, укажите часовой пояс вручную.",
@@ -393,9 +371,7 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     return PROFILE_TZ
 
 
-async def profile_timezone_save(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Save user timezone from input."""
     message = update.message
     if message is None:
@@ -420,9 +396,7 @@ async def profile_timezone_save(
         button = build_timezone_webapp_button()
         if button:
             keyboard = InlineKeyboardMarkup([[button]])
-            await message.reply_text(
-                "Можно определить автоматически:", reply_markup=keyboard
-            )
+            await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
         else:
             await message.reply_text(
                 "Автоматическое определение недоступно, введите часовой пояс вручную.",
@@ -455,9 +429,7 @@ async def profile_timezone_save(
     return END
 
 
-def _security_db(
-    session: Session, user_id: int, action: str | None
-) -> dict[str, object]:
+def _security_db(session: Session, user_id: int, action: str | None) -> dict[str, object]:
     profile = session.get(Profile, user_id)
     user = session.get(User, user_id)
     if not profile:
@@ -491,22 +463,13 @@ def _security_db(
     if changed:
         try:
             commit(session)
-            alert = (
-                session.query(Alert)
-                .filter_by(user_id=user_id)
-                .order_by(Alert.ts.desc())
-                .first()
-            )
+            alert = session.query(Alert).filter_by(user_id=user_id).order_by(Alert.ts.desc()).first()
             alert_sugar = alert.sugar if alert else None
         except CommitError:
             commit_ok = False
 
     rems = session.query(Reminder).filter_by(telegram_id=user_id).all()
-    rem_text = (
-        "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems)
-        if rems
-        else "нет"
-    )
+    rem_text = "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems) if rems else "нет"
     return {
         "found": True,
         "commit_ok": commit_ok,
@@ -590,20 +553,12 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton(
-                    "Низкий -0.5", callback_data="profile_security:low_dec"
-                ),
-                InlineKeyboardButton(
-                    "Низкий +0.5", callback_data="profile_security:low_inc"
-                ),
+                InlineKeyboardButton("Низкий -0.5", callback_data="profile_security:low_dec"),
+                InlineKeyboardButton("Низкий +0.5", callback_data="profile_security:low_inc"),
             ],
             [
-                InlineKeyboardButton(
-                    "Высокий -0.5", callback_data="profile_security:high_dec"
-                ),
-                InlineKeyboardButton(
-                    "Высокий +0.5", callback_data="profile_security:high_inc"
-                ),
+                InlineKeyboardButton("Высокий -0.5", callback_data="profile_security:high_dec"),
+                InlineKeyboardButton("Высокий +0.5", callback_data="profile_security:high_inc"),
             ],
             [
                 InlineKeyboardButton(
@@ -611,15 +566,9 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     callback_data="profile_security:toggle_sos",
                 )
             ],
+            [InlineKeyboardButton("SOS контакт", callback_data="profile_security:sos_contact")],
             [
-                InlineKeyboardButton(
-                    "SOS контакт", callback_data="profile_security:sos_contact"
-                )
-            ],
-            [
-                InlineKeyboardButton(
-                    "➕ Добавить", callback_data="profile_security:add"
-                ),
+                InlineKeyboardButton("➕ Добавить", callback_data="profile_security:add"),
                 InlineKeyboardButton("🗑 Удалить", callback_data="profile_security:del"),
             ],
             [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
@@ -645,13 +594,7 @@ async def profile_edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
 
 async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle ICR input."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
-        context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(UserData, user_data_raw)
-    context.user_data = user_data
+    user_data = cast(UserData, context.user_data)
     message = update.message
     if message is None or message.text is None:
         return END
@@ -677,13 +620,7 @@ async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
 async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle CF input."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
-        context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(UserData, user_data_raw)
-    context.user_data = user_data
+    user_data = cast(UserData, context.user_data)
     message = update.message
     if message is None or message.text is None:
         return END
@@ -713,13 +650,7 @@ async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle target BG input."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
-        context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(UserData, user_data_raw)
-    context.user_data = user_data
+    user_data = cast(UserData, context.user_data)
     message = update.message
     if message is None or message.text is None:
         return END
@@ -734,9 +665,7 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     try:
         target = float(text)
     except ValueError:
-        await message.reply_text(
-            "Введите целевой сахар числом.", reply_markup=back_keyboard
-        )
+        await message.reply_text("Введите целевой сахар числом.", reply_markup=back_keyboard)
         return PROFILE_TARGET
     if target <= 0:
         await message.reply_text(MSG_TARGET_GT0, reply_markup=back_keyboard)
@@ -751,13 +680,7 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle low threshold input."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
-        context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(UserData, user_data_raw)
-    context.user_data = user_data
+    user_data = cast(UserData, context.user_data)
     message = update.message
     if message is None or message.text is None:
         return END
@@ -772,9 +695,7 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     try:
         low = float(text)
     except ValueError:
-        await message.reply_text(
-            "Введите нижний порог числом.", reply_markup=back_keyboard
-        )
+        await message.reply_text("Введите нижний порог числом.", reply_markup=back_keyboard)
         return PROFILE_LOW
     if low <= 0:
         await message.reply_text(MSG_LOW_GT0, reply_markup=back_keyboard)
@@ -789,13 +710,7 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
 async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle high threshold input and save profile."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
-        context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(UserData, user_data_raw)
-    context.user_data = user_data
+    user_data = cast(UserData, context.user_data)
     message = update.message
     if message is None or message.text is None:
         return END
@@ -810,9 +725,7 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     try:
         high = float(text)
     except ValueError:
-        await message.reply_text(
-            "Введите верхний порог числом.", reply_markup=back_keyboard
-        )
+        await message.reply_text("Введите верхний порог числом.", reply_markup=back_keyboard)
         return PROFILE_HIGH
     low = user_data.get("profile_low")
     if high <= 0 or low is None or high <= low:
@@ -826,9 +739,7 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     target = user_data.pop("profile_target", None)
     user_data.pop("profile_low", None)
     if icr is None or cf is None or target is None:
-        await message.reply_text(
-            "⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново."
-        )
+        await message.reply_text("⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново.")
         return END
     user = update.effective_user
     if user is None:
@@ -891,15 +802,11 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return END
 
 
-async def _profile_edit_entry(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def _profile_edit_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     return await profile_edit(update, context)
 
 
-async def _profile_timezone_entry(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def _profile_timezone_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     return await profile_timezone(update, context)
 
 
@@ -907,16 +814,12 @@ profile_conv = ConversationHandler(
     entry_points=[
         CommandHandler("profile", profile_command),
         CallbackQueryNoWarnHandler(_profile_edit_entry, pattern="^profile_edit$"),
-        CallbackQueryNoWarnHandler(
-            _profile_timezone_entry, pattern="^profile_timezone$"
-        ),
+        CallbackQueryNoWarnHandler(_profile_timezone_entry, pattern="^profile_timezone$"),
     ],
     states={
         PROFILE_ICR: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_icr)],
         PROFILE_CF: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_cf)],
-        PROFILE_TARGET: [
-            MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)
-        ],
+        PROFILE_TARGET: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)],
         PROFILE_LOW: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_low)],
         PROFILE_HIGH: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_high)],
         PROFILE_TZ: [
@@ -938,9 +841,7 @@ profile_conv = ConversationHandler(
 )
 
 
-profile_webapp_handler = MessageHandler(
-    filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save
-)
+profile_webapp_handler = MessageHandler(filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- simplify user_data handling in profile conversation steps

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov --cov-fail-under=85` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b138ad9724832a89014177931a6a31