### PR TITLE
[bot] Configure JobQueue timezone

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -4,6 +4,7 @@ Bot entry point and configuration.
 
 import logging
 import sys
+from zoneinfo import ZoneInfo
 
 from sqlalchemy.exc import SQLAlchemyError
 from telegram import BotCommand
@@ -96,6 +97,11 @@ def main() -> None:  # pragma: no cover
         .token(BOT_TOKEN)
         .post_init(post_init)  # registers post-init handler
         .build()
+    )
+    application.job_queue.timezone = ZoneInfo("Europe/Moscow")
+    logger.info(
+        "✅ JobQueue initialized with timezone %s",
+        application.job_queue.timezone,
     )
     application.add_error_handler(error_handler)
 


### PR DESCRIPTION
## Summary
- import `ZoneInfo` and configure `JobQueue` to use Europe/Moscow timezone
- log initialized timezone before scheduling any reminders

## Testing
- `pytest tests/test_help_command.py -q` *(fails: ModuleNotFoundError: No module named 'openai')*
- `pytest tests/test_webapp_user.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named "fastapi")*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b42d352e18832a99e6ffeda6249bf2