### PR TITLE
[handlers] Schedule alert jobs with timezone

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 from collections.abc import Awaitable, Callable
 from typing import TypedDict, cast
+from zoneinfo import ZoneInfo
 
 from sqlalchemy.orm import Session, sessionmaker
 from telegram import Update
@@ -87,6 +88,7 @@ def schedule_alert(
         when=ALERT_REPEAT_DELAY,
         data=data,
         name=f"alert_{user_id}",
+        timezone=ZoneInfo("Europe/Moscow"),
     )
 
 


### PR DESCRIPTION
## Summary
- schedule diabetes alert follow-ups with explicit Europe/Moscow timezone

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: main.py untyped decorators; 108 errors)*
- `pytest -q --cov` *(fails: 97 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b43d6a62ac832aa6cbeedbe865588e