### PR TITLE
[handlers] warn on suspicious webapp profile values

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -85,7 +85,9 @@ back_keyboard: ReplyKeyboardMarkup = _back_keyboard
 from .. import UserData  # noqa: E402
 
 
-PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(6)
+PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(
+    6
+)
 END: int = ConversationHandler.END
 
 
@@ -114,9 +116,21 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         if callable(end_conv):
             end_conv(update, context, END)
         else:
-            chat_id = getattr(update.effective_chat, "id", None) if sugar_conv.per_chat else None
-            user_id = getattr(update.effective_user, "id", None) if sugar_conv.per_user else None
-            msg_id = getattr(update.effective_message, "message_id", None) if sugar_conv.per_message else None
+            chat_id = (
+                getattr(update.effective_chat, "id", None)
+                if sugar_conv.per_chat
+                else None
+            )
+            user_id = (
+                getattr(update.effective_user, "id", None)
+                if sugar_conv.per_user
+                else None
+            )
+            msg_id = (
+                getattr(update.effective_message, "message_id", None)
+                if sugar_conv.per_message
+                else None
+            )
             key = cast(
                 tuple[int | str, ...],
                 tuple(i for i in (chat_id, user_id, msg_id) if i is not None),
@@ -126,9 +140,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             else:
                 logger.warning("sugar_conv lacks _update_state method")
 
-    help_text = (
-        "Настройки профиля доступны в приложении. Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
-    )
+    help_text = "Настройки профиля доступны в приложении. Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
 
     if len(args) == 1 and args[0].lower() == "help":
         await message.reply_text(help_text, parse_mode="Markdown")
@@ -150,7 +162,9 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         low = float(values["low"].replace(",", "."))
         high = float(values["high"].replace(",", "."))
     except ValueError:
-        await message.reply_text("❗ Пожалуйста, введите корректные числа. Справка: /profile help")
+        await message.reply_text(
+            "❗ Пожалуйста, введите корректные числа. Справка: /profile help"
+        )
         return END
     error = validate_profile_numbers(icr, cf, target, low, high)
     if error:
@@ -219,7 +233,9 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         ]
 
     if not profile:
-        text = "Ваш профиль пока не настроен.\n\nНастройки профиля доступны в приложении."
+        text = (
+            "Ваш профиль пока не настроен.\n\nНастройки профиля доступны в приложении."
+        )
         if webapp_button is not None:
             text += " Нажмите кнопку ниже, чтобы открыть и обновить данные."
             keyboard = InlineKeyboardMarkup([webapp_button])
@@ -290,6 +306,16 @@ async def profile_webapp_save(
     if error:
         await eff_msg.reply_text(error, reply_markup=menu_keyboard())
         return
+    warning_msg = ""
+    if icr > 8 or cf < 3:
+        warning_msg = (
+            "\n⚠️ Проверьте, пожалуйста: возможно, вы перепутали местами ИКХ и КЧ.\n"
+            f"• Вы ввели ИКХ = {icr} г/ед. (высоковато)\n"
+            f"• КЧ = {cf} ммоль/л (низковато)\n\n"
+            "Если вы хотели ввести наоборот, отправьте:\n"
+            f"/profile {cf} {icr} {target} {low} {high}\n"
+            f"(ИКХ {cf}, КЧ {icr}, целевой {target}, низкий {low}, высокий {high})\n"
+        )
     user = update.effective_user
     if user is None:
         await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
@@ -318,7 +344,8 @@ async def profile_webapp_save(
         f"• КЧ: {cf} ммоль/л\n"
         f"• Целевой сахар: {target} ммоль/л\n"
         f"• Низкий порог: {low} ммоль/л\n"
-        f"• Высокий порог: {high} ммоль/л",
+        f"• Высокий порог: {high} ммоль/л"
+        f"{warning_msg}",
         reply_markup=menu_keyboard(),
     )
 
@@ -356,7 +383,9 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     button = build_timezone_webapp_button()
     if button:
         keyboard = InlineKeyboardMarkup([[button]])
-        await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
+        await message.reply_text(
+            "Можно определить автоматически:", reply_markup=keyboard
+        )
     else:
         await message.reply_text(
             "Автоматическое определение недоступно, укажите часовой пояс вручную.",
@@ -365,7 +394,9 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     return PROFILE_TZ
 
 
-async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def profile_timezone_save(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     """Save user timezone from input."""
     message = update.message
     if message is None:
@@ -390,7 +421,9 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
         button = build_timezone_webapp_button()
         if button:
             keyboard = InlineKeyboardMarkup([[button]])
-            await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
+            await message.reply_text(
+                "Можно определить автоматически:", reply_markup=keyboard
+            )
         else:
             await message.reply_text(
                 "Автоматическое определение недоступно, введите часовой пояс вручную.",
@@ -423,7 +456,9 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
     return END
 
 
-def _security_db(session: Session, user_id: int, action: str | None) -> dict[str, object]:
+def _security_db(
+    session: Session, user_id: int, action: str | None
+) -> dict[str, object]:
     profile = session.get(Profile, user_id)
     user = session.get(User, user_id)
     if not profile:
@@ -460,13 +495,22 @@ def _security_db(session: Session, user_id: int, action: str | None) -> dict[str
     if changed:
         try:
             commit(session)
-            alert = session.query(Alert).filter_by(user_id=user_id).order_by(Alert.ts.desc()).first()
+            alert = (
+                session.query(Alert)
+                .filter_by(user_id=user_id)
+                .order_by(Alert.ts.desc())
+                .first()
+            )
             alert_sugar = alert.sugar if alert else None
         except CommitError:
             commit_ok = False
 
     rems = session.query(Reminder).filter_by(telegram_id=user_id).all()
-    rem_text = "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems) if rems else "нет"
+    rem_text = (
+        "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems)
+        if rems
+        else "нет"
+    )
     return {
         "found": True,
         "commit_ok": commit_ok,
@@ -550,12 +594,20 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton("Низкий -0.5", callback_data="profile_security:low_dec"),
-                InlineKeyboardButton("Низкий +0.5", callback_data="profile_security:low_inc"),
+                InlineKeyboardButton(
+                    "Низкий -0.5", callback_data="profile_security:low_dec"
+                ),
+                InlineKeyboardButton(
+                    "Низкий +0.5", callback_data="profile_security:low_inc"
+                ),
             ],
             [
-                InlineKeyboardButton("Высокий -0.5", callback_data="profile_security:high_dec"),
-                InlineKeyboardButton("Высокий +0.5", callback_data="profile_security:high_inc"),
+                InlineKeyboardButton(
+                    "Высокий -0.5", callback_data="profile_security:high_dec"
+                ),
+                InlineKeyboardButton(
+                    "Высокий +0.5", callback_data="profile_security:high_inc"
+                ),
             ],
             [
                 InlineKeyboardButton(
@@ -563,9 +615,15 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     callback_data="profile_security:toggle_sos",
                 )
             ],
-            [InlineKeyboardButton("SOS контакт", callback_data="profile_security:sos_contact")],
             [
-                InlineKeyboardButton("➕ Добавить", callback_data="profile_security:add"),
+                InlineKeyboardButton(
+                    "SOS контакт", callback_data="profile_security:sos_contact"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    "➕ Добавить", callback_data="profile_security:add"
+                ),
                 InlineKeyboardButton("🗑 Удалить", callback_data="profile_security:del"),
             ],
             [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
@@ -662,7 +720,9 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     try:
         target = float(text)
     except ValueError:
-        await message.reply_text("Введите целевой сахар числом.", reply_markup=back_keyboard)
+        await message.reply_text(
+            "Введите целевой сахар числом.", reply_markup=back_keyboard
+        )
         return PROFILE_TARGET
     if target <= 0:
         await message.reply_text(MSG_TARGET_GT0, reply_markup=back_keyboard)
@@ -692,7 +752,9 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     try:
         low = float(text)
     except ValueError:
-        await message.reply_text("Введите нижний порог числом.", reply_markup=back_keyboard)
+        await message.reply_text(
+            "Введите нижний порог числом.", reply_markup=back_keyboard
+        )
         return PROFILE_LOW
     if low <= 0:
         await message.reply_text(MSG_LOW_GT0, reply_markup=back_keyboard)
@@ -722,14 +784,18 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     try:
         high = float(text)
     except ValueError:
-        await message.reply_text("Введите верхний порог числом.", reply_markup=back_keyboard)
+        await message.reply_text(
+            "Введите верхний порог числом.", reply_markup=back_keyboard
+        )
         return PROFILE_HIGH
     icr = user_data.get("profile_icr")
     cf = user_data.get("profile_cf")
     target = user_data.get("profile_target")
     low = user_data.get("profile_low")
     if None in (icr, cf, target, low):
-        await message.reply_text("⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново.")
+        await message.reply_text(
+            "⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново."
+        )
         return END
     error = validate_profile_numbers(icr, cf, target, low, high)
     if error:
@@ -801,11 +867,15 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return END
 
 
-async def _profile_edit_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def _profile_edit_entry(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     return await profile_edit(update, context)
 
 
-async def _profile_timezone_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def _profile_timezone_entry(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     return await profile_timezone(update, context)
 
 
@@ -813,12 +883,16 @@ profile_conv = ConversationHandler(
     entry_points=[
         CommandHandler("profile", profile_command),
         CallbackQueryNoWarnHandler(_profile_edit_entry, pattern="^profile_edit$"),
-        CallbackQueryNoWarnHandler(_profile_timezone_entry, pattern="^profile_timezone$"),
+        CallbackQueryNoWarnHandler(
+            _profile_timezone_entry, pattern="^profile_timezone$"
+        ),
     ],
     states={
         PROFILE_ICR: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_icr)],
         PROFILE_CF: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_cf)],
-        PROFILE_TARGET: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)],
+        PROFILE_TARGET: [
+            MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)
+        ],
         PROFILE_LOW: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_low)],
         PROFILE_HIGH: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_high)],
         PROFILE_TZ: [
@@ -840,7 +914,9 @@ profile_conv = ConversationHandler(
 )
 
 
-profile_webapp_handler = MessageHandler(filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save)
+profile_webapp_handler = MessageHandler(
+    filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save
+)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- warn if webapp profile ICR exceeds 8 or CF below 3 and append guidance
- cover webapp save with new suspicious values test

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b15cd6f9b4832a8cf495da766ae458