### PR TITLE
[jobs] Annotate timezone parameter with tzinfo

### DIFF
--- a/services/api/app/diabetes/utils/jobs.py
+++ b/services/api/app/diabetes/utils/jobs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timedelta, timezone as dt_timezone
+from datetime import datetime, timedelta, timezone as dt_timezone, tzinfo
 from typing import Any
 
 from telegram.ext import ContextTypes, Job, JobQueue
@@ -21,7 +21,7 @@ def schedule_once(
     when: datetime | timedelta | float,
     data: dict[str, object] | None = None,
     name: str | None = None,
-    timezone: datetime.tzinfo | None = None,
+    timezone: tzinfo | None = None,
 ) -> Job[CustomContext]:
     """Schedule ``callback`` to run once at ``when``.
 


### PR DESCRIPTION
## Summary
- import tzinfo from datetime
- type timezone parameter as `tzinfo | None`

## Testing
- `pytest -q --cov` *(fails: Too few arguments for <class 'telegram.ext._handlers.commandhandler.CommandHandler'>)*
- `mypy --strict .` *(fails: Argument 1 to "run_once" of "JobQueue" has incompatible type...; Found 44 errors)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b45a3fbbb4832a804e31eb85a6bdfa