### PR TITLE
[services] Drop profile SessionLocal alias

### DIFF
--- a/tests/test_profile_optional_fields.py
+++ b/tests/test_profile_optional_fields.py
@@ -2,6 +2,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+import services.api.app.diabetes.services.db as db
 from services.api.app.diabetes.services.db import Base, User
 from services.api.app.schemas.profile import ProfileSchema
 from services.api.app.services import profile as profile_service
@@ -14,7 +15,7 @@ async def test_save_profile_saves_computed_target(
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()

--- a/tests/test_profile_quiet_fields.py
+++ b/tests/test_profile_quiet_fields.py
@@ -3,6 +3,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from datetime import time as dt_time
 
+import services.api.app.diabetes.services.db as db
 from services.api.app.diabetes.services.db import Base, User
 from services.api.app.schemas.profile import ProfileSchema
 from services.api.app.services import profile as profile_service
@@ -13,7 +14,7 @@ async def test_save_profile_stores_quiet_fields(monkeypatch: pytest.MonkeyPatch)
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -40,7 +41,7 @@ async def test_save_profile_defaults_quiet_fields(monkeypatch: pytest.MonkeyPatc
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
         session.add(User(telegram_id=2, thread_id="t", timezone="UTC"))
         session.commit()

--- a/tests/test_profile_sos_fields.py
+++ b/tests/test_profile_sos_fields.py
@@ -4,6 +4,7 @@ from datetime import time
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+import services.api.app.diabetes.services.db as db
 from services.api.app.diabetes.services.db import Base, User
 from services.api.app.schemas.profile import ProfileSchema
 from services.api.app.services import profile as profile_service
@@ -14,7 +15,7 @@ async def test_save_profile_stores_sos_fields(monkeypatch: pytest.MonkeyPatch) -
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -43,7 +44,7 @@ async def test_save_profile_defaults_sos_fields(
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
         session.add(User(telegram_id=2, thread_id="t", timezone="UTC"))
         session.commit()
@@ -70,7 +71,7 @@ async def test_save_profile_persists_quiet_hours(
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
         session.add(User(telegram_id=3, thread_id="t", timezone="UTC"))
         session.commit()
@@ -99,7 +100,7 @@ async def test_save_profile_defaults_quiet_hours(
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
         session.add(User(telegram_id=4, thread_id="t", timezone="UTC"))
         session.commit()

--- a/tests/test_profiles_api.py
+++ b/tests/test_profiles_api.py
@@ -7,7 +7,6 @@ from sqlalchemy.pool import StaticPool
 
 from services.api.app.diabetes.services.db import Base
 import services.api.app.diabetes.services.db as db
-from services.api.app.services import profile as profile_service
 from services.api.app.legacy import router
 
 
@@ -31,8 +30,7 @@ def test_profiles_post_creates_user_for_missing_telegram_id(
     )
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
-    monkeypatch.setattr(db, "SessionLocal", TestSession, raising=False)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
 
     async def _run_db(fn, *args, **kwargs):
         return await db.run_db(fn, *args, sessionmaker=TestSession, **kwargs)
@@ -67,8 +65,7 @@ def test_profiles_post_invalid_values_returns_422(
     )
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
-    monkeypatch.setattr(db, "SessionLocal", TestSession, raising=False)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
 
     async def _run_db(fn, *args, **kwargs):
         return await db.run_db(fn, *args, sessionmaker=TestSession, **kwargs)
@@ -104,8 +101,7 @@ def test_profiles_post_invalid_icr_returns_422(
     )
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
-    monkeypatch.setattr(db, "SessionLocal", TestSession, raising=False)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
 
     async def _run_db(fn, *args, **kwargs):
         return await db.run_db(fn, *args, sessionmaker=TestSession, **kwargs)
@@ -140,8 +136,7 @@ def test_profiles_post_invalid_cf_returns_422(
     )
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
-    monkeypatch.setattr(db, "SessionLocal", TestSession, raising=False)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
 
     async def _run_db(fn, *args, **kwargs):
         return await db.run_db(fn, *args, sessionmaker=TestSession, **kwargs)
@@ -176,8 +171,7 @@ def test_profiles_post_updates_existing_profile(
     )
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(profile_service, "SessionLocal", TestSession)
-    monkeypatch.setattr(db, "SessionLocal", TestSession, raising=False)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
 
     async def _run_db(fn, *args, **kwargs):
         return await db.run_db(fn, *args, sessionmaker=TestSession, **kwargs)


### PR DESCRIPTION
## Summary
- remove module-level `SessionLocal` alias in profile service and use `db.SessionLocal`
- update profile-related tests to patch `db.SessionLocal`

## Testing
- `ruff check .`
- `mypy --strict services/api/app/services/profile.py tests/test_profile_optional_fields.py tests/test_profile_sos_fields.py tests/test_profiles_api.py tests/test_profile_quiet_fields.py`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68b2b92c7278832a975f5f0346d505d8