### PR TITLE
[ui] treat telegram id zero as valid

### DIFF
--- a/services/webapp/ui/src/pages/resolveTelegramId.ts
+++ b/services/webapp/ui/src/pages/resolveTelegramId.ts
@@ -3,7 +3,7 @@ export const resolveTelegramId = (
   initData: string | null,
 ): number | undefined => {
   let telegramId = Number.isFinite(user?.id) ? user?.id : undefined;
-  if (!telegramId) {
+  if (telegramId === undefined) {
     let userStr: string | null = null;
     if (initData) {
       try {

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -327,4 +327,14 @@ describe('resolveTelegramId', () => {
     )}`;
     expect(resolveTelegramId(null, initData)).toBeUndefined();
   });
+
+  it('treats 0 as valid user id and ignores initData', async () => {
+    const { resolveTelegramId } = await vi.importActual<
+      typeof import('../src/pages/resolveTelegramId')
+    >('../src/pages/resolveTelegramId');
+    const initData = `user=${encodeURIComponent(
+      JSON.stringify({ id: 123 }),
+    )}`;
+    expect(resolveTelegramId({ id: 0 }, initData)).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- fix resolveTelegramId to only fall back to initData when user id is undefined
- add test ensuring telegram id 0 is treated as valid

## Testing
- `pnpm --filter ./services/webapp/ui test tests/profile.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b17256d6c0832a9274443d5485d185