### PR TITLE
[services] Use timezone-aware date

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -90,7 +90,11 @@ def schedule_reminder(
                 rem.interval_hours or rem.interval_minutes,
                 rem.minutes_after,
             )
-            dt = datetime.datetime.combine(datetime.date.today(), rem.time, tzinfo=tz)
+            dt = datetime.datetime.combine(
+                datetime.datetime.now(tz).date(),
+                rem.time,
+                tzinfo=tz,
+            )
             job_time = dt.astimezone(job_tz).time().replace(tzinfo=None)
             job_queue.run_daily(
                 reminder_job,

--- a/services/api/app/services/stats.py
+++ b/services/api/app/services/stats.py
@@ -13,10 +13,12 @@ from ..schemas.stats import DayStats
 
 
 async def get_day_stats(
-    telegram_id: int, date: datetime.date | None = None
+    telegram_id: int,
+    date: datetime.date | None = None,
+    tz: datetime.tzinfo | None = None,
 ) -> DayStats | None:
     """Return aggregated stats for a given user's day."""
-    day = date or datetime.date.today()
+    day = date or datetime.datetime.now(tz or datetime.timezone.utc).date()
 
     def _query(session: Session) -> DayStats | None:
         avg_sugar, sum_bu, sum_insulin = (

--- a/tests/test_stats_service.py
+++ b/tests/test_stats_service.py
@@ -1,5 +1,6 @@
 from typing import ContextManager, Generator, cast
 import datetime
+from zoneinfo import ZoneInfo
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session as SASession, sessionmaker
@@ -60,8 +61,88 @@ async def test_get_day_stats(
 
     monkeypatch.setattr(stats, "SessionLocal", session_factory)
 
-    result = await stats.get_day_stats(1)
+    result = await stats.get_day_stats(1, date=today)
     assert result is not None
     assert result.sugar == pytest.approx(6.0)
     assert result.breadUnits == pytest.approx(3.0)
     assert result.insulin == pytest.approx(5.0)
+
+
+@pytest.mark.asyncio
+async def test_get_day_stats_tz_ahead(
+    monkeypatch: pytest.MonkeyPatch, session_factory: SessionMaker[SASession]
+) -> None:
+    now = datetime.datetime(2024, 1, 1, 23, 0, tzinfo=datetime.timezone.utc)
+
+    class DummyDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz: datetime.tzinfo | None = None) -> "DummyDatetime":
+            if tz is None:
+                return cast("DummyDatetime", now.replace(tzinfo=None))
+            return cast("DummyDatetime", now.astimezone(tz))
+
+    monkeypatch.setattr(stats.datetime, "datetime", DummyDatetime)
+
+    tz = ZoneInfo("Europe/Moscow")
+    day = now.astimezone(tz).date()
+
+    with cast(ContextManager[SASession], session_factory()) as session:
+        session.add(
+            HistoryRecord(
+                id="1",
+                telegram_id=1,
+                date=day,
+                time=datetime.time(8, 0),
+                sugar=5.0,
+                bread_units=1.0,
+                insulin=2.0,
+                type="sugar",
+            )
+        )
+        session.commit()
+
+    monkeypatch.setattr(stats, "SessionLocal", session_factory)
+
+    result = await stats.get_day_stats(1, tz=tz)
+    assert result is not None
+    assert result.sugar == pytest.approx(5.0)
+
+
+@pytest.mark.asyncio
+async def test_get_day_stats_tz_behind(
+    monkeypatch: pytest.MonkeyPatch, session_factory: SessionMaker[SASession]
+) -> None:
+    now = datetime.datetime(2024, 1, 2, 1, 0, tzinfo=datetime.timezone.utc)
+
+    class DummyDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz: datetime.tzinfo | None = None) -> "DummyDatetime":
+            if tz is None:
+                return cast("DummyDatetime", now.replace(tzinfo=None))
+            return cast("DummyDatetime", now.astimezone(tz))
+
+    monkeypatch.setattr(stats.datetime, "datetime", DummyDatetime)
+
+    tz = ZoneInfo("America/New_York")
+    day = now.astimezone(tz).date()
+
+    with cast(ContextManager[SASession], session_factory()) as session:
+        session.add(
+            HistoryRecord(
+                id="1",
+                telegram_id=1,
+                date=day,
+                time=datetime.time(8, 0),
+                sugar=5.0,
+                bread_units=1.0,
+                insulin=2.0,
+                type="sugar",
+            )
+        )
+        session.commit()
+
+    monkeypatch.setattr(stats, "SessionLocal", session_factory)
+
+    result = await stats.get_day_stats(1, tz=tz)
+    assert result is not None
+    assert result.sugar == pytest.approx(5.0)


### PR DESCRIPTION
## Summary
- replace naive date with timezone-aware date in stats service and reminder jobs
- add tests covering user timezones ahead/behind server

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'telegram.ext._basehandler')*
- `mypy --strict services/api/app/services/stats.py services/api/app/diabetes/handlers/reminder_jobs.py tests/test_stats_service.py` *(fails: interrupted)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b43a185fc8832aab96155dd31fcf1c