### PR TITLE
[ui] Validate telegram id parsing

### DIFF
--- a/services/webapp/ui/src/pages/resolveTelegramId.ts
+++ b/services/webapp/ui/src/pages/resolveTelegramId.ts
@@ -2,7 +2,7 @@ export const resolveTelegramId = (
   user: { id?: number } | null,
   initData: string | null,
 ): number | undefined => {
-  let telegramId = user?.id;
+  let telegramId = Number.isFinite(user?.id) ? user?.id : undefined;
   if (!telegramId) {
     let userStr: string | null = null;
     if (initData) {
@@ -15,7 +15,10 @@ export const resolveTelegramId = (
     if (userStr) {
       try {
         const parsed = JSON.parse(userStr);
-        telegramId = typeof parsed.id === "number" ? parsed.id : undefined;
+        telegramId =
+          typeof parsed.id === "number" && Number.isFinite(parsed.id)
+            ? parsed.id
+            : undefined;
       } catch (e) {
         console.error("[Profile] failed to parse initData user:", e);
       }

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -224,3 +224,22 @@ describe('Profile page', () => {
     expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('');
   });
 });
+
+describe('resolveTelegramId', () => {
+  it('returns undefined for NaN user id', async () => {
+    const { resolveTelegramId } = await vi.importActual<
+      typeof import('../src/pages/resolveTelegramId')
+    >('../src/pages/resolveTelegramId');
+    expect(resolveTelegramId({ id: Number.NaN }, null)).toBeUndefined();
+  });
+
+  it('returns undefined for non-numeric id in initData', async () => {
+    const { resolveTelegramId } = await vi.importActual<
+      typeof import('../src/pages/resolveTelegramId')
+    >('../src/pages/resolveTelegramId');
+    const initData = `user=${encodeURIComponent(
+      JSON.stringify({ id: 'abc' }),
+    )}`;
+    expect(resolveTelegramId(null, initData)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure resolveTelegramId only returns finite numeric IDs
- test NaN and non-numeric initData handling

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b16d7d64b8832a8c31c82a1c731991