### PR TITLE
[infra] Replace VITE_API_URL with VITE_API_BASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,18 +115,18 @@ sudo apt install python3.12 python3.12-venv
 Приложение автоматически загружает переменные окружения из этого файла в корне проекта.
 
 - обязательные значения: `TELEGRAM_TOKEN` (токен бота), `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
-- дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `VITE_API_URL`, `VITE_BASE_URL`, `UI_BASE_URL`, `UVICORN_WORKERS`
+- дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `VITE_API_BASE`, `VITE_BASE_URL`, `UI_BASE_URL`, `UVICORN_WORKERS`
 - для появления кнопки «Определить автоматически» при выборе часового пояса нужно задать `PUBLIC_ORIGIN` (и оставить `UI_BASE_URL` ненулевым)
 - при необходимости настройте прокси для OpenAI через переменные окружения
-Переменная `VITE_API_URL` задаёт базовый URL API для WebApp и используется SDK‑клиентом.
+Переменная `VITE_API_BASE` задаёт базовый URL API для WebApp и используется SDK‑клиентом.
 Пустое значение означает использование префикса `/api`.
 Для обращения к внешнему API задайте полный URL без завершающего `/`:
 
 ```env
 # префикс /api на том же домене
-VITE_API_URL=
+VITE_API_BASE=
 # внешний API
-# VITE_API_URL=http://localhost:8000
+# VITE_API_BASE=http://localhost:8000
 ```
 
 `VITE_BASE_URL` задаёт базовый путь веб-приложения. Значение по умолчанию — `/ui/`.

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -21,10 +21,10 @@ WEBAPP_URL=http://localhost:3000
 API_URL=http://localhost:8000
 # Base path for the web app; used by both frontend and backend. Defaults to /ui/
 UI_BASE_URL=/ui/
-# Optional base API URL for webapp; defaults to '/api'.
-# Leave empty to use the '/api' prefix; for an external API set a full URL without a trailing '/'.
-VITE_API_URL=/api
-# VITE_API_URL=http://localhost:8000
+# Base API URL for the webapp; defaults to '/api'.
+# Leave empty to use '/api' or set a full URL without a trailing slash.
+VITE_API_BASE=/api
+# VITE_API_BASE=http://localhost:8000
 
 # OpenAI configuration
 OPENAI_API_KEY=your-openai-api-key


### PR DESCRIPTION
## Summary
- rename VITE_API_URL to VITE_API_BASE in env example
- document VITE_API_BASE in README

## Testing
- `pytest -q --cov --cov-fail-under=85` (fails: async def functions not natively supported)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b1c24c878c832ab671fc8927b2cfe6