### PR TITLE
[profile] split icr and cf fields

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -35,6 +35,7 @@ async def profiles_get(
         raise HTTPException(status_code=404, detail="profile not found")
 
     icr: float | None = profile.icr
+    cf: float | None = profile.cf
     target_bg: float | None = profile.target_bg
     low_threshold: float | None = profile.low_threshold
     high_threshold: float | None = profile.high_threshold
@@ -42,6 +43,7 @@ async def profiles_get(
     return ProfileSchema(
         telegramId=profile.telegram_id,
         icr=float(icr) if icr is not None else 0.0,
+        cf=float(cf) if cf is not None else 0.0,
         target=float(target_bg) if target_bg is not None else 0.0,
         low=float(low_threshold) if low_threshold is not None else 0.0,
         high=float(high_threshold) if high_threshold is not None else 0.0,

--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -11,10 +11,15 @@ class ProfileSchema(BaseModel):
     telegramId: int = Field(
         alias="telegramId", validation_alias=AliasChoices("telegramId", "telegram_id")
     )
-    ratio: Optional[float] = Field(
+    icr: Optional[float] = Field(
         default=None,
         alias="icr",
-        validation_alias=AliasChoices("icr", "cf"),
+        validation_alias=AliasChoices("icr"),
+    )
+    cf: Optional[float] = Field(
+        default=None,
+        alias="cf",
+        validation_alias=AliasChoices("cf"),
     )
     target: Optional[float] = None
     low: Optional[float] = Field(

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -31,7 +31,8 @@ async def set_timezone(telegram_id: int, tz: str) -> None:  # pragma: no cover
 def _validate_profile(data: ProfileSchema) -> None:
     """Validate business rules for a patient profile."""
     required = {
-        "ratio": data.ratio,
+        "icr": data.icr,
+        "cf": data.cf,
         "target": data.target,
         "low": data.low,
         "high": data.high,
@@ -67,8 +68,8 @@ async def save_profile(data: ProfileSchema) -> None:
         profile_data = {
             "telegram_id": data.telegramId,
             "org_id": data.orgId,
-            "icr": data.ratio,
-            "cf": data.ratio,
+            "icr": data.icr,
+            "cf": data.cf,
             "target_bg": data.target,
             "low_threshold": data.low,
             "high_threshold": data.high,

--- a/tests/test_profile_aliases.py
+++ b/tests/test_profile_aliases.py
@@ -18,11 +18,13 @@ def _create_app() -> FastAPI:
 def test_profile_schema_accepts_aliases_and_computes_target() -> None:
     data = ProfileSchema(
         telegramId=1,
-        cf=1.0,
+        icr=1.0,
+        cf=2.0,
         targetLow=4.0,
         targetHigh=6.0,
     )
-    assert data.ratio == 1.0
+    assert data.icr == 1.0
+    assert data.cf == 2.0
     assert data.low == 4.0
     assert data.high == 6.0
     assert data.target == 5.0
@@ -39,6 +41,7 @@ def test_profiles_post_alias_mismatch_returns_422(field: str, value: dict) -> No
     app = _create_app()
     payload = {
         "telegramId": 1,
+        "icr": 1.0,
         "cf": 1.0,
         **value,
     }

--- a/tests/test_profile_optional_fields.py
+++ b/tests/test_profile_optional_fields.py
@@ -21,6 +21,7 @@ async def test_save_profile_saves_computed_target(
     data = ProfileSchema(
         telegramId=1,
         icr=1.0,
+        cf=1.0,
         low=4.0,
         high=6.0,
     )

--- a/tests/test_profile_quiet_fields.py
+++ b/tests/test_profile_quiet_fields.py
@@ -20,6 +20,7 @@ async def test_save_profile_stores_quiet_fields(monkeypatch: pytest.MonkeyPatch)
     data = ProfileSchema(
         telegramId=1,
         icr=1.0,
+        cf=1.0,
         target=3.0,
         low=1.0,
         high=5.0,
@@ -46,6 +47,7 @@ async def test_save_profile_defaults_quiet_fields(monkeypatch: pytest.MonkeyPatc
     data = ProfileSchema(
         telegramId=2,
         icr=1.0,
+        cf=1.0,
         target=3.0,
         low=1.0,
         high=5.0,

--- a/tests/test_profile_sos_fields.py
+++ b/tests/test_profile_sos_fields.py
@@ -21,6 +21,7 @@ async def test_save_profile_stores_sos_fields(monkeypatch: pytest.MonkeyPatch) -
     data = ProfileSchema(
         telegramId=1,
         icr=1.0,
+        cf=1.0,
         target=3.0,
         low=1.0,
         high=5.0,
@@ -49,6 +50,7 @@ async def test_save_profile_defaults_sos_fields(
     data = ProfileSchema(
         telegramId=2,
         icr=1.0,
+        cf=1.0,
         target=3.0,
         low=1.0,
         high=5.0,
@@ -75,6 +77,7 @@ async def test_save_profile_persists_quiet_hours(
     data = ProfileSchema(
         telegramId=3,
         icr=1.0,
+        cf=1.0,
         target=3.0,
         low=1.0,
         high=5.0,
@@ -103,6 +106,7 @@ async def test_save_profile_defaults_quiet_hours(
     data = ProfileSchema(
         telegramId=4,
         icr=1.0,
+        cf=1.0,
         target=3.0,
         low=1.0,
         high=5.0,

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -11,6 +11,7 @@ def test_validate_profile_allows_computed_target() -> None:
     data = ProfileSchema(
         telegramId=1,
         icr=1.0,
+        cf=1.0,
         low=4.0,
         high=6.0,
     )
@@ -23,6 +24,7 @@ def test_validate_profile_rejects_target_outside_limits(target: Any) -> None:
     data = ProfileSchema(
         telegramId=1,
         icr=1.0,
+        cf=1.0,
         target=target,
         low=4.0,
         high=7.0,
@@ -35,7 +37,8 @@ def test_validate_profile_rejects_target_outside_limits(target: Any) -> None:
 @pytest.mark.parametrize(
     "field,value,message",
     [
-        ("icr", 0.0, "ratio must be greater than 0"),
+        ("icr", 0.0, "icr must be greater than 0"),
+        ("cf", 0.0, "cf must be greater than 0"),
         ("target", 0.0, "target must be greater than 0"),
         ("low", 0.0, "low must be greater than 0"),
         ("high", 0.0, "high must be greater than 0"),
@@ -48,6 +51,7 @@ def test_validate_profile_rejects_invalid_values(
     kwargs = {
         "telegramId": 1,
         "icr": 1.0,
+        "cf": 1.0,
         "target": 5.0,
         "low": 4.0,
         "high": 7.0,
@@ -65,7 +69,8 @@ def test_validate_profile_rejects_invalid_values(
 @pytest.mark.parametrize(
     "field,message",
     [
-        ("icr", "ratio is required"),
+        ("icr", "icr is required"),
+        ("cf", "cf is required"),
         ("low", "target is required"),
         ("high", "target is required"),
     ],
@@ -74,6 +79,7 @@ def test_validate_profile_rejects_missing_fields(field: str, message: str) -> No
     kwargs = {
         "telegramId": 1,
         "icr": 1.0,
+        "cf": 1.0,
         "low": 4.0,
         "high": 7.0,
     }
@@ -92,6 +98,7 @@ def test_profile_rejects_malformed_quiet_times(field: str, value: str) -> None:
     kwargs = {
         "telegramId": 1,
         "icr": 1.0,
+        "cf": 1.0,
         "target": 5.0,
         "low": 4.0,
         "high": 7.0,

--- a/tests/test_profiles_api.py
+++ b/tests/test_profiles_api.py
@@ -34,6 +34,7 @@ def test_profiles_post_creates_user_for_missing_telegram_id(
     payload = {
         "telegramId": 777,
         "icr": 1.0,
+        "cf": 1.0,
         "target": 5.0,
         "low": 4.0,
         "high": 6.0,
@@ -61,6 +62,7 @@ def test_profiles_post_invalid_values_returns_422(
     payload = {
         "telegramId": 777,
         "icr": 1.0,
+        "cf": 1.0,
         "target": 5.0,
         "low": 6.0,
         "high": 5.0,
@@ -89,6 +91,7 @@ def test_profiles_post_invalid_icr_returns_422(
     payload = {
         "telegramId": 777,
         "icr": 0,
+        "cf": 1.0,
         "target": 5.0,
         "low": 4.0,
         "high": 6.0,
@@ -96,11 +99,11 @@ def test_profiles_post_invalid_icr_returns_422(
     with TestClient(app) as client:
         resp = client.post("/api/profiles", json=payload)
     assert resp.status_code == 422
-    assert resp.json() == {"detail": "ratio must be greater than 0"}
+    assert resp.json() == {"detail": "icr must be greater than 0"}
     engine.dispose()
 
 
-def test_profiles_post_invalid_cf_alias_returns_422(
+def test_profiles_post_invalid_cf_returns_422(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     app = FastAPI()
@@ -115,6 +118,7 @@ def test_profiles_post_invalid_cf_alias_returns_422(
     monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
     payload = {
         "telegramId": 777,
+        "icr": 1.0,
         "cf": -1,
         "target": 5.0,
         "low": 4.0,
@@ -123,7 +127,7 @@ def test_profiles_post_invalid_cf_alias_returns_422(
     with TestClient(app) as client:
         resp = client.post("/api/profiles", json=payload)
     assert resp.status_code == 422
-    assert resp.json() == {"detail": "ratio must be greater than 0"}
+    assert resp.json() == {"detail": "cf must be greater than 0"}
     engine.dispose()
 
 
@@ -144,6 +148,7 @@ def test_profiles_post_updates_existing_profile(
         payload = {
             "telegramId": 777,
             "icr": 1.0,
+            "cf": 2.0,
             "target": 5.0,
             "low": 4.0,
             "high": 6.0,
@@ -154,7 +159,8 @@ def test_profiles_post_updates_existing_profile(
 
         update = {
             "telegramId": 777,
-            "cf": 2.0,
+            "icr": 3.0,
+            "cf": 4.0,
             "target": 6.0,
             "low": 5.0,
             "high": 7.0,
@@ -166,7 +172,8 @@ def test_profiles_post_updates_existing_profile(
         resp = client.get("/api/profiles", params={"telegramId": 777})
         assert resp.status_code == 200
         data = resp.json()
-        assert data["icr"] == 2.0
+        assert data["icr"] == 3.0
+        assert data["cf"] == 4.0
         assert data["quietStart"] == "22:00:00"
         assert data["quietEnd"] == "06:00:00"
     engine.dispose()


### PR DESCRIPTION
## Summary
- model ProfileSchema with separate `icr` and `cf` fields
- validate and persist profile using distinct ratios
- update profile API tests for new fields

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b13ae53860832aa385ba2e25223d0d