### PR TITLE
[handlers] Clear interval minutes on reminder type change

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -47,9 +47,7 @@ run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    logging.getLogger(__name__).info(
-        "run_db is unavailable; proceeding without async DB runner"
-    )
+    logging.getLogger(__name__).info("run_db is unavailable; proceeding without async DB runner")
     run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
@@ -126,19 +124,13 @@ def _schedule_with_next(rem: Reminder, user: User | None = None) -> tuple[str, s
     next_dt: datetime.datetime | None
     if rem.time:
         type_icon = "⏰"
-        next_dt = now.replace(
-            hour=rem.time.hour, minute=rem.time.minute, second=0, microsecond=0
-        )
+        next_dt = now.replace(hour=rem.time.hour, minute=rem.time.minute, second=0, microsecond=0)
         if next_dt <= now:
             next_dt += timedelta(days=1)
         base = rem.time.strftime("%H:%M")
     elif rem.interval_hours or rem.interval_minutes:
         type_icon = "⏱"
-        minutes = (
-            rem.interval_hours * 60
-            if rem.interval_hours is not None
-            else rem.interval_minutes or 0
-        )
+        minutes = rem.interval_hours * 60 if rem.interval_hours is not None else rem.interval_minutes or 0
         next_dt = now + timedelta(minutes=minutes)
         if rem.interval_hours:
             base = f"каждые {rem.interval_hours} ч"
@@ -164,9 +156,7 @@ def _schedule_with_next(rem: Reminder, user: User | None = None) -> tuple[str, s
     return type_icon, schedule
 
 
-def _render_reminders(
-    session: Session, user_id: int
-) -> tuple[str, InlineKeyboardMarkup | None]:
+def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboardMarkup | None]:
     settings = config.get_settings()
     rems = session.query(Reminder).filter_by(telegram_id=user_id).all()
     user = session.query(User).filter_by(telegram_id=user_id).first()
@@ -195,10 +185,7 @@ def _render_reminders(
     )
     add_button_row = [add_button]
     if not rems:
-        text = (
-            header
-            + "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
-        )
+        text = header + "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
         return text, InlineKeyboardMarkup([add_button_row])
 
     by_time: list[tuple[str, list[InlineKeyboardButton]]] = []
@@ -236,9 +223,7 @@ def _render_reminders(
     lines: list[str] = []
     buttons: list[list[InlineKeyboardButton]] = []
 
-    def extend(
-        section: str, items: list[tuple[str, list[InlineKeyboardButton]]]
-    ) -> None:
+    def extend(section: str, items: list[tuple[str, list[InlineKeyboardButton]]]) -> None:
         if not items:
             return
         if lines:
@@ -379,11 +364,7 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             return
 
     def db_add(session: Session) -> tuple[str, User | None, int, int]:
-        count = (
-            session.query(Reminder)
-            .filter_by(telegram_id=user_id, is_enabled=True)
-            .count()
-        )
+        count = session.query(Reminder).filter_by(telegram_id=user_id, is_enabled=True).count()
         db_user = session.get(User, user_id)
         limit = _limit_for(db_user)
         if count >= limit:
@@ -400,16 +381,12 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         with SessionLocal() as session:
             status, db_user, limit, rid_or_count = db_add(session)
     else:
-        status, db_user, limit, rid_or_count = await run_db(
-            db_add, sessionmaker=SessionLocal
-        )
+        status, db_user, limit, rid_or_count = await run_db(db_add, sessionmaker=SessionLocal)
 
     if status == "limit":
         count = rid_or_count
         await message.reply_text(
-            (
-                f"У вас уже {count} активных из {limit}. Отключите одно или Апгрейд до Pro, чтобы поднять лимит до 10"
-            ),
+            (f"У вас уже {count} активных из {limit}. Отключите одно или Апгрейд до Pro, чтобы поднять лимит до 10"),
         )
         return
     if status == "error":
@@ -420,9 +397,7 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await message.reply_text(f"Сохранено: {_describe(reminder, db_user)}")
 
 
-async def reminder_webapp_save(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> None:
+async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Save reminder data sent from the web app."""
     msg: Message | None = update.effective_message
     user = update.effective_user
@@ -450,9 +425,7 @@ async def reminder_webapp_save(
         user_id = user.id
 
         def log_snooze(session: Session) -> Literal["ok"] | Literal["error"]:
-            session.add(
-                ReminderLog(reminder_id=int(rid), telegram_id=user_id, action="snooze")
-            )
+            session.add(ReminderLog(reminder_id=int(rid), telegram_id=user_id, action="snooze"))
             try:
                 commit(session)
             except CommitError:
@@ -469,9 +442,7 @@ async def reminder_webapp_save(
                 await run_db(log_snooze, sessionmaker=SessionLocal),
             )
         if status == "ok":
-            job_queue: DefaultJobQueue | None = cast(
-                DefaultJobQueue | None, context.job_queue
-            )
+            job_queue: DefaultJobQueue | None = cast(DefaultJobQueue | None, context.job_queue)
             if job_queue is not None:
                 job_queue.run_once(
                     reminder_job,
@@ -505,17 +476,13 @@ async def reminder_webapp_save(
     else:
         if not re.fullmatch(r"\d{1,2}:\d{2}|\d+h", value):
             logger.warning("Invalid reminder value format: %s", value)
-            await msg.reply_text(
-                "❌ Неверный формат. Используйте HH:MM или число часов с суффиксом h."
-            )
+            await msg.reply_text("❌ Неверный формат. Используйте HH:MM или число часов с суффиксом h.")
             return
         try:
             parsed = parse_time_interval(value)
         except ValueError:
             logger.warning("Failed to parse reminder value: %s", value)
-            await msg.reply_text(
-                "❌ Неверный формат. Используйте HH:MM или число часов с суффиксом h."
-            )
+            await msg.reply_text("❌ Неверный формат. Используйте HH:MM или число часов с суффиксом h.")
             return
         minutes = None
 
@@ -532,11 +499,7 @@ async def reminder_webapp_save(
             if not rem or rem.telegram_id != user_id:
                 return "not_found", None, None, None
         else:
-            count = (
-                session.query(Reminder)
-                .filter_by(telegram_id=user_id, is_enabled=True)
-                .count()
-            )
+            count = session.query(Reminder).filter_by(telegram_id=user_id, is_enabled=True).count()
             user = session.get(User, user_id)
             plan = getattr(user, "plan", "free").lower()
             limit = PLAN_LIMITS.get(plan, PLAN_LIMITS["free"])
@@ -548,11 +511,13 @@ async def reminder_webapp_save(
             rem.minutes_after = minutes
             rem.time = None
             rem.interval_hours = None
+            rem.interval_minutes = None
         else:
             rem.minutes_after = None
             if isinstance(parsed, time):
                 rem.time = parsed
                 rem.interval_hours = None
+                rem.interval_minutes = None
             else:
                 rem.time = None
                 if parsed is None:
@@ -578,9 +543,7 @@ async def reminder_webapp_save(
         if plan is None:
             return
         await msg.reply_text(
-            (
-                f"У вас уже {limit} активных (лимит {plan.upper()}). Отключите одно или откройте PRO."
-            ),
+            (f"У вас уже {limit} активных (лимит {plan.upper()}). Отключите одно или откройте PRO."),
         )
         return
     if status == "error":
@@ -605,9 +568,7 @@ async def reminder_webapp_save(
 
 
 async def delete_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    message: Message | None = update.message or (
-        update.callback_query.message if update.callback_query else None
-    )
+    message: Message | None = update.message or (update.callback_query.message if update.callback_query else None)
     args = getattr(context, "args", [])
     if not args:
         if message:
@@ -665,18 +626,14 @@ async def reminder_job(context: ContextTypes.DEFAULT_TYPE) -> None:
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton(
-                    "Отложить 10 мин", callback_data=f"remind_snooze:{rid}:10"
-                ),
+                InlineKeyboardButton("Отложить 10 мин", callback_data=f"remind_snooze:{rid}:10"),
                 InlineKeyboardButton("Отмена", callback_data=f"remind_cancel:{rid}"),
             ]
         ]
     )
     logger.info("Sending reminder %s to chat %s", rid, chat_id)
     try:
-        await context.bot.send_message(
-            chat_id=chat_id, text=text, reply_markup=keyboard
-        )
+        await context.bot.send_message(chat_id=chat_id, text=text, reply_markup=keyboard)
     except TelegramError:
         logger.exception("Failed to send reminder %s to chat %s", rid, chat_id)
 
@@ -725,16 +682,12 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         try:
             commit(session)
         except CommitError:
-            logger.error(
-                "Failed to log reminder action %s for reminder %s", log_action, rid
-            )
+            logger.error("Failed to log reminder action %s for reminder %s", log_action, rid)
             return
 
     if action == "remind_snooze":
         mins = minutes or 10
-        job_queue: DefaultJobQueue | None = cast(
-            DefaultJobQueue | None, context.job_queue
-        )
+        job_queue: DefaultJobQueue | None = cast(DefaultJobQueue | None, context.job_queue)
         if job_queue is not None:
             job_queue.run_once(
                 reminder_job,
@@ -760,9 +713,7 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
                 raise
 
 
-async def reminder_action_cb(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> None:
+async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
     user = update.effective_user
     if query is None or query.data is None or user is None:
@@ -800,9 +751,7 @@ async def reminder_action_cb(
         try:
             commit(session)
         except CommitError:
-            logger.error(
-                "Failed to commit reminder action %s for reminder %s", action, rid
-            )
+            logger.error("Failed to commit reminder action %s for reminder %s", action, rid)
             return "error", None
         if action == "toggle":
             session.refresh(rem)
@@ -860,9 +809,7 @@ async def reminder_action_cb(
         )
     try:
         if keyboard is not None:
-            await query.edit_message_text(
-                text, parse_mode="HTML", reply_markup=keyboard
-            )
+            await query.edit_message_text(text, parse_mode="HTML", reply_markup=keyboard)
         else:
             await query.edit_message_text(text, parse_mode="HTML")
     except BadRequest as exc:
@@ -879,11 +826,7 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
         logger.warning("schedule_after_meal called without job_queue")
         return
     with SessionLocal() as session:
-        rems = (
-            session.query(Reminder)
-            .filter_by(telegram_id=user_id, type="after_meal", is_enabled=True)
-            .all()
-        )
+        rems = session.query(Reminder).filter_by(telegram_id=user_id, type="after_meal", is_enabled=True).all()
     for rem in rems:
         minutes_after = rem.minutes_after
         if minutes_after is None:
@@ -896,12 +839,8 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
         )
 
 
-reminder_action_handler = CallbackQueryHandler(
-    reminder_action_cb, pattern="^rem_(del|toggle):"
-)
-reminder_webapp_handler = MessageHandler(
-    filters.StatusUpdate.WEB_APP_DATA, reminder_webapp_save
-)
+reminder_action_handler = CallbackQueryHandler(reminder_action_cb, pattern="^rem_(del|toggle):")
+reminder_webapp_handler = MessageHandler(filters.StatusUpdate.WEB_APP_DATA, reminder_webapp_save)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Reset `interval_minutes` when saving reminders after meal or with explicit time
- Test that switching reminder type clears obsolete interval settings

## Testing
- `pytest -q --cov`
- `mypy --strict .` *(fails: Argument "existing_server_default" has incompatible type TextClause; Item "None" has no attribute "timezone")*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b430f95c10832a911c4fde650dcdfa