### PR TITLE
[profile] Extract profile saved message helper

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -90,6 +90,26 @@ PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ =
 END: int = ConversationHandler.END
 
 
+def _profile_saved_message(
+    icr: float,
+    cf: float,
+    target: float,
+    low: float,
+    high: float,
+    warning_msg: str = "",
+) -> str:
+    """Compose the profile saved confirmation message."""
+
+    return (
+        "✅ Профиль обновлён:\n"
+        f"• ИКХ: {icr} г/ед.\n"
+        f"• КЧ: {cf} ммоль/л\n"
+        f"• Целевой сахар: {target} ммоль/л\n"
+        f"• Низкий порог: {low} ммоль/л\n"
+        f"• Высокий порог: {high} ммоль/л" + warning_msg
+    )
+
+
 async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle ``/profile`` command.
 
@@ -196,14 +216,9 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     if not ok:
         await message.reply_text(err or "⚠️ Не удалось сохранить профиль.")
         return END
-
+    msg = _profile_saved_message(icr, cf, target, low, high, warning_msg)
     await message.reply_text(
-        f"✅ Профиль обновлён:\n"
-        f"• ИКХ: {icr} г/ед.\n"
-        f"• КЧ: {cf} ммоль/л\n"
-        f"• Целевой сахар: {target} ммоль/л\n"
-        f"• Низкий порог: {low} ммоль/л\n"
-        f"• Высокий порог: {high} ммоль/л" + warning_msg,
+        msg,
         parse_mode="Markdown",
         reply_markup=menu_keyboard(),
     )
@@ -328,13 +343,9 @@ async def profile_webapp_save(
             reply_markup=menu_keyboard(),
         )
         return
+    msg = _profile_saved_message(icr, cf, target, low, high)
     await eff_msg.reply_text(
-        "✅ Профиль обновлён:\n"
-        f"• ИКХ: {icr} г/ед.\n"
-        f"• КЧ: {cf} ммоль/л\n"
-        f"• Целевой сахар: {target} ммоль/л\n"
-        f"• Низкий порог: {low} ммоль/л\n"
-        f"• Высокий порог: {high} ммоль/л",
+        msg,
         reply_markup=menu_keyboard(),
     )
 
@@ -831,13 +842,9 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
             f"/profile {cf} {icr} {target} {low} {high}\n"
             f"(ИКХ {cf}, КЧ {icr}, целевой {target}, низкий {low}, высокий {high})\n"
         )
+    msg = _profile_saved_message(icr, cf, target, low, high, warning_msg)
     await message.reply_text(
-        "✅ Профиль обновлён:\n"
-        f"• ИКХ: {icr} г/ед.\n"
-        f"• КЧ: {cf} ммоль/л\n"
-        f"• Целевой сахар: {target} ммоль/л\n"
-        f"• Низкий порог: {low} ммоль/л\n"
-        f"• Высокий порог: {high} ммоль/л" + warning_msg,
+        msg,
         reply_markup=menu_keyboard(),
     )
     return END

--- a/tests/handlers/profile/test_profile_saved_message.py
+++ b/tests/handlers/profile/test_profile_saved_message.py
@@ -1,0 +1,26 @@
+from services.api.app.diabetes.handlers.profile.conversation import _profile_saved_message
+
+
+def test_profile_saved_message_basic() -> None:
+    assert _profile_saved_message(1.0, 2.0, 3.0, 4.0, 5.0) == (
+        "✅ Профиль обновлён:\n"
+        "• ИКХ: 1.0 г/ед.\n"
+        "• КЧ: 2.0 ммоль/л\n"
+        "• Целевой сахар: 3.0 ммоль/л\n"
+        "• Низкий порог: 4.0 ммоль/л\n"
+        "• Высокий порог: 5.0 ммоль/л"
+    )
+
+
+def test_profile_saved_message_with_warning() -> None:
+    warning = "\n⚠️ предупреждение"
+    assert _profile_saved_message(1.0, 2.0, 3.0, 4.0, 5.0, warning) == (
+        "✅ Профиль обновлён:\n"
+        "• ИКХ: 1.0 г/ед.\n"
+        "• КЧ: 2.0 ммоль/л\n"
+        "• Целевой сахар: 3.0 ммоль/л\n"
+        "• Низкий порог: 4.0 ммоль/л\n"
+        "• Высокий порог: 5.0 ммоль/л\n"
+        "⚠️ предупреждение"
+    )
+


### PR DESCRIPTION
## Summary
- refactor profile saving to use reusable _profile_saved_message helper
- add unit tests for profile saved message helper

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b13e4a0f1c832aa62dd69d4eb77e11