### PR TITLE
[bot] remove duplicate test job scheduling

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -109,15 +109,17 @@ def main() -> None:  # pragma: no cover
 
     # 🟢 Тестовая задача (через 30 секунд после запуска)
     async def test_job(context: ContextTypes.DEFAULT_TYPE) -> None:
+        admin_id = settings.admin_id
+        if admin_id is None:  # pragma: no cover - misconfiguration
+            logger.warning("Admin ID not configured; skipping test reminder")
+            return
         await context.bot.send_message(
-            chat_id=settings.admin_id,
+            chat_id=admin_id,
             text="🔔 Test reminder fired! JobQueue работает ✅",
         )
 
     if application.job_queue:
         application.job_queue.run_once(test_job, when=30)
-
-    application.job_queue.run_once(test_job, when=30)
 
     application.run_polling()
 

--- a/tests/test_bot_single_test_reminder.py
+++ b/tests/test_bot_single_test_reminder.py
@@ -1,0 +1,95 @@
+"""Ensure only a single test reminder is scheduled on startup."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+def test_single_test_reminder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bot starts with only one scheduled test job."""
+
+    monkeypatch.setenv("DB_PASSWORD", "pwd")
+
+    for mod in ["services.api.app.config", "services.bot.main"]:
+        sys.modules.pop(mod, None)
+    bot = importlib.import_module("services.bot.main")
+    monkeypatch.setattr(bot.settings, "telegram_token", "token")
+    monkeypatch.setattr(bot.settings, "admin_id", 1, raising=False)
+    monkeypatch.setattr(bot, "TELEGRAM_TOKEN", "token")
+    monkeypatch.setattr(bot, "init_db", lambda: None)
+
+    class DummyJobQueue:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def run_once(self, *args: object, **kwargs: object) -> None:
+            self.calls += 1
+
+        def get_jobs_by_name(
+            self, name: str
+        ) -> list[object]:  # pragma: no cover - compatibility
+            return []
+
+        def run_repeating(
+            self, *args: object, **kwargs: object
+        ) -> None:  # pragma: no cover - compatibility
+            return None
+
+        def jobs(self) -> list[object]:  # pragma: no cover - compatibility
+            return []
+
+    class DummyBot:
+        def set_my_commands(
+            self, commands: list[tuple[str, str]]
+        ) -> None:  # pragma: no cover - compatibility
+            return None
+
+    class DummyApp:
+        def __init__(self) -> None:
+            self.bot = DummyBot()
+            self.job_queue = DummyJobQueue()
+
+        def add_error_handler(
+            self, handler: object
+        ) -> None:  # pragma: no cover - compatibility
+            return None
+
+        def add_handler(
+            self, handler: object
+        ) -> None:  # pragma: no cover - compatibility
+            return None
+
+        def run_polling(self) -> None:  # pragma: no cover - compatibility
+            return None
+
+    built_app = DummyApp()
+
+    class DummyBuilder:
+        def token(self, _: str) -> "DummyBuilder":
+            return self
+
+        def post_init(self, _: object) -> "DummyBuilder":
+            return self
+
+        def build(self) -> DummyApp:
+            return built_app
+
+    class DummyApplication:
+        @staticmethod
+        def builder() -> DummyBuilder:
+            return DummyBuilder()
+
+        def __class_getitem__(
+            cls, _: object
+        ) -> type["DummyApplication"]:  # pragma: no cover - typing helper
+            return cls
+
+    monkeypatch.setattr(bot, "Application", DummyApplication)
+    monkeypatch.setattr(bot, "register_handlers", lambda app: None, raising=False)
+
+    bot.main()
+
+    assert built_app.job_queue.calls == 1


### PR DESCRIPTION
## Summary
- ensure the test reminder job is scheduled only once at startup
- avoid sending test reminders when ADMIN_ID is missing
- cover startup scheduling with a unit test

## Testing
- `pytest -q`
- `mypy --strict services/bot/main.py tests/test_bot_single_test_reminder.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b42d3c0a48832aa3cda27708867bff