### PR TITLE
[handlers] register reminder job queue

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -16,6 +16,8 @@ from telegram.ext import (
 )
 from sqlalchemy.exc import SQLAlchemyError
 
+from services.api.app import reminder_events
+
 from .onboarding_handlers import onboarding_conv, onboarding_poll_answer
 from .common_handlers import menu_command, help_command, smart_input_help
 from .router import callback_router
@@ -113,6 +115,7 @@ def register_reminder_handlers(
     if job_queue:
         try:
             reminder_handlers.schedule_all(job_queue)
+            reminder_events.set_job_queue(job_queue)
         except SQLAlchemyError:
             logger.exception("Failed to schedule reminders")
 


### PR DESCRIPTION
## Summary
- register JobQueue in `reminder_events` when scheduling reminders

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported; Coverage failure: total of 52 is less than fail-under=85)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b339917ee0832a8c3df33961c5fa11