### PR TITLE
[handlers] Add profile_timezone stub

### DIFF
--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -189,6 +189,16 @@ async def handle_edit_field(
     await message.reply_text(prompt, reply_markup=ForceReply(selective=True))
 
 
+async def profile_timezone_stub(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    query: CallbackQuery,
+    _: str,
+) -> None:
+    """Placeholder handler for profile timezone callbacks."""
+    return None
+
+
 callback_handlers: dict[str, Handler] = {
     "confirm_entry": handle_confirm_entry,
     "edit_entry": handle_edit_entry,
@@ -196,6 +206,7 @@ callback_handlers: dict[str, Handler] = {
     "edit_field:": handle_edit_field,
     "edit:": handle_edit_or_delete,
     "del:": handle_edit_or_delete,
+    "profile_timezone": profile_timezone_stub,
 }
 
 


### PR DESCRIPTION
## Summary
- add placeholder handler for `profile_timezone` callbacks to suppress warnings

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b138b523e8832a973961adac5642c2