### PR TITLE
[reminders] avoid duplicate after meal jobs

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -888,6 +888,8 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
         minutes_after = rem.minutes_after
         if minutes_after is None:
             continue
+        for job in job_queue.get_jobs_by_name(f"reminder_{rem.id}"):
+            job.schedule_removal()
         job_queue.run_once(
             reminder_job,
             when=timedelta(minutes=float(minutes_after)),

--- a/tests/test_reminders_after_meal.py
+++ b/tests/test_reminders_after_meal.py
@@ -113,6 +113,33 @@ def test_schedule_after_meal_single_reminder() -> None:
     assert job.name == "reminder_1"
 
 
+def test_schedule_after_meal_no_duplicate_jobs() -> None:
+    TestSession = make_session()
+    handlers.SessionLocal = TestSession
+    with TestSession() as session:
+        user = DbUser(telegram_id=1, thread_id="t")
+        session.add(user)
+        session.add(
+            Reminder(
+                id=1,
+                telegram_id=1,
+                type="after_meal",
+                minutes_after=30,
+                is_enabled=True,
+                user=user,
+            )
+        )
+        session.commit()
+    dummy_queue = DummyJobQueue()
+    job_queue = cast(handlers.DefaultJobQueue, dummy_queue)
+    handlers.schedule_after_meal(1, job_queue)
+    handlers.schedule_after_meal(1, job_queue)
+    jobs = list(job_queue.get_jobs_by_name("reminder_1"))
+    assert len(jobs) == 2
+    assert jobs[0].removed is True
+    assert jobs[1].removed is False
+
+
 def test_schedule_after_meal_multiple_reminders() -> None:
     TestSession = make_session()
     handlers.SessionLocal = TestSession


### PR DESCRIPTION
## Summary
- clear existing `after_meal` jobs before scheduling
- add regression test to ensure duplicate jobs are removed

## Testing
- `pytest -q` (fails: async def functions are not natively supported)
- `mypy --strict .` (fails: Argument "existing_server_default" to "alter_column" has incompatible type)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b430f91e50832aa14319b9e36f8dae