### PR TITLE
[ui] allow comma decimal input on profile

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -29,11 +29,11 @@ type ParsedProfile = {
 
 export const parseProfile = (profile: ProfileForm): ParsedProfile | null => {
   const parsed = {
-    icr: Number(profile.icr.replace(",", ".")),
-    cf: Number(profile.cf.replace(",", ".")),
-    target: Number(profile.target.replace(",", ".")),
-    low: Number(profile.low.replace(",", ".")),
-    high: Number(profile.high.replace(",", ".")),
+    icr: Number(profile.icr.replace(",", ".").replace(/,/g, ".")),
+    cf: Number(profile.cf.replace(",", ".").replace(/,/g, ".")),
+    target: Number(profile.target.replace(",", ".").replace(/,/g, ".")),
+    low: Number(profile.low.replace(",", ".").replace(/,/g, ".")),
+    high: Number(profile.high.replace(",", ".").replace(/,/g, ".")),
   };
   const numbersValid = Object.values(parsed).every(
     (v) => Number.isFinite(v) && v > 0,
@@ -238,8 +238,9 @@ const Profile = () => {
               </label>
               <div className="relative">
                 <input
-                  type="number"
-                  step="0.1"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="[0-9]*[.,]?[0-9]*"
                   value={profile.icr}
                   onChange={(e) => handleInputChange("icr", e.target.value)}
                   className="medical-input"
@@ -261,8 +262,9 @@ const Profile = () => {
               </label>
               <div className="relative">
                 <input
-                  type="number"
-                  step="0.1"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="[0-9]*[.,]?[0-9]*"
                   value={profile.cf}
                   onChange={(e) => handleInputChange("cf", e.target.value)}
                   className="medical-input"
@@ -284,8 +286,9 @@ const Profile = () => {
               </label>
               <div className="relative">
                 <input
-                  type="number"
-                  step="0.1"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="[0-9]*[.,]?[0-9]*"
                   value={profile.target}
                   onChange={(e) => handleInputChange("target", e.target.value)}
                   className="medical-input"
@@ -305,8 +308,9 @@ const Profile = () => {
                 </label>
                 <div className="relative">
                   <input
-                    type="number"
-                    step="0.1"
+                    type="text"
+                    inputMode="decimal"
+                    pattern="[0-9]*[.,]?[0-9]*"
                     value={profile.low}
                     onChange={(e) => handleInputChange("low", e.target.value)}
                     className="medical-input"
@@ -324,8 +328,9 @@ const Profile = () => {
                 </label>
                 <div className="relative">
                   <input
-                    type="number"
-                    step="0.1"
+                    type="text"
+                    inputMode="decimal"
+                    pattern="[0-9]*[.,]?[0-9]*"
                     value={profile.high}
                     onChange={(e) => handleInputChange("high", e.target.value)}
                     className="medical-input"

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -13,6 +13,17 @@ describe("parseProfile", () => {
     expect(result).toEqual({ icr: 1, cf: 2, target: 5, low: 4, high: 10 });
   });
 
+  it("parses values with commas as decimal separators", () => {
+    const result = parseProfile({
+      icr: "1,5",
+      cf: "2,5",
+      target: "5,5",
+      low: "4,0",
+      high: "10,0",
+    });
+    expect(result).toEqual({ icr: 1.5, cf: 2.5, target: 5.5, low: 4, high: 10 });
+  });
+
   it("returns null when any value is non-positive or invalid", () => {
     expect(
       parseProfile({ icr: "0", cf: "2", target: "5", low: "4", high: "10" }),
@@ -34,6 +45,18 @@ describe("parseProfile", () => {
     ).toBeNull();
     expect(
       parseProfile({ icr: "1", cf: "2", target: "12", low: "4", high: "10" }),
+      ).toBeNull();
+  });
+
+  it("returns null when a value contains multiple commas", () => {
+    expect(
+      parseProfile({
+        icr: "1,2,3",
+        cf: "2",
+        target: "5",
+        low: "4",
+        high: "10",
+      }),
     ).toBeNull();
   });
 

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -129,23 +129,18 @@ describe('Profile page', () => {
     });
 
     const icrInput = getByPlaceholderText('12');
-    icrInput.setAttribute('type', 'text');
     fireEvent.change(icrInput, { target: { value: '1,5' } });
 
     const cfInput = getByPlaceholderText('2.5');
-    cfInput.setAttribute('type', 'text');
     fireEvent.change(cfInput, { target: { value: '2,5' } });
 
     const targetInput = getByPlaceholderText('6.0');
-    targetInput.setAttribute('type', 'text');
     fireEvent.change(targetInput, { target: { value: '5,5' } });
 
     const lowInput = getByPlaceholderText('4.0');
-    lowInput.setAttribute('type', 'text');
     fireEvent.change(lowInput, { target: { value: '4,0' } });
 
     const highInput = getByPlaceholderText('10.0');
-    highInput.setAttribute('type', 'text');
     fireEvent.change(highInput, { target: { value: '10,0' } });
 
     fireEvent.click(getByText('Сохранить настройки'));


### PR DESCRIPTION
## Summary
- allow text-based decimal inputs with comma or dot for profile fields
- sanitize multiple commas when parsing profile values
- test comma entry and parsing

## Testing
- `pnpm --filter ./services/webapp/ui test tests/profile.test.tsx tests/parseProfile.test.ts`
- `pnpm --filter ./services/webapp/ui lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68b1725d5b04832ab27a13378f7cfbda