### PR TITLE
[reminders] derive job queue timezone

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -49,7 +49,9 @@ run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    logging.getLogger(__name__).info("run_db is unavailable; proceeding without async DB runner")
+    logging.getLogger(__name__).info(
+        "run_db is unavailable; proceeding without async DB runner"
+    )
     run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
@@ -126,13 +128,19 @@ def _schedule_with_next(rem: Reminder, user: User | None = None) -> tuple[str, s
     next_dt: datetime.datetime | None
     if rem.time:
         type_icon = "⏰"
-        next_dt = now.replace(hour=rem.time.hour, minute=rem.time.minute, second=0, microsecond=0)
+        next_dt = now.replace(
+            hour=rem.time.hour, minute=rem.time.minute, second=0, microsecond=0
+        )
         if next_dt <= now:
             next_dt += timedelta(days=1)
         base = rem.time.strftime("%H:%M")
     elif rem.interval_hours or rem.interval_minutes:
         type_icon = "⏱"
-        minutes = rem.interval_hours * 60 if rem.interval_hours is not None else rem.interval_minutes or 0
+        minutes = (
+            rem.interval_hours * 60
+            if rem.interval_hours is not None
+            else rem.interval_minutes or 0
+        )
         next_dt = now + timedelta(minutes=minutes)
         if rem.interval_hours:
             base = f"каждые {rem.interval_hours} ч"
@@ -158,7 +166,9 @@ def _schedule_with_next(rem: Reminder, user: User | None = None) -> tuple[str, s
     return type_icon, schedule
 
 
-def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboardMarkup | None]:
+def _render_reminders(
+    session: Session, user_id: int
+) -> tuple[str, InlineKeyboardMarkup | None]:
     settings = config.get_settings()
     rems = session.query(Reminder).filter_by(telegram_id=user_id).all()
     user = session.query(User).filter_by(telegram_id=user_id).first()
@@ -187,7 +197,10 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
     )
     add_button_row = [add_button]
     if not rems:
-        text = header + "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
+        text = (
+            header
+            + "\nУ вас нет напоминаний. Нажмите кнопку ниже или отправьте /addreminder."
+        )
         return text, InlineKeyboardMarkup([add_button_row])
 
     by_time: list[tuple[str, list[InlineKeyboardButton]]] = []
@@ -225,7 +238,9 @@ def _render_reminders(session: Session, user_id: int) -> tuple[str, InlineKeyboa
     lines: list[str] = []
     buttons: list[list[InlineKeyboardButton]] = []
 
-    def extend(section: str, items: list[tuple[str, list[InlineKeyboardButton]]]) -> None:
+    def extend(
+        section: str, items: list[tuple[str, list[InlineKeyboardButton]]]
+    ) -> None:
         if not items:
             return
         if lines:
@@ -249,11 +264,7 @@ def schedule_all(job_queue: DefaultJobQueue | None) -> None:
         logger.warning("schedule_all called without job_queue")
         return
     with SessionLocal() as session:
-        reminders = (
-            session.query(Reminder)
-            .options(selectinload(Reminder.user))
-            .all()
-        )
+        reminders = session.query(Reminder).options(selectinload(Reminder.user)).all()
         count = len(reminders)
         logger.debug("Found %d reminders to schedule", count)
         for rem in reminders:
@@ -370,7 +381,11 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             return
 
     def db_add(session: Session) -> tuple[str, User | None, int, int]:
-        count = session.query(Reminder).filter_by(telegram_id=user_id, is_enabled=True).count()
+        count = (
+            session.query(Reminder)
+            .filter_by(telegram_id=user_id, is_enabled=True)
+            .count()
+        )
         db_user = session.get(User, user_id)
         limit = _limit_for(db_user)
         if count >= limit:
@@ -387,12 +402,16 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         with SessionLocal() as session:
             status, db_user, limit, rid_or_count = db_add(session)
     else:
-        status, db_user, limit, rid_or_count = await run_db(db_add, sessionmaker=SessionLocal)
+        status, db_user, limit, rid_or_count = await run_db(
+            db_add, sessionmaker=SessionLocal
+        )
 
     if status == "limit":
         count = rid_or_count
         await message.reply_text(
-            (f"У вас уже {count} активных из {limit}. Отключите одно или Апгрейд до Pro, чтобы поднять лимит до 10"),
+            (
+                f"У вас уже {count} активных из {limit}. Отключите одно или Апгрейд до Pro, чтобы поднять лимит до 10"
+            ),
         )
         return
     if status == "error":
@@ -403,7 +422,9 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await message.reply_text(f"Сохранено: {_describe(reminder, db_user)}")
 
 
-async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def reminder_webapp_save(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     """Save reminder data sent from the web app."""
     msg: Message | None = update.effective_message
     user = update.effective_user
@@ -431,7 +452,9 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
         user_id = user.id
 
         def log_snooze(session: Session) -> Literal["ok"] | Literal["error"]:
-            session.add(ReminderLog(reminder_id=int(rid), telegram_id=user_id, action="snooze"))
+            session.add(
+                ReminderLog(reminder_id=int(rid), telegram_id=user_id, action="snooze")
+            )
             try:
                 commit(session)
             except CommitError:
@@ -448,15 +471,20 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
                 await run_db(log_snooze, sessionmaker=SessionLocal),
             )
         if status == "ok":
-            job_queue: DefaultJobQueue | None = cast(DefaultJobQueue | None, context.job_queue)
+            job_queue: DefaultJobQueue | None = cast(
+                DefaultJobQueue | None, context.job_queue
+            )
             if job_queue is not None:
+                job_tz = getattr(
+                    getattr(job_queue, "application", None), "timezone", None
+                ) or getattr(getattr(job_queue, "scheduler", None), "timezone", None)
                 if "timezone" in inspect.signature(job_queue.run_once).parameters:
                     job_queue.run_once(  # type: ignore[call-arg]
                         reminder_job,
                         when=timedelta(minutes=minutes),
                         data={"reminder_id": int(rid), "chat_id": user_id},
                         name=f"reminder_{rid}",
-                        timezone=ZoneInfo("Europe/Moscow"),
+                        timezone=job_tz,
                     )
                 else:
                     job_queue.run_once(
@@ -605,7 +633,11 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
             if not rem or rem.telegram_id != user_id:
                 return "not_found", None, None, None
         else:
-            count = session.query(Reminder).filter_by(telegram_id=user_id, is_enabled=True).count()
+            count = (
+                session.query(Reminder)
+                .filter_by(telegram_id=user_id, is_enabled=True)
+                .count()
+            )
             user = session.get(User, user_id)
             plan = getattr(user, "plan", "free").lower()
             limit = PLAN_LIMITS.get(plan, PLAN_LIMITS["free"])
@@ -626,7 +658,9 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
             rem.time = None
             rem.interval_minutes = interval_minutes
             rem.interval_hours = (
-                interval_minutes // 60 if interval_minutes is not None and interval_minutes % 60 == 0 else None
+                interval_minutes // 60
+                if interval_minutes is not None and interval_minutes % 60 == 0
+                else None
             )
         else:  # at_time
             rem.minutes_after = None
@@ -653,7 +687,9 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
         if plan is None:
             return
         await msg.reply_text(
-            (f"У вас уже {limit} активных (лимит {plan.upper()}). Отключите одно или откройте PRO."),
+            (
+                f"У вас уже {limit} активных (лимит {plan.upper()}). Отключите одно или откройте PRO."
+            ),
         )
         return
     if status == "error":
@@ -678,7 +714,9 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
 
 
 async def delete_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    message: Message | None = update.message or (update.callback_query.message if update.callback_query else None)
+    message: Message | None = update.message or (
+        update.callback_query.message if update.callback_query else None
+    )
     args = getattr(context, "args", [])
     if not args:
         if message:
@@ -736,14 +774,18 @@ async def reminder_job(context: ContextTypes.DEFAULT_TYPE) -> None:
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton("Отложить 10 мин", callback_data=f"remind_snooze:{rid}:10"),
+                InlineKeyboardButton(
+                    "Отложить 10 мин", callback_data=f"remind_snooze:{rid}:10"
+                ),
                 InlineKeyboardButton("Отмена", callback_data=f"remind_cancel:{rid}"),
             ]
         ]
     )
     logger.info("Sending reminder %s to chat %s", rid, chat_id)
     try:
-        await context.bot.send_message(chat_id=chat_id, text=text, reply_markup=keyboard)
+        await context.bot.send_message(
+            chat_id=chat_id, text=text, reply_markup=keyboard
+        )
     except TelegramError:
         logger.exception("Failed to send reminder %s to chat %s", rid, chat_id)
 
@@ -792,20 +834,27 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         try:
             commit(session)
         except CommitError:
-            logger.error("Failed to log reminder action %s for reminder %s", log_action, rid)
+            logger.error(
+                "Failed to log reminder action %s for reminder %s", log_action, rid
+            )
             return
 
     if action == "remind_snooze":
         mins = minutes or 10
-        job_queue: DefaultJobQueue | None = cast(DefaultJobQueue | None, context.job_queue)
+        job_queue: DefaultJobQueue | None = cast(
+            DefaultJobQueue | None, context.job_queue
+        )
         if job_queue is not None:
+            job_tz = getattr(
+                getattr(job_queue, "application", None), "timezone", None
+            ) or getattr(getattr(job_queue, "scheduler", None), "timezone", None)
             if "timezone" in inspect.signature(job_queue.run_once).parameters:
                 job_queue.run_once(  # type: ignore[call-arg]
                     reminder_job,
                     when=timedelta(minutes=mins),
                     data={"reminder_id": rid, "chat_id": chat_id},
                     name=f"reminder_{rid}",
-                    timezone=ZoneInfo("Europe/Moscow"),
+                    timezone=job_tz,
                 )
             else:
                 job_queue.run_once(
@@ -832,7 +881,9 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
                 raise
 
 
-async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def reminder_action_cb(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     query = update.callback_query
     user = update.effective_user
     if query is None or query.data is None or user is None:
@@ -870,7 +921,9 @@ async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE)
         try:
             commit(session)
         except CommitError:
-            logger.error("Failed to commit reminder action %s for reminder %s", action, rid)
+            logger.error(
+                "Failed to commit reminder action %s for reminder %s", action, rid
+            )
             return "error", None
         if action == "toggle":
             session.refresh(rem)
@@ -928,7 +981,9 @@ async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE)
         )
     try:
         if keyboard is not None:
-            await query.edit_message_text(text, parse_mode="HTML", reply_markup=keyboard)
+            await query.edit_message_text(
+                text, parse_mode="HTML", reply_markup=keyboard
+            )
         else:
             await query.edit_message_text(text, parse_mode="HTML")
     except BadRequest as exc:
@@ -945,20 +1000,27 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
         logger.warning("schedule_after_meal called without job_queue")
         return
     with SessionLocal() as session:
-        rems = session.query(Reminder).filter_by(telegram_id=user_id, type="after_meal", is_enabled=True).all()
+        rems = (
+            session.query(Reminder)
+            .filter_by(telegram_id=user_id, type="after_meal", is_enabled=True)
+            .all()
+        )
     for rem in rems:
         minutes_after = rem.minutes_after
         if minutes_after is None:
             continue
         for job in job_queue.get_jobs_by_name(f"reminder_{rem.id}"):
             job.schedule_removal()
+        job_tz = getattr(
+            getattr(job_queue, "application", None), "timezone", None
+        ) or getattr(getattr(job_queue, "scheduler", None), "timezone", None)
         if "timezone" in inspect.signature(job_queue.run_once).parameters:
             job_queue.run_once(  # type: ignore[call-arg]
                 reminder_job,
                 when=timedelta(minutes=float(minutes_after)),
                 data={"reminder_id": rem.id, "chat_id": user_id},
                 name=f"reminder_{rem.id}",
-                timezone=ZoneInfo("Europe/Moscow"),
+                timezone=job_tz,
             )
         else:
             job_queue.run_once(
@@ -969,8 +1031,12 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
             )
 
 
-reminder_action_handler = CallbackQueryHandler(reminder_action_cb, pattern="^rem_(del|toggle):")
-reminder_webapp_handler = MessageHandler(filters.StatusUpdate.WEB_APP_DATA, reminder_webapp_save)
+reminder_action_handler = CallbackQueryHandler(
+    reminder_action_cb, pattern="^rem_(del|toggle):"
+)
+reminder_webapp_handler = MessageHandler(
+    filters.StatusUpdate.WEB_APP_DATA, reminder_webapp_save
+)
 
 
 __all__ = [

--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -87,7 +87,7 @@ def schedule_reminder(
                     when=when_td,
                     data=data,
                     name=name,
-                    timezone=ZoneInfo("Europe/Moscow"),
+                    timezone=job_tz,
                 )
             else:
                 job_queue.run_once(
@@ -119,7 +119,7 @@ def schedule_reminder(
                     time=job_time,
                     data=data,
                     name=name,
-                    timezone=ZoneInfo("Europe/Moscow"),
+                    timezone=job_tz,
                 )
             else:
                 job_queue.run_daily(

--- a/tests/test_reminders_timezone_compat.py
+++ b/tests/test_reminders_timezone_compat.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from datetime import time, timedelta
+from types import SimpleNamespace
+from typing import Any, cast
+from zoneinfo import ZoneInfo
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+from services.api.app.diabetes.services.db import (
+    Base,
+    Reminder,
+    User as DbUser,
+)
+import services.api.app.diabetes.handlers.reminder_handlers as handlers
+from services.api.app.diabetes.handlers.reminder_jobs import (
+    DefaultJobQueue,
+    schedule_reminder,
+)
+from services.api.app.diabetes.services.repository import commit
+from tests.test_reminders import (
+    DummyBot,
+    DummyCallbackQuery,
+    DummyMessage,
+    make_context,
+    make_update,
+    make_user,
+)
+
+
+class DummyJob:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.removed = False
+
+    def schedule_removal(self) -> None:
+        self.removed = True
+
+
+class BaseQueue:
+    def __init__(self, tz: ZoneInfo) -> None:
+        self.application = SimpleNamespace(timezone=tz)
+        self.scheduler = SimpleNamespace(timezone=tz)
+        self.jobs: list[DummyJob] = []
+        self.last_timezone: ZoneInfo | None = None
+        self.last_time: time | None = None
+
+    def get_jobs_by_name(self, name: str) -> list[DummyJob]:
+        return [j for j in self.jobs if j.name == name]
+
+
+class QueueV20(BaseQueue):
+    def run_daily(
+        self,
+        callback: Any,
+        time: time,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        timezone: ZoneInfo | None = None,
+    ) -> DummyJob:
+        self.last_timezone = timezone
+        self.last_time = time
+        job = DummyJob(name or "")
+        self.jobs.append(job)
+        return job
+
+    def run_once(
+        self,
+        callback: Any,
+        when: timedelta,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        timezone: ZoneInfo | None = None,
+    ) -> DummyJob:
+        self.last_timezone = timezone
+        job = DummyJob(name or "")
+        self.jobs.append(job)
+        return job
+
+
+class QueueV21(BaseQueue):
+    def run_daily(
+        self,
+        callback: Any,
+        time: time,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+    ) -> DummyJob:
+        self.last_timezone = None
+        self.last_time = time
+        job = DummyJob(name or "")
+        self.jobs.append(job)
+        return job
+
+    def run_once(
+        self,
+        callback: Any,
+        when: timedelta,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+    ) -> DummyJob:
+        self.last_timezone = None
+        job = DummyJob(name or "")
+        self.jobs.append(job)
+        return job
+
+
+@pytest.mark.parametrize(
+    "queue_cls, expects_tz",
+    [(QueueV20, True), (QueueV21, False)],
+)
+def test_schedule_reminder_respects_queue_timezone(
+    queue_cls: type[BaseQueue], expects_tz: bool
+) -> None:
+    user = DbUser(telegram_id=1, thread_id="t", timezone="Europe/Paris")
+    rem = Reminder(
+        id=1,
+        telegram_id=1,
+        type="sugar",
+        time=time(9, 0),
+        is_enabled=True,
+        user=user,
+    )
+    tz = ZoneInfo("UTC")
+    job_queue = cast(DefaultJobQueue, queue_cls(tz))
+    schedule_reminder(rem, job_queue, user)
+    assert job_queue.last_time == time(8, 0)
+    if expects_tz:
+        assert job_queue.last_timezone == tz
+    else:
+        assert job_queue.last_timezone is None
+
+
+@pytest.mark.parametrize(
+    "queue_cls, expects_tz",
+    [(QueueV20, True), (QueueV21, False)],
+)
+def test_schedule_after_meal_uses_queue_timezone(
+    queue_cls: type[BaseQueue], expects_tz: bool
+) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    handlers.SessionLocal = TestSession
+    with TestSession() as session:
+        session.add(DbUser(telegram_id=1, thread_id="t"))
+        session.add(
+            Reminder(
+                id=1,
+                telegram_id=1,
+                type="after_meal",
+                minutes_after=30,
+                is_enabled=True,
+            )
+        )
+        session.commit()
+    tz = ZoneInfo("UTC")
+    job_queue = cast(DefaultJobQueue, queue_cls(tz))
+    handlers.schedule_after_meal(1, job_queue)
+    assert job_queue.jobs
+    if expects_tz:
+        assert job_queue.last_timezone == tz
+    else:
+        assert job_queue.last_timezone is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "queue_cls, expects_tz",
+    [(QueueV20, True), (QueueV21, False)],
+)
+async def test_snooze_callback_uses_queue_timezone(
+    queue_cls: type[BaseQueue], expects_tz: bool
+) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    handlers.SessionLocal = TestSession
+    handlers.commit = commit
+    with TestSession() as session:
+        session.add(DbUser(telegram_id=1, thread_id="t"))
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0)))
+        session.commit()
+    query = DummyCallbackQuery("remind_snooze:1:15", DummyMessage())
+    update = make_update(callback_query=query, effective_user=make_user(1))
+    job_queue = cast(DefaultJobQueue, queue_cls(ZoneInfo("UTC")))
+    context = make_context(job_queue=job_queue, bot=DummyBot())
+    await handlers.reminder_callback(update, context)
+    assert job_queue.jobs
+    if expects_tz:
+        assert job_queue.last_timezone == ZoneInfo("UTC")
+    else:
+        assert job_queue.last_timezone is None


### PR DESCRIPTION
## Summary
- derive JobQueue timezone from application or scheduler when scheduling reminders
- propagate job queue timezone to snooze and after-meal reminder fallbacks
- test reminder scheduling in non-Moscow timezones for PTB v20 and v21 APIs

## Testing
- `ruff check services/api/app/diabetes/handlers/reminder_jobs.py services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders_timezone_compat.py`
- `mypy --strict services/api/app/diabetes/handlers/reminder_jobs.py services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders_timezone_compat.py` *(fails: services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py:13: error: Class cannot subclass value of type "Any"  [misc])* 
- `pytest -q tests/test_reminders_timezone_compat.py` *(fails: ModuleNotFoundError: No module named 'telegram.ext._basehandler')*

------
https://chatgpt.com/codex/tasks/task_e_68b44c720064832ab178ceaa639baf57