### PR TITLE
[reminders] Pass user to schedule_reminder

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -85,12 +85,8 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
             try:
                 thread_id = await create_thread()
             except OpenAIError as exc:  # pragma: no cover - network errors
-                logger.exception(
-                    "Failed to create thread for user %s: %s", user_id, exc
-                )
-                await message.reply_text(
-                    "⚠️ Не удалось инициализировать профиль. Попробуйте позже."
-                )
+                logger.exception("Failed to create thread for user %s: %s", user_id, exc)
+                await message.reply_text("⚠️ Не удалось инициализировать профиль. Попробуйте позже.")
                 return ConversationHandler.END
             user_obj = User(telegram_id=user_id, thread_id=thread_id)
             session.add(user_obj)
@@ -103,9 +99,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         if user_obj.onboarding_complete:
             greeting = f"👋 Привет, {first_name}!" if first_name else "👋 Привет!"
             greeting += " Рада видеть тебя. Надеюсь, у тебя сегодня всё отлично."
-            await message.reply_text(
-                f"{greeting}\n\n📋 Выберите действие:", reply_markup=menu_keyboard()
-            )
+            await message.reply_text(f"{greeting}\n\n📋 Выберите действие:", reply_markup=menu_keyboard())
             return ConversationHandler.END
 
     await message.reply_text(
@@ -118,9 +112,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
 def _skip_markup() -> InlineKeyboardMarkup:
     """Markup containing a single *skip* button."""
 
-    return InlineKeyboardMarkup(
-        [[InlineKeyboardButton("Пропустить", callback_data="onb_skip")]]
-    )
+    return InlineKeyboardMarkup([[InlineKeyboardButton("Пропустить", callback_data="onb_skip")]])
 
 
 async def onboarding_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -140,9 +132,7 @@ async def onboarding_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await message.reply_text("Введите ИКХ числом.", reply_markup=_skip_markup())
         return ONB_PROFILE_ICR
     if icr <= 0:
-        await message.reply_text(
-            "ИКХ должен быть больше 0.", reply_markup=_skip_markup()
-        )
+        await message.reply_text("ИКХ должен быть больше 0.", reply_markup=_skip_markup())
         return ONB_PROFILE_ICR
     user_data["profile_icr"] = icr
     await message.reply_text(
@@ -169,9 +159,7 @@ async def onboarding_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         await message.reply_text("Введите КЧ числом.", reply_markup=_skip_markup())
         return ONB_PROFILE_CF
     if cf <= 0:
-        await message.reply_text(
-            "КЧ должен быть больше 0.", reply_markup=_skip_markup()
-        )
+        await message.reply_text("КЧ должен быть больше 0.", reply_markup=_skip_markup())
         return ONB_PROFILE_CF
     user_data["profile_cf"] = cf
     await message.reply_text(
@@ -196,22 +184,16 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     try:
         target = float(message.text.replace(",", "."))
     except ValueError:
-        await message.reply_text(
-            "Введите целевой сахар числом.", reply_markup=_skip_markup()
-        )
+        await message.reply_text("Введите целевой сахар числом.", reply_markup=_skip_markup())
         return ONB_PROFILE_TARGET
     if target <= 0:
-        await message.reply_text(
-            "Целевой сахар должен быть больше 0.", reply_markup=_skip_markup()
-        )
+        await message.reply_text("Целевой сахар должен быть больше 0.", reply_markup=_skip_markup())
         return ONB_PROFILE_TARGET
 
     icr = user_data.pop("profile_icr", None)
     cf = user_data.pop("profile_cf", None)
     if icr is None or cf is None:
-        await message.reply_text(
-            "⚠️ Не хватает данных для профиля. Пожалуйста, начните заново."
-        )
+        await message.reply_text("⚠️ Не хватает данных для профиля. Пожалуйста, начните заново.")
         return ConversationHandler.END
     user_id = user.id
 
@@ -233,18 +215,13 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     keyboard_buttons: list[InlineKeyboardButton] = []
     if tz_button:
         keyboard_buttons.append(tz_button)
-        prompt = (
-            "Введите ваш часовой пояс (например Europe/Moscow) "
-            "или используйте кнопку ниже:"
-        )
+        prompt = "Введите ваш часовой пояс (например Europe/Moscow) или используйте кнопку ниже:"
     else:
         prompt = (
             "Введите ваш часовой пояс (например Europe/Moscow). "
             "Автоматическое определение недоступно, укажите его вручную."
         )
-    keyboard_buttons.append(
-        InlineKeyboardButton("Пропустить", callback_data="onb_skip")
-    )
+    keyboard_buttons.append(InlineKeyboardButton("Пропустить", callback_data="onb_skip"))
     await message.reply_text(
         prompt,
         reply_markup=InlineKeyboardMarkup([keyboard_buttons]),
@@ -252,9 +229,7 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     return ONB_PROFILE_TZ
 
 
-async def onboarding_timezone(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def onboarding_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle user timezone (text or WebApp) and proceed to demo."""
 
     message = update.message
@@ -276,10 +251,7 @@ async def onboarding_timezone(
         tz_button = build_timezone_webapp_button()
         if tz_button:
             buttons.append(tz_button)
-            prompt = (
-                "Введите корректный часовой пояс, например Europe/Moscow, "
-                "или используйте кнопку ниже."
-            )
+            prompt = "Введите корректный часовой пояс, например Europe/Moscow, или используйте кнопку ниже."
         else:
             prompt = (
                 "Введите корректный часовой пояс, например Europe/Moscow. "
@@ -320,9 +292,7 @@ async def onboarding_timezone(
                 await message.reply_text("⚠️ Не удалось сохранить часовой пояс.")
                 return ConversationHandler.END
 
-    keyboard = InlineKeyboardMarkup(
-        [[InlineKeyboardButton("Далее", callback_data="onb_next")]]
-    )
+    keyboard = InlineKeyboardMarkup([[InlineKeyboardButton("Далее", callback_data="onb_next")]])
     try:
         with DEMO_PHOTO_PATH.open("rb") as photo:
             await message.reply_photo(
@@ -339,9 +309,7 @@ async def onboarding_timezone(
     return ONB_DEMO
 
 
-async def onboarding_demo_next(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def onboarding_demo_next(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Proceed from demo to reminder suggestion."""
     query = update.callback_query
     if query is None or query.message is None:
@@ -364,9 +332,7 @@ async def onboarding_demo_next(
     return ONB_REMINDERS
 
 
-async def onboarding_reminders(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def onboarding_reminders(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle reminder choice and finish onboarding."""
     query = update.callback_query
     user = update.effective_user
@@ -381,11 +347,7 @@ async def onboarding_reminders(
         if user_obj:
             user_obj.onboarding_complete = True
             if enable:
-                reminders = (
-                    session.query(Reminder)
-                    .filter_by(telegram_id=user_id, type="sugar")
-                    .all()
-                )
+                reminders = session.query(Reminder).filter_by(telegram_id=user_id, type="sugar").all()
                 if not reminders:
                     reminders = [
                         Reminder(
@@ -399,11 +361,7 @@ async def onboarding_reminders(
                     for rem in reminders:
                         rem.is_enabled = True
             else:
-                reminders = (
-                    session.query(Reminder)
-                    .filter_by(telegram_id=user_id, type="sugar")
-                    .all()
-                )
+                reminders = session.query(Reminder).filter_by(telegram_id=user_id, type="sugar").all()
                 for rem in reminders:
                     rem.is_enabled = False
             try:
@@ -418,7 +376,7 @@ async def onboarding_reminders(
             from . import reminder_handlers
 
             for rem in reminders:
-                reminder_handlers.schedule_reminder(rem, job_queue)
+                reminder_handlers.schedule_reminder(rem, job_queue, user_obj)
         else:
             for rem in reminders:
                 for job in job_queue.get_jobs_by_name(f"reminder_{rem.id}"):
@@ -439,9 +397,7 @@ async def onboarding_reminders(
     else:
         logger.warning("Poll message missing poll object for user %s", user_id)
 
-    await query.message.reply_text(
-        "Готово! Спасибо за настройку.", reply_markup=menu_keyboard()
-    )
+    await query.message.reply_text("Готово! Спасибо за настройку.", reply_markup=menu_keyboard())
     return ConversationHandler.END
 
 
@@ -482,9 +438,7 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return ConversationHandler.END
 
 
-async def onboarding_poll_answer(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> None:
+async def onboarding_poll_answer(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Log poll answers from onboarding feedback."""
     poll_answer = update.poll_answer
     if poll_answer is None:
@@ -540,9 +494,7 @@ onboarding_conv = ConversationHandler(
             CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
         ],
         ONB_REMINDERS: [
-            CallbackQueryNoWarnHandler(
-                onboarding_reminders, pattern="^onb_rem_(yes|no)$"
-            ),
+            CallbackQueryNoWarnHandler(onboarding_reminders, pattern="^onb_rem_(yes|no)$"),
             CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
         ],
     },

--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -5,7 +5,7 @@ import logging
 from telegram.ext import ContextTypes, JobQueue
 
 from .diabetes.handlers.reminder_handlers import DefaultJobQueue, schedule_reminder
-from .diabetes.services.db import Reminder, SessionLocal
+from .diabetes.services.db import Reminder, SessionLocal, User
 
 logger = logging.getLogger(__name__)
 
@@ -30,10 +30,11 @@ def notify_reminder_saved(reminder_id: int) -> None:
         return
     with SessionLocal() as session:
         rem = session.get(Reminder, reminder_id)
+        user = session.get(User, rem.telegram_id) if rem is not None else None
     if rem is None:
         logger.warning("Reminder %s not found for scheduling", reminder_id)
         return
-    schedule_reminder(rem, jq)
+    schedule_reminder(rem, jq, user)
 
 
 __all__ = ["set_job_queue", "notify_reminder_saved"]


### PR DESCRIPTION
## Summary
- prevent DetachedInstanceError by passing User to `schedule_reminder`
- re-fetch the reminder's user after webapp saves and when toggling reminders
- load user in event notifier before scheduling

## Testing
- `pytest -q` *(fails: AttributeError: <module 'services.api.app.services.db'> has no attribute ...)*
- `mypy --strict .` *(fails: Function is missing a type annotation in services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py:15)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b29f677b90832ab2a983f8f555705d