### PR TITLE
[webapp] handle zero values in profile

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -73,15 +73,30 @@ const Profile = () => {
       .then((data) => {
         if (cancelled) return;
 
-        const icr = typeof data.icr === "number" ? data.icr.toString() : "";
-        const cf = typeof data.cf === "number" ? data.cf.toString() : "";
+        const icr =
+          typeof data.icr === "number" && data.icr > 0
+            ? data.icr.toString()
+            : "";
+        const cf =
+          typeof data.cf === "number" && data.cf > 0
+            ? data.cf.toString()
+            : "";
         const target =
-          typeof data.target === "number" ? data.target.toString() : "";
-        const low = typeof data.low === "number" ? data.low.toString() : "";
+          typeof data.target === "number" && data.target > 0
+            ? data.target.toString()
+            : "";
+        const low =
+          typeof data.low === "number" && data.low > 0
+            ? data.low.toString()
+            : "";
         const high =
-          typeof data.high === "number" ? data.high.toString() : "";
+          typeof data.high === "number" && data.high > 0
+            ? data.high.toString()
+            : "";
 
-        const isComplete = [icr, cf, target, low, high].every((v) => v !== "");
+        const isComplete = [icr, cf, target, low, high].every(
+          (v) => Number(v) > 0,
+        );
 
         setProfile({ icr, cf, target, low, high });
 

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -206,6 +206,37 @@ describe('Profile page', () => {
     );
   });
 
+  it('shows toast and clears zero values from profile data', async () => {
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
+    (getProfile as vi.Mock).mockResolvedValue({
+      telegramId: 123,
+      icr: 15,
+      cf: 0,
+      target: 5,
+      low: 3,
+      high: 8,
+    });
+
+    const { getByPlaceholderText } = render(<Profile />);
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalledWith(123);
+    });
+
+    expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('15');
+    expect((getByPlaceholderText('2.5') as HTMLInputElement).value).toBe('');
+    expect((getByPlaceholderText('6.0') as HTMLInputElement).value).toBe('5');
+    expect((getByPlaceholderText('4.0') as HTMLInputElement).value).toBe('3');
+    expect((getByPlaceholderText('10.0') as HTMLInputElement).value).toBe('8');
+
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Ошибка',
+        description: 'Профиль заполнен не полностью',
+        variant: 'destructive',
+      }),
+    );
+  });
+
   it('shows toast when profile load fails', async () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
     (getProfile as vi.Mock).mockRejectedValue(new Error('load failed'));


### PR DESCRIPTION
## Summary
- treat non-positive profile values from API as empty strings
- mark profile incomplete if any value is non-positive
- test zero values from API trigger incomplete profile toast

## Testing
- `npm test`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b16d7d7cec832a9fc279aea7f17a2b