### PR TITLE
[ui] handle profile effect deps

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -81,8 +81,11 @@ const Profile = () => {
       return;
     }
 
+    let cancelled = false;
+
     getProfile(telegramId)
       .then((data) => {
+        if (cancelled) return;
         setProfile({
           icr: data.icr.toString(),
           cf: data.cf.toString(),
@@ -92,6 +95,7 @@ const Profile = () => {
         });
       })
       .catch((error) => {
+        if (cancelled) return;
         const message = error instanceof Error ? error.message : String(error);
         toast({
           title: "Ошибка",
@@ -99,7 +103,11 @@ const Profile = () => {
           variant: "destructive",
         });
       });
-  }, []);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user, initData, toast]);
 
   const handleInputChange = (field: keyof ProfileForm, value: string) => {
     setProfile((prev) => ({ ...prev, [field]: value }));


### PR DESCRIPTION
## Summary
- ensure Profile useEffect reacts to user, initData and toast changes
- guard profile fetch with cancellation to avoid stale updates

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68b151c52a0c832abeafa318d21fd3ca