### PR TITLE
[ui] allow comma decimal input

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -60,6 +60,8 @@ const Profile = () => {
     high: "",
   });
 
+  const decimalRegex = /^\d*(?:[.,]\d*)?$/;
+
   useEffect(() => {
     const telegramId = resolveTelegramId(user, initData);
 
@@ -109,7 +111,9 @@ const Profile = () => {
   }, [user, initData, toast]);
 
   const handleInputChange = (field: keyof ProfileForm, value: string) => {
-    setProfile((prev) => ({ ...prev, [field]: value }));
+    if (decimalRegex.test(value)) {
+      setProfile((prev) => ({ ...prev, [field]: value }));
+    }
   };
 
   const handleSave = async () => {
@@ -179,8 +183,9 @@ const Profile = () => {
               </label>
               <div className="relative">
                 <input
-                  type="number"
-                  step="0.1"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="[0-9]*[.,]?[0-9]*"
                   value={profile.icr}
                   onChange={(e) => handleInputChange("icr", e.target.value)}
                   className="medical-input"
@@ -202,8 +207,9 @@ const Profile = () => {
               </label>
               <div className="relative">
                 <input
-                  type="number"
-                  step="0.1"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="[0-9]*[.,]?[0-9]*"
                   value={profile.cf}
                   onChange={(e) => handleInputChange("cf", e.target.value)}
                   className="medical-input"
@@ -225,8 +231,9 @@ const Profile = () => {
               </label>
               <div className="relative">
                 <input
-                  type="number"
-                  step="0.1"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="[0-9]*[.,]?[0-9]*"
                   value={profile.target}
                   onChange={(e) => handleInputChange("target", e.target.value)}
                   className="medical-input"
@@ -246,8 +253,9 @@ const Profile = () => {
                 </label>
                 <div className="relative">
                   <input
-                    type="number"
-                    step="0.1"
+                    type="text"
+                    inputMode="decimal"
+                    pattern="[0-9]*[.,]?[0-9]*"
                     value={profile.low}
                     onChange={(e) => handleInputChange("low", e.target.value)}
                     className="medical-input"
@@ -265,8 +273,9 @@ const Profile = () => {
                 </label>
                 <div className="relative">
                   <input
-                    type="number"
-                    step="0.1"
+                    type="text"
+                    inputMode="decimal"
+                    pattern="[0-9]*[.,]?[0-9]*"
                     value={profile.high}
                     onChange={(e) => handleInputChange("high", e.target.value)}
                     className="medical-input"

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -13,6 +13,17 @@ describe("parseProfile", () => {
     expect(result).toEqual({ icr: 1, cf: 2, target: 5, low: 4, high: 10 });
   });
 
+  it("parses values with commas", () => {
+    const result = parseProfile({
+      icr: "1,5",
+      cf: "2,5",
+      target: "5,5",
+      low: "4,0",
+      high: "10,0",
+    });
+    expect(result).toEqual({ icr: 1.5, cf: 2.5, target: 5.5, low: 4, high: 10 });
+  });
+
   it("returns null when any value is non-positive or invalid", () => {
     expect(
       parseProfile({ icr: "0", cf: "2", target: "5", low: "4", high: "10" }),

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -83,7 +83,7 @@ describe('Profile page', () => {
 
     const { getByText, getByPlaceholderText } = render(<Profile />);
     const icrInput = getByPlaceholderText('12');
-    fireEvent.change(icrInput, { target: { value: '-1' } });
+    fireEvent.change(icrInput, { target: { value: '0' } });
 
     fireEvent.click(getByText('Сохранить настройки'));
     expect(saveProfile).not.toHaveBeenCalled();
@@ -129,23 +129,18 @@ describe('Profile page', () => {
     });
 
     const icrInput = getByPlaceholderText('12');
-    icrInput.setAttribute('type', 'text');
     fireEvent.change(icrInput, { target: { value: '1,5' } });
 
     const cfInput = getByPlaceholderText('2.5');
-    cfInput.setAttribute('type', 'text');
     fireEvent.change(cfInput, { target: { value: '2,5' } });
 
     const targetInput = getByPlaceholderText('6.0');
-    targetInput.setAttribute('type', 'text');
     fireEvent.change(targetInput, { target: { value: '5,5' } });
 
     const lowInput = getByPlaceholderText('4.0');
-    lowInput.setAttribute('type', 'text');
     fireEvent.change(lowInput, { target: { value: '4,0' } });
 
     const highInput = getByPlaceholderText('10.0');
-    highInput.setAttribute('type', 'text');
     fireEvent.change(highInput, { target: { value: '10,0' } });
 
     fireEvent.click(getByText('Сохранить настройки'));


### PR DESCRIPTION
## Summary
- Allow decimal inputs with commas on profile page
- Drop test overrides for numeric fields and add coverage for comma parsing

## Testing
- `npm test`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b16d80c1a0832aa524bf52ff72ce22