### PR TITLE
[profile] remove timezone button from profile menu

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -255,7 +255,6 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     rows = [
         [InlineKeyboardButton("✏️ Изменить", callback_data="profile_edit")],
         [InlineKeyboardButton("🔔 Безопасность", callback_data="profile_security")],
-        [InlineKeyboardButton("🌐 Часовой пояс", callback_data="profile_timezone")],
         [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
     ]
     if webapp_button is not None:


### PR DESCRIPTION
## Summary
- remove timezone option from profile menu

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b2ed6b6800832aa2800863efe649ec