### PR TITLE
[utils] Add schedule_once helper

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import datetime
 import json
 import logging
-import inspect
 import re
 from datetime import time, timedelta, timezone
 from typing import Awaitable, Callable, Literal, cast
@@ -40,6 +39,7 @@ from services.api.app.diabetes.utils.helpers import (
     INVALID_TIME_MSG,
     parse_time_interval,
 )
+from services.api.app.diabetes.utils.jobs import schedule_once
 from services.api.app.diabetes.utils.ui import menu_keyboard
 from services.api.app.diabetes.schemas.reminders import ScheduleKind
 from .reminder_jobs import DefaultJobQueue, schedule_reminder
@@ -49,7 +49,9 @@ run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    logging.getLogger(__name__).info("run_db is unavailable; proceeding without async DB runner")
+    logging.getLogger(__name__).info(
+        "run_db is unavailable; proceeding without async DB runner"
+    )
     run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
@@ -126,13 +128,19 @@ def _schedule_with_next(rem: Reminder, user: User | None = None) -> tuple[str, s
     next_dt: datetime.datetime | None
     if rem.time:
         type_icon = "⏰"
-        next_dt = now.replace(hour=rem.time.hour, minute=rem.time.minute, second=0, microsecond=0)
+        next_dt = now.replace(
+            hour=rem.time.hour, minute=rem.time.minute, second=0, microsecond=0
+        )
         if next_dt <= now:
             next_dt += timedelta(days=1)
         base = rem.time.strftime("%H:%M")
     elif rem.interval_hours or rem.interval_minutes:
         type_icon = "⏱"
-        minutes = rem.interval_hours * 60 if rem.interval_hours is not None else rem.interval_minutes or 0
+        minutes = (
+            rem.interval_hours * 60
+            if rem.interval_hours is not None
+            else rem.interval_minutes or 0
+        )
         next_dt = now + timedelta(minutes=minutes)
         if rem.interval_hours:
             base = f"каждые {rem.interval_hours} ч"
@@ -158,7 +166,9 @@ def _schedule_with_next(rem: Reminder, user: User | None = None) -> tuple[str, s
     return type_icon, schedule
 
 
-def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboardMarkup | None]:
+def _render_reminders(
+    session: Session, user_id: int
+) -> tuple[str, InlineKeyboardMarkup | None]:
     settings = config.get_settings()
     rems = session.query(Reminder).filter_by(telegram_id=user_id).all()
     user = session.query(User).filter_by(telegram_id=user_id).first()
@@ -187,7 +197,10 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
     )
     add_button_row = [add_button]
     if not rems:
-        text = header + "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
+        text = (
+            header
+            + "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
+        )
         return text, InlineKeyboardMarkup([add_button_row])
 
     by_time: list[tuple[str, list[InlineKeyboardButton]]] = []
@@ -225,7 +238,9 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
     lines: list[str] = []
     buttons: list[list[InlineKeyboardButton]] = []
 
-    def extend(section: str, items: list[tuple[str, list[InlineKeyboardButton]]]) -> None:
+    def extend(
+        section: str, items: list[tuple[str, list[InlineKeyboardButton]]]
+    ) -> None:
         if not items:
             return
         if lines:
@@ -249,11 +264,7 @@ def schedule_all(job_queue: DefaultJobQueue | None) -> None:
         logger.warning("schedule_all called without job_queue")
         return
     with SessionLocal() as session:
-        reminders = (
-            session.query(Reminder)
-            .options(selectinload(Reminder.user))
-            .all()
-        )
+        reminders = session.query(Reminder).options(selectinload(Reminder.user)).all()
         count = len(reminders)
         logger.debug("Found %d reminders to schedule", count)
         for rem in reminders:
@@ -370,7 +381,11 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             return
 
     def db_add(session: Session) -> tuple[str, User | None, int, int]:
-        count = session.query(Reminder).filter_by(telegram_id=user_id, is_enabled=True).count()
+        count = (
+            session.query(Reminder)
+            .filter_by(telegram_id=user_id, is_enabled=True)
+            .count()
+        )
         db_user = session.get(User, user_id)
         limit = _limit_for(db_user)
         if count >= limit:
@@ -387,12 +402,16 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         with SessionLocal() as session:
             status, db_user, limit, rid_or_count = db_add(session)
     else:
-        status, db_user, limit, rid_or_count = await run_db(db_add, sessionmaker=SessionLocal)
+        status, db_user, limit, rid_or_count = await run_db(
+            db_add, sessionmaker=SessionLocal
+        )
 
     if status == "limit":
         count = rid_or_count
         await message.reply_text(
-            (f"У вас уже {count} активных из {limit}. Отключите одно или Апгрейд до Pro, чтобы поднять лимит до 10"),
+            (
+                f"У вас уже {count} активных из {limit}. Отключите одно или Апгрейд до Pro, чтобы поднять лимит до 10"
+            ),
         )
         return
     if status == "error":
@@ -403,7 +422,9 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await message.reply_text(f"Сохранено: {_describe(reminder, db_user)}")
 
 
-async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def reminder_webapp_save(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     """Save reminder data sent from the web app."""
     msg: Message | None = update.effective_message
     user = update.effective_user
@@ -431,7 +452,9 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
         user_id = user.id
 
         def log_snooze(session: Session) -> Literal["ok"] | Literal["error"]:
-            session.add(ReminderLog(reminder_id=int(rid), telegram_id=user_id, action="snooze"))
+            session.add(
+                ReminderLog(reminder_id=int(rid), telegram_id=user_id, action="snooze")
+            )
             try:
                 commit(session)
             except CommitError:
@@ -448,23 +471,17 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
                 await run_db(log_snooze, sessionmaker=SessionLocal),
             )
         if status == "ok":
-            job_queue: DefaultJobQueue | None = cast(DefaultJobQueue | None, context.job_queue)
+            job_queue: DefaultJobQueue | None = cast(
+                DefaultJobQueue | None, context.job_queue
+            )
             if job_queue is not None:
-                if "timezone" in inspect.signature(job_queue.run_once).parameters:
-                    job_queue.run_once(  # type: ignore[call-arg]
-                        reminder_job,
-                        when=timedelta(minutes=minutes),
-                        data={"reminder_id": int(rid), "chat_id": user_id},
-                        name=f"reminder_{rid}",
-                        timezone=ZoneInfo("Europe/Moscow"),
-                    )
-                else:
-                    job_queue.run_once(
-                        reminder_job,
-                        when=timedelta(minutes=minutes),
-                        data={"reminder_id": int(rid), "chat_id": user_id},
-                        name=f"reminder_{rid}",
-                    )
+                schedule_once(
+                    job_queue,
+                    reminder_job,
+                    when=timedelta(minutes=minutes),
+                    data={"reminder_id": int(rid), "chat_id": user_id},
+                    name=f"reminder_{rid}",
+                )
             await msg.reply_text(f"⏰ Отложено на {minutes} минут")
         return
 
@@ -605,7 +622,11 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
             if not rem or rem.telegram_id != user_id:
                 return "not_found", None, None, None
         else:
-            count = session.query(Reminder).filter_by(telegram_id=user_id, is_enabled=True).count()
+            count = (
+                session.query(Reminder)
+                .filter_by(telegram_id=user_id, is_enabled=True)
+                .count()
+            )
             user = session.get(User, user_id)
             plan = getattr(user, "plan", "free").lower()
             limit = PLAN_LIMITS.get(plan, PLAN_LIMITS["free"])
@@ -626,7 +647,9 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
             rem.time = None
             rem.interval_minutes = interval_minutes
             rem.interval_hours = (
-                interval_minutes // 60 if interval_minutes is not None and interval_minutes % 60 == 0 else None
+                interval_minutes // 60
+                if interval_minutes is not None and interval_minutes % 60 == 0
+                else None
             )
         else:  # at_time
             rem.minutes_after = None
@@ -653,7 +676,9 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
         if plan is None:
             return
         await msg.reply_text(
-            (f"У вас уже {limit} активных (лимит {plan.upper()}). Отключите одно или откройте PRO."),
+            (
+                f"У вас уже {limit} активных (лимит {plan.upper()}). Отключите одно или откройте PRO."
+            ),
         )
         return
     if status == "error":
@@ -678,7 +703,9 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
 
 
 async def delete_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    message: Message | None = update.message or (update.callback_query.message if update.callback_query else None)
+    message: Message | None = update.message or (
+        update.callback_query.message if update.callback_query else None
+    )
     args = getattr(context, "args", [])
     if not args:
         if message:
@@ -736,14 +763,18 @@ async def reminder_job(context: ContextTypes.DEFAULT_TYPE) -> None:
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton("Отложить 10 мин", callback_data=f"remind_snooze:{rid}:10"),
+                InlineKeyboardButton(
+                    "Отложить 10 мин", callback_data=f"remind_snooze:{rid}:10"
+                ),
                 InlineKeyboardButton("Отмена", callback_data=f"remind_cancel:{rid}"),
             ]
         ]
     )
     logger.info("Sending reminder %s to chat %s", rid, chat_id)
     try:
-        await context.bot.send_message(chat_id=chat_id, text=text, reply_markup=keyboard)
+        await context.bot.send_message(
+            chat_id=chat_id, text=text, reply_markup=keyboard
+        )
     except TelegramError:
         logger.exception("Failed to send reminder %s to chat %s", rid, chat_id)
 
@@ -792,28 +823,24 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         try:
             commit(session)
         except CommitError:
-            logger.error("Failed to log reminder action %s for reminder %s", log_action, rid)
+            logger.error(
+                "Failed to log reminder action %s for reminder %s", log_action, rid
+            )
             return
 
     if action == "remind_snooze":
         mins = minutes or 10
-        job_queue: DefaultJobQueue | None = cast(DefaultJobQueue | None, context.job_queue)
+        job_queue: DefaultJobQueue | None = cast(
+            DefaultJobQueue | None, context.job_queue
+        )
         if job_queue is not None:
-            if "timezone" in inspect.signature(job_queue.run_once).parameters:
-                job_queue.run_once(  # type: ignore[call-arg]
-                    reminder_job,
-                    when=timedelta(minutes=mins),
-                    data={"reminder_id": rid, "chat_id": chat_id},
-                    name=f"reminder_{rid}",
-                    timezone=ZoneInfo("Europe/Moscow"),
-                )
-            else:
-                job_queue.run_once(
-                    reminder_job,
-                    when=timedelta(minutes=mins),
-                    data={"reminder_id": rid, "chat_id": chat_id},
-                    name=f"reminder_{rid}",
-                )
+            schedule_once(
+                job_queue,
+                reminder_job,
+                when=timedelta(minutes=mins),
+                data={"reminder_id": rid, "chat_id": chat_id},
+                name=f"reminder_{rid}",
+            )
         try:
             await query.edit_message_text(f"⏰ Отложено на {mins} минут")
 
@@ -832,7 +859,9 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
                 raise
 
 
-async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def reminder_action_cb(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     query = update.callback_query
     user = update.effective_user
     if query is None or query.data is None or user is None:
@@ -870,7 +899,9 @@ async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE)
         try:
             commit(session)
         except CommitError:
-            logger.error("Failed to commit reminder action %s for reminder %s", action, rid)
+            logger.error(
+                "Failed to commit reminder action %s for reminder %s", action, rid
+            )
             return "error", None
         if action == "toggle":
             session.refresh(rem)
@@ -928,7 +959,9 @@ async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE)
         )
     try:
         if keyboard is not None:
-            await query.edit_message_text(text, parse_mode="HTML", reply_markup=keyboard)
+            await query.edit_message_text(
+                text, parse_mode="HTML", reply_markup=keyboard
+            )
         else:
             await query.edit_message_text(text, parse_mode="HTML")
     except BadRequest as exc:
@@ -945,32 +978,32 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
         logger.warning("schedule_after_meal called without job_queue")
         return
     with SessionLocal() as session:
-        rems = session.query(Reminder).filter_by(telegram_id=user_id, type="after_meal", is_enabled=True).all()
+        rems = (
+            session.query(Reminder)
+            .filter_by(telegram_id=user_id, type="after_meal", is_enabled=True)
+            .all()
+        )
     for rem in rems:
         minutes_after = rem.minutes_after
         if minutes_after is None:
             continue
         for job in job_queue.get_jobs_by_name(f"reminder_{rem.id}"):
             job.schedule_removal()
-        if "timezone" in inspect.signature(job_queue.run_once).parameters:
-            job_queue.run_once(  # type: ignore[call-arg]
-                reminder_job,
-                when=timedelta(minutes=float(minutes_after)),
-                data={"reminder_id": rem.id, "chat_id": user_id},
-                name=f"reminder_{rem.id}",
-                timezone=ZoneInfo("Europe/Moscow"),
-            )
-        else:
-            job_queue.run_once(
-                reminder_job,
-                when=timedelta(minutes=float(minutes_after)),
-                data={"reminder_id": rem.id, "chat_id": user_id},
-                name=f"reminder_{rem.id}",
-            )
+        schedule_once(
+            job_queue,
+            reminder_job,
+            when=timedelta(minutes=float(minutes_after)),
+            data={"reminder_id": rem.id, "chat_id": user_id},
+            name=f"reminder_{rem.id}",
+        )
 
 
-reminder_action_handler = CallbackQueryHandler(reminder_action_cb, pattern="^rem_(del|toggle):")
-reminder_webapp_handler = MessageHandler(filters.StatusUpdate.WEB_APP_DATA, reminder_webapp_save)
+reminder_action_handler = CallbackQueryHandler(
+    reminder_action_cb, pattern="^rem_(del|toggle):"
+)
+reminder_webapp_handler = MessageHandler(
+    filters.StatusUpdate.WEB_APP_DATA, reminder_webapp_save
+)
 
 
 __all__ = [

--- a/services/api/app/diabetes/utils/jobs.py
+++ b/services/api/app/diabetes/utils/jobs.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta
+from typing import Any
+
+from telegram.ext import ContextTypes, Job, JobQueue
+from typing import TypeAlias
+
+CustomContext: TypeAlias = ContextTypes.DEFAULT_TYPE
+DefaultJobQueue: TypeAlias = JobQueue[ContextTypes.DEFAULT_TYPE]
+
+JobCallback = Callable[[CustomContext], Awaitable[object] | object]
+
+
+def schedule_once(
+    job_queue: DefaultJobQueue,
+    callback: JobCallback,
+    *,
+    when: datetime | timedelta | float,
+    data: dict[str, object] | None = None,
+    name: str | None = None,
+) -> Job[CustomContext]:
+    """Schedule ``callback`` to run once at ``when``.
+
+    If ``job_queue.run_once`` supports a ``timezone`` argument, the job queue's
+    timezone is forwarded automatically.
+    """
+    params: dict[str, Any] = {"when": when, "data": data, "name": name}
+    if "timezone" in inspect.signature(job_queue.run_once).parameters:
+        tz = getattr(job_queue, "timezone", None) or getattr(
+            getattr(job_queue, "scheduler", None), "timezone", None
+        )
+        params["timezone"] = tz
+        return job_queue.run_once(callback, **params)
+    return job_queue.run_once(callback, **params)

--- a/tests/test_schedule_once.py
+++ b/tests/test_schedule_once.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import Callable
+
+from services.api.app.diabetes.utils.jobs import schedule_once
+
+
+def dummy_cb(context: object) -> None:  # pragma: no cover - simple callback
+    return None
+
+
+class Job:
+    def __init__(self, tz: object | None) -> None:
+        self.tz = tz
+
+
+class QueueWithTimezone:
+    timezone = "TZ"
+
+    def run_once(
+        self,
+        callback: Callable[..., object],
+        *,
+        when: timedelta,
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+        timezone: object | None = None,
+    ) -> Job:
+        self.args = SimpleNamespace(
+            callback=callback, when=when, data=data, name=name, timezone=timezone
+        )
+        return Job(timezone)
+
+
+class QueueNoTimezone:
+    def run_once(
+        self,
+        callback: Callable[..., object],
+        *,
+        when: timedelta,
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+    ) -> Job:
+        self.args = SimpleNamespace(callback=callback, when=when, data=data, name=name)
+        return Job(None)
+
+
+class QueueSchedulerTimezone:
+    scheduler = SimpleNamespace(timezone="SCH")
+
+    def run_once(
+        self,
+        callback: Callable[..., object],
+        *,
+        when: timedelta,
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+        timezone: object | None = None,
+    ) -> Job:
+        self.args = SimpleNamespace(
+            callback=callback, when=when, data=data, name=name, timezone=timezone
+        )
+        return Job(timezone)
+
+
+def test_schedule_once_uses_queue_timezone() -> None:
+    jq = QueueWithTimezone()
+    schedule_once(jq, dummy_cb, when=timedelta(seconds=1), data={"a": 1}, name="j1")
+    assert jq.args.timezone == jq.timezone
+
+
+def test_schedule_once_without_timezone_param() -> None:
+    jq = QueueNoTimezone()
+    schedule_once(jq, dummy_cb, when=timedelta(seconds=1))
+    assert jq.args.name is None
+
+
+def test_schedule_once_scheduler_timezone() -> None:
+    jq = QueueSchedulerTimezone()
+    schedule_once(jq, dummy_cb, when=timedelta(seconds=1))
+    assert jq.args.timezone == jq.scheduler.timezone


### PR DESCRIPTION
## Summary
- factor out timezone-aware schedule_once helper
- use schedule_once in alert, reminder handlers and jobs
- add unit tests for schedule_once

## Testing
- `ruff check services/api/app/diabetes/utils/jobs.py services/api/app/diabetes/handlers/reminder_jobs.py services/api/app/diabetes/handlers/alert_handlers.py services/api/app/diabetes/handlers/reminder_handlers.py tests/test_schedule_once.py`
- `mypy --strict --follow-imports=skip services/api/app/diabetes/utils/jobs.py tests/test_schedule_once.py`
- `pytest -q tests/test_schedule_once.py --noconftest -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68b44c75c2fc832a8d8bc64031e4cd23