### PR TITLE
[ui] Load profile on mount

### DIFF
--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,6 +1,31 @@
 import type { ProfileSchema } from '@sdk';
 import { getTelegramAuthHeaders } from '@/lib/telegram-auth';
 
+export async function getProfile(telegramId: number) {
+  const headers = getTelegramAuthHeaders() as HeadersInit;
+
+  try {
+    const params = new URLSearchParams({ telegramId: String(telegramId) });
+    const res = await fetch(`/api/profiles?${params.toString()}`, {
+      method: 'GET',
+      headers,
+    });
+
+    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    if (!res.ok) {
+      const msg = typeof data.detail === 'string' ? data.detail : 'Request failed';
+      throw new Error(msg);
+    }
+    return data as ProfileSchema;
+  } catch (error) {
+    console.error('Failed to load profile:', error);
+    if (error instanceof Error) {
+      throw new Error(`Не удалось получить профиль: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
 export async function saveProfile({
   telegramId,
   icr,

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Save } from "lucide-react";
 import { MedicalHeader } from "@/components/MedicalHeader";
 import { useToast } from "@/hooks/use-toast";
 import MedicalButton from "@/components/MedicalButton";
-import { saveProfile } from "@/api/profile";
+import { saveProfile, getProfile } from "@/api/profile";
 import { useTelegram } from "@/hooks/useTelegram";
 import { useTelegramInitData } from "@/hooks/useTelegramInitData";
 
@@ -49,6 +49,51 @@ const Profile = () => {
     low: "4.0",
     high: "10.0",
   });
+
+  useEffect(() => {
+    let telegramId = user?.id;
+    if (!telegramId) {
+      let userStr: string | null = null;
+      if (initData) {
+        try {
+          userStr = new URLSearchParams(initData).get("user");
+        } catch (e) {
+          console.error("[Profile] failed to parse initData:", e);
+        }
+      }
+      if (userStr) {
+        try {
+          const parsed = JSON.parse(userStr);
+          telegramId = typeof parsed.id === "number" ? parsed.id : undefined;
+        } catch (e) {
+          console.error("[Profile] failed to parse initData user:", e);
+        }
+      }
+    }
+
+    if (typeof telegramId !== "number") {
+      return;
+    }
+
+    getProfile(telegramId)
+      .then((data) => {
+        setProfile({
+          icr: data.icr.toString(),
+          cf: data.cf.toString(),
+          target: data.target.toString(),
+          low: data.low.toString(),
+          high: data.high.toString(),
+        });
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        toast({
+          title: "Ошибка",
+          description: message,
+          variant: "destructive",
+        });
+      });
+  }, []);
 
   const handleInputChange = (field: keyof ProfileForm, value: string) => {
     setProfile((prev) => ({ ...prev, [field]: value }));

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { render, fireEvent, cleanup } from '@testing-library/react';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const toast = vi.fn();
 
 vi.mock('../src/api/profile', () => ({
   saveProfile: vi.fn(),
+  getProfile: vi.fn(),
 }));
 
 vi.mock('../src/hooks/use-toast', () => ({
@@ -25,12 +26,20 @@ vi.mock('react-router-dom', () => ({
 }));
 
 import Profile from '../src/pages/Profile';
-import { saveProfile } from '../src/api/profile';
+import { saveProfile, getProfile } from '../src/api/profile';
 import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
 
 describe('Profile page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (getProfile as vi.Mock).mockResolvedValue({
+      telegramId: 0,
+      icr: 12,
+      cf: 2.5,
+      target: 6,
+      low: 4,
+      high: 10,
+    });
   });
 
   afterEach(() => {
@@ -87,5 +96,48 @@ describe('Profile page', () => {
         variant: 'destructive',
       }),
     );
+  });
+
+  it('loads profile on mount and updates form', async () => {
+    const validInitData = new URLSearchParams({
+      user: JSON.stringify({ id: 123 }),
+    }).toString();
+    useTelegramInitData.mockReturnValue(validInitData);
+    (getProfile as vi.Mock).mockResolvedValue({
+      telegramId: 123,
+      icr: 15,
+      cf: 3,
+      target: 5,
+      low: 3,
+      high: 8,
+    });
+
+    const { getByPlaceholderText } = render(<Profile />);
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalledWith(123);
+    });
+    expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('15');
+    expect((getByPlaceholderText('2.5') as HTMLInputElement).value).toBe('3');
+  });
+
+  it('shows toast when profile load fails', async () => {
+    const validInitData = new URLSearchParams({
+      user: JSON.stringify({ id: 123 }),
+    }).toString();
+    useTelegramInitData.mockReturnValue(validInitData);
+    (getProfile as vi.Mock).mockRejectedValue(new Error('load failed'));
+
+    const { getByPlaceholderText } = render(<Profile />);
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalledWith(123);
+    });
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Ошибка',
+        description: 'load failed',
+        variant: 'destructive',
+      }),
+    );
+    expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('12');
   });
 });


### PR DESCRIPTION
## Summary
- fetch profile on mount and populate form
- add API helper for loading profile
- test profile load success and failure cases

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b13af76260832abb736ce7fb101422