### PR TITLE
[handlers] Annotate reminder job data mapping

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -47,6 +47,11 @@ def schedule_reminder(
         )
         return
 
+    data: dict[str, object] = {
+        "reminder_id": rem.id,
+        "chat_id": rem.telegram_id,
+    }
+
     tz: datetime.tzinfo = ZoneInfo("Europe/Moscow")
     if user is None:
         with SessionLocal() as session:
@@ -87,7 +92,6 @@ def schedule_reminder(
                 minutes_after,
             )
             when_td = timedelta(minutes=float(minutes_after))
-            data = {"reminder_id": rem.id, "chat_id": rem.telegram_id}
             schedule_once(
                 job_queue,
                 reminder_job,
@@ -112,7 +116,6 @@ def schedule_reminder(
                 tzinfo=tz,
             )
             job_time = dt.astimezone(job_tz).time().replace(tzinfo=None)
-            data = {"reminder_id": rem.id, "chat_id": rem.telegram_id}
             if "timezone" in inspect.signature(job_queue.run_daily).parameters:
                 job_queue.run_daily(  # type: ignore[call-arg]
                     reminder_job,
@@ -145,7 +148,7 @@ def schedule_reminder(
             job_queue.run_repeating(
                 reminder_job,
                 interval=timedelta(minutes=minutes),
-                data={"reminder_id": rem.id, "chat_id": rem.telegram_id},
+                data=data,
                 name=name,
             )
     logger.debug(


### PR DESCRIPTION
## Summary
- Annotate reminder job payload as `dict[str, object]`
- Reuse the typed payload for all reminder scheduling calls

## Testing
- `pytest -q` *(fails: TypeError: Too few arguments for <class 'telegram.ext._handlers.commandhandler.CommandHandler'>)*
- `mypy --strict .` *(fails: Found 44 errors in 6 files)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b45804679c832ab4d81b74d6d771fe