### PR TITLE
[reminders] memoize reminders api hook

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/reminders.ts
+++ b/services/webapp/ui/src/features/reminders/api/reminders.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Configuration } from "@sdk/runtime.ts";
 import { RemindersApi } from "@sdk/apis";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
@@ -16,5 +17,5 @@ export function makeRemindersApi(initData: string | null) {
 
 export function useRemindersApi() {
   const initData = useTelegramInitData();
-  return makeRemindersApi(initData);
+  return useMemo(() => makeRemindersApi(initData), [initData]);
 }


### PR DESCRIPTION
## Summary
- memoize Reminders API hook so it only recreates when init data changes

## Testing
- `NODE_OPTIONS="--max-old-space-size=4096" pnpm test`
- `pnpm lint` *(fails: Unexpected any. Specify a different type)*
- `pytest -q --cov` *(fails: command not found)*
- `mypy --strict .` *(fails: command not found)*
- `ruff check .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2df0b1c6c832aaecb91aef2e71a85