### PR TITLE
[webapp] Guard reminder creation debug logs

### DIFF
--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -74,7 +74,9 @@ export default function RemindersCreate() {
     setLoading(true);
     try {
       const reminder = buildReminderPayload({ ...form, telegramId });
-      console.log("Payload being sent:", reminder);
+      if (import.meta.env.DEV) {
+        console.log("Payload being sent:", reminder);
+      }
 
       let rid: number | undefined;
       try {
@@ -83,10 +85,12 @@ export default function RemindersCreate() {
         rid = res?.id;
       } catch (apiError) {
         if (isDev) {
-          console.warn("Backend API failed, using mock API:", apiError);
+          if (import.meta.env.DEV) {
+            console.warn("Backend API failed, using mock API:", apiError);
+          }
           // Fallback на mock API
           const res = await mockApi.createReminder(reminder);
-          rid = (res as any)?.id;
+          rid = (res as { id?: number })?.id;
         } else {
           throw apiError;
         }


### PR DESCRIPTION
## Summary
- wrap reminders debug logging with import.meta.env.DEV

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any in many files)*
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: async tests require plugin)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b156c109b4832a866817935748585c