### PR TITLE
[ui] limit useTelegram logs to dev

### DIFF
--- a/services/webapp/ui/src/hooks/useTelegram.ts
+++ b/services/webapp/ui/src/hooks/useTelegram.ts
@@ -192,15 +192,21 @@ export const useTelegram = (
         if (userStr) {
           try {
             devUser = JSON.parse(userStr);
-            console.log("[TG] parsed dev user from initData:", devUser);
+            if (import.meta.env.DEV) {
+              console.log("[TG] parsed dev user from initData:", devUser);
+            }
           } catch (e) {
             console.error("[TG] failed to parse dev user:", e);
           }
         } else {
-          console.warn("[TG] initData does not contain user field");
+          if (import.meta.env.DEV) {
+            console.warn("[TG] initData does not contain user field");
+          }
         }
       } else {
-        console.warn("[TG] no initData found in localStorage or env");
+        if (import.meta.env.DEV) {
+          console.warn("[TG] no initData found in localStorage or env");
+        }
       }
 
       // If no user from initData, create fallback test user
@@ -213,14 +219,18 @@ export const useTelegram = (
           username: "testuser",
           language_code: "ru",
         };
-        console.log("[TG] created fallback dev user:", devUser);
+        if (import.meta.env.DEV) {
+          console.log("[TG] created fallback dev user:", devUser);
+        }
       }
 
       return devUser;
     };
 
     if (!tg) {
-      console.warn("[TG] not in Telegram, enabling dev fallback");
+      if (import.meta.env.DEV) {
+        console.warn("[TG] not in Telegram, enabling dev fallback");
+      }
 
       // In development mode, create fallback user
       if (import.meta.env.MODE !== "production") {
@@ -246,7 +256,9 @@ export const useTelegram = (
 
       const tgUser = tg.user || tg.initDataUnsafe?.user;
       if (!tgUser && import.meta.env.MODE !== "production") {
-        console.warn("[TG] no user in Telegram WebApp, creating dev fallback");
+        if (import.meta.env.DEV) {
+          console.warn("[TG] no user in Telegram WebApp, creating dev fallback");
+        }
         setUser(createDevUser());
       } else {
         setUser(tgUser ?? null);


### PR DESCRIPTION
## Summary
- guard useTelegram console.log/console.warn with import.meta.env.DEV to suppress logs in production

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any in unrelated files)*
- `pnpm --filter ./services/webapp/ui exec eslint src/hooks/useTelegram.ts`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui build`
- `rg -l "created fallback dev user" services/webapp/ui/dist | grep -v '.map'`

------
https://chatgpt.com/codex/tasks/task_e_68b156cacc98832a9312066f7388ccaf