### PR TITLE
[webapp] Support configurable API base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,18 +115,18 @@ sudo apt install python3.12 python3.12-venv
 Приложение автоматически загружает переменные окружения из этого файла в корне проекта.
 
 - обязательные значения: `TELEGRAM_TOKEN` (токен бота), `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
-- дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `VITE_API_URL`, `VITE_BASE_URL`, `UI_BASE_URL`, `UVICORN_WORKERS`
+- дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `VITE_API_BASE`, `VITE_BASE_URL`, `UI_BASE_URL`, `UVICORN_WORKERS`
 - для появления кнопки «Определить автоматически» при выборе часового пояса нужно задать `PUBLIC_ORIGIN` (и оставить `UI_BASE_URL` ненулевым)
 - при необходимости настройте прокси для OpenAI через переменные окружения
-Переменная `VITE_API_URL` задаёт базовый URL API для WebApp и используется SDK‑клиентом.
-Пустое значение означает использование префикса `/api`.
+Переменная `VITE_API_BASE` задаёт базовый URL API для WebApp.
+Значение по умолчанию — `/api`.
 Для обращения к внешнему API задайте полный URL без завершающего `/`:
 
 ```env
 # префикс /api на том же домене
-VITE_API_URL=
+VITE_API_BASE=/api
 # внешний API
-# VITE_API_URL=http://localhost:8000
+# VITE_API_BASE=http://localhost:8000/api
 ```
 
 `VITE_BASE_URL` задаёт базовый путь веб-приложения. Значение по умолчанию — `/ui/`.
@@ -251,11 +251,11 @@ API требует заголовок `X-Telegram-Init-Data`, содержащи
 
 ```ts
 import { Configuration, ProfilesApi } from '@offonika/diabetes-ts-sdk';
-import { tgFetch } from './tgFetch';
+import { tgFetch, API_BASE } from './tgFetch';
 
 
 const api = new ProfilesApi(
-  new Configuration({ basePath: '/api', fetchApi: tgFetch })
+  new Configuration({ basePath: API_BASE, fetchApi: tgFetch })
 );
 
 const profile = await api.profilesGet({ telegramId: 123 });

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -21,10 +21,10 @@ WEBAPP_URL=http://localhost:3000
 API_URL=http://localhost:8000
 # Base path for the web app; used by both frontend and backend. Defaults to /ui/
 UI_BASE_URL=/ui/
-# Optional base API URL for webapp; defaults to '/api'.
-# Leave empty to use the '/api' prefix; for an external API set a full URL without a trailing '/'.
-VITE_API_URL=/api
-# VITE_API_URL=http://localhost:8000
+# Base API path for the webapp; defaults to '/api'.
+# Set to a full URL without a trailing '/' when using an external API.
+VITE_API_BASE=/api
+# VITE_API_BASE=http://localhost:8000/api
 
 # OpenAI configuration
 OPENAI_API_KEY=your-openai-api-key

--- a/services/webapp/ui/src/api/tgFetch.ts
+++ b/services/webapp/ui/src/api/tgFetch.ts
@@ -1,0 +1,28 @@
+import { getTelegramAuthHeaders } from '@/lib/telegram-auth';
+
+const rawBase =
+  ((import.meta.env.VITE_API_BASE as string | undefined) || '/api').replace(/\/$/, '');
+export const API_BASE = rawBase || '/api';
+
+export const tgFetch: typeof fetch = (input: RequestInfo | URL, init: RequestInit = {}) => {
+  let url: RequestInfo | URL = input;
+  if (typeof input === 'string') {
+    const isAbsolute = /^https?:\/\//.test(input);
+    if (!isAbsolute) {
+      if (input.startsWith(API_BASE)) {
+        url = input;
+      } else if (input.startsWith('/')) {
+        url = `${API_BASE}${input}`;
+      } else {
+        url = `${API_BASE}/${input}`;
+      }
+    }
+  }
+
+  const headers = new Headers(init.headers);
+  Object.entries(getTelegramAuthHeaders()).forEach(([key, value]) =>
+    headers.set(key, value),
+  );
+
+  return fetch(url, { ...init, headers });
+};

--- a/services/webapp/ui/tests/tgFetch.test.ts
+++ b/services/webapp/ui/tests/tgFetch.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('tgFetch', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults to /api when env is empty', async () => {
+    vi.stubEnv('VITE_API_BASE', '');
+    const mockFetch = vi.fn().mockResolvedValue(new Response(null));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { tgFetch } = await import('../src/api/tgFetch');
+    await tgFetch('/foo');
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/foo', expect.any(Object));
+  });
+
+  it('uses VITE_API_BASE value', async () => {
+    vi.stubEnv('VITE_API_BASE', '/custom');
+    const mockFetch = vi.fn().mockResolvedValue(new Response(null));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { tgFetch } = await import('../src/api/tgFetch');
+    await tgFetch('/bar');
+
+    expect(mockFetch).toHaveBeenCalledWith('/custom/bar', expect.any(Object));
+  });
+
+  it('does not double prefix when path already includes base', async () => {
+    vi.stubEnv('VITE_API_BASE', '/api');
+    const mockFetch = vi.fn().mockResolvedValue(new Response(null));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { tgFetch } = await import('../src/api/tgFetch');
+    await tgFetch('/api/baz');
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/baz', expect.any(Object));
+  });
+});


### PR DESCRIPTION
## Summary
- document `VITE_API_BASE` env var and README usage
- add `tgFetch` wrapper reading `VITE_API_BASE` with `/api` fallback
- cover `tgFetch` base path handling with vitest

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: Fast refresh & typing warnings/errors)*
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: async plugin missing, many test failures)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b1bd5f7d58832aaef23bdc2301a926