### PR TITLE
[jobs] enforce async job callbacks

### DIFF
--- a/services/api/app/diabetes/utils/jobs.py
+++ b/services/api/app/diabetes/utils/jobs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable, Coroutine
 from datetime import datetime, timedelta, timezone as dt_timezone
 from typing import Any
 
@@ -11,7 +11,7 @@ from typing import TypeAlias
 CustomContext: TypeAlias = ContextTypes.DEFAULT_TYPE
 DefaultJobQueue: TypeAlias = JobQueue[ContextTypes.DEFAULT_TYPE]
 
-JobCallback = Callable[[CustomContext], Awaitable[object] | object]
+JobCallback = Callable[[CustomContext], Coroutine[Any, Any, object]]
 
 
 def schedule_once(
@@ -30,6 +30,10 @@ def schedule_once(
     explicitly; otherwise the timezone is derived from the job queue's
     application or scheduler.
     """
+    if not inspect.iscoroutinefunction(callback):
+        msg = "callback must be an async function"
+        raise TypeError(msg)
+
     tz = (
         timezone
         or getattr(getattr(job_queue, "application", None), "timezone", None)

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from types import SimpleNamespace
 from typing import Any, Sequence, cast

--- a/tests/test_schedule_once.py
+++ b/tests/test_schedule_once.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from datetime import timedelta
 from types import SimpleNamespace
-from typing import Callable
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+import pytest
 
 from services.api.app.diabetes.utils.jobs import schedule_once
 
 
-def dummy_cb(context: object) -> None:  # pragma: no cover - simple callback
+async def dummy_cb(context: object) -> None:  # pragma: no cover - simple callback
     return None
 
 
@@ -21,7 +24,7 @@ class QueueWithTimezone:
 
     def run_once(
         self,
-        callback: Callable[..., object],
+        callback: Callable[..., Coroutine[Any, Any, object]],
         *,
         when: timedelta,
         data: dict[str, object] | None = None,
@@ -37,7 +40,7 @@ class QueueWithTimezone:
 class QueueNoTimezone:
     def run_once(
         self,
-        callback: Callable[..., object],
+        callback: Callable[..., Coroutine[Any, Any, object]],
         *,
         when: timedelta,
         data: dict[str, object] | None = None,
@@ -52,7 +55,7 @@ class QueueSchedulerTimezone:
 
     def run_once(
         self,
-        callback: Callable[..., object],
+        callback: Callable[..., Coroutine[Any, Any, object]],
         *,
         when: timedelta,
         data: dict[str, object] | None = None,
@@ -70,7 +73,7 @@ class QueueApplicationTimezone:
 
     def run_once(
         self,
-        callback: Callable[..., object],
+        callback: Callable[..., Coroutine[Any, Any, object]],
         *,
         when: timedelta,
         data: dict[str, object] | None = None,
@@ -105,3 +108,13 @@ def test_schedule_once_application_timezone() -> None:
     jq = QueueApplicationTimezone()
     schedule_once(jq, dummy_cb, when=timedelta(seconds=1))
     assert jq.args.timezone == jq.application.timezone
+
+
+def test_schedule_once_requires_async_callback() -> None:
+    jq = QueueNoTimezone()
+
+    def sync_cb(context: object) -> None:  # pragma: no cover - simple
+        return None
+
+    with pytest.raises(TypeError):
+        schedule_once(jq, sync_cb, when=timedelta(seconds=1))

--- a/tests/test_schedule_timezone_fire.py
+++ b/tests/test_schedule_timezone_fire.py
@@ -2,15 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable, Coroutine
 from types import SimpleNamespace
+from typing import Any
 from zoneinfo import ZoneInfo
 
 import pytest
 
 from services.api.app.diabetes.utils.jobs import schedule_once
 
-JobCallback = Callable[[object], Awaitable[object] | object]
+JobCallback = Callable[[object], Coroutine[Any, Any, object]]
 
 
 class _Queue:


### PR DESCRIPTION
## Summary
- require scheduled job callbacks to be async
- add runtime check and tests for async callbacks

## Testing
- `pytest --no-cov tests/test_schedule_once.py tests/test_schedule_timezone_fire.py -q`
- `pytest -q` *(fails: many tests require async plugin and other setup; 400 failed, 334 passed)*
- `mypy --strict .` *(fails: Type application has too few types in multiple files)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b45ad17d98832a814b15a823286c60