### PR TITLE
[tests] Add reminder time update persistence test

### DIFF
--- a/services/webapp/ui/tests/reminders.api.test.ts
+++ b/services/webapp/ui/tests/reminders.api.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { makeRemindersApi } from '../src/features/reminders/api/reminders';
+import React from 'react';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { ReminderType } from '@sdk/models/ReminderType';
 
 describe('RemindersApi', () => {
@@ -17,16 +18,84 @@ describe('RemindersApi', () => {
         }),
       );
     vi.stubGlobal('fetch', mockFetch);
-
+    const { makeRemindersApi } = await import('../src/features/reminders/api/reminders');
     const api = makeRemindersApi(null);
     const result = await api.remindersPost({
       reminder: { telegramId: 1, type: ReminderType.Sugar },
     });
-
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/reminders',
       expect.objectContaining({ method: 'POST' }),
     );
     expect(result).toEqual({ ok: true });
+  });
+});
+
+describe('RemindersEdit', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('updates time via UI and persists', async () => {
+    vi.resetModules();
+
+    let backendReminder = {
+      id: 1,
+      telegramId: 1,
+      type: ReminderType.Sugar,
+      kind: 'at_time',
+      time: '08:00',
+      isEnabled: true,
+      title: 'Test',
+    };
+
+    const remindersIdGet = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(backendReminder));
+    const remindersPatch = vi.fn().mockImplementation(({ reminder }) => {
+      backendReminder = { ...backendReminder, ...reminder };
+      return Promise.resolve({});
+    });
+
+    vi.doMock('../src/features/reminders/api/reminders', () => ({
+      useRemindersApi: () => ({ remindersIdGet, remindersPatch }),
+    }));
+    vi.doMock('../src/shared/toast', () => ({
+      useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+    }));
+    vi.doMock('../src/hooks/useTelegram', () => ({
+      useTelegram: () => ({ user: { id: 1 }, sendData: vi.fn() }),
+    }));
+    vi.doMock('../src/hooks/useTelegramInitData', () => ({
+      useTelegramInitData: () => null,
+    }));
+    vi.doMock('react-router-dom', () => ({
+      useNavigate: () => vi.fn(),
+      useParams: () => ({ id: '1' }),
+    }));
+
+    const { default: RemindersEdit } = await import('../src/features/reminders/pages/RemindersEdit');
+    const { container, getByText } = render(React.createElement(RemindersEdit));
+
+    await waitFor(() => {
+      const input = container.querySelector('input[type="time"]') as HTMLInputElement;
+      expect(input.value).toBe('08:00');
+    });
+
+    const input = container.querySelector('input[type="time"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '09:30' } });
+    fireEvent.click(getByText('Сохранить'));
+
+    await waitFor(() => {
+      expect(remindersPatch).toHaveBeenCalledWith({
+        reminder: expect.objectContaining({ time: '09:30' }),
+      });
+    });
+
+    await expect(
+      remindersIdGet({ id: 1, telegramId: 1 }),
+    ).resolves.toHaveProperty('time', '09:30');
   });
 });


### PR DESCRIPTION
## Summary
- add test ensuring edited reminder time is submitted and persists after save

## Testing
- `pytest -q --cov` *(fails: pytest: error: unrecognized arguments: --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=85 --cov)*
- `mypy --strict .` *(fails: Function is missing a type annotation)*
- `ruff check .` *(not run)*
- `pnpm --filter ./services/webapp/ui test tests/reminders.api.test.ts` *(hangs at tests/reminders.api.test.ts 1/2)*

------
https://chatgpt.com/codex/tasks/task_e_68b28ef04b50832ab1fa029974f6ddfc