### PR TITLE
[webapp] handle timezone patch

### DIFF
--- a/services/webapp/ui/src/api/profile.ts
+++ b/services/webapp/ui/src/api/profile.ts
@@ -1,3 +1,0 @@
-// TODO: remove this file after migrating to '@/features/profile/api'
-export { getProfile, saveProfile, patchProfile } from '../features/profile/api';
-export type { PatchProfileDto } from '../features/profile/api';

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -7,7 +7,8 @@ import MedicalButton from "@/components/MedicalButton";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import Modal from "@/components/Modal";
-import { saveProfile, getProfile, patchProfile } from "@/features/profile/api";
+import { saveProfile, getProfile } from "@/features/profile/api";
+import { patchProfile } from "@/features/profile/api";
 import { getTimezones } from "@/api/timezones";
 import { useTelegram } from "@/hooks/useTelegram";
 import { useTelegramInitData } from "@/hooks/useTelegramInitData";
@@ -142,9 +143,25 @@ const Profile = () => {
         });
 
         if (timezoneAuto && timezone !== deviceTz) {
-          patchProfile({ timezone: deviceTz, auto_detect_timezone: true }).catch(
-            () => undefined,
-          );
+          patchProfile({
+            timezone: deviceTz ?? null,
+            auto_detect_timezone: true,
+          })
+            .then(() =>
+              toast({
+                title: "Профиль обновлен",
+                description: "Часовой пояс обновлен",
+              }),
+            )
+            .catch((error) => {
+              const message =
+                error instanceof Error ? error.message : String(error);
+              toast({
+                title: "Ошибка",
+                description: message,
+                variant: "destructive",
+              });
+            });
           setProfile((prev) => ({ ...prev, timezone: deviceTz }));
         }
 
@@ -190,8 +207,8 @@ const Profile = () => {
   ): Promise<void> => {
     try {
       await patchProfile({
-        timezone: data.timezone,
-        auto_detect_timezone: data.timezoneAuto,
+        timezone: data.timezone ?? null,
+        auto_detect_timezone: data.timezoneAuto ?? null,
       });
       await saveProfile({
         telegramId: data.telegramId,


### PR DESCRIPTION
## Summary
- adjust profile page to patch timezone with nullable payload and toast result
- drop obsolete profile API re-export

## Testing
- `pnpm run lint` *(fails: Unexpected any, react-refresh warnings)*
- `pnpm test`
- `pytest -q --cov` *(fails: database engine not initialized, detached instance errors)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b1c06a9504832aba3517e55a89518c