### PR TITLE
[reminders] Fix user detachment for scheduling

### DIFF
--- a/services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py
+++ b/services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py
@@ -1,8 +1,10 @@
 """add quiet_start and quiet_end to profiles"""
 
+from typing import Any
+
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy import inspect
+from sqlalchemy import Connection, inspect
 
 
 # ID предыдущей и текущей миграции
@@ -12,12 +14,12 @@ branch_labels = None
 depends_on = None
 
 
-def column_exists(conn, table_name, column_name):
+def column_exists(conn: Connection, table_name: str, column_name: str) -> bool:
     insp = inspect(conn)
     return column_name in [col["name"] for col in insp.get_columns(table_name)]
 
 
-def upgrade():
+def upgrade() -> None:
     bind = op.get_bind()
     
     if not column_exists(bind, "profiles", "quiet_start"):
@@ -33,6 +35,6 @@ def upgrade():
         )
 
 
-def downgrade():
+def downgrade() -> None:
     op.drop_column("profiles", "quiet_end")
     op.drop_column("profiles", "quiet_start")

--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -30,6 +30,8 @@ def notify_reminder_saved(reminder_id: int) -> None:
         return
     with SessionLocal() as session:
         rem = session.get(Reminder, reminder_id)
+        if rem is not None:
+            _ = getattr(rem, "user", None)
     if rem is None:
         logger.warning("Reminder %s not found for scheduling", reminder_id)
         return

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -6,10 +6,21 @@ from typing import cast
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
-from ..diabetes.services.db import Profile, SessionLocal, User, run_db
+from typing import Callable
+
+from ..diabetes.services import db
+from ..diabetes.services.db import Profile, User, run_db
 from ..diabetes.services.repository import CommitError, commit
 from ..schemas.profile import ProfileSchema
 from ..types import SessionProtocol
+
+
+class _SessionLocalProxy:
+    def __call__(self) -> Session:
+        return db.SessionLocal()
+
+
+SessionLocal: Callable[[], Session] = _SessionLocalProxy()
 
 
 async def set_timezone(telegram_id: int, tz: str) -> None:  # pragma: no cover


### PR DESCRIPTION
## Summary
- refresh and attach `Reminder.user` before scheduling to avoid detached instances
- ensure `notify_reminder_saved` preloads reminder user
- proxy `SessionLocal` in profile service for easier test session injection

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b29aa43290832a9a89d41f0bc2bbeb