### PR TITLE
[handlers] Use Moscow fallback timezone

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -58,10 +58,10 @@ def schedule_reminder(
                 getattr(user, "telegram_id", None),
                 tzname,
             )
-        except (OSError, ValueError) as exc:
-            logger.exception("Unexpected error loading timezone %s: %s", tzname, exc)
+        except Exception as exc:
+            logger.warning("Unexpected error loading timezone %s: %s", tzname, exc)
 
-    job_tz = getattr(job_queue, "timezone", None) or ZoneInfo("Europe/Moscow")
+    job_tz = getattr(job_queue, "timezone", None) or tz
 
     if rem.type == "after_meal":
         minutes_after = rem.minutes_after

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -245,6 +245,20 @@ def test_schedule_reminder_without_user_defaults_to_moscow() -> None:
     assert job_time.tzinfo is None
 
 
+def test_schedule_reminder_uses_user_timezone_when_queue_has_none() -> None:
+    user = DbUser(telegram_id=1, thread_id="t", timezone="UTC")
+    rem = Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user)
+    job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
+    handlers.schedule_reminder(rem, job_queue, user)
+    jobs: list[DummyJob] = list(job_queue.get_jobs_by_name("reminder_1"))
+    assert jobs
+    job = jobs[0]
+    assert job.time is not None
+    job_time = cast(time, job.time)
+    assert job_time == time(8, 0)
+    assert job_time.tzinfo is None
+
+
 def test_schedule_with_next_interval(monkeypatch: pytest.MonkeyPatch) -> None:
     now = datetime(2024, 1, 1, 10, 0)
 


### PR DESCRIPTION
## Summary
- ensure reminder scheduling defaults to Europe/Moscow timezone and logs errors
- fallback to user timezone when job queue lacks one
- test scheduling uses user timezone without queue tz

## Testing
- `pytest -q` (fails: async plugin missing, 382 failed)
- `mypy --strict .` (fails: 14 errors)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b42f64a700832a95dc471254530019