### PR TITLE
[utils] require keyword for smart_input numbers

### DIFF
--- a/services/api/app/diabetes/utils/functions.py
+++ b/services/api/app/diabetes/utils/functions.py
@@ -269,7 +269,8 @@ def smart_input(message: str) -> dict[str, float | None]:
     ``"сахар"`` и ``"доза"``. Если после названия показателя указаны
     единицы, не соответствующие ему (например, ``"сахар 7 XE"``), или
     вместо числа идёт произвольный текст (``"доза=abc"``), будет вызван
-    ``ValueError``.
+    ``ValueError``. Одиночное число без явного указания показателя
+    считается неоднозначным и также приводит к ``ValueError``.
 
     Args:
         message: Исходное сообщение пользователя.
@@ -287,6 +288,10 @@ def smart_input(message: str) -> dict[str, float | None]:
         Traceback (most recent call last):
         ...
         ValueError: mismatched unit for sugar
+        >>> smart_input("5")
+        Traceback (most recent call last):
+        ...
+        ValueError: ambiguous number without keyword
     """
 
     if not isinstance(message, str):
@@ -333,7 +338,7 @@ def smart_input(message: str) -> dict[str, float | None]:
     if all(v is None for v in result.values()):
         m = ONLY_NUMBER_RE.fullmatch(text)
         if m:
-            result["sugar"] = _safe_float(m.group(1))
+            raise ValueError("ambiguous number without keyword")
 
     # Явное упоминание показателя без числового значения считается ошибкой.
     for key, pattern in [

--- a/tests/test_smart_input.py
+++ b/tests/test_smart_input.py
@@ -12,6 +12,9 @@ from services.api.app.diabetes.utils.functions import smart_input
         ("7 ммоль/л, 3 XE", {"sugar": 7.0, "xe": 3.0, "dose": None}),
         ("сахар 5 XE 3.2 доза 6", {"sugar": 5.0, "xe": 3.2, "dose": 6.0}),
         ("Xe 1.5 dose 2", {"sugar": None, "xe": 1.5, "dose": 2.0}),
+        ("5 ммоль/л", {"sugar": 5.0, "xe": None, "dose": None}),
+        ("5 XE", {"sugar": None, "xe": 5.0, "dose": None}),
+        ("4 units", {"sugar": None, "xe": None, "dose": 4.0}),
     ],
 )
 def test_smart_input_valid_cases(message: Any, expected: Any) -> None:
@@ -23,10 +26,13 @@ def test_smart_input_invalid_dose() -> None:
         smart_input("доза=abc")
 
 
-@pytest.mark.parametrize(
-    "message",
-    ["sugar=7abc", "xe=3foo", "dose=4bar"],
-)
+@pytest.mark.parametrize("message", ["sugar=7abc", "xe=3foo", "dose=4bar"])
 def test_smart_input_rejects_garbage(message: str) -> None:
+    with pytest.raises(ValueError):
+        smart_input(message)
+
+
+@pytest.mark.parametrize("message", ["5", " 7 "])
+def test_smart_input_plain_number(message: str) -> None:
     with pytest.raises(ValueError):
         smart_input(message)


### PR DESCRIPTION
## Summary
- require explicit field name for bare numbers in smart_input
- expand smart_input tests for single-number inputs

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b185fb85e8832a89942a9052d72c15