### PR TITLE
[handlers] log reminder job execution

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -706,6 +706,7 @@ async def reminder_job(context: ContextTypes.DEFAULT_TYPE) -> None:
             ]
         ]
     )
+    logger.info("Sending reminder %s to chat %s", rid, chat_id)
     try:
         await context.bot.send_message(chat_id=chat_id, text=text, reply_markup=keyboard)
     except TelegramError:


### PR DESCRIPTION
## Summary
- log when reminder job sends a message

## Testing
- `pytest -q` *(fails: sqlalchemy.exc.UnboundExecutionError: Could not locate a bind configured on mapper Mapper[Reminder(reminders)], SQL expression or this Session.)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b338f27758832a9d43ed29fce34d04