### PR TITLE
ui: mask TimeInput in Telegram

### DIFF
--- a/services/webapp/ui/src/components/TimeInput.tsx
+++ b/services/webapp/ui/src/components/TimeInput.tsx
@@ -8,20 +8,18 @@ interface TimeInputProps {
 }
 
 const TimeInput: React.FC<TimeInputProps> = ({ value, onChange, className }) => {
-  const platform =
-    typeof window !== "undefined" ? window.Telegram?.WebApp?.platform : undefined;
-  const userAgent =
-    typeof navigator !== "undefined" ? navigator.userAgent : undefined;
+  const isTelegram = React.useMemo(() => {
+    return typeof window !== "undefined" && Boolean(window.Telegram?.WebApp);
+  }, []);
 
   const isIOS = React.useMemo(() => {
-    if (!userAgent && !platform) {
-      return false;
-    }
+    return (
+      typeof navigator !== "undefined" &&
+      /iPad|iPhone|iPod/.test(navigator.userAgent)
+    );
+  }, []);
 
-    return /iPad|iPhone|iPod/.test(userAgent ?? "") || platform === "ios";
-  }, [platform, userAgent]);
-
-  if (isIOS) {
+  if (isTelegram || isIOS) {
     return (
       <InputMask
         mask="99:99"

--- a/services/webapp/ui/tests/TimeInput.test.tsx
+++ b/services/webapp/ui/tests/TimeInput.test.tsx
@@ -4,25 +4,27 @@ import { describe, it, expect } from 'vitest';
 import TimeInput from '../src/components/TimeInput';
 
 describe('TimeInput', () => {
-  it('renders native time input on non-iOS', () => {
+  it('renders native time input when Telegram is absent', () => {
+    const win = window as typeof window & { Telegram?: unknown };
+    const originalTelegram = win.Telegram;
+    delete win.Telegram;
+
     const { container } = render(<TimeInput value="" onChange={() => {}} />);
     expect(container.querySelector('input[type="time"]')).not.toBeNull();
+
+    win.Telegram = originalTelegram;
   });
 
-  it('renders masked text input when platform switches to iOS', () => {
-    const originalTelegram = window.Telegram;
-    const { container, rerender } = render(
-      <TimeInput value="" onChange={() => {}} />,
-    );
+  it('renders masked text input inside Telegram WebApp', () => {
+    const win = window as typeof window & { Telegram?: unknown };
+    const originalTelegram = win.Telegram;
+    win.Telegram = { WebApp: {} };
 
-    expect(container.querySelector('input[type="time"]')).not.toBeNull();
-
-    (window as any).Telegram = { WebApp: { platform: 'ios' } };
-    rerender(<TimeInput value="" onChange={() => {}} />);
-
+    const { container } = render(<TimeInput value="" onChange={() => {}} />);
     const input = container.querySelector('input');
     expect(input?.getAttribute('type')).toBe('text');
 
-    window.Telegram = originalTelegram;
+    win.Telegram = originalTelegram;
   });
 });
+


### PR DESCRIPTION
## Summary
- mask TimeInput when running in Telegram WebApp and detect iOS at runtime
- test TimeInput behavior for Telegram and non-Telegram environments

## Testing
- `pnpm lint` *(fails: Unexpected any in existing files)*
- `pnpm typecheck`
- `pnpm test tests/TimeInput.test.tsx`
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: Function is missing a type annotation in Alembic migration)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b291d3e550832a8b0220c752128088