### PR TITLE
[bot] Pass timezone via Application builder

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -106,8 +106,7 @@ def main() -> None:  # pragma: no cover
     job_queue = application.job_queue
     if job_queue is None:
         raise RuntimeError("JobQueue not initialized")
-    tzinfo = getattr(application, "timezone", getattr(job_queue, "timezone", None))
-    logger.info("✅ JobQueue initialized with timezone %s", tzinfo)
+    logger.info("✅ JobQueue initialized with timezone %s", getattr(application, "timezone", None))
     application.add_error_handler(error_handler)
 
     from services.api.app import reminder_events


### PR DESCRIPTION
## Summary
- configure `Application` with `ZoneInfo("Europe/Moscow")`
- log configured scheduler timezone via `application.timezone`

## Testing
- `pytest -q --cov`
- `mypy --strict .` *(fails: Argument "existing_server_default" to "alter_column" has incompatible type "TextClause")*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b43a0f87ec832a944a7a70d4625746