### PR TITLE
[handlers] Ensure query message is Message

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -20,6 +20,7 @@ from typing import cast
 from telegram import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
+    Message,
     Update,
 )
 from telegram.ext import (
@@ -85,8 +86,12 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
             try:
                 thread_id = await create_thread()
             except OpenAIError as exc:  # pragma: no cover - network errors
-                logger.exception("Failed to create thread for user %s: %s", user_id, exc)
-                await message.reply_text("⚠️ Не удалось инициализировать профиль. Попробуйте позже.")
+                logger.exception(
+                    "Failed to create thread for user %s: %s", user_id, exc
+                )
+                await message.reply_text(
+                    "⚠️ Не удалось инициализировать профиль. Попробуйте позже."
+                )
                 return ConversationHandler.END
             user_obj = User(telegram_id=user_id, thread_id=thread_id)
             session.add(user_obj)
@@ -99,7 +104,9 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         if user_obj.onboarding_complete:
             greeting = f"👋 Привет, {first_name}!" if first_name else "👋 Привет!"
             greeting += " Рада видеть тебя. Надеюсь, у тебя сегодня всё отлично."
-            await message.reply_text(f"{greeting}\n\n📋 Выберите действие:", reply_markup=menu_keyboard())
+            await message.reply_text(
+                f"{greeting}\n\n📋 Выберите действие:", reply_markup=menu_keyboard()
+            )
             return ConversationHandler.END
 
     await message.reply_text(
@@ -112,7 +119,9 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
 def _skip_markup() -> InlineKeyboardMarkup:
     """Markup containing a single *skip* button."""
 
-    return InlineKeyboardMarkup([[InlineKeyboardButton("Пропустить", callback_data="onb_skip")]])
+    return InlineKeyboardMarkup(
+        [[InlineKeyboardButton("Пропустить", callback_data="onb_skip")]]
+    )
 
 
 async def onboarding_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -132,7 +141,9 @@ async def onboarding_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await message.reply_text("Введите ИКХ числом.", reply_markup=_skip_markup())
         return ONB_PROFILE_ICR
     if icr <= 0:
-        await message.reply_text("ИКХ должен быть больше 0.", reply_markup=_skip_markup())
+        await message.reply_text(
+            "ИКХ должен быть больше 0.", reply_markup=_skip_markup()
+        )
         return ONB_PROFILE_ICR
     user_data["profile_icr"] = icr
     await message.reply_text(
@@ -159,7 +170,9 @@ async def onboarding_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         await message.reply_text("Введите КЧ числом.", reply_markup=_skip_markup())
         return ONB_PROFILE_CF
     if cf <= 0:
-        await message.reply_text("КЧ должен быть больше 0.", reply_markup=_skip_markup())
+        await message.reply_text(
+            "КЧ должен быть больше 0.", reply_markup=_skip_markup()
+        )
         return ONB_PROFILE_CF
     user_data["profile_cf"] = cf
     await message.reply_text(
@@ -184,16 +197,22 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     try:
         target = float(message.text.replace(",", "."))
     except ValueError:
-        await message.reply_text("Введите целевой сахар числом.", reply_markup=_skip_markup())
+        await message.reply_text(
+            "Введите целевой сахар числом.", reply_markup=_skip_markup()
+        )
         return ONB_PROFILE_TARGET
     if target <= 0:
-        await message.reply_text("Целевой сахар должен быть больше 0.", reply_markup=_skip_markup())
+        await message.reply_text(
+            "Целевой сахар должен быть больше 0.", reply_markup=_skip_markup()
+        )
         return ONB_PROFILE_TARGET
 
     icr = user_data.pop("profile_icr", None)
     cf = user_data.pop("profile_cf", None)
     if icr is None or cf is None:
-        await message.reply_text("⚠️ Не хватает данных для профиля. Пожалуйста, начните заново.")
+        await message.reply_text(
+            "⚠️ Не хватает данных для профиля. Пожалуйста, начните заново."
+        )
         return ConversationHandler.END
     user_id = user.id
 
@@ -221,7 +240,9 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             "Введите ваш часовой пояс (например Europe/Moscow). "
             "Автоматическое определение недоступно, укажите его вручную."
         )
-    keyboard_buttons.append(InlineKeyboardButton("Пропустить", callback_data="onb_skip"))
+    keyboard_buttons.append(
+        InlineKeyboardButton("Пропустить", callback_data="onb_skip")
+    )
     await message.reply_text(
         prompt,
         reply_markup=InlineKeyboardMarkup([keyboard_buttons]),
@@ -229,7 +250,9 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     return ONB_PROFILE_TZ
 
 
-async def onboarding_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def onboarding_timezone(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     """Handle user timezone (text or WebApp) and proceed to demo."""
 
     message = update.message
@@ -292,7 +315,9 @@ async def onboarding_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE
                 await message.reply_text("⚠️ Не удалось сохранить часовой пояс.")
                 return ConversationHandler.END
 
-    keyboard = InlineKeyboardMarkup([[InlineKeyboardButton("Далее", callback_data="onb_next")]])
+    keyboard = InlineKeyboardMarkup(
+        [[InlineKeyboardButton("Далее", callback_data="onb_next")]]
+    )
     try:
         with DEMO_PHOTO_PATH.open("rb") as photo:
             await message.reply_photo(
@@ -309,13 +334,16 @@ async def onboarding_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE
     return ONB_DEMO
 
 
-async def onboarding_demo_next(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def onboarding_demo_next(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     """Proceed from demo to reminder suggestion."""
     query = update.callback_query
     if query is None or query.message is None:
         return ConversationHandler.END
     await query.answer()
-    await query.message.delete()
+    message = cast(Message, query.message)
+    await message.delete()
 
     keyboard = InlineKeyboardMarkup(
         [
@@ -325,20 +353,23 @@ async def onboarding_demo_next(update: Update, context: ContextTypes.DEFAULT_TYP
             ]
         ]
     )
-    await query.message.reply_text(
+    await message.reply_text(
         "3/3. Включить напоминания о замерах сахара?",
         reply_markup=keyboard,
     )
     return ONB_REMINDERS
 
 
-async def onboarding_reminders(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def onboarding_reminders(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     """Handle reminder choice and finish onboarding."""
     query = update.callback_query
     user = update.effective_user
     if query is None or query.message is None or user is None:
         return ConversationHandler.END
     await query.answer()
+    message = cast(Message, query.message)
     enable = query.data == "onb_rem_yes"
     user_id = user.id
     reminders: list[Reminder] = []
@@ -347,7 +378,11 @@ async def onboarding_reminders(update: Update, context: ContextTypes.DEFAULT_TYP
         if user_obj:
             user_obj.onboarding_complete = True
             if enable:
-                reminders = session.query(Reminder).filter_by(telegram_id=user_id, type="sugar").all()
+                reminders = (
+                    session.query(Reminder)
+                    .filter_by(telegram_id=user_id, type="sugar")
+                    .all()
+                )
                 if not reminders:
                     reminders = [
                         Reminder(
@@ -361,13 +396,17 @@ async def onboarding_reminders(update: Update, context: ContextTypes.DEFAULT_TYP
                     for rem in reminders:
                         rem.is_enabled = True
             else:
-                reminders = session.query(Reminder).filter_by(telegram_id=user_id, type="sugar").all()
+                reminders = (
+                    session.query(Reminder)
+                    .filter_by(telegram_id=user_id, type="sugar")
+                    .all()
+                )
                 for rem in reminders:
                     rem.is_enabled = False
             try:
                 commit(session)
             except CommitError:
-                await query.message.reply_text("⚠️ Не удалось сохранить настройки.")
+                await message.reply_text("⚠️ Не удалось сохранить настройки.")
                 return ConversationHandler.END
 
     job_queue = getattr(context, "job_queue", None)
@@ -386,7 +425,7 @@ async def onboarding_reminders(update: Update, context: ContextTypes.DEFAULT_TYP
 
     logger.info("User %s reminder choice: %s", user_id, enable)
 
-    poll_msg = await query.message.reply_poll(
+    poll_msg = await message.reply_poll(
         "Как вам онбординг?",
         ["👍", "🙂", "👎"],
         is_anonymous=False,
@@ -397,7 +436,9 @@ async def onboarding_reminders(update: Update, context: ContextTypes.DEFAULT_TYP
     else:
         logger.warning("Poll message missing poll object for user %s", user_id)
 
-    await query.message.reply_text("Готово! Спасибо за настройку.", reply_markup=menu_keyboard())
+    await message.reply_text(
+        "Готово! Спасибо за настройку.", reply_markup=menu_keyboard()
+    )
     return ConversationHandler.END
 
 
@@ -408,6 +449,7 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     if query is None or query.message is None or user is None:
         return ConversationHandler.END
     await query.answer()
+    message = cast(Message, query.message)
 
     user_id = user.id
     with SessionLocal() as session:
@@ -417,13 +459,13 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             try:
                 commit(session)
             except CommitError:
-                await query.message.reply_text(
+                await message.reply_text(
                     "⚠️ Не удалось сохранить настройки.",
                     reply_markup=menu_keyboard(),
                 )
                 return ConversationHandler.END
 
-    poll_msg = await query.message.reply_poll(
+    poll_msg = await message.reply_poll(
         "Как вам онбординг?",
         ["👍", "🙂", "👎"],
         is_anonymous=False,
@@ -434,11 +476,13 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     else:
         logger.warning("Poll message missing poll object for user %s", user_id)
 
-    await query.message.reply_text("Пропущено.", reply_markup=menu_keyboard())
+    await message.reply_text("Пропущено.", reply_markup=menu_keyboard())
     return ConversationHandler.END
 
 
-async def onboarding_poll_answer(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def onboarding_poll_answer(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     """Log poll answers from onboarding feedback."""
     poll_answer = update.poll_answer
     if poll_answer is None:
@@ -494,7 +538,9 @@ onboarding_conv = ConversationHandler(
             CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
         ],
         ONB_REMINDERS: [
-            CallbackQueryNoWarnHandler(onboarding_reminders, pattern="^onb_rem_(yes|no)$"),
+            CallbackQueryNoWarnHandler(
+                onboarding_reminders, pattern="^onb_rem_(yes|no)$"
+            ),
             CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
         ],
     },

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from telegram import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
+    Message,
     ReplyKeyboardMarkup,
     Update,
     WebAppInfo,
@@ -377,7 +378,7 @@ async def profile_back(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     query = update.callback_query
     if query is None or query.message is None:
         return
-    message = query.message
+    message = cast(Message, query.message)
     await query.answer()
     await message.delete()
     await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
@@ -388,7 +389,7 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     query = update.callback_query
     if query is None or query.message is None:
         return END
-    message = query.message
+    message = cast(Message, query.message)
     await query.answer()
     await message.reply_text(
         "Введите ваш часовой пояс (например Europe/Moscow):",
@@ -546,6 +547,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     q_message = query.message
     if q_message is None:
         return
+    message = cast(Message, q_message)
     user = update.effective_user
     if user is None:
         return
@@ -568,7 +570,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 web_app=WebAppInfo(app_config.build_ui_url("/reminders")),
             )
             keyboard = InlineKeyboardMarkup([[button]])
-            await q_message.reply_text("Создать напоминание:", reply_markup=keyboard)
+            await message.reply_text("Создать напоминание:", reply_markup=keyboard)
     elif action == "del":
         await reminder_handlers.delete_reminder(update, context)
 
@@ -584,7 +586,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         await query.edit_message_text("Профиль не найден.")
         return
     if not result.get("commit_ok", True):
-        await q_message.reply_text(
+        await message.reply_text(
             "⚠️ Не удалось сохранить настройки.",
             reply_markup=menu_keyboard(),
         )
@@ -651,7 +653,7 @@ async def profile_edit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     query = update.callback_query
     if query is None or query.message is None:
         return END
-    message = query.message
+    message = cast(Message, query.message)
     await query.answer()
     await message.delete()
     await message.reply_text(

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -703,9 +703,10 @@ async def reminder_webapp_save(
 
 
 async def delete_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    message: Message | None = update.message or (
-        update.callback_query.message if update.callback_query else None
-    )
+    query = update.callback_query
+    message: Message | None = update.message
+    if message is None and query is not None and query.message is not None:
+        message = cast(Message, query.message)
     args = getattr(context, "args", [])
     if not args:
         if message:

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -18,6 +18,7 @@ from telegram import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     KeyboardButton,
+    Message,
     ReplyKeyboardMarkup,
     Update,
     WebAppInfo,
@@ -62,7 +63,9 @@ class EntryLike(Protocol):
 def render_entry(entry: EntryLike) -> str:
     """Render a single diary entry as HTML-formatted text."""
     day_str = html.escape(entry.event_time.strftime("%d.%m %H:%M"))
-    sugar = html.escape(str(entry.sugar_before)) if entry.sugar_before is not None else "—"
+    sugar = (
+        html.escape(str(entry.sugar_before)) if entry.sugar_before is not None else "—"
+    )
     dose = html.escape(str(entry.dose)) if entry.dose is not None else "—"
 
     if entry.carbs_g is not None:
@@ -142,9 +145,7 @@ async def history_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             return (
                 session.query(HistoryRecord)
                 .filter(HistoryRecord.telegram_id == user_id)
-                .order_by(
-                    HistoryRecord.date.desc(), HistoryRecord.time.desc()
-                )
+                .order_by(HistoryRecord.date.desc(), HistoryRecord.time.desc())
                 .limit(limit)
                 .all()
             )
@@ -166,12 +167,16 @@ async def history_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 [
                     InlineKeyboardButton(
                         "🌐 Открыть историю в WebApp",
-                        web_app=WebAppInfo(config.build_ui_url(f"/history?limit={limit}")),
+                        web_app=WebAppInfo(
+                            config.build_ui_url(f"/history?limit={limit}")
+                        ),
                     )
                 ]
             ]
         )
-        await message.reply_text("История также доступна в WebApp:", reply_markup=open_markup)
+        await message.reply_text(
+            "История также доступна в WebApp:", reply_markup=open_markup
+        )
 
     entries = [_history_record_to_entry(r) for r in records]
     for entry in entries:
@@ -179,28 +184,33 @@ async def history_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         markup = InlineKeyboardMarkup(
             [
                 [
-                    InlineKeyboardButton("✏️ Изменить", callback_data=f"edit:{entry.id}"),
+                    InlineKeyboardButton(
+                        "✏️ Изменить", callback_data=f"edit:{entry.id}"
+                    ),
                     InlineKeyboardButton("🗑 Удалить", callback_data=f"del:{entry.id}"),
                 ]
             ]
         )
         await message.reply_text(text, parse_mode="HTML", reply_markup=markup)
 
-    back_markup = InlineKeyboardMarkup([[InlineKeyboardButton("🔙 Назад", callback_data="report_back")]])
+    back_markup = InlineKeyboardMarkup(
+        [[InlineKeyboardButton("🔙 Назад", callback_data="report_back")]]
+    )
     await message.reply_text("Готово.", reply_markup=back_markup)
 
 
-async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def report_period_callback(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     """Handle report period selection via inline buttons."""
     query = update.callback_query
-    if query is None or query.data is None:
+    if query is None or query.data is None or query.message is None:
         return
     await query.answer()
-    message = query.message
+    message = cast(Message, query.message)
     if query.data == "report_back":
-        if message is not None:
-            await message.delete()
-            await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
+        await message.delete()
+        await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
         return
     period = query.data.split(":", 1)[1]
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -208,10 +218,14 @@ async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_T
         date_from = now.replace(hour=0, minute=0, second=0, microsecond=0)
         await send_report(update, context, date_from, "сегодня", query=query)
     elif period == "week":
-        date_from = (now - datetime.timedelta(days=7)).replace(hour=0, minute=0, second=0, microsecond=0)
+        date_from = (now - datetime.timedelta(days=7)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
         await send_report(update, context, date_from, "последнюю неделю", query=query)
     elif period == "month":
-        date_from = (now - datetime.timedelta(days=30)).replace(hour=0, minute=0, second=0, microsecond=0)
+        date_from = (now - datetime.timedelta(days=30)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
         await send_report(update, context, date_from, "последний месяц", query=query)
     elif period == "custom":
         user_data_raw = context.user_data
@@ -221,16 +235,17 @@ async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_T
         assert user_data_raw is not None
         user_data = cast(UserData, user_data_raw)
         user_data["awaiting_report_date"] = True
-        await query.edit_message_text("Введите дату начала отчёта в формате YYYY-MM-DD\nОтправьте «назад» для отмены.")
-        if message is not None:
-            await message.reply_text(
-                "Ожидаю дату…",
-                reply_markup=ReplyKeyboardMarkup(
-                    [[KeyboardButton(BACK_BUTTON_TEXT)]],
-                    resize_keyboard=True,
-                    one_time_keyboard=True,
-                ),
-            )
+        await query.edit_message_text(
+            "Введите дату начала отчёта в формате YYYY-MM-DD\nОтправьте «назад» для отмены."
+        )
+        await message.reply_text(
+            "Ожидаю дату…",
+            reply_markup=ReplyKeyboardMarkup(
+                [[KeyboardButton(BACK_BUTTON_TEXT)]],
+                resize_keyboard=True,
+                one_time_keyboard=True,
+            ),
+        )
     else:  # pragma: no cover - defensive
         await query.edit_message_text("Команда не распознана")
 
@@ -371,7 +386,9 @@ async def send_report(
     report_msg = "<b>Отчёт сформирован</b>\n\n" + "\n".join(summary_lines + day_lines)
 
     plot_buf = make_sugar_plot(entries, period_label)
-    pdf_buf = generate_pdf_report(summary_lines, errors, day_lines, gpt_text or default_gpt_text, plot_buf)
+    pdf_buf = generate_pdf_report(
+        summary_lines, errors, day_lines, gpt_text or default_gpt_text, plot_buf
+    )
     plot_buf.seek(0)
     pdf_buf.seek(0)
     if query is not None:
@@ -379,11 +396,12 @@ async def send_report(
         q_message = query.message
         if q_message is None:
             return
-        await q_message.reply_photo(
+        message = cast(Message, q_message)
+        await message.reply_photo(
             plot_buf,
             caption="График сахара за период",
         )
-        await q_message.reply_document(
+        await message.reply_document(
             pdf_buf,
             filename="diabetes_report.pdf",
             caption="PDF-отчёт для врача",

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -6,6 +6,7 @@ from telegram import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     ForceReply,
+    Message,
     CallbackQuery,
 )
 from telegram.ext import ContextTypes
@@ -96,6 +97,7 @@ async def handle_cancel_entry(
     message = query.message
     if message is None:
         return
+    message = cast(Message, message)
     await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
 
 
@@ -141,6 +143,7 @@ async def handle_edit_or_delete(
     message = query.message
     if message is None:
         return
+    message = cast(Message, message)
     user_data["edit_entry"] = {
         "id": entry_id,
         "chat_id": message.chat_id,
@@ -186,6 +189,7 @@ async def handle_edit_field(
     message = query.message
     if message is None:
         return
+    message = cast(Message, message)
     await message.reply_text(prompt, reply_markup=ForceReply(selective=True))
 
 


### PR DESCRIPTION
## Summary
- cast callback query messages to telegram `Message` after null checks
- propagate `Message` usage across onboarding, profile, reporting, router and reminder handlers

## Testing
- `ruff check services/api/app/diabetes/handlers/onboarding_handlers.py services/api/app/diabetes/handlers/profile/conversation.py services/api/app/diabetes/handlers/reminder_handlers.py services/api/app/diabetes/handlers/reporting_handlers.py services/api/app/diabetes/handlers/router.py`
- `mypy --strict .` *(fails: "Argument 1 to run_once of JobQueue has incompatible type...", "List item 1 has incompatible type 'CallbackQueryNoWarnHandler'" etc.)*
- `pytest -q` *(fails: AttributeError: 'DummyJobQueue' object has no attribute 'scheduler')*


------
https://chatgpt.com/codex/tasks/task_e_68b45c04cd78832ab1cedf33cc142aec