### PR TITLE
[reminders] use job queue timezone

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -475,12 +475,24 @@ async def reminder_webapp_save(
                 DefaultJobQueue | None, context.job_queue
             )
             if job_queue is not None:
+                job_tz = (
+                    getattr(getattr(job_queue, "application", None), "timezone", None)
+                    or getattr(
+                        getattr(
+                            getattr(job_queue, "application", None), "scheduler", None
+                        ),
+                        "timezone",
+                        None,
+                    )
+                    or getattr(getattr(job_queue, "scheduler", None), "timezone", None)
+                )
                 schedule_once(
                     job_queue,
                     reminder_job,
                     when=timedelta(minutes=minutes),
                     data={"reminder_id": int(rid), "chat_id": user_id},
                     name=f"reminder_{rid}",
+                    timezone=job_tz,
                 )
             await msg.reply_text(f"⏰ Отложено на {minutes} минут")
         return
@@ -834,12 +846,22 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             DefaultJobQueue | None, context.job_queue
         )
         if job_queue is not None:
+            job_tz = (
+                getattr(getattr(job_queue, "application", None), "timezone", None)
+                or getattr(
+                    getattr(getattr(job_queue, "application", None), "scheduler", None),
+                    "timezone",
+                    None,
+                )
+                or getattr(getattr(job_queue, "scheduler", None), "timezone", None)
+            )
             schedule_once(
                 job_queue,
                 reminder_job,
                 when=timedelta(minutes=mins),
                 data={"reminder_id": rid, "chat_id": chat_id},
                 name=f"reminder_{rid}",
+                timezone=job_tz,
             )
         try:
             await query.edit_message_text(f"⏰ Отложено на {mins} минут")
@@ -989,12 +1011,22 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
             continue
         for job in job_queue.get_jobs_by_name(f"reminder_{rem.id}"):
             job.schedule_removal()
+        job_tz = (
+            getattr(getattr(job_queue, "application", None), "timezone", None)
+            or getattr(
+                getattr(getattr(job_queue, "application", None), "scheduler", None),
+                "timezone",
+                None,
+            )
+            or getattr(getattr(job_queue, "scheduler", None), "timezone", None)
+        )
         schedule_once(
             job_queue,
             reminder_job,
             when=timedelta(minutes=float(minutes_after)),
             data={"reminder_id": rem.id, "chat_id": user_id},
             name=f"reminder_{rem.id}",
+            timezone=job_tz,
         )
 
 

--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -66,6 +66,11 @@ def schedule_reminder(
 
     job_tz = (
         getattr(getattr(job_queue, "application", None), "timezone", None)
+        or getattr(
+            getattr(getattr(job_queue, "application", None), "scheduler", None),
+            "timezone",
+            None,
+        )
         or getattr(getattr(job_queue, "scheduler", None), "timezone", None)
         or tz
     )
@@ -89,6 +94,7 @@ def schedule_reminder(
                 when=when_td,
                 data=data,
                 name=name,
+                timezone=job_tz,
             )
     else:
         if rem.time:
@@ -113,7 +119,7 @@ def schedule_reminder(
                     time=job_time,
                     data=data,
                     name=name,
-                    timezone=ZoneInfo("Europe/Moscow"),
+                    timezone=job_tz,
                 )
             else:
                 job_queue.run_daily(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,26 @@ import sqlite3
 import subprocess
 from typing import Any, Callable, cast
 import warnings
+import sys
+from types import ModuleType
 
 import pytest
 import sqlalchemy
 from services.api.app.diabetes.services import db as db_module
+
+dummy = ModuleType("telegram.ext._basehandler")
+
+
+class _DummyBaseHandler:  # pragma: no cover - minimal stub
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        return None
+
+    def __class_getitem__(cls, item: object) -> type[_DummyBaseHandler]:
+        return cls
+
+
+dummy.BaseHandler = _DummyBaseHandler
+sys.modules.setdefault("telegram.ext._basehandler", dummy)
 
 warnings.filterwarnings(
     "ignore", category=ResourceWarning, module=r"anyio\.streams\.memory"

--- a/tests/test_reminder_timezones.py
+++ b/tests/test_reminder_timezones.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import inspect
+from types import SimpleNamespace
+from typing import Type, TypeAlias
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from services.api.app.diabetes.handlers import reminder_handlers, reminder_jobs
+
+
+class _FakeJob:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def schedule_removal(self) -> None:
+        return None
+
+
+class _BaseQueue:
+    def __init__(self, tz: ZoneInfo) -> None:
+        scheduler = SimpleNamespace(timezone=tz)
+        self.application = SimpleNamespace(timezone=tz, scheduler=scheduler)
+        self.scheduler = scheduler
+        self.jobs: dict[str, list[_FakeJob]] = {}
+
+    def get_jobs_by_name(self, name: str) -> list[_FakeJob]:
+        return self.jobs.get(name, [])
+
+    def _schedule(
+        self, callback, delay: float, data: dict[str, object] | None, name: str | None
+    ) -> _FakeJob:
+        job = _FakeJob(name or "")
+        self.jobs.setdefault(name or "", []).append(job)
+        asyncio.get_event_loop().create_task(self._run(callback, delay, data))
+        return job
+
+    async def _run(self, callback, delay: float, data: dict[str, object] | None) -> None:
+        await asyncio.sleep(delay)
+        ctx = SimpleNamespace(
+            job=SimpleNamespace(data=data),
+            bot=SimpleNamespace(send_message=lambda **kw: None),
+        )
+        if inspect.iscoroutinefunction(callback):
+            await callback(ctx)
+        else:
+            callback(ctx)
+
+
+class JobQueueV20(_BaseQueue):
+    def run_once(
+        self,
+        callback,
+        *,
+        when: dt.timedelta,
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+        timezone: ZoneInfo | None = None,
+    ) -> _FakeJob:
+        delay = when.total_seconds()
+        return self._schedule(callback, delay, data, name)
+
+    def run_daily(
+        self,
+        callback,
+        *,
+        time: dt.time,
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+        timezone: ZoneInfo,
+    ) -> _FakeJob:
+        now = dt.datetime.now(timezone)
+        target = dt.datetime.combine(now.date(), time, tzinfo=timezone)
+        if target <= now:
+            target += dt.timedelta(days=1)
+        delay = (target - now).total_seconds()
+        return self._schedule(callback, delay, data, name)
+
+
+class JobQueueV21(_BaseQueue):
+    def run_once(
+        self,
+        callback,
+        *,
+        when: dt.timedelta,
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+    ) -> _FakeJob:
+        delay = when.total_seconds()
+        return self._schedule(callback, delay, data, name)
+
+    def run_daily(
+        self,
+        callback,
+        *,
+        time: dt.time,
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+    ) -> _FakeJob:
+        tz = self.application.timezone
+        now = dt.datetime.now(tz)
+        target = dt.datetime.combine(now.date(), time, tzinfo=tz)
+        if target <= now:
+            target += dt.timedelta(days=1)
+        delay = (target - now).total_seconds()
+        return self._schedule(callback, delay, data, name)
+
+
+QueueType: TypeAlias = Type[JobQueueV20] | Type[JobQueueV21]
+
+
+@pytest.mark.parametrize("queue_cls", [JobQueueV20, JobQueueV21])
+@pytest.mark.asyncio()
+async def test_daily_reminder_respects_timezone(queue_cls: QueueType) -> None:
+    tz = ZoneInfo("Asia/Tokyo")
+    job_queue = queue_cls(tz)
+    event = asyncio.Event()
+
+    async def fake_job(context: object) -> None:
+        event.set()
+
+    original = reminder_handlers.reminder_job
+    reminder_handlers.reminder_job = fake_job  # type: ignore[assignment]
+    try:
+        now = dt.datetime.now(tz)
+        rem_time = (now + dt.timedelta(seconds=1)).time().replace(microsecond=0)
+        rem = SimpleNamespace(
+            id=1,
+            telegram_id=1,
+            type="sugar",
+            time=rem_time,
+            interval_hours=None,
+            interval_minutes=None,
+            minutes_after=None,
+            is_enabled=True,
+        )
+        user = SimpleNamespace(timezone="Asia/Tokyo")
+        reminder_jobs.schedule_reminder(rem, job_queue, user)
+        await asyncio.wait_for(event.wait(), timeout=5)
+    finally:
+        reminder_handlers.reminder_job = original  # type: ignore[assignment]
+
+
+@pytest.mark.parametrize("queue_cls", [JobQueueV20, JobQueueV21])
+@pytest.mark.asyncio()
+async def test_after_meal_reminder_respects_timezone(queue_cls: QueueType) -> None:
+    tz = ZoneInfo("Asia/Tokyo")
+    job_queue = queue_cls(tz)
+    event = asyncio.Event()
+
+    async def fake_job(context: object) -> None:
+        event.set()
+
+    original_job = reminder_handlers.reminder_job
+    original_session = reminder_handlers.SessionLocal
+    reminder_handlers.reminder_job = fake_job  # type: ignore[assignment]
+
+    class Session:
+        def __enter__(self) -> "Session":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def query(self, model: object) -> "Session":
+            return self
+
+        def filter_by(self, **kwargs: object) -> "Session":
+            return self
+
+        def all(self) -> list[object]:
+            rem = SimpleNamespace(
+                id=2,
+                telegram_id=1,
+                type="after_meal",
+                time=None,
+                interval_hours=None,
+                interval_minutes=None,
+                minutes_after=0.01,
+                is_enabled=True,
+            )
+            return [rem]
+
+    reminder_handlers.SessionLocal = lambda: Session()  # type: ignore[assignment]
+    try:
+        reminder_handlers.schedule_after_meal(user_id=1, job_queue=job_queue)
+        await asyncio.wait_for(event.wait(), timeout=5)
+    finally:
+        reminder_handlers.reminder_job = original_job  # type: ignore[assignment]
+        reminder_handlers.SessionLocal = original_session  # type: ignore[assignment]

--- a/tests/test_schedule_once.py
+++ b/tests/test_schedule_once.py
@@ -65,6 +65,24 @@ class QueueSchedulerTimezone:
         return Job(timezone)
 
 
+class QueueApplicationTimezone:
+    application = SimpleNamespace(timezone="APP", scheduler=SimpleNamespace(timezone="APP_SCH"))
+
+    def run_once(
+        self,
+        callback: Callable[..., object],
+        *,
+        when: timedelta,
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+        timezone: object | None = None,
+    ) -> Job:
+        self.args = SimpleNamespace(
+            callback=callback, when=when, data=data, name=name, timezone=timezone
+        )
+        return Job(timezone)
+
+
 def test_schedule_once_uses_queue_timezone() -> None:
     jq = QueueWithTimezone()
     schedule_once(jq, dummy_cb, when=timedelta(seconds=1), data={"a": 1}, name="j1")
@@ -81,3 +99,9 @@ def test_schedule_once_scheduler_timezone() -> None:
     jq = QueueSchedulerTimezone()
     schedule_once(jq, dummy_cb, when=timedelta(seconds=1))
     assert jq.args.timezone == jq.scheduler.timezone
+
+
+def test_schedule_once_application_timezone() -> None:
+    jq = QueueApplicationTimezone()
+    schedule_once(jq, dummy_cb, when=timedelta(seconds=1))
+    assert jq.args.timezone == jq.application.timezone


### PR DESCRIPTION
## Summary
- forward JobQueue timezone to run_once for compatibility
- schedule reminders using job queue timezone instead of Europe/Moscow
- ensure snooze and after-meal reminders respect JobQueue timezone
- test reminder scheduling for non-Moscow timezones across PTB versions

## Testing
- `pytest -q --cov` *(fails: Coverage failure: total of 26 is less than fail-under=85)*
- `mypy --strict .` *(fails: Function "datetime.datetime.tzinfo" is not valid as a type)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b44fa02c28832aa16c708bdc5832d9