### PR TITLE
tests(profile): add ContextStub and guard user_data

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -645,13 +645,8 @@ async def profile_edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
 
 async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle ICR input."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
-        context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(UserData, user_data_raw)
-    context.user_data = user_data
+    user_data = cast(UserData, context.user_data)
+    assert user_data is not None
     message = update.message
     if message is None or message.text is None:
         return END
@@ -677,13 +672,8 @@ async def profile_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
 async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle CF input."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
-        context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(UserData, user_data_raw)
-    context.user_data = user_data
+    user_data = cast(UserData, context.user_data)
+    assert user_data is not None
     message = update.message
     if message is None or message.text is None:
         return END
@@ -713,13 +703,8 @@ async def profile_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
 async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle target BG input."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
-        context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(UserData, user_data_raw)
-    context.user_data = user_data
+    user_data = cast(UserData, context.user_data)
+    assert user_data is not None
     message = update.message
     if message is None or message.text is None:
         return END
@@ -751,13 +736,8 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle low threshold input."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
-        context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(UserData, user_data_raw)
-    context.user_data = user_data
+    user_data = cast(UserData, context.user_data)
+    assert user_data is not None
     message = update.message
     if message is None or message.text is None:
         return END
@@ -789,13 +769,8 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
 async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle high threshold input and save profile."""
-    user_data_raw = context.user_data
-    if user_data_raw is None:
-        context.user_data = {}
-        user_data_raw = context.user_data
-    assert user_data_raw is not None
-    user_data = cast(UserData, user_data_raw)
-    context.user_data = user_data
+    user_data = cast(UserData, context.user_data)
+    assert user_data is not None
     message = update.message
     if message is None or message.text is None:
         return END

--- a/tests/handlers/profile/test_conversation_flow.py
+++ b/tests/handlers/profile/test_conversation_flow.py
@@ -1,11 +1,13 @@
 import importlib
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
-from unittest.mock import AsyncMock
+
+from tests.profile_context_stub import ContextStub
 
 handlers = importlib.import_module(
     "services.api.app.diabetes.handlers.profile.conversation"
@@ -52,7 +54,7 @@ async def test_profile_creation_flow_success(monkeypatch: pytest.MonkeyPatch) ->
 
     ctx = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={}),
+        ContextStub(),
     )
     user = SimpleNamespace(id=1)
 
@@ -134,7 +136,7 @@ async def test_profile_creation_db_error(monkeypatch: pytest.MonkeyPatch) -> Non
 async def test_profile_icr_invalid() -> None:
     ctx = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={}),
+        ContextStub(),
     )
     user = SimpleNamespace(id=1)
     msg = DummyMessage("abc")

--- a/tests/profile_context_stub.py
+++ b/tests/profile_context_stub.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+class ContextStub:
+    def __init__(self) -> None:
+        self._user_data: dict[str, Any] = {}
+
+    @property
+    def user_data(self) -> dict[str, Any]:
+        return self._user_data

--- a/tests/test_profile_conversation.py
+++ b/tests/test_profile_conversation.py
@@ -7,6 +7,8 @@ import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
 
+from .profile_context_stub import ContextStub
+
 handlers = importlib.import_module(
     "services.api.app.diabetes.handlers.profile.conversation"
 )
@@ -25,6 +27,20 @@ class DummyMessage:
 
     async def delete(self) -> None:
         pass
+
+
+@pytest.mark.asyncio
+async def test_profile_icr_keeps_user_data() -> None:
+    msg = DummyMessage("1")
+    update = cast(
+        Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+    )
+    ctx = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        ContextStub(),
+    )
+    await handlers.profile_icr(update, ctx)
+    assert ctx.user_data["profile_icr"] == 1.0
 
 
 @pytest.mark.asyncio
@@ -140,7 +156,7 @@ async def test_profile_cf_cases(
     )
     ctx = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={}),
+        ContextStub(),
     )
     state = await handlers.profile_cf(update, ctx)
     assert state == expected_state
@@ -168,7 +184,7 @@ async def test_profile_target_cases(
     )
     ctx = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={}),
+        ContextStub(),
     )
     state = await handlers.profile_target(update, ctx)
     assert state == expected_state
@@ -196,8 +212,9 @@ async def test_profile_low_cases(
     )
     ctx = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={"profile_target": 6.0}),
+        ContextStub(),
     )
+    ctx.user_data["profile_target"] = 6.0
     state = await handlers.profile_low(update, ctx)
     assert state == expected_state
     assert expected_fragment in msg.replies[0]
@@ -224,8 +241,9 @@ async def test_profile_high_invalid(
     )
     ctx = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={"profile_low": 4.0}),
+        ContextStub(),
     )
+    ctx.user_data["profile_low"] = 4.0
     state = await handlers.profile_high(update, ctx)
     assert state == expected_state
     assert expected_fragment in msg.replies[0]
@@ -239,14 +257,15 @@ async def test_profile_high_db_error(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     ctx = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(
-            user_data={
-                "profile_icr": 8.0,
-                "profile_cf": 3.0,
-                "profile_target": 6.0,
-                "profile_low": 4.0,
-            }
-        ),
+        ContextStub(),
+    )
+    ctx.user_data.update(
+        {
+            "profile_icr": 8.0,
+            "profile_cf": 3.0,
+            "profile_target": 6.0,
+            "profile_low": 4.0,
+        }
     )
     run_db_mock = AsyncMock(return_value=False)
     monkeypatch.setattr(handlers, "run_db", run_db_mock)
@@ -264,14 +283,15 @@ async def test_profile_high_success_warning(monkeypatch: pytest.MonkeyPatch) -> 
     )
     ctx = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(
-            user_data={
-                "profile_icr": 9.0,
-                "profile_cf": 2.0,
-                "profile_target": 6.0,
-                "profile_low": 4.0,
-            }
-        ),
+        ContextStub(),
+    )
+    ctx.user_data.update(
+        {
+            "profile_icr": 9.0,
+            "profile_cf": 2.0,
+            "profile_target": 6.0,
+            "profile_low": 4.0,
+        }
     )
     run_db_mock = AsyncMock(return_value=True)
     monkeypatch.setattr(handlers, "run_db", run_db_mock)

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -8,6 +8,8 @@ import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
 
+from .profile_context_stub import ContextStub
+
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
@@ -80,8 +82,9 @@ async def test_profile_input_not_logged_as_sugar(
     shared_chat_data: dict[str, Any] = {}
     sugar_context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={}, chat_data=shared_chat_data),
+        ContextStub(),
     )
+    sugar_context.chat_data = shared_chat_data
     await sugar_handlers.sugar_start(sugar_update, sugar_context)
 
     # Open profile view which should cancel sugar conversation
@@ -96,8 +99,10 @@ async def test_profile_input_not_logged_as_sugar(
     )
     prof_context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(args=[], user_data={}, chat_data=shared_chat_data),
+        ContextStub(),
     )
+    prof_context.args = []
+    prof_context.chat_data = shared_chat_data
     result = await profile_handlers.profile_command(prof_update, prof_context)
     assert result == profile_handlers.END
     assert "Ваш профиль" in prof_msg.replies[0]
@@ -115,8 +120,9 @@ async def test_profile_input_not_logged_as_sugar(
     )
     icr_context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={}, chat_data=shared_chat_data),
+        ContextStub(),
     )
+    icr_context.chat_data = shared_chat_data
     result_icr = await sugar_handlers.sugar_val(icr_update, icr_context)
     assert result_icr == sugar_handlers.END
 

--- a/tests/test_profile_no_sdk.py
+++ b/tests/test_profile_no_sdk.py
@@ -9,6 +9,8 @@ from sqlalchemy.orm import sessionmaker
 from telegram import Update
 from telegram.ext import CallbackContext
 
+from .profile_context_stub import ContextStub
+
 from services.api.app.diabetes.services.db import Base, User, Profile
 
 
@@ -129,8 +131,9 @@ async def test_profile_command_and_view_without_sdk(
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(args=["8", "3", "6", "4", "9"], user_data={}),
+        ContextStub(),
     )
+    context.args = ["8", "3", "6", "4", "9"]
 
     with caplog.at_level(logging.WARNING):
         await handlers.profile_command(update, context)
@@ -150,7 +153,7 @@ async def test_profile_command_and_view_without_sdk(
     )
     context2 = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={}),
+        ContextStub(),
     )
 
     with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
## Summary
- avoid reassigning `context.user_data` in profile conversation handlers
- introduce `ContextStub` with read-only `user_data`
- use ContextStub across profile tests and add regression test for `profile_icr`

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b138ae378c832ab594bf5b36cd2ba5