### PR TITLE
[db] enforce reminder log telegram FK

### DIFF
--- a/services/api/alembic/versions/20250902_reminder_log_telegram_foreign_key.py
+++ b/services/api/alembic/versions/20250902_reminder_log_telegram_foreign_key.py
@@ -1,0 +1,74 @@
+"""add foreign key to reminder_logs.telegram_id"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20250902_reminder_log_telegram_foreign_key"
+down_revision: Union[str, Sequence[str], None] = "20250901_history_record_foreign_key"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE reminder_logs
+            SET telegram_id = NULL
+            WHERE telegram_id IS NOT NULL
+              AND telegram_id NOT IN (SELECT telegram_id FROM users)
+            """
+        )
+    )
+
+    op.alter_column(
+        "reminder_logs",
+        "telegram_id",
+        existing_type=sa.BigInteger(),
+        nullable=True,
+    )
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("reminder_logs")]
+    if "ix_reminder_logs_telegram_id" not in indexes:
+        op.create_index(
+            "ix_reminder_logs_telegram_id",
+            "reminder_logs",
+            ["telegram_id"],
+        )
+
+    fks = inspector.get_foreign_keys("reminder_logs")
+    has_fk = any(
+        fk["referred_table"] == "users" and fk["constrained_columns"] == ["telegram_id"]
+        for fk in fks
+    )
+    if not has_fk:
+        op.create_foreign_key(
+            "reminder_logs_telegram_id_fkey",
+            "reminder_logs",
+            "users",
+            ["telegram_id"],
+            ["telegram_id"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    fks = [fk["name"] for fk in inspector.get_foreign_keys("reminder_logs")]
+    if "reminder_logs_telegram_id_fkey" in fks:
+        op.drop_constraint(
+            "reminder_logs_telegram_id_fkey",
+            "reminder_logs",
+            type_="foreignkey",
+        )
+
+    indexes = [idx["name"] for idx in inspector.get_indexes("reminder_logs")]
+    if "ix_reminder_logs_telegram_id" in indexes:
+        op.drop_index("ix_reminder_logs_telegram_id", table_name="reminder_logs")

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -276,7 +276,12 @@ class ReminderLog(Base):
     reminder_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("reminders.id")
     )
-    telegram_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+    telegram_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger,
+        ForeignKey("users.telegram_id"),
+        index=True,
+        nullable=True,
+    )
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
     action: Mapped[Optional[str]] = mapped_column(String)
     snooze_minutes: Mapped[Optional[int]] = mapped_column(Integer)


### PR DESCRIPTION
## Summary
- link `reminder_logs.telegram_id` to `users.telegram_id`
- migration cleans up orphaned reminder logs and adds FK + index

## Testing
- `python -m black services/api/app/diabetes/services/db.py services/api/alembic/versions/20250902_reminder_log_telegram_foreign_key.py`
- `pytest -q --cov` *(fails: KeyboardInterrupt after hang)*
- `mypy --strict .` *(fails: interrupted due to long runtime)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b1303b83dc832a9488801d96f984b1