### PR TITLE
[webapp] handle comma decimal inputs on profile

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -29,11 +29,11 @@ type ParsedProfile = {
 
 export const parseProfile = (profile: ProfileForm): ParsedProfile | null => {
   const parsed = {
-    icr: Number(profile.icr.replace(",", ".")),
-    cf: Number(profile.cf.replace(",", ".")),
-    target: Number(profile.target.replace(",", ".")),
-    low: Number(profile.low.replace(",", ".")),
-    high: Number(profile.high.replace(",", ".")),
+    icr: Number(profile.icr.replace(/,/g, ".")),
+    cf: Number(profile.cf.replace(/,/g, ".")),
+    target: Number(profile.target.replace(/,/g, ".")),
+    low: Number(profile.low.replace(/,/g, ".")),
+    high: Number(profile.high.replace(/,/g, ".")),
   };
   const numbersValid = Object.values(parsed).every(
     (v) => Number.isFinite(v) && v > 0,

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -25,6 +25,28 @@ describe("parseProfile", () => {
     ).toBeNull();
   });
 
+  it("parses comma decimal numbers", () => {
+    const result = parseProfile({
+      icr: "1,5",
+      cf: "2,5",
+      target: "5,5",
+      low: "4",
+      high: "10",
+    });
+    expect(result).toEqual({ icr: 1.5, cf: 2.5, target: 5.5, low: 4, high: 10 });
+  });
+
+  it("returns null for multiple commas", () => {
+    const result = parseProfile({
+      icr: "1,2,3",
+      cf: "2",
+      target: "5",
+      low: "4",
+      high: "10",
+    });
+    expect(result).toBeNull();
+  });
+
   it("returns null when low/high bounds are invalid", () => {
     expect(
       parseProfile({ icr: "1", cf: "2", target: "5", low: "8", high: "6" }),

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -141,20 +141,25 @@ describe('Profile page', () => {
       expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('12');
     });
 
-    const icrInput = getByPlaceholderText('12');
+    const icrInput = getByPlaceholderText('12') as HTMLInputElement;
     fireEvent.change(icrInput, { target: { value: '1,5' } });
+    expect(icrInput.value).toBe('1,5');
 
-    const cfInput = getByPlaceholderText('2.5');
+    const cfInput = getByPlaceholderText('2.5') as HTMLInputElement;
     fireEvent.change(cfInput, { target: { value: '2,5' } });
+    expect(cfInput.value).toBe('2,5');
 
-    const targetInput = getByPlaceholderText('6.0');
+    const targetInput = getByPlaceholderText('6.0') as HTMLInputElement;
     fireEvent.change(targetInput, { target: { value: '5,5' } });
+    expect(targetInput.value).toBe('5,5');
 
-    const lowInput = getByPlaceholderText('4.0');
+    const lowInput = getByPlaceholderText('4.0') as HTMLInputElement;
     fireEvent.change(lowInput, { target: { value: '4,0' } });
+    expect(lowInput.value).toBe('4,0');
 
-    const highInput = getByPlaceholderText('10.0');
+    const highInput = getByPlaceholderText('10.0') as HTMLInputElement;
     fireEvent.change(highInput, { target: { value: '10,0' } });
+    expect(highInput.value).toBe('10,0');
 
     fireEvent.click(getByText('Сохранить настройки'));
 
@@ -167,6 +172,9 @@ describe('Profile page', () => {
         low: 4,
         high: 10,
       });
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Профиль сохранен' }),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Allow profile parsing to replace all commas before numeric conversion
- Test profile parsing and UI interaction with comma-based decimal input

## Testing
- `pnpm --filter ./services/webapp/ui test tests/profile.test.tsx tests/parseProfile.test.ts`
- `pytest -q --maxfail=1` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b173c79fd0832a9ca2702ae002087f