### PR TITLE
[config] Accept standard log level names

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -11,7 +11,9 @@ from pydantic import Field, field_validator
 try:  # pragma: no cover - import guard
     from pydantic_settings import BaseSettings, SettingsConfigDict
 except ModuleNotFoundError as exc:  # pragma: no cover - executed at import time
-    raise ImportError("`pydantic-settings` is required. Install it with `pip install pydantic-settings`.") from exc
+    raise ImportError(
+        "`pydantic-settings` is required. Install it with `pip install pydantic-settings`."
+    ) from exc
 
 
 logger = logging.getLogger(__name__)
@@ -52,17 +54,31 @@ class Settings(BaseSettings):
     ui_base_url: str = Field(default="/ui", alias="UI_BASE_URL")
     api_url: Optional[str] = Field(default=None, alias="API_URL")
     openai_api_key: Optional[str] = Field(default=None, alias="OPENAI_API_KEY")
-    openai_assistant_id: Optional[str] = Field(default=None, alias="OPENAI_ASSISTANT_ID")
+    openai_assistant_id: Optional[str] = Field(
+        default=None, alias="OPENAI_ASSISTANT_ID"
+    )
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
     font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
     telegram_token: Optional[str] = Field(default=None, alias="TELEGRAM_TOKEN")
 
     @field_validator("log_level", mode="before")
     @classmethod
-    def parse_log_level(cls, v: int | str | None) -> int:  # pragma: no cover - simple parsing
+    def parse_log_level(
+        cls, v: int | str | None
+    ) -> int:  # pragma: no cover - simple parsing
         if isinstance(v, str):
             v_lower = v.lower()
-            if v_lower in {"1", "true", "debug"}:
+            level_map: dict[str, int] = {
+                "critical": logging.CRITICAL,
+                "error": logging.ERROR,
+                "warning": logging.WARNING,
+                "info": logging.INFO,
+                "debug": logging.DEBUG,
+                "notset": logging.NOTSET,
+            }
+            if v_lower in level_map:
+                return level_map[v_lower]
+            if v_lower in {"1", "true"}:
                 return logging.DEBUG
             try:
                 return int(v)

--- a/tests/test_log_level_names.py
+++ b/tests/test_log_level_names.py
@@ -1,0 +1,32 @@
+"""Tests for standard log level name parsing."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("INFO", logging.INFO),
+        ("warning", logging.WARNING),
+        ("ERROR", logging.ERROR),
+        ("critical", logging.CRITICAL),
+        ("notset", logging.NOTSET),
+        ("DEBUG", logging.DEBUG),
+    ],
+)
+def test_log_level_name_mapping(
+    monkeypatch: pytest.MonkeyPatch, value: str, expected: int
+) -> None:
+    """LOG_LEVEL names are mapped to logging constants."""
+
+    monkeypatch.setenv("LOG_LEVEL", value)
+    module = "services.api.app.config"
+    sys.modules.pop(module, None)
+    config = importlib.import_module(module)
+    assert config.settings.log_level == expected


### PR DESCRIPTION
## Summary
- support string log level names in configuration
- test LOG_LEVEL mapping to logging constants

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b185e96170832aa608003fd7126bb6