### PR TITLE
[reminders] store time objects for manual reminders

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -343,7 +343,7 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 await message.reply_text(INVALID_TIME_MSG)
                 return
             if isinstance(parsed, time):
-                reminder.time = parsed.strftime("%H:%M")
+                reminder.time = parsed
             else:
                 await message.reply_text(INVALID_TIME_MSG)
                 return
@@ -367,7 +367,7 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             await message.reply_text(INVALID_TIME_MSG)
             return
         if isinstance(parsed, time):
-            reminder.time = parsed.strftime("%H:%M")
+            reminder.time = parsed
         else:
             await message.reply_text(INVALID_TIME_MSG)
             return


### PR DESCRIPTION
## Summary
- store parsed time values directly in reminder handler
- test time-based reminder saving and description

## Testing
- `pytest -q --cov` *(fails: TypeError in tests/test_menu_fallbacks.py)*
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminder_handlers.py`
- `ruff check services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminder_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b430fa2d5c832a9125d9cf2242591d