### PR TITLE
[bot] Initialize reminder job queue before scheduling

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -16,8 +16,6 @@ from telegram.ext import (
 )
 from sqlalchemy.exc import SQLAlchemyError
 
-from services.api.app import reminder_events
-
 from .onboarding_handlers import onboarding_conv, onboarding_poll_answer
 from .common_handlers import menu_command, help_command, smart_input_help
 from .router import callback_router
@@ -115,7 +113,6 @@ def register_reminder_handlers(
     if job_queue:
         try:
             reminder_handlers.schedule_all(job_queue)
-            reminder_events.set_job_queue(job_queue)
         except SQLAlchemyError:
             logger.exception("Failed to schedule reminders")
 

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -99,6 +99,10 @@ def main() -> None:  # pragma: no cover
     )
     application.add_error_handler(error_handler)
 
+    from services.api.app import reminder_events
+
+    reminder_events.set_job_queue(application.job_queue)
+
     from services.api.app.diabetes.handlers.registration import register_handlers
 
     register_handlers(application)
@@ -113,14 +117,13 @@ def main() -> None:  # pragma: no cover
     if application.job_queue:
         application.job_queue.run_once(test_job, when=30)
 
-  
     application.job_queue.run_once(test_job, when=30)
 
     application.run_polling()
+
 
 __all__ = ["main", "error_handler", "settings", "TELEGRAM_TOKEN"]
 
 
 if __name__ == "__main__":  # pragma: no cover
     main()
-


### PR DESCRIPTION
## Summary
- ensure reminder job queue is set right after building the bot application
- clean up reminder registration to rely on globally configured queue

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: Untyped decorator makes function untyped, Class cannot subclass BaseModel)*
- `pytest -q --cov` *(fails: 95 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b41e8bd288832a918438f26c810097