### PR TITLE
[profile] validate profile thresholds and target ranges

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -68,21 +68,25 @@ from .api import (  # noqa: E402
     fetch_profile,
     post_profile,
 )
-from .validation import parse_profile_args  # noqa: E402
+from .validation import (  # noqa: E402
+    MSG_CF_GT0,
+    MSG_HIGH_GT_LOW,
+    MSG_ICR_GT0,
+    MSG_LOW_GT0,
+    MSG_TARGET_GT0,
+    MSG_TARGET_RANGE,  # noqa: F401 - re-exported for tests
+    parse_profile_args,
+    validate_profile_numbers,
+)
 
 back_keyboard: ReplyKeyboardMarkup = _back_keyboard
 
 from .. import UserData  # noqa: E402
 
 
-MSG_ICR_GT0 = "ИКХ должен быть больше 0."
-MSG_CF_GT0 = "КЧ должен быть больше 0."
-MSG_TARGET_GT0 = "Целевой сахар должен быть больше 0."
-MSG_LOW_GT0 = "Нижний порог должен быть больше 0."
-MSG_HIGH_GT_LOW = "Верхний порог должен быть больше нижнего и больше 0."
-
-
-PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(6)
+PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(
+    6
+)
 END: int = ConversationHandler.END
 
 
@@ -111,9 +115,21 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         if callable(end_conv):
             end_conv(update, context, END)
         else:
-            chat_id = getattr(update.effective_chat, "id", None) if sugar_conv.per_chat else None
-            user_id = getattr(update.effective_user, "id", None) if sugar_conv.per_user else None
-            msg_id = getattr(update.effective_message, "message_id", None) if sugar_conv.per_message else None
+            chat_id = (
+                getattr(update.effective_chat, "id", None)
+                if sugar_conv.per_chat
+                else None
+            )
+            user_id = (
+                getattr(update.effective_user, "id", None)
+                if sugar_conv.per_user
+                else None
+            )
+            msg_id = (
+                getattr(update.effective_message, "message_id", None)
+                if sugar_conv.per_message
+                else None
+            )
             key = cast(
                 tuple[int | str, ...],
                 tuple(i for i in (chat_id, user_id, msg_id) if i is not None),
@@ -123,9 +139,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             else:
                 logger.warning("sugar_conv lacks _update_state method")
 
-    help_text = (
-        "Настройки профиля доступны в приложении. Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
-    )
+    help_text = "Настройки профиля доступны в приложении. Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
 
     if len(args) == 1 and args[0].lower() == "help":
         await message.reply_text(help_text, parse_mode="Markdown")
@@ -147,23 +161,13 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         low = float(values["low"].replace(",", "."))
         high = float(values["high"].replace(",", "."))
     except ValueError:
-        await message.reply_text("❗ Пожалуйста, введите корректные числа. Справка: /profile help")
+        await message.reply_text(
+            "❗ Пожалуйста, введите корректные числа. Справка: /profile help"
+        )
         return END
-
-    if icr <= 0:
-        await message.reply_text(MSG_ICR_GT0)
-        return END
-    if cf <= 0:
-        await message.reply_text(MSG_CF_GT0)
-        return END
-    if target <= 0:
-        await message.reply_text(MSG_TARGET_GT0)
-        return END
-    if low <= 0:
-        await message.reply_text(MSG_LOW_GT0)
-        return END
-    if high <= low:
-        await message.reply_text(MSG_HIGH_GT_LOW)
+    error = validate_profile_numbers(icr, cf, target, low, high)
+    if error:
+        await message.reply_text(error)
         return END
 
     warning_msg = ""
@@ -229,7 +233,9 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         ]
 
     if not profile:
-        text = "Ваш профиль пока не настроен.\n\nНастройки профиля доступны в приложении."
+        text = (
+            "Ваш профиль пока не настроен.\n\nНастройки профиля доступны в приложении."
+        )
         if webapp_button is not None:
             text += " Нажмите кнопку ниже, чтобы открыть и обновить данные."
             keyboard = InlineKeyboardMarkup([webapp_button])
@@ -295,6 +301,10 @@ async def profile_webapp_save(
         high = float(str(data["high"]).replace(",", "."))
     except ValueError:
         await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
+        return
+    error = validate_profile_numbers(icr, cf, target, low, high)
+    if error:
+        await eff_msg.reply_text(error, reply_markup=menu_keyboard())
         return
     user = update.effective_user
     if user is None:
@@ -362,7 +372,9 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     button = build_timezone_webapp_button()
     if button:
         keyboard = InlineKeyboardMarkup([[button]])
-        await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
+        await message.reply_text(
+            "Можно определить автоматически:", reply_markup=keyboard
+        )
     else:
         await message.reply_text(
             "Автоматическое определение недоступно, укажите часовой пояс вручную.",
@@ -371,7 +383,9 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     return PROFILE_TZ
 
 
-async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def profile_timezone_save(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     """Save user timezone from input."""
     message = update.message
     if message is None:
@@ -396,7 +410,9 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
         button = build_timezone_webapp_button()
         if button:
             keyboard = InlineKeyboardMarkup([[button]])
-            await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
+            await message.reply_text(
+                "Можно определить автоматически:", reply_markup=keyboard
+            )
         else:
             await message.reply_text(
                 "Автоматическое определение недоступно, введите часовой пояс вручную.",
@@ -429,7 +445,9 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
     return END
 
 
-def _security_db(session: Session, user_id: int, action: str | None) -> dict[str, object]:
+def _security_db(
+    session: Session, user_id: int, action: str | None
+) -> dict[str, object]:
     profile = session.get(Profile, user_id)
     user = session.get(User, user_id)
     if not profile:
@@ -463,13 +481,22 @@ def _security_db(session: Session, user_id: int, action: str | None) -> dict[str
     if changed:
         try:
             commit(session)
-            alert = session.query(Alert).filter_by(user_id=user_id).order_by(Alert.ts.desc()).first()
+            alert = (
+                session.query(Alert)
+                .filter_by(user_id=user_id)
+                .order_by(Alert.ts.desc())
+                .first()
+            )
             alert_sugar = alert.sugar if alert else None
         except CommitError:
             commit_ok = False
 
     rems = session.query(Reminder).filter_by(telegram_id=user_id).all()
-    rem_text = "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems) if rems else "нет"
+    rem_text = (
+        "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems)
+        if rems
+        else "нет"
+    )
     return {
         "found": True,
         "commit_ok": commit_ok,
@@ -553,12 +580,20 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton("Низкий -0.5", callback_data="profile_security:low_dec"),
-                InlineKeyboardButton("Низкий +0.5", callback_data="profile_security:low_inc"),
+                InlineKeyboardButton(
+                    "Низкий -0.5", callback_data="profile_security:low_dec"
+                ),
+                InlineKeyboardButton(
+                    "Низкий +0.5", callback_data="profile_security:low_inc"
+                ),
             ],
             [
-                InlineKeyboardButton("Высокий -0.5", callback_data="profile_security:high_dec"),
-                InlineKeyboardButton("Высокий +0.5", callback_data="profile_security:high_inc"),
+                InlineKeyboardButton(
+                    "Высокий -0.5", callback_data="profile_security:high_dec"
+                ),
+                InlineKeyboardButton(
+                    "Высокий +0.5", callback_data="profile_security:high_inc"
+                ),
             ],
             [
                 InlineKeyboardButton(
@@ -566,9 +601,15 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     callback_data="profile_security:toggle_sos",
                 )
             ],
-            [InlineKeyboardButton("SOS контакт", callback_data="profile_security:sos_contact")],
             [
-                InlineKeyboardButton("➕ Добавить", callback_data="profile_security:add"),
+                InlineKeyboardButton(
+                    "SOS контакт", callback_data="profile_security:sos_contact"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    "➕ Добавить", callback_data="profile_security:add"
+                ),
                 InlineKeyboardButton("🗑 Удалить", callback_data="profile_security:del"),
             ],
             [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
@@ -665,7 +706,9 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     try:
         target = float(text)
     except ValueError:
-        await message.reply_text("Введите целевой сахар числом.", reply_markup=back_keyboard)
+        await message.reply_text(
+            "Введите целевой сахар числом.", reply_markup=back_keyboard
+        )
         return PROFILE_TARGET
     if target <= 0:
         await message.reply_text(MSG_TARGET_GT0, reply_markup=back_keyboard)
@@ -695,7 +738,9 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     try:
         low = float(text)
     except ValueError:
-        await message.reply_text("Введите нижний порог числом.", reply_markup=back_keyboard)
+        await message.reply_text(
+            "Введите нижний порог числом.", reply_markup=back_keyboard
+        )
         return PROFILE_LOW
     if low <= 0:
         await message.reply_text(MSG_LOW_GT0, reply_markup=back_keyboard)
@@ -725,22 +770,27 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     try:
         high = float(text)
     except ValueError:
-        await message.reply_text("Введите верхний порог числом.", reply_markup=back_keyboard)
-        return PROFILE_HIGH
-    low = user_data.get("profile_low")
-    if high <= 0 or low is None or high <= low:
         await message.reply_text(
-            MSG_HIGH_GT_LOW,
-            reply_markup=back_keyboard,
+            "Введите верхний порог числом.", reply_markup=back_keyboard
         )
         return PROFILE_HIGH
-    icr = user_data.pop("profile_icr", None)
-    cf = user_data.pop("profile_cf", None)
-    target = user_data.pop("profile_target", None)
-    user_data.pop("profile_low", None)
-    if icr is None or cf is None or target is None:
-        await message.reply_text("⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново.")
+    icr = user_data.get("profile_icr")
+    cf = user_data.get("profile_cf")
+    target = user_data.get("profile_target")
+    low = user_data.get("profile_low")
+    if None in (icr, cf, target, low):
+        await message.reply_text(
+            "⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново."
+        )
         return END
+    error = validate_profile_numbers(icr, cf, target, low, high)
+    if error:
+        await message.reply_text(error, reply_markup=back_keyboard)
+        return PROFILE_HIGH
+    icr = cast(float, user_data.pop("profile_icr"))
+    cf = cast(float, user_data.pop("profile_cf"))
+    target = cast(float, user_data.pop("profile_target"))
+    low = cast(float, user_data.pop("profile_low"))
     user = update.effective_user
     if user is None:
         await message.reply_text("⚠️ Не удалось определить пользователя.")
@@ -802,11 +852,15 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return END
 
 
-async def _profile_edit_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def _profile_edit_entry(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     return await profile_edit(update, context)
 
 
-async def _profile_timezone_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def _profile_timezone_entry(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     return await profile_timezone(update, context)
 
 
@@ -814,12 +868,16 @@ profile_conv = ConversationHandler(
     entry_points=[
         CommandHandler("profile", profile_command),
         CallbackQueryNoWarnHandler(_profile_edit_entry, pattern="^profile_edit$"),
-        CallbackQueryNoWarnHandler(_profile_timezone_entry, pattern="^profile_timezone$"),
+        CallbackQueryNoWarnHandler(
+            _profile_timezone_entry, pattern="^profile_timezone$"
+        ),
     ],
     states={
         PROFILE_ICR: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_icr)],
         PROFILE_CF: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_cf)],
-        PROFILE_TARGET: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)],
+        PROFILE_TARGET: [
+            MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)
+        ],
         PROFILE_LOW: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_low)],
         PROFILE_HIGH: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_high)],
         PROFILE_TZ: [
@@ -841,7 +899,9 @@ profile_conv = ConversationHandler(
 )
 
 
-profile_webapp_handler = MessageHandler(filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save)
+profile_webapp_handler = MessageHandler(
+    filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save
+)
 
 
 __all__ = [

--- a/services/api/app/diabetes/handlers/profile/validation.py
+++ b/services/api/app/diabetes/handlers/profile/validation.py
@@ -1,6 +1,15 @@
+from __future__ import annotations
+
 """Utilities for parsing and validating user input for profile handlers."""
 
-from __future__ import annotations
+
+# User-facing validation messages reused across conversation flows.
+MSG_ICR_GT0 = "ИКХ должен быть больше 0."
+MSG_CF_GT0 = "КЧ должен быть больше 0."
+MSG_TARGET_GT0 = "Целевой сахар должен быть больше 0."
+MSG_LOW_GT0 = "Нижний порог должен быть больше 0."
+MSG_HIGH_GT_LOW = "Верхний порог должен быть больше нижнего и больше 0."
+MSG_TARGET_RANGE = "Целевой сахар должен быть между нижним и верхним порогами."
 
 
 def parse_profile_args(args: list[str]) -> dict[str, str] | None:
@@ -30,4 +39,27 @@ def parse_profile_args(args: list[str]) -> dict[str, str] | None:
         parsed[match] = val
     if set(parsed) == {"icr", "cf", "target", "low", "high"}:
         return parsed
+    return None
+
+
+def validate_profile_numbers(
+    icr: float, cf: float, target: float, low: float, high: float
+) -> str | None:
+    """Validate numeric profile parameters.
+
+    Returns an error message if validation fails, otherwise ``None``.
+    """
+
+    if icr <= 0:
+        return MSG_ICR_GT0
+    if cf <= 0:
+        return MSG_CF_GT0
+    if target <= 0:
+        return MSG_TARGET_GT0
+    if low <= 0:
+        return MSG_LOW_GT0
+    if high <= low:
+        return MSG_HIGH_GT_LOW
+    if not (low < target < high):
+        return MSG_TARGET_RANGE
     return None

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -143,6 +143,11 @@ async def test_profile_command_and_view(
         (["icr=8", "cf=3", "target=6", "low=0", "high=9"], "MSG_LOW_GT0"),
         (["8", "3", "6", "4", "3"], "MSG_HIGH_GT_LOW"),
         (["icr=8", "cf=3", "target=6", "low=4", "high=3"], "MSG_HIGH_GT_LOW"),
+        (["8", "3", "10", "4", "9"], "MSG_TARGET_RANGE"),
+        (
+            ["icr=8", "cf=3", "target=3", "low=4", "high=9"],
+            "MSG_TARGET_RANGE",
+        ),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/test_handlers_profile_webapp.py
+++ b/tests/test_handlers_profile_webapp.py
@@ -33,9 +33,7 @@ async def test_webapp_save_no_data(monkeypatch: pytest.MonkeyPatch) -> None:
     msg = DummyMessage()
     update = cast(
         Update,
-        SimpleNamespace(
-            effective_message=msg, effective_user=SimpleNamespace(id=1)
-        ),
+        SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -57,9 +55,7 @@ async def test_webapp_save_invalid_json(
     msg.web_app_data = SimpleNamespace(data="{bad")
     update = cast(
         Update,
-        SimpleNamespace(
-            effective_message=msg, effective_user=SimpleNamespace(id=1)
-        ),
+        SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -81,9 +77,7 @@ async def test_webapp_save_missing_keys(monkeypatch: pytest.MonkeyPatch) -> None
     )
     update = cast(
         Update,
-        SimpleNamespace(
-            effective_message=msg, effective_user=SimpleNamespace(id=1)
-        ),
+        SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -101,15 +95,11 @@ async def test_webapp_save_non_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(handlers, "post_profile", post_mock)
     msg = DummyMessage()
     msg.web_app_data = SimpleNamespace(
-        data=json.dumps(
-            {"icr": "a", "cf": "b", "target": "c", "low": "d", "high": "e"}
-        )
+        data=json.dumps({"icr": "a", "cf": "b", "target": "c", "low": "d", "high": "e"})
     )
     update = cast(
         Update,
-        SimpleNamespace(
-            effective_message=msg, effective_user=SimpleNamespace(id=1)
-        ),
+        SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -120,6 +110,42 @@ async def test_webapp_save_non_numeric(monkeypatch: pytest.MonkeyPatch) -> None:
     assert msg.texts == [ERROR_MSG]
 
 
+@pytest.mark.parametrize(
+    "payload, expected_msg",
+    [
+        ({"icr": 0, "cf": 3, "target": 6, "low": 4, "high": 9}, handlers.MSG_ICR_GT0),
+        (
+            {"icr": 8, "cf": 3, "target": 6, "low": 4, "high": 3},
+            handlers.MSG_HIGH_GT_LOW,
+        ),
+        (
+            {"icr": 8, "cf": 3, "target": 10, "low": 4, "high": 9},
+            handlers.MSG_TARGET_RANGE,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_webapp_save_invalid_values(
+    monkeypatch: pytest.MonkeyPatch, payload: dict[str, float], expected_msg: str
+) -> None:
+    post_mock = MagicMock()
+    monkeypatch.setattr(handlers, "get_api", lambda: (None, None, None))
+    monkeypatch.setattr(handlers, "post_profile", post_mock)
+    msg = DummyMessage()
+    msg.web_app_data = SimpleNamespace(data=json.dumps(payload))
+    update = cast(
+        Update,
+        SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    await handlers.profile_webapp_save(update, context)
+    assert post_mock.call_count == 0
+    assert msg.texts == [expected_msg]
+
+
 @pytest.mark.asyncio
 async def test_webapp_save_success(monkeypatch: pytest.MonkeyPatch) -> None:
     post_mock = MagicMock(return_value=(True, None))
@@ -127,15 +153,11 @@ async def test_webapp_save_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(handlers, "post_profile", post_mock)
     msg = DummyMessage()
     msg.web_app_data = SimpleNamespace(
-        data=json.dumps(
-            {"icr": 8, "cf": 3, "target": 6, "low": 4, "high": 9}
-        )
+        data=json.dumps({"icr": 8, "cf": 3, "target": 6, "low": 4, "high": 9})
     )
     update = cast(
         Update,
-        SimpleNamespace(
-            effective_message=msg, effective_user=SimpleNamespace(id=1)
-        ),
+        SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1)),
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],

--- a/tests/test_profile_conversation.py
+++ b/tests/test_profile_conversation.py
@@ -207,16 +207,57 @@ async def test_profile_low_cases(
 
 
 @pytest.mark.parametrize(
-    "text, expected_state, expected_fragment",
+    "text, user_data, expected_state, expected_fragment",
     [
-        ("назад", handlers.PROFILE_LOW, "Введите нижний порог сахара"),
-        ("abc", handlers.PROFILE_HIGH, "Введите верхний порог числом."),
-        ("3", handlers.PROFILE_HIGH, handlers.MSG_HIGH_GT_LOW),
+        (
+            "назад",
+            {
+                "profile_icr": 8.0,
+                "profile_cf": 3.0,
+                "profile_target": 6.0,
+                "profile_low": 4.0,
+            },
+            handlers.PROFILE_LOW,
+            "Введите нижний порог сахара",
+        ),
+        (
+            "abc",
+            {
+                "profile_icr": 8.0,
+                "profile_cf": 3.0,
+                "profile_target": 6.0,
+                "profile_low": 4.0,
+            },
+            handlers.PROFILE_HIGH,
+            "Введите верхний порог числом.",
+        ),
+        (
+            "3",
+            {
+                "profile_icr": 8.0,
+                "profile_cf": 3.0,
+                "profile_target": 6.0,
+                "profile_low": 4.0,
+            },
+            handlers.PROFILE_HIGH,
+            handlers.MSG_HIGH_GT_LOW,
+        ),
+        (
+            "9",
+            {
+                "profile_icr": 8.0,
+                "profile_cf": 3.0,
+                "profile_target": 10.0,
+                "profile_low": 4.0,
+            },
+            handlers.PROFILE_HIGH,
+            handlers.MSG_TARGET_RANGE,
+        ),
     ],
 )
 @pytest.mark.asyncio
 async def test_profile_high_invalid(
-    text: str, expected_state: int, expected_fragment: str
+    text: str, user_data: dict[str, float], expected_state: int, expected_fragment: str
 ) -> None:
     msg = DummyMessage(text)
     update = cast(
@@ -224,7 +265,7 @@ async def test_profile_high_invalid(
     )
     ctx = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={"profile_low": 4.0}),
+        SimpleNamespace(user_data=user_data),
     )
     state = await handlers.profile_high(update, ctx)
     assert state == expected_state


### PR DESCRIPTION
## Summary
- add shared `validate_profile_numbers` for profile data
- ensure positive numbers and proper target/threshold relation
- cover validation from WebApp, `/profile` args, and step-by-step flow

## Testing
- `pytest -q`
- `mypy --strict services/api/app/diabetes/handlers/profile/validation.py services/api/app/diabetes/handlers/profile/conversation.py tests/test_handlers_profile_webapp.py tests/test_handlers_profile.py tests/test_profile_conversation.py`
- `ruff check services/api/app/diabetes/handlers/profile/validation.py services/api/app/diabetes/handlers/profile/conversation.py tests/test_handlers_profile_webapp.py tests/test_handlers_profile.py tests/test_profile_conversation.py`

------
https://chatgpt.com/codex/tasks/task_e_68b13ae995d8832aac8ad388c0a0deef