### PR TITLE
[handlers] add Message type checks

### DIFF
--- a/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
+++ b/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
@@ -2,15 +2,14 @@ import re
 from typing import Callable, Coroutine, Optional
 
 from telegram import CallbackQuery, Update
-from telegram.ext import ContextTypes
-from telegram.ext._basehandler import BaseHandler
+from telegram.ext import BaseHandler, ContextTypes
 
-CallbackQueryHandlerCallback = Callable[
-    [Update, ContextTypes.DEFAULT_TYPE], Coroutine[object, object, int | None]
-]
+CallbackQueryHandlerCallback = Callable[[Update, ContextTypes.DEFAULT_TYPE], Coroutine[object, object, int | None]]
 
 
-class CallbackQueryNoWarnHandler(BaseHandler[Update, ContextTypes.DEFAULT_TYPE]):
+class CallbackQueryNoWarnHandler(
+    BaseHandler[Update, ContextTypes.DEFAULT_TYPE, int | None]  # type: ignore[misc]
+):
     """Handle callback queries without triggering ConversationHandler warnings."""
 
     def __init__(
@@ -19,6 +18,7 @@ class CallbackQueryNoWarnHandler(BaseHandler[Update, ContextTypes.DEFAULT_TYPE])
         pattern: str | None = None,
     ) -> None:
         super().__init__(callback)
+        self.callback = callback
         self.pattern: Optional[re.Pattern[str]] = re.compile(pattern) if pattern else None
 
     def check_update(self, update: object) -> Optional[CallbackQuery]:

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from telegram import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
+    Message,
     ReplyKeyboardMarkup,
     Update,
     WebAppInfo,
@@ -85,9 +86,7 @@ back_keyboard: ReplyKeyboardMarkup = _back_keyboard
 from .. import UserData  # noqa: E402
 
 
-PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(
-    6
-)
+PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(6)
 END: int = ConversationHandler.END
 
 
@@ -116,21 +115,9 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         if callable(end_conv):
             end_conv(update, context, END)
         else:
-            chat_id = (
-                getattr(update.effective_chat, "id", None)
-                if sugar_conv.per_chat
-                else None
-            )
-            user_id = (
-                getattr(update.effective_user, "id", None)
-                if sugar_conv.per_user
-                else None
-            )
-            msg_id = (
-                getattr(update.effective_message, "message_id", None)
-                if sugar_conv.per_message
-                else None
-            )
+            chat_id = getattr(update.effective_chat, "id", None) if sugar_conv.per_chat else None
+            user_id = getattr(update.effective_user, "id", None) if sugar_conv.per_user else None
+            msg_id = getattr(update.effective_message, "message_id", None) if sugar_conv.per_message else None
             key = cast(
                 tuple[int | str, ...],
                 tuple(i for i in (chat_id, user_id, msg_id) if i is not None),
@@ -140,7 +127,9 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             else:
                 logger.warning("sugar_conv lacks _update_state method")
 
-    help_text = "Настройки профиля доступны в приложении. Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
+    help_text = (
+        "Настройки профиля доступны в приложении. Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
+    )
 
     if len(args) == 1 and args[0].lower() == "help":
         await message.reply_text(help_text, parse_mode="Markdown")
@@ -162,9 +151,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         low = float(values["low"].replace(",", "."))
         high = float(values["high"].replace(",", "."))
     except ValueError:
-        await message.reply_text(
-            "❗ Пожалуйста, введите корректные числа. Справка: /profile help"
-        )
+        await message.reply_text("❗ Пожалуйста, введите корректные числа. Справка: /profile help")
         return END
     error = validate_profile_numbers(icr, cf, target, low, high)
     if error:
@@ -233,9 +220,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         ]
 
     if not profile:
-        text = (
-            "Ваш профиль пока не настроен.\n\nНастройки профиля доступны в приложении."
-        )
+        text = "Ваш профиль пока не настроен.\n\nНастройки профиля доступны в приложении."
         if webapp_button is not None:
             text += " Нажмите кнопку ниже, чтобы открыть и обновить данные."
             keyboard = InlineKeyboardMarkup([webapp_button])
@@ -377,7 +362,7 @@ async def profile_back(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     query = update.callback_query
     if query is None or query.message is None:
         return
-    message = query.message
+    message = cast(Message, query.message)
     await query.answer()
     await message.delete()
     await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
@@ -388,7 +373,7 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     query = update.callback_query
     if query is None or query.message is None:
         return END
-    message = query.message
+    message = cast(Message, query.message)
     await query.answer()
     await message.reply_text(
         "Введите ваш часовой пояс (например Europe/Moscow):",
@@ -397,9 +382,7 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     button = build_timezone_webapp_button()
     if button:
         keyboard = InlineKeyboardMarkup([[button]])
-        await message.reply_text(
-            "Можно определить автоматически:", reply_markup=keyboard
-        )
+        await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
     else:
         await message.reply_text(
             "Автоматическое определение недоступно, укажите часовой пояс вручную.",
@@ -408,9 +391,7 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     return PROFILE_TZ
 
 
-async def profile_timezone_save(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Save user timezone from input."""
     message = update.message
     if message is None:
@@ -435,9 +416,7 @@ async def profile_timezone_save(
         button = build_timezone_webapp_button()
         if button:
             keyboard = InlineKeyboardMarkup([[button]])
-            await message.reply_text(
-                "Можно определить автоматически:", reply_markup=keyboard
-            )
+            await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
         else:
             await message.reply_text(
                 "Автоматическое определение недоступно, введите часовой пояс вручную.",
@@ -470,9 +449,7 @@ async def profile_timezone_save(
     return END
 
 
-def _security_db(
-    session: Session, user_id: int, action: str | None
-) -> dict[str, object]:
+def _security_db(session: Session, user_id: int, action: str | None) -> dict[str, object]:
     profile = session.get(Profile, user_id)
     user = session.get(User, user_id)
     if not profile:
@@ -509,22 +486,13 @@ def _security_db(
     if changed:
         try:
             commit(session)
-            alert = (
-                session.query(Alert)
-                .filter_by(user_id=user_id)
-                .order_by(Alert.ts.desc())
-                .first()
-            )
+            alert = session.query(Alert).filter_by(user_id=user_id).order_by(Alert.ts.desc()).first()
             alert_sugar = alert.sugar if alert else None
         except CommitError:
             commit_ok = False
 
     rems = session.query(Reminder).filter_by(telegram_id=user_id).all()
-    rem_text = (
-        "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems)
-        if rems
-        else "нет"
-    )
+    rem_text = "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems) if rems else "нет"
     return {
         "found": True,
         "commit_ok": commit_ok,
@@ -546,6 +514,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     q_message = query.message
     if q_message is None:
         return
+    q_message = cast(Message, q_message)
     user = update.effective_user
     if user is None:
         return
@@ -608,20 +577,12 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton(
-                    "Низкий -0.5", callback_data="profile_security:low_dec"
-                ),
-                InlineKeyboardButton(
-                    "Низкий +0.5", callback_data="profile_security:low_inc"
-                ),
+                InlineKeyboardButton("Низкий -0.5", callback_data="profile_security:low_dec"),
+                InlineKeyboardButton("Низкий +0.5", callback_data="profile_security:low_inc"),
             ],
             [
-                InlineKeyboardButton(
-                    "Высокий -0.5", callback_data="profile_security:high_dec"
-                ),
-                InlineKeyboardButton(
-                    "Высокий +0.5", callback_data="profile_security:high_inc"
-                ),
+                InlineKeyboardButton("Высокий -0.5", callback_data="profile_security:high_dec"),
+                InlineKeyboardButton("Высокий +0.5", callback_data="profile_security:high_inc"),
             ],
             [
                 InlineKeyboardButton(
@@ -629,15 +590,9 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     callback_data="profile_security:toggle_sos",
                 )
             ],
+            [InlineKeyboardButton("SOS контакт", callback_data="profile_security:sos_contact")],
             [
-                InlineKeyboardButton(
-                    "SOS контакт", callback_data="profile_security:sos_contact"
-                )
-            ],
-            [
-                InlineKeyboardButton(
-                    "➕ Добавить", callback_data="profile_security:add"
-                ),
+                InlineKeyboardButton("➕ Добавить", callback_data="profile_security:add"),
                 InlineKeyboardButton("🗑 Удалить", callback_data="profile_security:del"),
             ],
             [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
@@ -651,7 +606,7 @@ async def profile_edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     query = update.callback_query
     if query is None or query.message is None:
         return END
-    message = query.message
+    message = cast(Message, query.message)
     await query.answer()
     await message.delete()
     await message.reply_text(
@@ -734,9 +689,7 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     try:
         target = float(text)
     except ValueError:
-        await message.reply_text(
-            "Введите целевой сахар числом.", reply_markup=back_keyboard
-        )
+        await message.reply_text("Введите целевой сахар числом.", reply_markup=back_keyboard)
         return PROFILE_TARGET
     if target <= 0:
         await message.reply_text(MSG_TARGET_GT0, reply_markup=back_keyboard)
@@ -766,9 +719,7 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     try:
         low = float(text)
     except ValueError:
-        await message.reply_text(
-            "Введите нижний порог числом.", reply_markup=back_keyboard
-        )
+        await message.reply_text("Введите нижний порог числом.", reply_markup=back_keyboard)
         return PROFILE_LOW
     if low <= 0:
         await message.reply_text(MSG_LOW_GT0, reply_markup=back_keyboard)
@@ -798,18 +749,14 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     try:
         high = float(text)
     except ValueError:
-        await message.reply_text(
-            "Введите верхний порог числом.", reply_markup=back_keyboard
-        )
+        await message.reply_text("Введите верхний порог числом.", reply_markup=back_keyboard)
         return PROFILE_HIGH
     icr = user_data.get("profile_icr")
     cf = user_data.get("profile_cf")
     target = user_data.get("profile_target")
     low = user_data.get("profile_low")
     if None in (icr, cf, target, low):
-        await message.reply_text(
-            "⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново."
-        )
+        await message.reply_text("⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново.")
         return END
     error = validate_profile_numbers(icr, cf, target, low, high)
     if error:
@@ -881,15 +828,11 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return END
 
 
-async def _profile_edit_entry(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def _profile_edit_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     return await profile_edit(update, context)
 
 
-async def _profile_timezone_entry(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def _profile_timezone_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     return await profile_timezone(update, context)
 
 
@@ -897,16 +840,12 @@ profile_conv = ConversationHandler(
     entry_points=[
         CommandHandler("profile", profile_command),
         CallbackQueryNoWarnHandler(_profile_edit_entry, pattern="^profile_edit$"),
-        CallbackQueryNoWarnHandler(
-            _profile_timezone_entry, pattern="^profile_timezone$"
-        ),
+        CallbackQueryNoWarnHandler(_profile_timezone_entry, pattern="^profile_timezone$"),
     ],
     states={
         PROFILE_ICR: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_icr)],
         PROFILE_CF: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_cf)],
-        PROFILE_TARGET: [
-            MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)
-        ],
+        PROFILE_TARGET: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)],
         PROFILE_LOW: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_low)],
         PROFILE_HIGH: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_high)],
         PROFILE_TZ: [
@@ -928,9 +867,7 @@ profile_conv = ConversationHandler(
 )
 
 
-profile_webapp_handler = MessageHandler(
-    filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save
-)
+profile_webapp_handler = MessageHandler(filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save)
 
 
 __all__ = [

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -49,21 +49,9 @@ def register_profile_handlers(
 
     app.add_handler(profile.profile_conv)
     app.add_handler(profile.profile_webapp_handler)
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
-            profile.profile_security, pattern="^profile_security"
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
-            profile.profile_back, pattern="^profile_back$"
-        )
-    )
+    app.add_handler(MessageHandler(filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view))
+    app.add_handler(CallbackQueryHandler(profile.profile_security, pattern="^profile_security"))
+    app.add_handler(CallbackQueryHandler(profile.profile_back, pattern="^profile_back$"))
 
 
 def register_reminder_handlers(
@@ -80,34 +68,18 @@ def register_reminder_handlers(
 
     from . import reminder_handlers
 
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "reminders", reminder_handlers.reminders_list
-        )
-    )
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "addreminder", reminder_handlers.add_reminder
-        )
-    )
+    app.add_handler(CommandHandler("reminders", reminder_handlers.reminders_list))
+    app.add_handler(CommandHandler("addreminder", reminder_handlers.add_reminder))
     app.add_handler(reminder_handlers.reminder_action_handler)
     app.add_handler(reminder_handlers.reminder_webapp_handler)
+    app.add_handler(CommandHandler("delreminder", reminder_handlers.delete_reminder))
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "delreminder", reminder_handlers.delete_reminder
-        )
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler(
             filters.Regex(re.escape(REMINDERS_BUTTON_TEXT)),
             reminder_handlers.reminders_list,
         )
     )
-    app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
-            reminder_handlers.reminder_callback, pattern="^remind_"
-        )
-    )
+    app.add_handler(CallbackQueryHandler(reminder_handlers.reminder_callback, pattern="^remind_"))
 
     job_queue = app.job_queue
     if job_queue:
@@ -143,100 +115,46 @@ def register_handlers(
     )
 
     app.add_handler(onboarding_conv)
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("menu", menu_command))
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "report", reporting_handlers.report_request
-        )
-    )
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "history", reporting_handlers.history_view
-        )
-    )
+    app.add_handler(CommandHandler("menu", menu_command))
+    app.add_handler(CommandHandler("report", reporting_handlers.report_request))
+    app.add_handler(CommandHandler("history", reporting_handlers.history_view))
     app.add_handler(dose_calc.dose_conv)
     # Register profile conversation before sugar conversation so that numeric
     # inputs for profile aren't captured by sugar logging
     register_profile_handlers(app)
     app.add_handler(sugar_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE]("cancel", dose_calc.dose_cancel)
-    )
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE]("help", help_command))
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE]("gpt", gpt_handlers.chat_with_gpt)
-    )
+    app.add_handler(CommandHandler("cancel", dose_calc.dose_cancel))
+    app.add_handler(CommandHandler("help", help_command))
+    app.add_handler(CommandHandler("gpt", gpt_handlers.chat_with_gpt))
     register_reminder_handlers(app)
+    app.add_handler(CommandHandler("alertstats", alert_handlers.alert_stats))
+    app.add_handler(CommandHandler("hypoalert", security_handlers.hypo_alert_faq))
+    app.add_handler(PollAnswerHandler(onboarding_poll_answer))
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "alertstats", alert_handlers.alert_stats
-        )
-    )
-    app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE](
-            "hypoalert", security_handlers.hypo_alert_faq
-        )
-    )
-    app.add_handler(
-        PollAnswerHandler[ContextTypes.DEFAULT_TYPE](onboarding_poll_answer)
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler(
             filters.Regex(re.escape(REPORT_BUTTON_TEXT)),
             reporting_handlers.report_request,
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler(
             filters.Regex(re.escape(HISTORY_BUTTON_TEXT)),
             reporting_handlers.history_view,
         )
     )
+    app.add_handler(MessageHandler(filters.Regex(re.escape(PHOTO_BUTTON_TEXT)), photo_handlers.photo_prompt))
+    app.add_handler(MessageHandler(filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help))
+    app.add_handler(MessageHandler(filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command))
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex(re.escape(PHOTO_BUTTON_TEXT)), photo_handlers.photo_prompt
-        )
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help
-        )
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command
-        )
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
+        MessageHandler(
             filters.Regex(re.escape(SOS_BUTTON_TEXT)),
             sos_handlers.sos_contact_start,
         )
     )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler
-        )
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.PHOTO, photo_handlers.photo_handler
-        )
-    )
-    app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE](
-            filters.Document.IMAGE, photo_handlers.doc_handler
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
-            reporting_handlers.report_period_callback, pattern="^report_back$"
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](
-            reporting_handlers.report_period_callback, pattern="^report_period:"
-        )
-    )
-    app.add_handler(CallbackQueryHandler[ContextTypes.DEFAULT_TYPE](callback_router))
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler))
+    app.add_handler(MessageHandler(filters.PHOTO, photo_handlers.photo_handler))
+    app.add_handler(MessageHandler(filters.Document.IMAGE, photo_handlers.doc_handler))
+    app.add_handler(CallbackQueryHandler(reporting_handlers.report_period_callback, pattern="^report_back$"))
+    app.add_handler(CallbackQueryHandler(reporting_handlers.report_period_callback, pattern="^report_period:"))
+    app.add_handler(CallbackQueryHandler(callback_router))

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -19,6 +19,7 @@ from telegram import (
     InlineKeyboardMarkup,
     KeyboardButton,
     ReplyKeyboardMarkup,
+    Message,
     Update,
     WebAppInfo,
 )
@@ -142,9 +143,7 @@ async def history_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             return (
                 session.query(HistoryRecord)
                 .filter(HistoryRecord.telegram_id == user_id)
-                .order_by(
-                    HistoryRecord.date.desc(), HistoryRecord.time.desc()
-                )
+                .order_by(HistoryRecord.date.desc(), HistoryRecord.time.desc())
                 .limit(limit)
                 .all()
             )
@@ -198,7 +197,7 @@ async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_T
     await query.answer()
     message = query.message
     if query.data == "report_back":
-        if message is not None:
+        if isinstance(message, Message):
             await message.delete()
             await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
         return
@@ -222,7 +221,7 @@ async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_T
         user_data = cast(UserData, user_data_raw)
         user_data["awaiting_report_date"] = True
         await query.edit_message_text("Введите дату начала отчёта в формате YYYY-MM-DD\nОтправьте «назад» для отмены.")
-        if message is not None:
+        if isinstance(message, Message):
             await message.reply_text(
                 "Ожидаю дату…",
                 reply_markup=ReplyKeyboardMarkup(
@@ -379,6 +378,7 @@ async def send_report(
         q_message = query.message
         if q_message is None:
             return
+        q_message = cast(Message, q_message)
         await q_message.reply_photo(
             plot_buf,
             caption="График сахара за период",
@@ -389,7 +389,7 @@ async def send_report(
             caption="PDF-отчёт для врача",
         )
     elif message is not None:
-        msg = message
+        msg = cast(Message, message)
         await msg.reply_text(report_msg, parse_mode="HTML")
         await msg.reply_photo(
             plot_buf,

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -7,6 +7,7 @@ from telegram import (
     InlineKeyboardMarkup,
     ForceReply,
     CallbackQuery,
+    Message,
 )
 from telegram.ext import ContextTypes
 from typing import Awaitable, Callable, cast
@@ -20,9 +21,7 @@ from . import EntryData, UserData
 logger = logging.getLogger(__name__)
 
 
-Handler = Callable[
-    [Update, ContextTypes.DEFAULT_TYPE, CallbackQuery, str], Awaitable[None]
-]
+Handler = Callable[[Update, ContextTypes.DEFAULT_TYPE, CallbackQuery, str], Awaitable[None]]
 
 
 async def handle_confirm_entry(
@@ -62,9 +61,7 @@ async def handle_confirm_entry(
         reminder_handlers.schedule_after_meal(user.id, job_queue)
 
 
-async def handle_edit_entry(
-    update: Update, context: ContextTypes.DEFAULT_TYPE, query: CallbackQuery, _: str
-) -> None:
+async def handle_edit_entry(update: Update, context: ContextTypes.DEFAULT_TYPE, query: CallbackQuery, _: str) -> None:
     """Prompt user to resend data to update the pending entry."""
     user_data_raw = context.user_data
     if user_data_raw is None:
@@ -83,9 +80,7 @@ async def handle_edit_entry(
     )
 
 
-async def handle_cancel_entry(
-    update: Update, context: ContextTypes.DEFAULT_TYPE, query: CallbackQuery, _: str
-) -> None:
+async def handle_cancel_entry(update: Update, context: ContextTypes.DEFAULT_TYPE, query: CallbackQuery, _: str) -> None:
     """Discard pending entry and show main menu keyboard."""
     user_data_raw = context.user_data
     if user_data_raw is None:
@@ -96,6 +91,7 @@ async def handle_cancel_entry(
     message = query.message
     if message is None:
         return
+    message = cast(Message, message)
     await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
 
 
@@ -119,9 +115,7 @@ async def handle_edit_or_delete(
         if user is None:
             return
         if existing_entry.telegram_id != user.id:
-            await query.edit_message_text(
-                "⚠️ Эта запись принадлежит другому пользователю."
-            )
+            await query.edit_message_text("⚠️ Эта запись принадлежит другому пользователю.")
             return
         if action == "del":
             session.delete(existing_entry)
@@ -141,6 +135,7 @@ async def handle_edit_or_delete(
     message = query.message
     if message is None:
         return
+    message = cast(Message, message)
     user_data["edit_entry"] = {
         "id": entry_id,
         "chat_id": message.chat_id,
@@ -148,11 +143,7 @@ async def handle_edit_or_delete(
     }
     keyboard = InlineKeyboardMarkup(
         [
-            [
-                InlineKeyboardButton(
-                    "сахар", callback_data=f"edit_field:{entry_id}:sugar"
-                )
-            ],
+            [InlineKeyboardButton("сахар", callback_data=f"edit_field:{entry_id}:sugar")],
             [InlineKeyboardButton("xe", callback_data=f"edit_field:{entry_id}:xe")],
             [InlineKeyboardButton("dose", callback_data=f"edit_field:{entry_id}:dose")],
         ]
@@ -186,6 +177,7 @@ async def handle_edit_field(
     message = query.message
     if message is None:
         return
+    message = cast(Message, message)
     await message.reply_text(prompt, reply_markup=ForceReply(selective=True))
 
 

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -25,8 +25,8 @@ class DummyMessage:
 
 
 def _get_menu_handler(
-    fallbacks: Sequence[CommandHandler[Any]],
-) -> CommandHandler[Any]:
+    fallbacks: Sequence[CommandHandler[Any, Any]],
+) -> CommandHandler[Any, Any]:
     return next(h for h in fallbacks if "menu" in getattr(h, "commands", []))
 
 
@@ -34,18 +34,12 @@ def _get_menu_handler(
 async def test_sugar_conv_menu_then_photo() -> None:
     handler = _get_menu_handler(
         cast(
-            Sequence[CommandHandler[Any]],
-            [
-                h
-                for h in dose_calc.sugar_conv.fallbacks
-                if isinstance(h, CommandHandler)
-            ],
+            Sequence[CommandHandler[Any, Any]],
+            [h for h in dose_calc.sugar_conv.fallbacks if isinstance(h, CommandHandler)],
         )
     )
     message = DummyMessage("/menu")
-    update = cast(
-        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    )
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),
@@ -70,14 +64,12 @@ async def test_sugar_conv_menu_then_photo() -> None:
 async def test_dose_conv_menu_then_photo() -> None:
     handler = _get_menu_handler(
         cast(
-            Sequence[CommandHandler[Any]],
+            Sequence[CommandHandler[Any, Any]],
             [h for h in dose_calc.dose_conv.fallbacks if isinstance(h, CommandHandler)],
         )
     )
     message = DummyMessage("/menu")
-    update = cast(
-        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    )
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={"pending_entry": {"foo": "bar"}}),


### PR DESCRIPTION
## Summary
- ensure query.message is typed before use across handlers
- fix type issues in custom CallbackQuery handler and tests

## Testing
- `pytest -q`
- `mypy --strict --follow-imports=skip services/api/app/diabetes/handlers/router.py services/api/app/diabetes/handlers/reporting_handlers.py services/api/app/diabetes/handlers/profile/conversation.py services/api/app/diabetes/handlers/onboarding_handlers.py services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b458055b40832aa4fffb5697ff6362