### PR TITLE
[utils] enforce async job callbacks

### DIFF
--- a/services/api/app/diabetes/utils/jobs.py
+++ b/services/api/app/diabetes/utils/jobs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable, Coroutine
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -11,7 +11,7 @@ from typing import TypeAlias
 CustomContext: TypeAlias = ContextTypes.DEFAULT_TYPE
 DefaultJobQueue: TypeAlias = JobQueue[ContextTypes.DEFAULT_TYPE]
 
-JobCallback = Callable[[CustomContext], Awaitable[object] | object]
+JobCallback = Callable[[CustomContext], Coroutine[Any, Any, object]]
 
 
 def schedule_once(
@@ -30,6 +30,9 @@ def schedule_once(
     explicitly; otherwise the timezone is derived from the job queue's
     application or scheduler.
     """
+    if not inspect.iscoroutinefunction(callback):
+        msg = "callback must be async"
+        raise TypeError(msg)
     params: dict[str, Any] = {"when": when, "data": data, "name": name}
     if "timezone" in inspect.signature(job_queue.run_once).parameters:
         tz = (

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -25,8 +25,8 @@ class DummyMessage:
 
 
 def _get_menu_handler(
-    fallbacks: Sequence[CommandHandler[Any]],
-) -> CommandHandler[Any]:
+    fallbacks: Sequence[CommandHandler[Any, Any]],
+) -> CommandHandler[Any, Any]:
     return next(h for h in fallbacks if "menu" in getattr(h, "commands", []))
 
 
@@ -34,7 +34,7 @@ def _get_menu_handler(
 async def test_sugar_conv_menu_then_photo() -> None:
     handler = _get_menu_handler(
         cast(
-            Sequence[CommandHandler[Any]],
+            Sequence[CommandHandler[Any, Any]],
             [
                 h
                 for h in dose_calc.sugar_conv.fallbacks
@@ -70,7 +70,7 @@ async def test_sugar_conv_menu_then_photo() -> None:
 async def test_dose_conv_menu_then_photo() -> None:
     handler = _get_menu_handler(
         cast(
-            Sequence[CommandHandler[Any]],
+            Sequence[CommandHandler[Any, Any]],
             [h for h in dose_calc.dose_conv.fallbacks if isinstance(h, CommandHandler)],
         )
     )

--- a/tests/test_schedule_once.py
+++ b/tests/test_schedule_once.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 from datetime import timedelta
 from types import SimpleNamespace
-from typing import Callable
+from typing import Callable, Coroutine, Any
+
+import pytest
 
 from services.api.app.diabetes.utils.jobs import schedule_once
 
 
-def dummy_cb(context: object) -> None:  # pragma: no cover - simple callback
+async def dummy_cb(context: object) -> None:  # pragma: no cover - simple callback
+    return None
+
+
+def sync_cb(context: object) -> None:  # pragma: no cover - helper for tests
     return None
 
 
@@ -21,7 +27,7 @@ class QueueWithTimezone:
 
     def run_once(
         self,
-        callback: Callable[..., object],
+        callback: Callable[..., Coroutine[Any, Any, object]],
         *,
         when: timedelta,
         data: dict[str, object] | None = None,
@@ -37,7 +43,7 @@ class QueueWithTimezone:
 class QueueNoTimezone:
     def run_once(
         self,
-        callback: Callable[..., object],
+        callback: Callable[..., Coroutine[Any, Any, object]],
         *,
         when: timedelta,
         data: dict[str, object] | None = None,
@@ -52,7 +58,7 @@ class QueueSchedulerTimezone:
 
     def run_once(
         self,
-        callback: Callable[..., object],
+        callback: Callable[..., Coroutine[Any, Any, object]],
         *,
         when: timedelta,
         data: dict[str, object] | None = None,
@@ -66,11 +72,13 @@ class QueueSchedulerTimezone:
 
 
 class QueueApplicationTimezone:
-    application = SimpleNamespace(timezone="APP", scheduler=SimpleNamespace(timezone="APP_SCH"))
+    application = SimpleNamespace(
+        timezone="APP", scheduler=SimpleNamespace(timezone="APP_SCH")
+    )
 
     def run_once(
         self,
-        callback: Callable[..., object],
+        callback: Callable[..., Coroutine[Any, Any, object]],
         *,
         when: timedelta,
         data: dict[str, object] | None = None,
@@ -105,3 +113,9 @@ def test_schedule_once_application_timezone() -> None:
     jq = QueueApplicationTimezone()
     schedule_once(jq, dummy_cb, when=timedelta(seconds=1))
     assert jq.args.timezone == jq.application.timezone
+
+
+def test_schedule_once_requires_async() -> None:
+    jq = QueueWithTimezone()
+    with pytest.raises(TypeError):
+        schedule_once(jq, sync_cb, when=timedelta(seconds=1))


### PR DESCRIPTION
## Summary
- require async coroutine callbacks in job scheduler
- add tests covering async enforcement and handler generics

## Testing
- `ruff check services/api/app/diabetes/utils/jobs.py tests/test_schedule_once.py tests/test_menu_fallbacks.py`
- `pytest tests/test_schedule_once.py tests/test_menu_fallbacks.py -q` *(fails: Required test coverage of 85% not reached. Total coverage: 25.34%)*

------
https://chatgpt.com/codex/tasks/task_e_68b45800a260832a8e637f3c75b1b387