### PR TITLE
[webapp] validate profile ranges

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -32,8 +32,14 @@ export const parseProfile = (profile: ProfileForm): ParsedProfile | null => {
     low: Number(profile.low),
     high: Number(profile.high),
   };
-  const valid = Object.values(parsed).every((v) => Number.isFinite(v) && v > 0);
-  return valid ? parsed : null;
+  const numbersValid = Object.values(parsed).every(
+    (v) => Number.isFinite(v) && v > 0,
+  );
+  const rangeValid =
+    parsed.low < parsed.high &&
+    parsed.low < parsed.target &&
+    parsed.target < parsed.high;
+  return numbersValid && rangeValid ? parsed : null;
 };
 
 const Profile = () => {
@@ -90,7 +96,9 @@ const Profile = () => {
     if (!parsed) {
       toast({
         title: "Ошибка",
-        description: "Все значения должны быть положительными числами",
+        description:
+          "Проверьте, что все значения положительны, нижний порог меньше верхнего," +
+          " а целевой уровень между ними",
         variant: "destructive",
       });
       return;

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -3,13 +3,37 @@ import { parseProfile } from '../src/pages/Profile';
 
 describe('parseProfile', () => {
   it('returns parsed numbers for valid input', () => {
-    const result = parseProfile({ icr: '1', cf: '2', target: '3', low: '4', high: '5' });
-    expect(result).toEqual({ icr: 1, cf: 2, target: 3, low: 4, high: 5 });
+    const result = parseProfile({
+      icr: '1',
+      cf: '2',
+      target: '5',
+      low: '4',
+      high: '10',
+    });
+    expect(result).toEqual({ icr: 1, cf: 2, target: 5, low: 4, high: 10 });
   });
 
   it('returns null when any value is non-positive or invalid', () => {
-    expect(parseProfile({ icr: '0', cf: '2', target: '3', low: '4', high: '5' })).toBeNull();
-    expect(parseProfile({ icr: '1', cf: '-1', target: '3', low: '4', high: '5' })).toBeNull();
-    expect(parseProfile({ icr: 'a', cf: '2', target: '3', low: '4', high: '5' })).toBeNull();
+    expect(
+      parseProfile({ icr: '0', cf: '2', target: '5', low: '4', high: '10' }),
+    ).toBeNull();
+    expect(
+      parseProfile({ icr: '1', cf: '-1', target: '5', low: '4', high: '10' }),
+    ).toBeNull();
+    expect(
+      parseProfile({ icr: 'a', cf: '2', target: '5', low: '4', high: '10' }),
+    ).toBeNull();
+  });
+
+  it('returns null when low/high bounds are invalid', () => {
+    expect(
+      parseProfile({ icr: '1', cf: '2', target: '5', low: '8', high: '6' }),
+    ).toBeNull();
+    expect(
+      parseProfile({ icr: '1', cf: '2', target: '3', low: '4', high: '10' }),
+    ).toBeNull();
+    expect(
+      parseProfile({ icr: '1', cf: '2', target: '12', low: '4', high: '10' }),
+    ).toBeNull();
   });
 });

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -83,7 +83,32 @@ describe('Profile page', () => {
     expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
         title: 'Ошибка',
-        description: 'Все значения должны быть положительными числами',
+        description:
+          'Проверьте, что все значения положительны, нижний порог меньше' +
+          ' верхнего, а целевой уровень между ними',
+        variant: 'destructive',
+      }),
+    );
+  });
+
+  it('blocks save when target is out of range and shows toast', () => {
+    const validInitData = new URLSearchParams({
+      user: JSON.stringify({ id: 123 }),
+    }).toString();
+    useTelegramInitData.mockReturnValue(validInitData);
+
+    const { getByText, getByPlaceholderText } = render(<Profile />);
+    const targetInput = getByPlaceholderText('6.0');
+    fireEvent.change(targetInput, { target: { value: '12' } });
+
+    fireEvent.click(getByText('Сохранить настройки'));
+    expect(saveProfile).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Ошибка',
+        description:
+          'Проверьте, что все значения положительны, нижний порог меньше' +
+          ' верхнего, а целевой уровень между ними',
         variant: 'destructive',
       }),
     );


### PR DESCRIPTION
## Summary
- validate target value is between low and high
- show descriptive error toast when profile values invalid
- test profile parsing and save behaviour

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b13af11ba0832aa945fd60d19bd6f0