### PR TITLE
[webapp] add timezone selection

### DIFF
--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -65,3 +65,38 @@ export async function saveProfile({
     throw error;
   }
 }
+
+export async function patchProfile({
+  timezone,
+  timezone_auto,
+}: {
+  timezone: string
+  timezone_auto: boolean
+}) {
+  const headers = {
+    'Content-Type': 'application/json',
+    ...getTelegramAuthHeaders(),
+  } as HeadersInit
+
+  try {
+    const res = await fetch('/api/profile', {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ timezone, timezone_auto }),
+    })
+
+    if (!res.ok) {
+      const errorText = await res.text().catch(() => '')
+      const msg = errorText || 'Request failed'
+      throw new Error(msg)
+    }
+
+    return (await res.json().catch(() => ({}))) as unknown
+  } catch (error) {
+    console.error('Failed to update profile:', error)
+    if (error instanceof Error) {
+      throw new Error(`Не удалось обновить профиль: ${error.message}`)
+    }
+    throw error
+  }
+}

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -9,19 +9,45 @@ describe("parseProfile", () => {
       target: "5",
       low: "4",
       high: "10",
+      timezone: "",
+      timezoneAuto: false,
     });
     expect(result).toEqual({ icr: 1, cf: 2, target: 5, low: 4, high: 10 });
   });
 
   it("returns null when any value is non-positive or invalid", () => {
     expect(
-      parseProfile({ icr: "0", cf: "2", target: "5", low: "4", high: "10" }),
+      parseProfile({
+        icr: "0",
+        cf: "2",
+        target: "5",
+        low: "4",
+        high: "10",
+        timezone: "",
+        timezoneAuto: false,
+      }),
     ).toBeNull();
     expect(
-      parseProfile({ icr: "1", cf: "-1", target: "5", low: "4", high: "10" }),
+      parseProfile({
+        icr: "1",
+        cf: "-1",
+        target: "5",
+        low: "4",
+        high: "10",
+        timezone: "",
+        timezoneAuto: false,
+      }),
     ).toBeNull();
     expect(
-      parseProfile({ icr: "a", cf: "2", target: "5", low: "4", high: "10" }),
+      parseProfile({
+        icr: "a",
+        cf: "2",
+        target: "5",
+        low: "4",
+        high: "10",
+        timezone: "",
+        timezoneAuto: false,
+      }),
     ).toBeNull();
   });
 
@@ -32,6 +58,8 @@ describe("parseProfile", () => {
       target: "5,5",
       low: "4",
       high: "10",
+      timezone: "",
+      timezoneAuto: false,
     });
     expect(result).toEqual({ icr: 1.5, cf: 2.5, target: 5.5, low: 4, high: 10 });
   });
@@ -43,19 +71,45 @@ describe("parseProfile", () => {
       target: "5",
       low: "4",
       high: "10",
+      timezone: "",
+      timezoneAuto: false,
     });
     expect(result).toBeNull();
   });
 
   it("returns null when low/high bounds are invalid", () => {
     expect(
-      parseProfile({ icr: "1", cf: "2", target: "5", low: "8", high: "6" }),
+      parseProfile({
+        icr: "1",
+        cf: "2",
+        target: "5",
+        low: "8",
+        high: "6",
+        timezone: "",
+        timezoneAuto: false,
+      }),
     ).toBeNull();
     expect(
-      parseProfile({ icr: "1", cf: "2", target: "3", low: "4", high: "10" }),
+      parseProfile({
+        icr: "1",
+        cf: "2",
+        target: "3",
+        low: "4",
+        high: "10",
+        timezone: "",
+        timezoneAuto: false,
+      }),
     ).toBeNull();
     expect(
-      parseProfile({ icr: "1", cf: "2", target: "12", low: "4", high: "10" }),
+      parseProfile({
+        icr: "1",
+        cf: "2",
+        target: "12",
+        low: "4",
+        high: "10",
+        timezone: "",
+        timezoneAuto: false,
+      }),
     ).toBeNull();
   });
 

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { getProfile, saveProfile } from '../src/api/profile';
+import { getProfile, saveProfile, patchProfile } from '../src/api/profile';
 
 vi.mock('@/lib/telegram-auth', () => ({
   getTelegramAuthHeaders: () => ({}),
@@ -52,6 +52,19 @@ describe('profile api', () => {
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/profiles',
       expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('throws error when patchProfile request fails', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response('fail', { status: 500 }));
+    vi.stubGlobal('fetch', mockFetch);
+
+    await expect(
+      patchProfile({ timezone: 'Europe/Moscow', timezone_auto: true }),
+    ).rejects.toThrow('Не удалось обновить профиль: fail');
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/profile',
+      expect.objectContaining({ method: 'PATCH' }),
     );
   });
 });


### PR DESCRIPTION
## Summary
- allow manual or automatic timezone selection in profile settings
- expose API helper to patch timezone fields
- test timezone auto-detection and manual override

## Testing
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b18b96d01c832ab42250ea3dc7e4a5