### PR TITLE
[handlers] enforce job queue presence for reminders

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -829,9 +829,15 @@ async def reminder_action_cb(
     job_queue: DefaultJobQueue | None = cast(DefaultJobQueue | None, context.job_queue)
     if status == "toggle":
         if rem and rem.is_enabled:
-            with SessionLocal() as session:
-                user_obj = session.get(User, rem.telegram_id)
-            schedule_reminder(rem, job_queue, user_obj)
+            if job_queue is None:
+                logger.warning(
+                    "Job queue not available, skipping scheduling for reminder %s",
+                    rid,
+                )
+            else:
+                with SessionLocal() as session:
+                    user_obj = session.get(User, rem.telegram_id)
+                schedule_reminder(rem, job_queue, user_obj)
         elif job_queue is not None:
             for job in job_queue.get_jobs_by_name(f"reminder_{rid}"):
                 job.schedule_removal()

--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -19,8 +19,8 @@ def schedule_reminder(
 ) -> None:
     """Schedule a reminder in the provided job queue."""
     if job_queue is None:
-        logger.warning("schedule_reminder called without job_queue")
-        return
+        msg = "schedule_reminder called without job_queue"
+        raise RuntimeError(msg)
 
     # Import lazily to avoid circular imports.
     from services.api.app import reminder_events


### PR DESCRIPTION
## Summary
- raise when scheduling reminders without a job queue
- guard reminder callbacks against missing job queue
- test reminder scheduling failure when job queue missing

## Testing
- `pytest -q --cov`
- `mypy --strict services/api/app/diabetes/handlers/reminder_jobs.py services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b421ce69a8832a958fea79ea409b1d