### PR TITLE
[ui] warn on suspicious profile values

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -43,6 +43,8 @@ export const parseProfile = (profile: ProfileForm): ParsedProfile | null => {
   return numbersValid && rangeValid ? parsed : null;
 };
 
+export const shouldWarnProfile = (profile: ParsedProfile): boolean =>
+  profile.icr > 8 && profile.cf < 3;
 
 const Profile = () => {
   const navigate = useNavigate();
@@ -117,6 +119,15 @@ const Profile = () => {
           "Проверьте, что все значения положительны, нижний порог меньше верхнего," +
           " а целевой уровень между ними",
         variant: "destructive",
+      });
+      return;
+    }
+
+    if (shouldWarnProfile(parsed)) {
+      toast({
+        title: "Проверьте значения",
+        description:
+          "ICR больше 8 и CF меньше 3. Пожалуйста, убедитесь в корректности введенных данных",
       });
       return;
     }

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -1,39 +1,51 @@
-import { describe, it, expect } from 'vitest';
-import { parseProfile } from '../src/pages/Profile';
+import { describe, it, expect } from "vitest";
+import { parseProfile, shouldWarnProfile } from "../src/pages/Profile";
 
-describe('parseProfile', () => {
-  it('returns parsed numbers for valid input', () => {
+describe("parseProfile", () => {
+  it("returns parsed numbers for valid input", () => {
     const result = parseProfile({
-      icr: '1',
-      cf: '2',
-      target: '5',
-      low: '4',
-      high: '10',
+      icr: "1",
+      cf: "2",
+      target: "5",
+      low: "4",
+      high: "10",
     });
     expect(result).toEqual({ icr: 1, cf: 2, target: 5, low: 4, high: 10 });
   });
 
-  it('returns null when any value is non-positive or invalid', () => {
+  it("returns null when any value is non-positive or invalid", () => {
     expect(
-      parseProfile({ icr: '0', cf: '2', target: '5', low: '4', high: '10' }),
+      parseProfile({ icr: "0", cf: "2", target: "5", low: "4", high: "10" }),
     ).toBeNull();
     expect(
-      parseProfile({ icr: '1', cf: '-1', target: '5', low: '4', high: '10' }),
+      parseProfile({ icr: "1", cf: "-1", target: "5", low: "4", high: "10" }),
     ).toBeNull();
     expect(
-      parseProfile({ icr: 'a', cf: '2', target: '5', low: '4', high: '10' }),
+      parseProfile({ icr: "a", cf: "2", target: "5", low: "4", high: "10" }),
     ).toBeNull();
   });
 
-  it('returns null when low/high bounds are invalid', () => {
+  it("returns null when low/high bounds are invalid", () => {
     expect(
-      parseProfile({ icr: '1', cf: '2', target: '5', low: '8', high: '6' }),
+      parseProfile({ icr: "1", cf: "2", target: "5", low: "8", high: "6" }),
     ).toBeNull();
     expect(
-      parseProfile({ icr: '1', cf: '2', target: '3', low: '4', high: '10' }),
+      parseProfile({ icr: "1", cf: "2", target: "3", low: "4", high: "10" }),
     ).toBeNull();
     expect(
-      parseProfile({ icr: '1', cf: '2', target: '12', low: '4', high: '10' }),
+      parseProfile({ icr: "1", cf: "2", target: "12", low: "4", high: "10" }),
     ).toBeNull();
+  });
+
+  it("detects suspicious profile values", () => {
+    expect(
+      shouldWarnProfile({ icr: 9, cf: 2, target: 5, low: 4, high: 10 }),
+    ).toBe(true);
+    expect(
+      shouldWarnProfile({ icr: 8, cf: 2, target: 5, low: 4, high: 10 }),
+    ).toBe(false);
+    expect(
+      shouldWarnProfile({ icr: 9, cf: 3, target: 5, low: 4, high: 10 }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- warn when saving profile with icr>8 and cf<3
- add utility to flag suspicious profiles and tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `npm test`
- `npm run lint` (fails: Unexpected any)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b15cedc474832aa568dc066cb75330