### PR TITLE
[bot] Remove timezone kwarg from test job

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -4,6 +4,7 @@ Bot entry point and configuration.
 
 import logging
 import sys
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from sqlalchemy.exc import SQLAlchemyError
@@ -132,9 +133,10 @@ def main() -> None:  # pragma: no cover
         )
 
     if application.job_queue:
+        when = datetime.now(tz=application.timezone) + timedelta(seconds=30)
         application.job_queue.run_once(
             test_job,
-            when=30,
+            when=when,
         )
 
     application.run_polling()


### PR DESCRIPTION
## Summary
- schedule example reminder with timezone-aware `datetime` instead of using `timezone` kwarg

## Testing
- `TELEGRAM_TOKEN=dummy python -m services.bot.main` *(fails: DB_PASSWORD environment variable must be set)*
- `pytest -q --cov` *(fails: 98 errors during collection)*
- `mypy --strict --ignore-missing-imports services/bot/main.py` *(interrupted)*
- `ruff check services/bot/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4579e0510832a9500c44c3173edcb