### PR TITLE
[webapp] improve profile API error handling

### DIFF
--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -11,11 +11,12 @@ export async function getProfile(telegramId: number) {
       headers,
     });
 
-    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
     if (!res.ok) {
-      const msg = typeof data.detail === 'string' ? data.detail : 'Request failed';
+      const errorText = await res.text().catch(() => '');
+      const msg = errorText || 'Request failed';
       throw new Error(msg);
     }
+    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
     return data as ProfileSchema;
   } catch (error) {
     console.error('Failed to load profile:', error);
@@ -46,11 +47,12 @@ export async function saveProfile({
       body: JSON.stringify({ telegramId, icr, cf, target, low, high }),
     });
 
-    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
     if (!res.ok) {
-      const msg = typeof data.detail === 'string' ? data.detail : 'Request failed';
+      const errorText = await res.text().catch(() => '');
+      const msg = errorText || 'Request failed';
       throw new Error(msg);
     }
+    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
     return data as ProfileSchema;
   } catch (error) {
     console.error('Failed to save profile:', error);

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getProfile, saveProfile } from '../src/api/profile';
+
+vi.mock('@/lib/telegram-auth', () => ({
+  getTelegramAuthHeaders: () => ({}),
+}));
+
+describe('profile api', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('throws error when getProfile request fails', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response('boom', { status: 400 }));
+    vi.stubGlobal('fetch', mockFetch);
+
+    await expect(getProfile(1)).rejects.toThrow('Не удалось получить профиль: boom');
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/profiles?telegramId=1',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('throws error when saveProfile request fails', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response('fail', { status: 500 }));
+    vi.stubGlobal('fetch', mockFetch);
+
+    await expect(
+      saveProfile({ telegramId: 1, icr: 1, cf: 2, target: 5, low: 4, high: 10 }),
+    ).rejects.toThrow('Не удалось сохранить профиль: fail');
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/profiles',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- throw on `getProfile` and `saveProfile` failures using response text
- cover profile API failures with new vitest tests

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b151dc9de8832a8dc74a9dbd6e51a1