### PR TITLE
[reminders] Keep session open while scheduling

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -329,11 +329,11 @@ def schedule_all(job_queue: DefaultJobQueue | None) -> None:
         return
     with SessionLocal() as session:
         reminders = session.query(Reminder).all()
-    count = len(reminders)
-    logger.debug("Found %d reminders to schedule", count)
-    for rem in reminders:
-        schedule_reminder(rem, job_queue)
-    logger.debug("Scheduled %d reminders", count)
+        count = len(reminders)
+        logger.debug("Found %d reminders to schedule", count)
+        for rem in reminders:
+            schedule_reminder(rem, job_queue)
+        logger.debug("Scheduled %d reminders", count)
 
 
 async def reminders_list(


### PR DESCRIPTION
## Summary
- Ensure `schedule_all` keeps DB session open when scheduling reminders

## Testing
- `pytest -q --cov` *(fails: DetachedInstanceError and DB engine initialization issues)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b1b09a49d4832a962827a7f8a64e03