### PR TITLE
[handlers] Use Moscow fallback for reminders

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import logging
-from datetime import timedelta, timezone
+from datetime import timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from telegram.ext import ContextTypes, JobQueue
@@ -44,7 +44,7 @@ def schedule_reminder(
         )
         return
 
-    tz: datetime.tzinfo = timezone.utc
+    tz: datetime.tzinfo = ZoneInfo("Europe/Moscow")
     if user is None:
         with SessionLocal() as session:
             user = session.get(User, rem.telegram_id)
@@ -54,12 +54,16 @@ def schedule_reminder(
             tz = ZoneInfo(tzname)
         except ZoneInfoNotFoundError:
             logger.warning(
-                "Invalid timezone for user %s: %s",
+                "Invalid timezone for user %s: %s; falling back to Europe/Moscow",
                 getattr(user, "telegram_id", None),
                 tzname,
             )
         except (OSError, ValueError) as exc:
-            logger.exception("Unexpected error loading timezone %s: %s", tzname, exc)
+            logger.warning(
+                "Unexpected error loading timezone %s: %s; falling back to Europe/Moscow",
+                tzname,
+                exc,
+            )
 
     if rem.type == "after_meal":
         minutes_after = rem.minutes_after

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -211,7 +211,7 @@ def test_schedule_reminder_requires_job_queue() -> None:
         handlers.schedule_reminder(rem, None, user)
 
 
-def test_schedule_reminder_without_user_defaults_to_utc() -> None:
+def test_schedule_reminder_without_user_defaults_to_moscow() -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -237,7 +237,7 @@ def test_schedule_reminder_without_user_defaults_to_utc() -> None:
     job = jobs[0]
     assert job.time is not None
     job_time = cast(time, job.time)
-    assert job_time.tzinfo == timezone.utc
+    assert job_time.tzinfo == ZoneInfo("Europe/Moscow")
 
 
 def test_schedule_with_next_interval(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -342,7 +342,7 @@ def test_schedule_reminder_invalid_timezone_logs_warning(
     assert job.time is not None
     job_time = cast(datetime, job.time)
     assert job_time.tzinfo is not None
-    assert job_time.tzinfo == timezone.utc
+    assert job_time.tzinfo == ZoneInfo("Europe/Moscow")
     assert any("Invalid timezone" in r.message for r in caplog.records)
 
 


### PR DESCRIPTION
## Summary
- use Europe/Moscow as default timezone for reminders
- log and fall back to Moscow when user timezone is invalid
- update tests for new Moscow default

## Testing
- `pytest -q --cov`
- `mypy --strict .` *(fails: Argument "existing_server_default" ...; Item "None" of "JobQueue" has no attribute "run_once")*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b42d4f9e3c832a854dc24e0e0a658b