### PR TITLE
[utils] Use tzinfo for job scheduling

### DIFF
--- a/services/api/app/diabetes/utils/jobs.py
+++ b/services/api/app/diabetes/utils/jobs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, tzinfo
 from typing import Any
 
 from telegram.ext import ContextTypes, Job, JobQueue
@@ -21,7 +21,7 @@ def schedule_once(
     when: datetime | timedelta | float,
     data: dict[str, object] | None = None,
     name: str | None = None,
-    timezone: datetime.tzinfo | None = None,
+    timezone: tzinfo | None = None,
 ) -> Job[CustomContext]:
     """Schedule ``callback`` to run once at ``when``.
 


### PR DESCRIPTION
## Summary
- import `tzinfo` to annotate job scheduler timezone

## Testing
- `pytest -q` *(fails: TypeError: Too few arguments for CommandHandler)*
- `mypy --strict .` *(fails: Type application has too few types)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b457fec260832ab66605d0a76f8f4f