### PR TITLE
[webapp] Normalize reminder time in edit form

### DIFF
--- a/services/webapp/ui/src/features/reminders/logic/validate.test.ts
+++ b/services/webapp/ui/src/features/reminders/logic/validate.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { validate } from "./validate";
+import type { ReminderFormValues } from "../api/buildPayload";
+
+describe("validate", () => {
+  const base: ReminderFormValues = {
+    telegramId: 1,
+    type: "sugar",
+    kind: "at_time",
+    time: "07:30",
+    isEnabled: true,
+  };
+
+  it("accepts valid HH:MM time", () => {
+    const errors = validate(base);
+    expect(errors.time).toBeUndefined();
+  });
+
+  it("rejects invalid time format", () => {
+    const errors = validate({ ...base, time: "7:30" });
+    expect(errors.time).toBe("Формат HH:MM");
+  });
+});

--- a/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
@@ -48,7 +48,7 @@ function mapToForm(reminder: ReminderSchema): ReminderFormValues {
     telegramId: reminder.telegramId,
     type: reminder.type as ReminderType,
     kind,
-    time: reminder.time ?? undefined,
+    time: reminder.time?.slice(0, 5) ?? undefined,
     intervalMinutes: reminder.intervalMinutes ?? undefined,
     minutesAfter: reminder.minutesAfter ?? undefined,
     daysOfWeek: reminder.daysOfWeek


### PR DESCRIPTION
## Summary
- normalize reminder time to HH:MM in RemindersEdit mapToForm
- test time validation for HH:MM format

## Testing
- `pnpm --filter ./services/webapp/ui lint` (fails: Unexpected any in existing tests)
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` (fails: async def functions are not natively supported)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b181f75054832ab296c3bcf1439584