### PR TITLE
[webapp] fix time input for ios

### DIFF
--- a/services/webapp/ui/package-lock.json
+++ b/services/webapp/ui/package-lock.json
@@ -50,6 +50,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.61.1",
+        "react-input-mask": "^2.0.4",
         "react-resizable-panels": "^2.1.9",
         "react-router-dom": "^6.30.1",
         "recharts": "^2.15.4",
@@ -67,6 +68,7 @@
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
+        "@types/react-input-mask": "^3.0.6",
         "@vitejs/plugin-react-swc": "^3.11.0",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.32.0",
@@ -3256,6 +3258,16 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/react-input-mask": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-input-mask/-/react-input-mask-3.0.6.tgz",
+      "integrity": "sha512-+5I18WKyG3eWIj7TVPWfK1VitI9mPpS9y6jE/BfmTCe+iL27NfBw/yzKRvCFp1DRBvlvvcsiZf05bub0YC1k8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.41.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.41.0.tgz",
@@ -5132,6 +5144,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -6104,6 +6125,20 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-input-mask": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
+      "integrity": "sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0",
+        "react-dom": ">=0.14.0"
       }
     },
     "node_modules/react-is": {
@@ -7852,6 +7887,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/services/webapp/ui/package.json
+++ b/services/webapp/ui/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --config ../../../vitest.config.ts"
+    "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -55,6 +55,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.61.1",
+    "react-input-mask": "^2.0.4",
     "react-resizable-panels": "^2.1.9",
     "react-router-dom": "^6.30.1",
     "recharts": "^2.15.4",
@@ -72,6 +73,7 @@
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
+    "@types/react-input-mask": "^3.0.6",
     "@vitejs/plugin-react-swc": "^3.11.0",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.32.0",

--- a/services/webapp/ui/src/components/TimeInput.tsx
+++ b/services/webapp/ui/src/components/TimeInput.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import InputMask from "react-input-mask";
+
+interface TimeInputProps {
+  value: string;
+  onChange: (val: string) => void;
+  className?: string;
+}
+
+const isIOS =
+  /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+  window.Telegram?.WebApp?.platform === "ios";
+
+const TimeInput: React.FC<TimeInputProps> = ({ value, onChange, className }) => {
+  if (isIOS) {
+    return (
+      <InputMask
+        mask="99:99"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {(inputProps) => (
+          <input
+            {...inputProps}
+            type="text"
+            className={className}
+            placeholder="HH:MM"
+          />
+        )}
+      </InputMask>
+    );
+  }
+
+  return (
+    <input
+      type="time"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className={className}
+    />
+  );
+};
+
+export default TimeInput;

--- a/services/webapp/ui/src/components/index.ts
+++ b/services/webapp/ui/src/components/index.ts
@@ -3,3 +3,4 @@ export { SegmentedControl } from './SegmentedControl';
 export { default as MedicalButton } from './MedicalButton';
 export { default as ThemeToggle } from './ThemeToggle';
 export { default as Sheet } from './Sheet';
+export { default as TimeInput } from './TimeInput';

--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -15,6 +15,7 @@ import { useTelegram } from "../../../hooks/useTelegram";
 import { getTelegramUserId } from "../../../shared/telegram";
 import { mockApi } from "../../../api/mock-server";
 import { useToast } from "../../../shared/toast";
+import TimeInput from "@/components/TimeInput";
 
 const TYPE_OPTIONS: { value: ReminderType; label: string }[] = [
   { value: "sugar", label: "Измерение сахара" },
@@ -214,11 +215,10 @@ export default function RemindersCreate() {
               <label className="block text-sm font-medium text-foreground">
                 Время (HH:MM)
               </label>
-              <input
-                type="time"
+              <TimeInput
                 className={`medical-input ${errors.time ? "border-destructive focus:border-destructive" : ""}`}
                 value={form.time || ""}
-                onChange={(e) => onChange("time", e.target.value)}
+                onChange={(val) => onChange("time", val)}
               />
               {errors.time && (
                 <p className="text-xs text-destructive mt-1">{errors.time}</p>

--- a/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
@@ -16,6 +16,7 @@ import { getTelegramUserId } from "../../../shared/telegram";
 import { mockApi } from "../../../api/mock-server";
 import { useToast } from "../../../shared/toast";
 import { useTelegram } from "@/hooks/useTelegram";
+import TimeInput from "@/components/TimeInput";
 
 const TYPE_OPTIONS: { value: ReminderType; label: string }[] = [
   { value: "sugar", label: "Измерение сахара" },
@@ -238,13 +239,12 @@ export default function RemindersEdit() {
               <label className="block text-sm font-medium text-foreground">
                 Время (HH:MM)
               </label>
-              <input
-                type="time"
+              <TimeInput
                 className={`medical-input ${
                   errors.time ? "border-destructive focus:border-destructive" : ""
                 }`}
                 value={form.time || ""}
-                onChange={(e) => onChange("time", e.target.value)}
+                onChange={(val) => onChange("time", val)}
               />
               {errors.time && (
                 <p className="text-xs text-destructive mt-1">{errors.time}</p>

--- a/services/webapp/ui/src/pages/History.tsx
+++ b/services/webapp/ui/src/pages/History.tsx
@@ -4,6 +4,7 @@ import { Calendar, TrendingUp, Edit2, Trash2, Filter } from 'lucide-react';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { useToast } from '@/hooks/use-toast';
 import MedicalButton from '@/components/MedicalButton';
+import TimeInput from '@/components/TimeInput';
 import { getHistory, updateRecord, deleteRecord } from '@/api/history';
 import type {
   HistoryRecordSchemaInput,
@@ -306,12 +307,11 @@ const History = () => {
                 <label className="block text-sm font-medium text-foreground mb-2">
                   Время
                 </label>
-                <input
-                  type="time"
+                <TimeInput
                   value={editingRecord.time}
-                  onChange={e =>
+                  onChange={val =>
                     setEditingRecord(prev =>
-                      prev ? { ...prev, time: e.target.value } : prev
+                      prev ? { ...prev, time: val } : prev
                     )
                   }
                   className="medical-input"

--- a/services/webapp/ui/tests/TimeInput.test.tsx
+++ b/services/webapp/ui/tests/TimeInput.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import TimeInput from '../src/components/TimeInput';
+
+describe('TimeInput', () => {
+  it('renders native time input on non-iOS', () => {
+    const { container } = render(<TimeInput value="" onChange={() => {}} />);
+    expect(container.querySelector('input[type="time"]')).not.toBeNull();
+  });
+
+  it('renders masked text input on iOS', async () => {
+    const originalUA = navigator.userAgent;
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'iPhone',
+      configurable: true,
+    });
+    vi.resetModules();
+    const TimeInputIOS = (await import('../src/components/TimeInput')).default;
+    const { container } = render(<TimeInputIOS value="" onChange={() => {}} />);
+    const input = container.querySelector('input');
+    expect(input?.getAttribute('type')).toBe('text');
+    Object.defineProperty(navigator, 'userAgent', {
+      value: originalUA,
+      configurable: true,
+    });
+  });
+});

--- a/services/webapp/ui/vitest.config.ts
+++ b/services/webapp/ui/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+  resolve: {
+    alias: [
+      { find: '@sdk', replacement: path.resolve(__dirname, '../../../libs/ts-sdk') },
+      { find: '@', replacement: path.resolve(__dirname, './src') },
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- add cross-platform TimeInput component with iOS mask fallback
- use TimeInput in reminder and history forms
- test masked input behavior and configure local vitest setup

## Testing
- `npm --prefix services/webapp/ui run lint` *(fails: 16 errors, 12 warnings)*
- `npm --prefix services/webapp/ui run typecheck`
- `npm --prefix services/webapp/ui test`
- `pytest -q --cov` *(fails: async plugin missing, many tests failed)*
- `mypy --strict .` *(fails: 5 errors in alembic revision)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b1d3f8d47c832a8570a5874995bc37