### PR TITLE
[api] Add timezones list endpoint and SDK

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -235,6 +235,26 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
         '404':
           description: Reminder not found or telegramId mismatch
+  /timezones:
+    get:
+      summary: Get Timezones
+      operationId: get_timezones_timezones_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                title: Response Get Timezones Timezones Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /timezone:
     get:
       summary: Get Timezone

--- a/libs/ts-sdk/apis/DefaultApi.ts
+++ b/libs/ts-sdk/apis/DefaultApi.ts
@@ -285,6 +285,39 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
+     * Get Timezones
+     */
+    async getTimezonesTimezonesGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<string>>> {
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["X-Telegram-Init-Data"] = await this.configuration.apiKey("X-Telegram-Init-Data"); // telegramInitData authentication
+        }
+
+
+        let urlPath = `/timezones`;
+
+        const response = await this.request({
+            path: urlPath,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse<any>(response);
+    }
+
+    /**
+     * Get Timezones
+     */
+    async getTimezonesTimezonesGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<string>> {
+        const response = await this.getTimezonesTimezonesGetRaw(initOverrides);
+        return await response.value();
+    }
+
+    /**
      * Health
      */
     async healthGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string; }>> {

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 import sys
 from typing import cast
+import zoneinfo
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 # ────────── Path-хаки, когда файл запускают напрямую ──────────
@@ -114,6 +115,12 @@ def _validate_history_type(value: str, status_code: int = 400) -> HistoryType:
 @api_router.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+# ────────── timezones list ──────────
+@api_router.get("/timezones")
+async def get_timezones() -> list[str]:
+    return sorted(zoneinfo.available_timezones())
 
 
 # ────────── timezone ──────────

--- a/services/webapp/ui/src/api/timezones.ts
+++ b/services/webapp/ui/src/api/timezones.ts
@@ -1,0 +1,13 @@
+export async function getTimezones(): Promise<string[]> {
+  const res = await fetch('/api/timezones');
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => '');
+    const msg = errorText || 'Request failed';
+    throw new Error(msg);
+  }
+  const data = await res.json();
+  if (Array.isArray(data)) {
+    return data as string[];
+  }
+  throw new Error('Invalid response');
+}

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import Modal from "@/components/Modal";
 import { saveProfile, getProfile, patchProfile } from "@/api/profile";
+import { getTimezones } from "@/api/timezones";
 import { useTelegram } from "@/hooks/useTelegram";
 import { useTelegramInitData } from "@/hooks/useTelegramInitData";
 import { resolveTelegramId } from "./resolveTelegramId";
@@ -83,12 +84,7 @@ const Profile = () => {
     try {
       setTimezones(Intl.supportedValuesOf("timeZone"));
     } catch {
-      fetch("/api/timezones")
-        .then((res) => res.json())
-        .then((data) => {
-          if (Array.isArray(data)) setTimezones(data as string[]);
-        })
-        .catch(() => undefined);
+      getTimezones().then(setTimezones).catch(() => undefined);
     }
   }, []);
 

--- a/tests/test_timezones_api.py
+++ b/tests/test_timezones_api.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+
+import services.api.app.main as server
+
+
+def test_timezones_returns_sorted_list() -> None:
+    with TestClient(server.app) as client:
+        resp = client.get('/api/timezones')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert data == sorted(data)
+    assert 'UTC' in data


### PR DESCRIPTION
## Summary
- expose `/api/timezones` endpoint returning available IANA timezones
- document the endpoint and regenerate TS SDK
- use new API in web profile page with fallback fetcher
- cover timezones list with test

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: DetachedInstanceError in reminder tests)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b198f16454832a840799f981e6e6b5