### PR TITLE
[reminders] remove jobs on reminder deletion

### DIFF
--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -43,4 +43,17 @@ def notify_reminder_saved(reminder_id: int) -> None:
     schedule_reminder(rem, jq, user)
 
 
-__all__ = ["set_job_queue", "notify_reminder_saved"]
+def notify_reminder_deleted(reminder_id: int) -> None:
+    """Remove reminder jobs from the job queue.
+
+    Raises RuntimeError if the job queue is not configured.
+    """
+    jq = _job_queue
+    if jq is None:
+        msg = "notify_reminder_deleted called without job_queue"
+        raise RuntimeError(msg)
+    for job in jq.get_jobs_by_name(f"reminder_{reminder_id}"):
+        job.schedule_removal()
+
+
+__all__ = ["set_job_queue", "notify_reminder_saved", "notify_reminder_deleted"]

--- a/services/api/app/routers/reminders.py
+++ b/services/api/app/routers/reminders.py
@@ -13,7 +13,7 @@ from ..services.reminders import (
 )
 from ..services.audit import log_patient_access
 from ..telegram_auth import require_tg_user
-from ..reminder_events import notify_reminder_saved
+from ..reminder_events import notify_reminder_deleted, notify_reminder_saved
 
 logger = logging.getLogger(__name__)
 
@@ -169,4 +169,5 @@ async def delete_reminder(
         raise HTTPException(status_code=404, detail="reminder not found")
     log_patient_access(getattr(request.state, "user_id", None), tid)
     await remove_reminder(tid, id)
+    notify_reminder_deleted(id)
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- remove reminder jobs from queue when a reminder is deleted
- call job removal after deleting reminders via API
- test that API deletion removes scheduled jobs

## Testing
- `pytest -q --cov`
- `mypy --strict services/api/app/reminder_events.py services/api/app/routers/reminders.py tests/test_reminders_api.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b430fb22b4832a8cbfa72d58b58fcb