### PR TITLE
[webapp] use timezoneAuto field

### DIFF
--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -44,7 +44,7 @@ export async function saveProfile({
 
 export type PatchProfileDto = {
   timezone?: string | null;
-  auto_detect_timezone?: boolean | null;
+  timezoneAuto?: boolean | null;
 };
 
 export async function patchProfile(payload: PatchProfileDto) {

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -126,7 +126,7 @@ const Profile = () => {
           typeof data.timezone === "string" && data.timezone
             ? data.timezone
             : deviceTz;
-        const timezoneAuto = data.timezone_auto === true;
+        const timezoneAuto = data.timezoneAuto === true;
 
         const isComplete = [icr, cf, target, low, high].every(
           (v) => Number(v) > 0,
@@ -145,7 +145,7 @@ const Profile = () => {
         if (timezoneAuto && timezone !== deviceTz) {
           patchProfile({
             timezone: deviceTz ?? null,
-            auto_detect_timezone: true,
+            timezoneAuto: true,
           })
             .then(() =>
               toast({
@@ -208,7 +208,7 @@ const Profile = () => {
     try {
       await patchProfile({
         timezone: data.timezone ?? null,
-        auto_detect_timezone: data.timezoneAuto ?? null,
+        timezoneAuto: data.timezoneAuto ?? null,
       });
       await saveProfile({
         telegramId: data.telegramId,

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -81,7 +81,7 @@ describe('profile api', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     await expect(
-      patchProfile({ timezone: 'Europe/Moscow', auto_detect_timezone: true }),
+      patchProfile({ timezone: 'Europe/Moscow', timezoneAuto: true }),
     ).rejects.toThrow('Не удалось обновить профиль: fail');
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/profile',

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -47,7 +47,7 @@ describe('Profile page', () => {
       low: 4,
       high: 10,
       timezone: 'Europe/Moscow',
-      timezone_auto: false,
+      timezoneAuto: false,
     });
     const realDTF = Intl.DateTimeFormat;
     const realResolved = realDTF.prototype.resolvedOptions;
@@ -198,7 +198,7 @@ describe('Profile page', () => {
       });
       expect(patchProfile).toHaveBeenCalledWith({
         timezone: 'Europe/Moscow',
-        auto_detect_timezone: false,
+        timezoneAuto: false,
       });
       expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({ title: 'Профиль сохранен' }),
@@ -206,7 +206,7 @@ describe('Profile page', () => {
     });
   });
 
-  it('auto updates timezone on mount when timezone_auto is true', async () => {
+  it('auto updates timezone on mount when timezoneAuto is true', async () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
     (getProfile as vi.Mock).mockResolvedValue({
       telegramId: 123,
@@ -216,7 +216,7 @@ describe('Profile page', () => {
       low: 4,
       high: 10,
       timezone: 'Europe/Moscow',
-      timezone_auto: true,
+      timezoneAuto: true,
     });
 
     render(<Profile />);
@@ -224,7 +224,7 @@ describe('Profile page', () => {
     await waitFor(() => {
       expect(patchProfile).toHaveBeenCalledWith({
         timezone: 'Europe/Berlin',
-        auto_detect_timezone: true,
+        timezoneAuto: true,
       });
     });
   });
@@ -240,7 +240,7 @@ describe('Profile page', () => {
       low: 4,
       high: 10,
       timezone: 'Europe/Moscow',
-      timezone_auto: false,
+      timezoneAuto: false,
     });
 
     const { getByLabelText, getByText, getByPlaceholderText } = render(<Profile />);
@@ -257,7 +257,7 @@ describe('Profile page', () => {
     await waitFor(() => {
       expect(patchProfile).toHaveBeenCalledWith({
         timezone: 'Europe/Berlin',
-        auto_detect_timezone: false,
+        timezoneAuto: false,
       });
       expect(saveProfile).toHaveBeenCalled();
     });
@@ -410,7 +410,7 @@ describe('Profile page', () => {
       });
       expect(patchProfile).toHaveBeenCalledWith({
         timezone: 'Europe/Moscow',
-        auto_detect_timezone: false,
+        timezoneAuto: false,
       });
       expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({ title: 'Профиль сохранен' }),


### PR DESCRIPTION
## Summary
- switch profile API to `timezoneAuto`
- update profile page and tests to send/expect `timezoneAuto`

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Unexpected any. Specify a different type)*
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b2edbf3b10832aa3ce5a9f6826376f