### PR TITLE
[api] add timezones endpoint

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -235,6 +235,21 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
         '404':
           description: Reminder not found or telegramId mismatch
+  /timezones:
+    get:
+      summary: Timezones Get
+      operationId: get_timezones_timezones_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                title: Response Timezones Get
+      security: []
   /timezone:
     get:
       summary: Get Timezone

--- a/libs/ts-sdk/apis/DefaultApi.ts
+++ b/libs/ts-sdk/apis/DefaultApi.ts
@@ -285,6 +285,35 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
+     * Timezones Get
+     */
+    async getTimezonesTimezonesGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<string>>> {
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+
+        let urlPath = `/timezones`;
+
+        const response = await this.request({
+            path: urlPath,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse<any>(response);
+    }
+
+    /**
+     * Timezones Get
+     */
+    async getTimezonesTimezonesGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<string>> {
+        const response = await this.getTimezonesTimezonesGetRaw(initOverrides);
+        return await response.value();
+    }
+
+    /**
      * Health
      */
     async healthGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string; }>> {

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 import sys
 from typing import cast
+import zoneinfo
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 # ────────── Path-хаки, когда файл запускают напрямую ──────────
@@ -114,6 +115,12 @@ def _validate_history_type(value: str, status_code: int = 400) -> HistoryType:
 @api_router.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+# ────────── timezones ──────────
+@api_router.get("/timezones")
+async def list_timezones() -> list[str]:
+    return sorted(zoneinfo.available_timezones())
 
 
 # ────────── timezone ──────────

--- a/services/webapp/ui/src/api/timezones.ts
+++ b/services/webapp/ui/src/api/timezones.ts
@@ -1,0 +1,11 @@
+import { http } from './http';
+
+export async function getTimezones(): Promise<string[]> {
+  try {
+    return await http.get<string[]>('/timezones');
+  } catch (error) {
+    console.warn('Failed to load timezones:', error);
+    return [];
+  }
+}
+

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -7,6 +7,7 @@ import MedicalButton from "@/components/MedicalButton";
 import { Button } from "@/components/ui/button";
 import Modal from "@/components/Modal";
 import { saveProfile, getProfile } from "@/api/profile";
+import { getTimezones } from "@/api/timezones";
 import { useTelegram } from "@/hooks/useTelegram";
 import { useTelegramInitData } from "@/hooks/useTelegramInitData";
 import { resolveTelegramId } from "./resolveTelegramId";
@@ -66,6 +67,23 @@ const Profile = () => {
   const [pendingProfile, setPendingProfile] = useState<
     (ParsedProfile & { telegramId: number }) | null
   >(null);
+
+  const [timezones, setTimezones] = useState<string[]>(() => {
+    if (typeof Intl.supportedValuesOf === "function") {
+      try {
+        return Intl.supportedValuesOf("timeZone");
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  });
+
+  useEffect(() => {
+    if (timezones.length === 0) {
+      getTimezones().then(setTimezones).catch(() => undefined);
+    }
+  }, [timezones]);
 
   useEffect(() => {
     const telegramId = resolveTelegramId(user, initData);

--- a/tests/test_timezones_api.py
+++ b/tests/test_timezones_api.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+
+import services.api.app.main as server
+
+
+def test_timezones_list_sorted_and_contains_utc() -> None:
+    with TestClient(server.app) as client:
+        resp = client.get("/api/timezones")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert data == sorted(data)
+    assert "UTC" in data
+


### PR DESCRIPTION
## Summary
- expose `/api/timezones` listing IANA names
- document endpoint in OpenAPI and regenerate TS SDK
- add web client for timezones and hook into profile page
- cover new endpoint with tests

## Testing
- `pytest -q --cov` *(fails: DetachedInstanceError in reminders tests)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b18b992db0832a834d7cac75c77466