### PR TITLE
[ui] Clear default profile values

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -49,11 +49,11 @@ const Profile = () => {
   const initData = useTelegramInitData();
 
   const [profile, setProfile] = useState<ProfileForm>({
-    icr: "12",
-    cf: "2.5",
-    target: "6.0",
-    low: "4.0",
-    high: "10.0",
+    icr: "",
+    cf: "",
+    target: "",
+    low: "",
+    high: "",
   });
 
   useEffect(() => {

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -163,6 +163,6 @@ describe('Profile page', () => {
         variant: 'destructive',
       }),
     );
-    expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('12');
+    expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- reset profile form to empty fields and rely on placeholder hints
- adjust profile tests for empty initial fields

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b151d45bdc832a83f44d9af921c5b5