### PR TITLE
[infra] Set MPLCONFIGDIR for matplotlib

### DIFF
--- a/run_dev.sh
+++ b/run_dev.sh
@@ -7,6 +7,9 @@ set -a
 source ./.env
 set +a
 
+# Конфигурация для Matplotlib
+export MPLCONFIGDIR="${MPLCONFIGDIR:-/var/cache/matplotlib}"
+
 # Запускаем API с авто-reload (1 процесс)
 uvicorn services.api.app.main:app \
         --reload --host 0.0.0.0 --port 8000 &


### PR DESCRIPTION
## Summary
- set `MPLCONFIGDIR` in `run_dev.sh` so Matplotlib uses a writable cache directory

## Testing
- `pytest -q --cov` *(fails: No module named 'openai')*
- `mypy --strict services/api/app/main.py` *(fails: No module named 'fastapi')*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b441de4c10832aaf02fceea50e7114