### PR TITLE
[webapp] drop mock fallback in reminders

### DIFF
--- a/services/webapp/ui/src/api/http.ts
+++ b/services/webapp/ui/src/api/http.ts
@@ -1,5 +1,4 @@
 import { getTelegramAuthHeaders } from '@/lib/telegram-auth';
-import { mockApi } from './mock-server';
 
 const API_BASE = '/api';
 
@@ -32,26 +31,9 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
     }
     return data as T;
   } catch (error) {
-    console.warn('[API] Backend request failed, falling back to mock API:', error);
-    // Fallback to mock API for development
-    return await handleMockRequest<T>(path, init);
+    console.warn('[API] Backend request failed:', error);
+    throw error;
   }
-}
-
-async function handleMockRequest<T>(path: string, init: RequestInit): Promise<T> {
-  const urlParams = new URLSearchParams(path.split('?')[1] || '');
-  const telegramId = parseInt(urlParams.get('telegramId') || urlParams.get('telegram_id') || '12345');
-  
-  if (path.startsWith('/reminders')) {
-    if (init.method === 'POST') {
-      const body = JSON.parse(init.body as string);
-      return await mockApi.createReminder(body.reminder || body) as T;
-    } else {
-      return await mockApi.getReminders(telegramId) as T;
-    }
-  }
-  
-  return {} as T;
 }
 
 export const http = {

--- a/services/webapp/ui/tests/mockApi.test.tsx
+++ b/services/webapp/ui/tests/mockApi.test.tsx
@@ -55,8 +55,8 @@ describe('mockApi not used in production', () => {
 
   it('RemindersList uses toast and not mockApi in production', async () => {
     remindersGet.mockRejectedValue(new Error('fail'));
+    vi.stubEnv('DEV', 'false');
     const { default: RemindersList } = await import('../src/features/reminders/pages/RemindersList');
-    vi.stubEnv('NODE_ENV', 'production');
     render(<RemindersList planLimit={5} />);
     await waitFor(() => {
       expect(remindersGet).toHaveBeenCalled();
@@ -67,8 +67,8 @@ describe('mockApi not used in production', () => {
 
   it('RemindersCreate uses toast and not mockApi in production', async () => {
     remindersPost.mockRejectedValue(new Error('fail'));
-    const { default: RemindersCreate } = await import('../src/features/reminders/pages/RemindersCreate');
     vi.stubEnv('NODE_ENV', 'production');
+    const { default: RemindersCreate } = await import('../src/features/reminders/pages/RemindersCreate');
     const { container } = render(<RemindersCreate />);
     const form = container.querySelector('form')!;
     fireEvent.submit(form);


### PR DESCRIPTION
## Summary
- remove mock API fallback from http client and rethrow errors
- only use mock API in reminders under explicit dev flag
- update tests to stub `import.meta.env.DEV`

## Testing
- `pnpm typecheck`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b176fd8a0c832a85976798cabb6620