### PR TITLE
[webapp] allow comma decimal input on profile

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -131,7 +131,9 @@ const Profile = () => {
   }, [user, initData, toast]);
 
   const handleInputChange = (field: keyof ProfileForm, value: string) => {
-    setProfile((prev) => ({ ...prev, [field]: value }));
+    if (/^\d*(?:[.,]\d*)?$/.test(value)) {
+      setProfile((prev) => ({ ...prev, [field]: value }));
+    }
   };
 
   const saveParsedProfile = async (
@@ -238,8 +240,9 @@ const Profile = () => {
               </label>
               <div className="relative">
                 <input
-                  type="number"
-                  step="0.1"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="^\\d*(?:[.,]\\d*)?$"
                   value={profile.icr}
                   onChange={(e) => handleInputChange("icr", e.target.value)}
                   className="medical-input"
@@ -261,8 +264,9 @@ const Profile = () => {
               </label>
               <div className="relative">
                 <input
-                  type="number"
-                  step="0.1"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="^\\d*(?:[.,]\\d*)?$"
                   value={profile.cf}
                   onChange={(e) => handleInputChange("cf", e.target.value)}
                   className="medical-input"
@@ -284,8 +288,9 @@ const Profile = () => {
               </label>
               <div className="relative">
                 <input
-                  type="number"
-                  step="0.1"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="^\\d*(?:[.,]\\d*)?$"
                   value={profile.target}
                   onChange={(e) => handleInputChange("target", e.target.value)}
                   className="medical-input"
@@ -305,8 +310,9 @@ const Profile = () => {
                 </label>
                 <div className="relative">
                   <input
-                    type="number"
-                    step="0.1"
+                    type="text"
+                    inputMode="decimal"
+                    pattern="^\\d*(?:[.,]\\d*)?$"
                     value={profile.low}
                     onChange={(e) => handleInputChange("low", e.target.value)}
                     className="medical-input"
@@ -324,8 +330,9 @@ const Profile = () => {
                 </label>
                 <div className="relative">
                   <input
-                    type="number"
-                    step="0.1"
+                    type="text"
+                    inputMode="decimal"
+                    pattern="^\\d*(?:[.,]\\d*)?$"
                     value={profile.high}
                     onChange={(e) => handleInputChange("high", e.target.value)}
                     className="medical-input"

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -83,7 +83,7 @@ describe('Profile page', () => {
 
     const { getByText, getByPlaceholderText } = render(<Profile />);
     const icrInput = getByPlaceholderText('12');
-    fireEvent.change(icrInput, { target: { value: '-1' } });
+    fireEvent.change(icrInput, { target: { value: '0' } });
 
     fireEvent.click(getByText('Сохранить настройки'));
     expect(saveProfile).not.toHaveBeenCalled();
@@ -129,23 +129,18 @@ describe('Profile page', () => {
     });
 
     const icrInput = getByPlaceholderText('12');
-    icrInput.setAttribute('type', 'text');
     fireEvent.change(icrInput, { target: { value: '1,5' } });
 
     const cfInput = getByPlaceholderText('2.5');
-    cfInput.setAttribute('type', 'text');
     fireEvent.change(cfInput, { target: { value: '2,5' } });
 
     const targetInput = getByPlaceholderText('6.0');
-    targetInput.setAttribute('type', 'text');
     fireEvent.change(targetInput, { target: { value: '5,5' } });
 
     const lowInput = getByPlaceholderText('4.0');
-    lowInput.setAttribute('type', 'text');
     fireEvent.change(lowInput, { target: { value: '4,0' } });
 
     const highInput = getByPlaceholderText('10.0');
-    highInput.setAttribute('type', 'text');
     fireEvent.change(highInput, { target: { value: '10,0' } });
 
     fireEvent.click(getByText('Сохранить настройки'));


### PR DESCRIPTION
## Summary
- allow entering numbers with comma separators on the profile page
- adjust profile tests for text inputs that accept commas

## Testing
- `pnpm test`
- `pytest -q --cov` *(fails: async def functions are not natively supported, many tests fail)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b170c406d0832aae9d74441b1398b7