### PR TITLE
[webapp] add tgFetch utility

### DIFF
--- a/services/webapp/ui/src/lib/tgFetch.ts
+++ b/services/webapp/ui/src/lib/tgFetch.ts
@@ -1,0 +1,74 @@
+const API_BASE = (
+  import.meta.env.VITE_API_BASE as string | undefined
+) ?? '/api';
+
+function buildHeaders(init: RequestInit): Headers {
+  const headers = new Headers(init.headers);
+
+  if (init.body !== undefined && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  const initData = (
+    window as unknown as { Telegram?: { WebApp?: { initData?: string } } }
+  )?.Telegram?.WebApp?.initData;
+
+  if (initData && !headers.has('X-Telegram-Init-Data')) {
+    headers.set('X-Telegram-Init-Data', initData);
+  }
+
+  return headers;
+}
+
+async function tgFetch<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const headers = buildHeaders(init);
+  let body: BodyInit | null | undefined = init.body;
+
+  if (body !== undefined && body !== null) {
+    if (typeof body !== 'string' && !(body instanceof FormData)) {
+      body = JSON.stringify(body);
+    }
+  }
+
+  const res = await fetch(`${API_BASE}${path}`, { ...init, headers, body });
+  const isJson = res.headers.get('content-type')?.includes('application/json');
+  let data: unknown;
+
+  if (isJson) {
+    try {
+      data = await res.json();
+    } catch {
+      throw new Error('Некорректный ответ сервера');
+    }
+  } else {
+    data = await res.text();
+  }
+
+  if (!res.ok) {
+    const msg =
+      typeof (data as Record<string, unknown> | undefined)?.detail === 'string'
+        ? ((data as Record<string, string>).detail)
+        : typeof data === 'string'
+          ? data
+          : 'Request failed';
+    throw new Error(msg);
+  }
+
+  return data as T;
+}
+
+export const api = {
+  get: <T>(path: string) => tgFetch<T>(path),
+  post: <T>(path: string, body: unknown) =>
+    tgFetch<T>(path, { method: 'POST', body }),
+  patch: <T>(path: string, body: unknown) =>
+    tgFetch<T>(path, { method: 'PATCH', body }),
+  put: <T>(path: string, body: unknown) =>
+    tgFetch<T>(path, { method: 'PUT', body }),
+  delete: <T>(path: string) => tgFetch<T>(path, { method: 'DELETE' }),
+};
+
+export { tgFetch };

--- a/services/webapp/ui/tests/tgFetch.test.ts
+++ b/services/webapp/ui/tests/tgFetch.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const makeJsonResponse = () =>
+  new Response('{}', {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('tgFetch', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('prefixes base url and adds telegram header', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeJsonResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    (window as unknown as { Telegram: { WebApp: { initData: string } } }).Telegram = {
+      WebApp: { initData: 'init' },
+    };
+
+    const { tgFetch } = await import('../src/lib/tgFetch');
+    await tgFetch('/ping');
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/ping', expect.any(Object));
+    const headers = fetchMock.mock.calls[0][1]!.headers as Headers;
+    expect(headers.get('X-Telegram-Init-Data')).toBe('init');
+  });
+
+  it('overrides base url via env', async () => {
+    vi.stubEnv('VITE_API_BASE', 'http://example.com');
+    const fetchMock = vi.fn().mockResolvedValue(makeJsonResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { tgFetch } = await import('../src/lib/tgFetch');
+    await tgFetch('/test');
+    expect(fetchMock).toHaveBeenCalledWith('http://example.com/test', expect.any(Object));
+  });
+
+  it('serializes JSON bodies', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeJsonResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { api } = await import('../src/lib/tgFetch');
+    await api.post('/item', { a: 1 });
+    const init = fetchMock.mock.calls[0][1]!;
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe('{"a":1}');
+    const headers = init.headers as Headers;
+    expect(headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('throws error on failed response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ detail: 'fail' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const { tgFetch } = await import('../src/lib/tgFetch');
+    await expect(tgFetch('/boom')).rejects.toThrow('fail');
+  });
+
+  it('api.delete uses DELETE method', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeJsonResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { api } = await import('../src/lib/tgFetch');
+    await api.delete('/item/1');
+    const init = fetchMock.mock.calls[0][1]!;
+    expect(init.method).toBe('DELETE');
+  });
+});


### PR DESCRIPTION
## Summary
- add generic tgFetch helper with automatic Telegram auth header
- expose REST wrappers in exported api object
- cover tgFetch with vitest

## Testing
- `npm test --prefix services/webapp/ui`
- `pytest -q --cov` (fails: async def functions are not natively supported)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b1bd3e4b30832ab696635b2f7d7282