### PR TITLE
[webapp] handle invalid profile json

### DIFF
--- a/services/webapp/ui/src/api/http.ts
+++ b/services/webapp/ui/src/api/http.ts
@@ -25,7 +25,7 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
       throw new Error('Backend returned HTML instead of JSON');
     }
 
-    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const data = (await res.json()) as Record<string, unknown>;
     if (!res.ok) {
       const msg = typeof data.detail === 'string' ? data.detail : 'Request failed';
       throw new Error(msg);

--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -16,10 +16,13 @@ export async function getProfile(telegramId: number) {
       const msg = errorText || 'Request failed';
       throw new Error(msg);
     }
-    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const data = (await res.json()) as Record<string, unknown>;
     return data as ProfileSchema;
   } catch (error) {
     console.error('Failed to load profile:', error);
+    if (error instanceof SyntaxError) {
+      throw new Error('Не удалось получить профиль: некорректный ответ сервера');
+    }
     if (error instanceof Error) {
       throw new Error(`Не удалось получить профиль: ${error.message}`);
     }
@@ -52,7 +55,7 @@ export async function saveProfile({
       const msg = errorText || 'Request failed';
       throw new Error(msg);
     }
-    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const data = (await res.json()) as Record<string, unknown>;
     return data as ProfileSchema;
   } catch (error) {
     console.error('Failed to save profile:', error);

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -22,6 +22,26 @@ describe('profile api', () => {
     );
   });
 
+  it('throws error when getProfile returns invalid JSON', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response('not-json', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', mockFetch);
+
+    await expect(getProfile(1)).rejects.toThrow(
+      'Не удалось получить профиль: некорректный ответ сервера',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/profiles?telegramId=1',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
   it('throws error when saveProfile request fails', async () => {
     const mockFetch = vi.fn().mockResolvedValue(new Response('fail', { status: 500 }));
     vi.stubGlobal('fetch', mockFetch);


### PR DESCRIPTION
## Summary
- let http client reject on invalid JSON
- throw descriptive error when profile endpoint returns malformed data
- test profile API failure on invalid JSON

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b15ce7e258832a9996dc942fb31bda