### PR TITLE
[webapp] Load Telegram SDK in timezone page

### DIFF
--- a/services/webapp/ui/public/timezone.html
+++ b/services/webapp/ui/public/timezone.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/style.css">
     <title>Часовой пояс</title>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <script type="module" src="%BASE_URL%telegram-init.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
@@ -18,11 +19,11 @@
                 document.body.appendChild(btn);
             };
 
-            if (window.Telegram && Telegram.WebApp) {
+            if (window.Telegram && window.Telegram.WebApp) {
                 try {
-                    Telegram.WebApp.sendData(tz);
+                    window.Telegram.WebApp.sendData(tz);
                     status.textContent = 'Часовой пояс определён';
-                    addButton('Закрыть', () => Telegram.WebApp.close());
+                    addButton('Закрыть', () => window.Telegram.WebApp.close());
                 } catch (err) {
                     status.textContent = 'Не удалось отправить данные. Проверьте подключение к сети и попробуйте ещё раз.';
                     addButton('Повторить', () => location.reload());

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -1,4 +1,5 @@
 import pytest
+from pathlib import Path
 from telegram import InlineKeyboardButton
 
 import services.api.app.config as config
@@ -25,3 +26,10 @@ def test_timezone_button_webapp_enabled(monkeypatch: pytest.MonkeyPatch) -> None
     web_app = button.web_app
     assert web_app is not None
     assert web_app.url.endswith("/timezone.html")
+
+
+def test_timezone_page_loads_sdk_and_sends_timezone() -> None:
+    """Timezone webapp should include Telegram SDK and send timezone."""
+    html = Path("services/webapp/ui/public/timezone.html").read_text(encoding="utf-8")
+    assert "https://telegram.org/js/telegram-web-app.js" in html
+    assert "window.Telegram.WebApp.sendData" in html


### PR DESCRIPTION
## Summary
- load Telegram WebApp SDK for timezone page
- test timezone webapp loads SDK and sends timezone

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b170e38994832a904aa44e6b3817c0