### PR TITLE
[ui] add confirmation step for profile warnings

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -4,6 +4,8 @@ import { Save } from "lucide-react";
 import { MedicalHeader } from "@/components/MedicalHeader";
 import { useToast } from "@/hooks/use-toast";
 import MedicalButton from "@/components/MedicalButton";
+import { Button } from "@/components/ui/button";
+import Modal from "@/components/Modal";
 import { saveProfile, getProfile } from "@/api/profile";
 import { useTelegram } from "@/hooks/useTelegram";
 import { useTelegramInitData } from "@/hooks/useTelegramInitData";
@@ -60,6 +62,11 @@ const Profile = () => {
     high: "",
   });
 
+  const [warningOpen, setWarningOpen] = useState(false);
+  const [pendingProfile, setPendingProfile] = useState<
+    (ParsedProfile & { telegramId: number }) | null
+  >(null);
+
   useEffect(() => {
     const telegramId = resolveTelegramId(user, initData);
 
@@ -112,6 +119,25 @@ const Profile = () => {
     setProfile((prev) => ({ ...prev, [field]: value }));
   };
 
+  const saveParsedProfile = async (
+    data: ParsedProfile & { telegramId: number },
+  ): Promise<void> => {
+    try {
+      await saveProfile(data);
+      toast({
+        title: "Профиль сохранен",
+        description: "Ваши настройки успешно обновлены",
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      toast({
+        title: "Ошибка",
+        description: message,
+        variant: "destructive",
+      });
+    }
+  };
+
   const handleSave = async () => {
     const telegramId = resolveTelegramId(user, initData);
 
@@ -137,6 +163,8 @@ const Profile = () => {
     }
 
     if (shouldWarnProfile(parsed)) {
+      setPendingProfile({ telegramId, ...parsed });
+      setWarningOpen(true);
       toast({
         title: "Проверьте значения",
         description:
@@ -145,32 +173,48 @@ const Profile = () => {
       return;
     }
 
-    try {
-      await saveProfile({ telegramId, ...parsed });
-      toast({
-        title: "Профиль сохранен",
-        description: "Ваши настройки успешно обновлены",
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      toast({
-        title: "Ошибка",
-        description: message,
-        variant: "destructive",
-      });
-    }
+    await saveParsedProfile({ telegramId, ...parsed });
+  };
+
+  const handleConfirmSave = async () => {
+    if (!pendingProfile) return;
+    await saveParsedProfile(pendingProfile);
+    setPendingProfile(null);
+    setWarningOpen(false);
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
-      <MedicalHeader
-        title="Мой профиль"
-        showBack
-        onBack={() => navigate("/")}
-      />
+    <>
+      <Modal
+        open={warningOpen}
+        onClose={() => setWarningOpen(false)}
+        title="Проверьте значения"
+        footer={
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setWarningOpen(false)}>
+              Отмена
+            </Button>
+            <MedicalButton onClick={handleConfirmSave}>
+              Продолжить
+            </MedicalButton>
+          </div>
+        }
+      >
+        <p>
+          ICR больше 8 и CF меньше 3. Пожалуйста, убедитесь в корректности
+          введенных данных
+        </p>
+      </Modal>
 
-      <main className="container mx-auto px-4 py-6">
-        <div className="medical-card animate-slide-up bg-gradient-to-br from-primary/5 to-primary/10 border-primary/20">
+      <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
+        <MedicalHeader
+          title="Мой профиль"
+          showBack
+          onBack={() => navigate("/")}
+        />
+
+        <main className="container mx-auto px-4 py-6">
+          <div className="medical-card animate-slide-up bg-gradient-to-br from-primary/5 to-primary/10 border-primary/20">
           <div className="space-y-6">
             {/* ICR */}
             <div>
@@ -313,6 +357,7 @@ const Profile = () => {
         </div>
       </main>
     </div>
+    </>
   );
 };
 

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -223,4 +223,58 @@ describe('Profile page', () => {
     );
     expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('');
   });
+
+  it('shows warning modal and blocks save until confirmation', async () => {
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
+    const { getByText, getByPlaceholderText } = render(<Profile />);
+
+    await waitFor(() => {
+      expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('12');
+    });
+
+    fireEvent.click(getByText('Сохранить настройки'));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Проверьте значения' }),
+      );
+    });
+
+    expect(
+      getByText(
+        'ICR больше 8 и CF меньше 3. Пожалуйста, убедитесь в корректности введенных данных',
+      ),
+    ).toBeTruthy();
+    expect(saveProfile).not.toHaveBeenCalled();
+  });
+
+  it('saves after user confirms warning', async () => {
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
+    (saveProfile as vi.Mock).mockResolvedValue(undefined);
+
+    const { getByText, getByPlaceholderText } = render(<Profile />);
+
+    await waitFor(() => {
+      expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('12');
+    });
+
+    fireEvent.click(getByText('Сохранить настройки'));
+
+    await waitFor(() => getByText('Продолжить'));
+    fireEvent.click(getByText('Продолжить'));
+
+    await waitFor(() => {
+      expect(saveProfile).toHaveBeenCalledWith({
+        telegramId: 123,
+        icr: 12,
+        cf: 2.5,
+        target: 6,
+        low: 4,
+        high: 10,
+      });
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Профиль сохранен' }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add confirmation modal when profile values look suspicious
- allow saving after user acknowledges warning
- test warning modal display and confirmed save

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: KeyboardInterrupt)*
- `mypy --strict .` *(fails: Interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b16d7f62ac832aa26012218884cb3c