### PR TITLE
[ui] Handle commas in profile numbers

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -26,11 +26,11 @@ type ParsedProfile = {
 
 export const parseProfile = (profile: ProfileForm): ParsedProfile | null => {
   const parsed = {
-    icr: Number(profile.icr),
-    cf: Number(profile.cf),
-    target: Number(profile.target),
-    low: Number(profile.low),
-    high: Number(profile.high),
+    icr: Number(profile.icr.replace(',', '.')),
+    cf: Number(profile.cf.replace(',', '.')),
+    target: Number(profile.target.replace(',', '.')),
+    low: Number(profile.low.replace(',', '.')),
+    high: Number(profile.high.replace(',', '.')),
   };
   const numbersValid = Object.values(parsed).every(
     (v) => Number.isFinite(v) && v > 0,

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -13,6 +13,23 @@ describe('parseProfile', () => {
     expect(result).toEqual({ icr: 1, cf: 2, target: 5, low: 4, high: 10 });
   });
 
+  it('handles comma as decimal separator', () => {
+    const result = parseProfile({
+      icr: '1,5',
+      cf: '2,5',
+      target: '5,5',
+      low: '4,4',
+      high: '10,1',
+    });
+    expect(result).toEqual({
+      icr: 1.5,
+      cf: 2.5,
+      target: 5.5,
+      low: 4.4,
+      high: 10.1,
+    });
+  });
+
   it('returns null when any value is non-positive or invalid', () => {
     expect(
       parseProfile({ icr: '0', cf: '2', target: '5', low: '4', high: '10' }),

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -28,6 +28,7 @@ vi.mock('react-router-dom', () => ({
 import Profile from '../src/pages/Profile';
 import { saveProfile, getProfile } from '../src/api/profile';
 import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
+import { parseProfile } from '../src/pages/Profile';
 
 describe('Profile page', () => {
   beforeEach(() => {
@@ -123,6 +124,7 @@ describe('Profile page', () => {
     );
   });
 
+
   it('loads profile on mount and updates form', async () => {
     const validInitData = new URLSearchParams({
       user: JSON.stringify({ id: 123 }),
@@ -164,5 +166,19 @@ describe('Profile page', () => {
       }),
     );
     expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('12');
+  });
+});
+
+describe('parseProfile', () => {
+  it('parses values with commas', () => {
+    expect(
+      parseProfile({
+        icr: '1,5',
+        cf: '2,5',
+        target: '5,5',
+        low: '4,4',
+        high: '10,1',
+      }),
+    ).toEqual({ icr: 1.5, cf: 2.5, target: 5.5, low: 4.4, high: 10.1 });
   });
 });


### PR DESCRIPTION
## Summary
- allow comma decimals in profile form parsing
- test parsing of comma-separated decimals

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov --cov-fail-under=85` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any and react warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b151cad7b8832aa13234e860a77f36