### PR TITLE
[handlers] Use implicit concatenation for profile texts

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -198,12 +198,12 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         return END
 
     await message.reply_text(
-        f"✅ Профиль обновлён:\n"
+        "✅ Профиль обновлён:\n"
         f"• ИКХ: {icr} г/ед.\n"
         f"• КЧ: {cf} ммоль/л\n"
         f"• Целевой сахар: {target} ммоль/л\n"
         f"• Низкий порог: {low} ммоль/л\n"
-        f"• Высокий порог: {high} ммоль/л" + warning_msg,
+        f"• Высокий порог: {high} ммоль/л{warning_msg}",
         parse_mode="Markdown",
         reply_markup=menu_keyboard(),
     )
@@ -329,12 +329,14 @@ async def profile_webapp_save(
         )
         return
     await eff_msg.reply_text(
-        "✅ Профиль обновлён:\n"
-        f"• ИКХ: {icr} г/ед.\n"
-        f"• КЧ: {cf} ммоль/л\n"
-        f"• Целевой сахар: {target} ммоль/л\n"
-        f"• Низкий порог: {low} ммоль/л\n"
-        f"• Высокий порог: {high} ммоль/л",
+        (
+            "✅ Профиль обновлён:\n"
+            f"• ИКХ: {icr} г/ед.\n"
+            f"• КЧ: {cf} ммоль/л\n"
+            f"• Целевой сахар: {target} ммоль/л\n"
+            f"• Низкий порог: {low} ммоль/л\n"
+            f"• Высокий порог: {high} ммоль/л"
+        ),
         reply_markup=menu_keyboard(),
     )
 
@@ -837,7 +839,7 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         f"• КЧ: {cf} ммоль/л\n"
         f"• Целевой сахар: {target} ммоль/л\n"
         f"• Низкий порог: {low} ммоль/л\n"
-        f"• Высокий порог: {high} ммоль/л" + warning_msg,
+        f"• Высокий порог: {high} ммоль/л{warning_msg}",
         reply_markup=menu_keyboard(),
     )
     return END


### PR DESCRIPTION
## Summary
- unify profile update messages using implicit string concatenation

## Testing
- `pytest` *(fails: async functions require plugin)*
- `mypy --strict services/api/app/diabetes/handlers/profile/conversation.py`
- `ruff check services/api/app/diabetes/handlers/profile/conversation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b13e35a990832ab1fee665ef67ede4