### PR TITLE
[webapp] Handle incomplete profile data

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -70,13 +70,26 @@ const Profile = () => {
     getProfile(telegramId)
       .then((data) => {
         if (cancelled) return;
-        setProfile({
-          icr: data.icr.toString(),
-          cf: data.cf.toString(),
-          target: data.target.toString(),
-          low: data.low.toString(),
-          high: data.high.toString(),
-        });
+
+        const icr = typeof data.icr === "number" ? data.icr.toString() : "";
+        const cf = typeof data.cf === "number" ? data.cf.toString() : "";
+        const target =
+          typeof data.target === "number" ? data.target.toString() : "";
+        const low = typeof data.low === "number" ? data.low.toString() : "";
+        const high =
+          typeof data.high === "number" ? data.high.toString() : "";
+
+        const isComplete = [icr, cf, target, low, high].every((v) => v !== "");
+
+        setProfile({ icr, cf, target, low, high });
+
+        if (!isComplete) {
+          toast({
+            title: "Ошибка",
+            description: "Профиль заполнен не полностью",
+            variant: "destructive",
+          });
+        }
       })
       .catch((error) => {
         if (cancelled) return;

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -181,6 +181,31 @@ describe('Profile page', () => {
     expect((getByPlaceholderText('2.5') as HTMLInputElement).value).toBe('3');
   });
 
+  it('shows toast and defaults when profile data is incomplete', async () => {
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
+    (getProfile as vi.Mock).mockResolvedValue({
+      telegramId: 123,
+      icr: 15,
+      cf: 3,
+    });
+
+    const { getByPlaceholderText } = render(<Profile />);
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalledWith(123);
+    });
+    expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('15');
+    expect((getByPlaceholderText('2.5') as HTMLInputElement).value).toBe('3');
+    expect((getByPlaceholderText('6.0') as HTMLInputElement).value).toBe('');
+    expect((getByPlaceholderText('4.0') as HTMLInputElement).value).toBe('');
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Ошибка',
+        description: 'Профиль заполнен не полностью',
+        variant: 'destructive',
+      }),
+    );
+  });
+
   it('shows toast when profile load fails', async () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
     (getProfile as vi.Mock).mockRejectedValue(new Error('load failed'));


### PR DESCRIPTION
## Summary
- guard against missing profile fields
- alert users about incomplete profiles
- cover profile form with incomplete data test

## Testing
- `pnpm --filter vite_react_shadcn_ts test`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter vite_react_shadcn_ts lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68b15ce0df40832a9830f45c4fb6a78a