### PR TITLE
[handlers] specify timezone for run_once

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -454,6 +454,7 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
                     when=timedelta(minutes=minutes),
                     data={"reminder_id": int(rid), "chat_id": user_id},
                     name=f"reminder_{rid}",
+                    timezone=ZoneInfo("Europe/Moscow"),
                 )
             await msg.reply_text(f"⏰ Отложено на {minutes} минут")
         return
@@ -794,6 +795,7 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
                 when=timedelta(minutes=mins),
                 data={"reminder_id": rid, "chat_id": chat_id},
                 name=f"reminder_{rid}",
+                timezone=ZoneInfo("Europe/Moscow"),
             )
         try:
             await query.edit_message_text(f"⏰ Отложено на {mins} минут")
@@ -938,6 +940,7 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
             when=timedelta(minutes=float(minutes_after)),
             data={"reminder_id": rem.id, "chat_id": user_id},
             name=f"reminder_{rem.id}",
+            timezone=ZoneInfo("Europe/Moscow"),
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,7 @@ class _DummyJobQueue:
         when: object,
         data: dict[str, Any] | None = None,
         name: str | None = None,
+        timezone: object | None = None,
     ) -> _DummyJob:
         job = _DummyJob(name or "", data, when)
         self.jobs.append(job)

--- a/tests/test_alert_handlers.py
+++ b/tests/test_alert_handlers.py
@@ -48,6 +48,7 @@ class DummyJobQueue:
         *,
         data: dict[str, object] | None = None,
         name: str | None = None,
+        timezone: object | None = None,
     ) -> None:
         self.jobs.append(DummyJob(callback, when, data, name))
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -45,6 +45,7 @@ class DummyJobQueue:
         when: timedelta,
         data: Optional[dict[str, Any]] = None,
         name: Optional[str] = None,
+        timezone: object | None = None,
     ) -> None:
         self.jobs.append(DummyJob(callback, when, data, name))
 

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -175,6 +175,7 @@ async def test_add_reminder_commit_failure(
     update = make_update(message=message, effective_user=make_user(1))
     job_queue = MagicMock(spec=JobQueue)
     job_queue.get_jobs_by_name.return_value = []
+    job_queue.run_once = MagicMock()
     context = make_context(args=["sugar", "23:00"], job_queue=job_queue)
 
     with caplog.at_level(logging.ERROR):
@@ -216,7 +217,9 @@ async def test_reminder_webapp_save_commit_failure(
         json.dumps({"type": "sugar", "value": "23:00", "id": 1})
     )
     update = make_update(effective_message=message, effective_user=make_user(1))
-    context = make_context(job_queue=MagicMock(spec=JobQueue))
+    job_queue = MagicMock(spec=JobQueue)
+    job_queue.run_once = MagicMock()
+    context = make_context(job_queue=job_queue)
 
     with caplog.at_level(logging.ERROR):
         await reminder_handlers.reminder_webapp_save(update, context)
@@ -245,6 +248,7 @@ async def test_delete_reminder_commit_failure(
 
     job_queue = MagicMock(spec=JobQueue)
     job_queue.get_jobs_by_name = MagicMock()
+    job_queue.run_once = MagicMock()
     message = DummyMessage()
     update = make_update(message=message)
     context = make_context(args=["1"], job_queue=job_queue)
@@ -347,6 +351,7 @@ async def test_reminder_action_cb_commit_failure(
 
     job_queue = MagicMock(spec=JobQueue)
     job_queue.get_jobs_by_name = MagicMock()
+    job_queue.run_once = MagicMock()
     query = DummyQuery(DummyMessage(), "rem_toggle:1")
     update = make_update(callback_query=query, effective_user=make_user(1))
     context = make_context(job_queue=job_queue)

--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -69,6 +69,7 @@ class DummyJobQueue:
         when: Any,
         data: dict[str, Any] | None = None,
         name: str | None = None,
+        timezone: object | None = None,
     ) -> None:
         self.calls.append((callback, when, data, name))
 

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -133,6 +133,7 @@ class DummyJobQueue:
         when: Any,
         data: dict[str, Any] | None = None,
         name: str | None = None,
+        timezone: object | None = None,
     ) -> DummyJob:
         job = DummyJob(callback, data, name)
         self.jobs.append(job)
@@ -878,6 +879,7 @@ async def test_snooze_callback_custom_delay(
     query = DummyCallbackQuery("remind_snooze:1:15", DummyMessage())
     update = make_update(callback_query=query, effective_user=make_user(1))
     job_queue = MagicMock(spec=JobQueue)
+    job_queue.run_once = MagicMock()
     context = make_context(job_queue=job_queue, bot=DummyBot())
     await handlers.reminder_callback(update, context)
     job_queue.run_once.assert_called_once()

--- a/tests/test_reminders_after_meal.py
+++ b/tests/test_reminders_after_meal.py
@@ -37,6 +37,7 @@ class DummyJobQueue:
         when: timedelta,
         data: dict[str, Any] | None = None,
         name: str | None = None,
+        timezone: object | None = None,
     ) -> DummyJob:
         job = DummyJob(callback, when, data or {}, name or "")
         self.jobs.append(job)

--- a/tests/test_schedule_all_queries.py
+++ b/tests/test_schedule_all_queries.py
@@ -57,6 +57,7 @@ class DummyJobQueue:
         when: object,
         data: dict[str, object] | None = None,
         name: str | None = None,
+        timezone: object | None = None,
     ) -> DummyJob:
         job = DummyJob(name, data)
         self._jobs.append(job)


### PR DESCRIPTION
## Summary
- ensure reminder snoozes and after-meal checks run in Moscow timezone
- adjust tests for new run_once signature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b43d64b7d8832a80eeebc27c74391e