### PR TITLE
[reminders] Store time object for reminders

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -328,7 +328,7 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 await message.reply_text(INVALID_TIME_MSG)
                 return
             if isinstance(parsed, time):
-                reminder.time = parsed.strftime("%H:%M")
+                reminder.time = parsed
             else:
                 await message.reply_text(INVALID_TIME_MSG)
                 return
@@ -352,7 +352,7 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             await message.reply_text(INVALID_TIME_MSG)
             return
         if isinstance(parsed, time):
-            reminder.time = parsed.strftime("%H:%M")
+            reminder.time = parsed
         else:
             await message.reply_text(INVALID_TIME_MSG)
             return

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -98,16 +98,18 @@ def main() -> None:  # pragma: no cover
         .post_init(post_init)  # registers post-init handler
         .build()
     )
-    application.job_queue.timezone = ZoneInfo("Europe/Moscow")
+    job_queue = application.job_queue
+    if job_queue is None:
+        raise RuntimeError("JobQueue not initialized")
+    job_queue.timezone = ZoneInfo("Europe/Moscow")  # type: ignore[attr-defined]
     logger.info(
-        "✅ JobQueue initialized with timezone %s",
-        application.job_queue.timezone,
+        "✅ JobQueue initialized with timezone %s", job_queue.timezone  # type: ignore[attr-defined]
     )
     application.add_error_handler(error_handler)
 
     from services.api.app import reminder_events
 
-    reminder_events.set_job_queue(application.job_queue)
+    reminder_events.set_job_queue(job_queue)
 
     from services.api.app.diabetes.handlers.registration import register_handlers
 


### PR DESCRIPTION
## Summary
- store `datetime.time` directly for time-based reminders
- ensure bot JobQueue is initialized before setting timezone
- test saving and describing time-based reminders

## Testing
- `pytest -q --cov`
- `mypy --strict services/api/app tests`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b433bdc2d4832aa168a98257cd295a