### PR TITLE
[reminders] Raise error on missing job queue

### DIFF
--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -24,13 +24,12 @@ def set_job_queue(job_queue: JobQueue[ContextTypes.DEFAULT_TYPE] | None) -> None
 def notify_reminder_saved(reminder_id: int) -> None:
     """Send reminder to the job queue for scheduling.
 
-    If the job queue is not configured, this function logs a warning and
-    returns without scheduling.
+    Raises RuntimeError if the job queue is not configured.
     """
     jq = _job_queue
     if jq is None:
-        logger.warning("notify_reminder_saved called without job_queue")
-        return
+        msg = "notify_reminder_saved called without job_queue"
+        raise RuntimeError(msg)
 
     from .diabetes.handlers import reminder_handlers
 

--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -28,13 +28,26 @@ def test_log_level_debug(monkeypatch: pytest.MonkeyPatch) -> None:
     # Stub external interactions
     monkeypatch.setattr(bot, "init_db", lambda: None)
 
+    class DummyJobQueue:
+        def run_once(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def get_jobs_by_name(self, name: str) -> list[object]:
+            return []
+
+        def run_repeating(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def jobs(self) -> list[object]:
+            return []
+
     class DummyBot:
         def set_my_commands(self, commands: list[tuple[str, str]]) -> None:
             return None
 
     class DummyApp:
         bot = DummyBot()
-        job_queue = None
+        job_queue = DummyJobQueue()
 
         def add_error_handler(
             self,

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -35,7 +35,7 @@ async def test_post_init_sets_chat_menu_button(
         set_my_commands=AsyncMock(),
         set_chat_menu_button=AsyncMock(),
     )
-    app = SimpleNamespace(bot=bot)
+    app = SimpleNamespace(bot=bot, job_queue=None)
     await main.post_init(app)
     bot.set_my_commands.assert_awaited_once_with(main.commands)
     bot.set_chat_menu_button.assert_awaited_once()
@@ -57,7 +57,7 @@ async def test_post_init_skips_chat_menu_button_without_url(
         set_my_commands=AsyncMock(),
         set_chat_menu_button=AsyncMock(),
     )
-    app = SimpleNamespace(bot=bot)
+    app = SimpleNamespace(bot=bot, job_queue=None)
     await main.post_init(app)
     bot.set_my_commands.assert_awaited_once_with(main.commands)
     bot.set_chat_menu_button.assert_awaited_once()

--- a/tests/test_legacy_reminders_auth.py
+++ b/tests/test_legacy_reminders_auth.py
@@ -16,6 +16,7 @@ import services.api.app.main as server
 from services.api.app.config import settings
 from services.api.app.diabetes.services.db import Base, User
 from services.api.app.services import reminders
+from services.api.app.routers import reminders as reminders_router
 
 TOKEN = "test-token"
 
@@ -44,6 +45,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     monkeypatch.setattr(reminders, "SessionLocal", TestSession)
+    monkeypatch.setattr(reminders_router, "notify_reminder_saved", lambda rid: None)
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()

--- a/tests/test_reminder_events.py
+++ b/tests/test_reminder_events.py
@@ -1,0 +1,9 @@
+import pytest
+
+from services.api.app import reminder_events
+
+
+def test_notify_without_job_queue_raises() -> None:
+    reminder_events.set_job_queue(None)
+    with pytest.raises(RuntimeError):
+        reminder_events.notify_reminder_saved(1)

--- a/tests/test_reminders_after_meal.py
+++ b/tests/test_reminders_after_meal.py
@@ -49,7 +49,9 @@ class DummyJobQueue:
 def make_session() -> sessionmaker[Session]:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
-    return sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    return sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
+    )
 
 
 def test_schedule_reminder_after_meal() -> None:

--- a/tests/test_reminders_api.py
+++ b/tests/test_reminders_api.py
@@ -229,8 +229,10 @@ def test_get_single_reminder_not_found(
 
 
 def test_patch_updates_reminder(
-    client: TestClient, session_factory: sessionmaker[Session]
+    client_with_job_queue: tuple[TestClient, DummyJobQueue],
+    session_factory: sessionmaker[Session],
 ) -> None:
+    client, _ = client_with_job_queue
     with session_factory() as session:
         session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(


### PR DESCRIPTION
## Summary
- raise `RuntimeError` if reminders are saved without an initialized JobQueue
- cover missing JobQueue configuration with tests and fixtures

## Testing
- `pytest -q --cov`
- `mypy --strict services/api/app/reminder_events.py tests/test_reminder_events.py tests/test_reminders_api.py tests/test_legacy_reminders_auth.py tests/test_chat_menu_button.py tests/test_bot_debug_logging.py tests/test_reminders_after_meal.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b41e8f0d88832a8a4cde7ccb9594e0