### PR TITLE
[webapp] extract telegramId resolver

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -7,6 +7,7 @@ import MedicalButton from "@/components/MedicalButton";
 import { saveProfile, getProfile } from "@/api/profile";
 import { useTelegram } from "@/hooks/useTelegram";
 import { useTelegramInitData } from "@/hooks/useTelegramInitData";
+import { resolveTelegramId } from "./resolveTelegramId";
 
 type ProfileForm = {
   icr: string;
@@ -42,6 +43,7 @@ export const parseProfile = (profile: ProfileForm): ParsedProfile | null => {
   return numbersValid && rangeValid ? parsed : null;
 };
 
+
 const Profile = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -57,25 +59,7 @@ const Profile = () => {
   });
 
   useEffect(() => {
-    let telegramId = user?.id;
-    if (!telegramId) {
-      let userStr: string | null = null;
-      if (initData) {
-        try {
-          userStr = new URLSearchParams(initData).get("user");
-        } catch (e) {
-          console.error("[Profile] failed to parse initData:", e);
-        }
-      }
-      if (userStr) {
-        try {
-          const parsed = JSON.parse(userStr);
-          telegramId = typeof parsed.id === "number" ? parsed.id : undefined;
-        } catch (e) {
-          console.error("[Profile] failed to parse initData user:", e);
-        }
-      }
-    }
+    const telegramId = resolveTelegramId(user, initData);
 
     if (typeof telegramId !== "number") {
       return;
@@ -106,27 +90,7 @@ const Profile = () => {
   };
 
   const handleSave = async () => {
-    let telegramId = user?.id;
-    if (!telegramId) {
-      let userStr: string | null = null;
-      if (initData) {
-        try {
-          userStr = new URLSearchParams(initData).get("user");
-        } catch (e) {
-          console.error("[Profile] failed to parse initData:", e);
-        }
-      }
-      if (userStr) {
-        try {
-          const parsed = JSON.parse(userStr);
-          telegramId = typeof parsed.id === "number" ? parsed.id : undefined;
-        } catch (e) {
-          console.error("[Profile] failed to parse initData user:", e);
-        }
-      } else {
-        console.warn("[Profile] no user field in initData");
-      }
-    }
+    const telegramId = resolveTelegramId(user, initData);
 
     if (typeof telegramId !== "number") {
       toast({

--- a/services/webapp/ui/src/pages/resolveTelegramId.ts
+++ b/services/webapp/ui/src/pages/resolveTelegramId.ts
@@ -1,0 +1,27 @@
+export const resolveTelegramId = (
+  user: { id?: number } | null,
+  initData: string | null,
+): number | undefined => {
+  let telegramId = user?.id;
+  if (!telegramId) {
+    let userStr: string | null = null;
+    if (initData) {
+      try {
+        userStr = new URLSearchParams(initData).get("user");
+      } catch (e) {
+        console.error("[Profile] failed to parse initData:", e);
+      }
+    }
+    if (userStr) {
+      try {
+        const parsed = JSON.parse(userStr);
+        telegramId = typeof parsed.id === "number" ? parsed.id : undefined;
+      } catch (e) {
+        console.error("[Profile] failed to parse initData user:", e);
+      }
+    } else {
+      console.warn("[Profile] no user field in initData");
+    }
+  }
+  return telegramId;
+};

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -25,9 +25,13 @@ vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn(),
 }));
 
+vi.mock('../src/pages/resolveTelegramId', () => ({
+  resolveTelegramId: vi.fn(),
+}));
+
 import Profile from '../src/pages/Profile';
 import { saveProfile, getProfile } from '../src/api/profile';
-import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
+import { resolveTelegramId } from '../src/pages/resolveTelegramId';
 
 describe('Profile page', () => {
   beforeEach(() => {
@@ -47,7 +51,7 @@ describe('Profile page', () => {
   });
 
   it('blocks save without telegramId and shows toast', () => {
-    useTelegramInitData.mockReturnValue(null);
+    (resolveTelegramId as vi.Mock).mockReturnValue(undefined);
     const { getByText } = render(<Profile />);
     fireEvent.click(getByText('Сохранить настройки'));
     expect(saveProfile).not.toHaveBeenCalled();
@@ -61,10 +65,7 @@ describe('Profile page', () => {
   });
 
   it('blocks save with non-numeric id in initData and shows toast', () => {
-    const invalidInitData = new URLSearchParams({
-      user: JSON.stringify({ id: 'abc' }),
-    }).toString();
-    useTelegramInitData.mockReturnValue(invalidInitData);
+    (resolveTelegramId as vi.Mock).mockReturnValue(undefined);
     const { getByText } = render(<Profile />);
     fireEvent.click(getByText('Сохранить настройки'));
     expect(saveProfile).not.toHaveBeenCalled();
@@ -78,10 +79,7 @@ describe('Profile page', () => {
   });
 
   it('blocks save with invalid numeric input and shows toast', () => {
-    const validInitData = new URLSearchParams({
-      user: JSON.stringify({ id: 123 }),
-    }).toString();
-    useTelegramInitData.mockReturnValue(validInitData);
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
 
     const { getByText, getByPlaceholderText } = render(<Profile />);
     const icrInput = getByPlaceholderText('12');
@@ -101,10 +99,7 @@ describe('Profile page', () => {
   });
 
   it('blocks save when target is out of range and shows toast', () => {
-    const validInitData = new URLSearchParams({
-      user: JSON.stringify({ id: 123 }),
-    }).toString();
-    useTelegramInitData.mockReturnValue(validInitData);
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
 
     const { getByText, getByPlaceholderText } = render(<Profile />);
     const targetInput = getByPlaceholderText('6.0');
@@ -124,10 +119,7 @@ describe('Profile page', () => {
   });
 
   it('loads profile on mount and updates form', async () => {
-    const validInitData = new URLSearchParams({
-      user: JSON.stringify({ id: 123 }),
-    }).toString();
-    useTelegramInitData.mockReturnValue(validInitData);
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
     (getProfile as vi.Mock).mockResolvedValue({
       telegramId: 123,
       icr: 15,
@@ -146,10 +138,7 @@ describe('Profile page', () => {
   });
 
   it('shows toast when profile load fails', async () => {
-    const validInitData = new URLSearchParams({
-      user: JSON.stringify({ id: 123 }),
-    }).toString();
-    useTelegramInitData.mockReturnValue(validInitData);
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
     (getProfile as vi.Mock).mockRejectedValue(new Error('load failed'));
 
     const { getByPlaceholderText } = render(<Profile />);


### PR DESCRIPTION
## Summary
- centralize telegramId lookup in resolveTelegramId utility
- reuse resolver in Profile and tests to avoid duplicated parsing logic

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b151bfc8c4832a9888b57d78b24c8f