### PR TITLE
[handlers] specify handler generics

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -50,17 +50,17 @@ def register_profile_handlers(
     app.add_handler(profile.profile_conv)
     app.add_handler(profile.profile_webapp_handler)
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
             filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view
         )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, None](
             profile.profile_security, pattern="^profile_security"
         )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, None](
             profile.profile_back, pattern="^profile_back$"
         )
     )
@@ -81,30 +81,30 @@ def register_reminder_handlers(
     from . import reminder_handlers
 
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
+        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
             "reminders", reminder_handlers.reminders_list
         )
     )
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
+        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
             "addreminder", reminder_handlers.add_reminder
         )
     )
     app.add_handler(reminder_handlers.reminder_action_handler)
     app.add_handler(reminder_handlers.reminder_webapp_handler)
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
+        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
             "delreminder", reminder_handlers.delete_reminder
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
             filters.Regex(re.escape(REMINDERS_BUTTON_TEXT)),
             reminder_handlers.reminders_list,
         )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, None](
             reminder_handlers.reminder_callback, pattern="^remind_"
         )
     )
@@ -143,14 +143,14 @@ def register_handlers(
     )
 
     app.add_handler(onboarding_conv)
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("menu", menu_command))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE, None]("menu", menu_command))
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
+        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
             "report", reporting_handlers.report_request
         )
     )
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
+        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
             "history", reporting_handlers.history_view
         )
     )
@@ -161,82 +161,82 @@ def register_handlers(
     app.add_handler(sugar_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE]("cancel", dose_calc.dose_cancel)
+        CommandHandler[ContextTypes.DEFAULT_TYPE, int]("cancel", dose_calc.dose_cancel)
     )
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("help", help_command))
+    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE, None]("help", help_command))
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE]("gpt", gpt_handlers.chat_with_gpt)
+        CommandHandler[ContextTypes.DEFAULT_TYPE, None]("gpt", gpt_handlers.chat_with_gpt)
     )
     register_reminder_handlers(app)
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
+        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
             "alertstats", alert_handlers.alert_stats
         )
     )
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
+        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
             "hypoalert", security_handlers.hypo_alert_faq
         )
     )
     app.add_handler(
-        PollAnswerHandler[ContextTypes.DEFAULT_TYPE](onboarding_poll_answer)
+        PollAnswerHandler[ContextTypes.DEFAULT_TYPE, None](onboarding_poll_answer)
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
             filters.Regex(re.escape(REPORT_BUTTON_TEXT)),
             reporting_handlers.report_request,
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
             filters.Regex(re.escape(HISTORY_BUTTON_TEXT)),
             reporting_handlers.history_view,
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
             filters.Regex(re.escape(PHOTO_BUTTON_TEXT)), photo_handlers.photo_prompt
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
             filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
             filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler[ContextTypes.DEFAULT_TYPE, int](
             filters.Regex(re.escape(SOS_BUTTON_TEXT)),
             sos_handlers.sos_contact_start,
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
             filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler[ContextTypes.DEFAULT_TYPE, int](
             filters.PHOTO, photo_handlers.photo_handler
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler[ContextTypes.DEFAULT_TYPE, int](
             filters.Document.IMAGE, photo_handlers.doc_handler
         )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, None](
             reporting_handlers.report_period_callback, pattern="^report_back$"
         )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
+        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, None](
             reporting_handlers.report_period_callback, pattern="^report_period:"
         )
     )
-    app.add_handler(CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](callback_router))
+    app.add_handler(CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, None](callback_router))

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -25,7 +25,8 @@ def _find_handler(
     ],
     regex: str,
 ) -> MessageHandler[
-    CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+    CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+    Any,
 ]:
     for h in fallbacks:
         if isinstance(h, MessageHandler):

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -25,8 +25,8 @@ class DummyMessage:
 
 
 def _get_menu_handler(
-    fallbacks: Sequence[CommandHandler[Any]],
-) -> CommandHandler[Any]:
+    fallbacks: Sequence[CommandHandler[Any, Any]],
+) -> CommandHandler[Any, Any]:
     return next(h for h in fallbacks if "menu" in getattr(h, "commands", []))
 
 
@@ -34,7 +34,7 @@ def _get_menu_handler(
 async def test_sugar_conv_menu_then_photo() -> None:
     handler = _get_menu_handler(
         cast(
-            Sequence[CommandHandler[Any]],
+            Sequence[CommandHandler[Any, Any]],
             [
                 h
                 for h in dose_calc.sugar_conv.fallbacks
@@ -70,7 +70,7 @@ async def test_sugar_conv_menu_then_photo() -> None:
 async def test_dose_conv_menu_then_photo() -> None:
     handler = _get_menu_handler(
         cast(
-            Sequence[CommandHandler[Any]],
+            Sequence[CommandHandler[Any, Any]],
             [h for h in dose_calc.dose_conv.fallbacks if isinstance(h, CommandHandler)],
         )
     )

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -31,7 +31,8 @@ def _find_handler(
     ],
     regex: str,
 ) -> MessageHandler[
-    CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+    CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+    Any,
 ]:
     for h in fallbacks:
         if isinstance(h, MessageHandler):
@@ -55,7 +56,8 @@ class DummyMessage:
 
 async def _exercise(
     handler: MessageHandler[
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        Any,
     ],
 ) -> None:
     message = DummyMessage(PHOTO_BUTTON_TEXT)


### PR DESCRIPTION
## Summary
- provide explicit context and return type generics for handlers in registration
- adjust tests to use full handler type parameters

## Testing
- `ruff check .`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: Function "datetime.datetime.tzinfo" is not valid as a type)*

------
https://chatgpt.com/codex/tasks/task_e_68b45807bb00832aab0606f8d7ee0845