### PR TITLE
[handlers] Extract reminder job scheduling module

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -40,7 +40,7 @@ from services.api.app.diabetes.utils.helpers import (
     parse_time_interval,
 )
 from services.api.app.diabetes.utils.ui import menu_keyboard
-from services.api.app.reminders.common import DefaultJobQueue, schedule_reminder
+from .reminder_jobs import DefaultJobQueue, schedule_reminder
 from . import UserData
 
 run_db: Callable[..., Awaitable[object]] | None

--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -24,7 +24,7 @@ def schedule_reminder(
 
     # Import lazily to avoid circular imports.
     from services.api.app import reminder_events
-    from services.api.app.diabetes.handlers import reminder_handlers
+    from . import reminder_handlers
 
     reminder_events.set_job_queue(job_queue)
     reminder_job = reminder_handlers.reminder_job

--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -7,7 +7,7 @@ from telegram.ext import ContextTypes, JobQueue
 from sqlalchemy.orm import Session, sessionmaker
 
 from .diabetes.services.db import Reminder, User
-from .reminders.common import DefaultJobQueue, schedule_reminder
+from .diabetes.handlers.reminder_jobs import DefaultJobQueue, schedule_reminder
 
 logger = logging.getLogger(__name__)
 

--- a/services/api/app/reminders/__init__.py
+++ b/services/api/app/reminders/__init__.py
@@ -1,5 +1,0 @@
-"""Reminder utilities."""
-
-from .common import DefaultJobQueue, schedule_reminder
-
-__all__ = ["DefaultJobQueue", "schedule_reminder"]


### PR DESCRIPTION
## Summary
- factor out reminder scheduling utilities into `reminder_jobs`
- reference new module from handlers and events
- drop legacy `reminders` package

## Testing
- `pytest -q --cov` *(fails: AttributeError 'NoneType' object has no attribute 'run_once'; 4 failed)*
- `mypy --strict .` *(fails: 12 errors in alembic versions and bot main)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b41ae7250c832a9716e7484488aab0