### PR TITLE
[deps] Add placeholder py-sdk requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,8 @@ venv*/
 services/api/app/*.bak.*
 .env
 # Generated SDKs
-libs/py-sdk/
+libs/py-sdk/*
+!libs/py-sdk/requirements.txt
 
 # Webapp build output
 services/webapp/ui/dist/

--- a/libs/py-sdk/requirements.txt
+++ b/libs/py-sdk/requirements.txt
@@ -1,0 +1,2 @@
+# Placeholder requirements for optional Python SDK.
+# Actual dependencies will be generated alongside the SDK.


### PR DESCRIPTION
## Summary
- prevent CI failures by adding placeholder `libs/py-sdk/requirements.txt`
- allow tracking placeholder file via `.gitignore` exception

## Testing
- `pip install -r requirements.txt`
- `pip install -r services/api/app/requirements-dev.txt`
- `ruff check .`
- `mypy --strict .` *(fails: Type application has too few types)*
- `pytest --cov=services.api.app.diabetes --cov-report=term-missing --cov-report=xml --cov-fail-under=85` *(fails: 59 errors, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b44f655e38832ab5a5ccc6f222e1cf