### PR TITLE
[webapp] Move iOS detection inside TimeInput

### DIFF
--- a/services/webapp/ui/src/components/TimeInput.tsx
+++ b/services/webapp/ui/src/components/TimeInput.tsx
@@ -7,11 +7,20 @@ interface TimeInputProps {
   className?: string;
 }
 
-const isIOS =
-  /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-  window.Telegram?.WebApp?.platform === "ios";
-
 const TimeInput: React.FC<TimeInputProps> = ({ value, onChange, className }) => {
+  const platform =
+    typeof window !== "undefined" ? window.Telegram?.WebApp?.platform : undefined;
+  const userAgent =
+    typeof navigator !== "undefined" ? navigator.userAgent : undefined;
+
+  const isIOS = React.useMemo(() => {
+    if (!userAgent && !platform) {
+      return false;
+    }
+
+    return /iPad|iPhone|iPod/.test(userAgent ?? "") || platform === "ios";
+  }, [platform, userAgent]);
+
   if (isIOS) {
     return (
       <InputMask

--- a/services/webapp/ui/tests/TimeInput.test.tsx
+++ b/services/webapp/ui/tests/TimeInput.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import TimeInput from '../src/components/TimeInput';
 
 describe('TimeInput', () => {
@@ -9,20 +9,20 @@ describe('TimeInput', () => {
     expect(container.querySelector('input[type="time"]')).not.toBeNull();
   });
 
-  it('renders masked text input on iOS', async () => {
-    const originalUA = navigator.userAgent;
-    Object.defineProperty(navigator, 'userAgent', {
-      value: 'iPhone',
-      configurable: true,
-    });
-    vi.resetModules();
-    const TimeInputIOS = (await import('../src/components/TimeInput')).default;
-    const { container } = render(<TimeInputIOS value="" onChange={() => {}} />);
+  it('renders masked text input when platform switches to iOS', () => {
+    const originalTelegram = window.Telegram;
+    const { container, rerender } = render(
+      <TimeInput value="" onChange={() => {}} />,
+    );
+
+    expect(container.querySelector('input[type="time"]')).not.toBeNull();
+
+    (window as any).Telegram = { WebApp: { platform: 'ios' } };
+    rerender(<TimeInput value="" onChange={() => {}} />);
+
     const input = container.querySelector('input');
     expect(input?.getAttribute('type')).toBe('text');
-    Object.defineProperty(navigator, 'userAgent', {
-      value: originalUA,
-      configurable: true,
-    });
+
+    window.Telegram = originalTelegram;
   });
 });


### PR DESCRIPTION
## Summary
- compute iOS platform detection within TimeInput with SSR guards
- update TimeInput tests to switch Telegram platform after render

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `ruff check .`
- `pytest -q tests` *(fails: KeyboardInterrupt in pypdf)*
- `mypy --strict services` *(fails: Interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b28eefc32c832a88cb8c0cd7f8e3f2