### PR TITLE
[bot] Remove hardcoded timezone from test job

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -135,8 +135,7 @@ def main() -> None:  # pragma: no cover
         application.job_queue.run_once(
             test_job,
             when=30,
-            timezone=ZoneInfo("Europe/Moscow"),
-        )  # type: ignore[call-arg]
+        )
 
     application.run_polling()
 


### PR DESCRIPTION
## Summary
- Remove explicit timezone from scheduled test job, relying on the application's JobQueue configuration

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b441d779a0832a9c9bd2e8c08d0699