### PR TITLE
[handlers] drop runtime generics from telegram handlers

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import logging
 from collections.abc import Awaitable, Callable
-from typing import TypedDict, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 from sqlalchemy.orm import Session, sessionmaker
 from telegram import Update
@@ -36,7 +36,11 @@ SessionLocal: sessionmaker[Session] = _SessionLocal
 commit: Callable[[Session], None] = _commit
 
 CustomContext = ContextTypes.DEFAULT_TYPE
-DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]
+
+if TYPE_CHECKING:
+    DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]
+else:
+    DefaultJobQueue = JobQueue
 
 
 class AlertJobData(TypedDict, total=False):

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -15,6 +15,7 @@ from telegram.ext import (
     filters,
 )
 from sqlalchemy.exc import SQLAlchemyError
+from typing import TYPE_CHECKING, TypeAlias
 
 from .onboarding_handlers import onboarding_conv, onboarding_poll_answer
 from .common_handlers import menu_command, help_command, smart_input_help
@@ -31,6 +32,17 @@ from ..utils.ui import (
 )
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    CommandHandlerT: TypeAlias = CommandHandler[ContextTypes.DEFAULT_TYPE, object]
+    MessageHandlerT: TypeAlias = MessageHandler[ContextTypes.DEFAULT_TYPE, object]
+    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, object]
+    PollAnswerHandlerT: TypeAlias = PollAnswerHandler[ContextTypes.DEFAULT_TYPE, object]
+else:
+    CommandHandlerT = CommandHandler
+    MessageHandlerT = MessageHandler
+    CallbackQueryHandlerT = CallbackQueryHandler
+    PollAnswerHandlerT = PollAnswerHandler
 
 
 def register_profile_handlers(
@@ -50,17 +62,17 @@ def register_profile_handlers(
     app.add_handler(profile.profile_conv)
     app.add_handler(profile.profile_webapp_handler)
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
+        MessageHandlerT(
             filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view
         )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, None](
+        CallbackQueryHandlerT(
             profile.profile_security, pattern="^profile_security"
         )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, None](
+        CallbackQueryHandlerT(
             profile.profile_back, pattern="^profile_back$"
         )
     )
@@ -81,30 +93,30 @@ def register_reminder_handlers(
     from . import reminder_handlers
 
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
+        CommandHandlerT(
             "reminders", reminder_handlers.reminders_list
         )
     )
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
+        CommandHandlerT(
             "addreminder", reminder_handlers.add_reminder
         )
     )
     app.add_handler(reminder_handlers.reminder_action_handler)
     app.add_handler(reminder_handlers.reminder_webapp_handler)
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
+        CommandHandlerT(
             "delreminder", reminder_handlers.delete_reminder
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
+        MessageHandlerT(
             filters.Regex(re.escape(REMINDERS_BUTTON_TEXT)),
             reminder_handlers.reminders_list,
         )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, None](
+        CallbackQueryHandlerT(
             reminder_handlers.reminder_callback, pattern="^remind_"
         )
     )
@@ -143,14 +155,14 @@ def register_handlers(
     )
 
     app.add_handler(onboarding_conv)
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE, None]("menu", menu_command))
+    app.add_handler(CommandHandlerT("menu", menu_command))
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
+        CommandHandlerT(
             "report", reporting_handlers.report_request
         )
     )
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
+        CommandHandlerT(
             "history", reporting_handlers.history_view
         )
     )
@@ -161,82 +173,82 @@ def register_handlers(
     app.add_handler(sugar_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE, int]("cancel", dose_calc.dose_cancel)
+        CommandHandlerT("cancel", dose_calc.dose_cancel)
     )
-    app.add_handler(CommandHandler[ContextTypes.DEFAULT_TYPE, None]("help", help_command))
+    app.add_handler(CommandHandlerT("help", help_command))
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE, None]("gpt", gpt_handlers.chat_with_gpt)
+        CommandHandlerT("gpt", gpt_handlers.chat_with_gpt)
     )
     register_reminder_handlers(app)
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
+        CommandHandlerT(
             "alertstats", alert_handlers.alert_stats
         )
     )
     app.add_handler(
-        CommandHandler[ContextTypes.DEFAULT_TYPE, None](
+        CommandHandlerT(
             "hypoalert", security_handlers.hypo_alert_faq
         )
     )
     app.add_handler(
-        PollAnswerHandler[ContextTypes.DEFAULT_TYPE, None](onboarding_poll_answer)
+        PollAnswerHandlerT(onboarding_poll_answer)
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
+        MessageHandlerT(
             filters.Regex(re.escape(REPORT_BUTTON_TEXT)),
             reporting_handlers.report_request,
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
+        MessageHandlerT(
             filters.Regex(re.escape(HISTORY_BUTTON_TEXT)),
             reporting_handlers.history_view,
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
+        MessageHandlerT(
             filters.Regex(re.escape(PHOTO_BUTTON_TEXT)), photo_handlers.photo_prompt
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
+        MessageHandlerT(
             filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
+        MessageHandlerT(
             filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE, int](
+        MessageHandlerT(
             filters.Regex(re.escape(SOS_BUTTON_TEXT)),
             sos_handlers.sos_contact_start,
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE, None](
+        MessageHandlerT(
             filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE, int](
+        MessageHandlerT(
             filters.PHOTO, photo_handlers.photo_handler
         )
     )
     app.add_handler(
-        MessageHandler[ContextTypes.DEFAULT_TYPE, int](
+        MessageHandlerT(
             filters.Document.IMAGE, photo_handlers.doc_handler
         )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, None](
+        CallbackQueryHandlerT(
             reporting_handlers.report_period_callback, pattern="^report_back$"
         )
     )
     app.add_handler(
-        CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, None](
+        CallbackQueryHandlerT(
             reporting_handlers.report_period_callback, pattern="^report_period:"
         )
     )
-    app.add_handler(CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, None](callback_router))
+    app.add_handler(CallbackQueryHandlerT(callback_router))

--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -4,7 +4,7 @@ import datetime
 import inspect
 import logging
 from datetime import timedelta
-from typing import TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from telegram.ext import ContextTypes, JobQueue
@@ -14,7 +14,10 @@ from services.api.app.diabetes.utils.jobs import schedule_once
 
 logger = logging.getLogger(__name__)
 
-DefaultJobQueue: TypeAlias = JobQueue[ContextTypes.DEFAULT_TYPE]
+if TYPE_CHECKING:
+    DefaultJobQueue: TypeAlias = JobQueue[ContextTypes.DEFAULT_TYPE]
+else:
+    DefaultJobQueue = JobQueue
 
 
 def schedule_reminder(

--- a/services/api/app/diabetes/utils/jobs.py
+++ b/services/api/app/diabetes/utils/jobs.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import inspect
 from collections.abc import Callable, Coroutine
 from datetime import datetime, timedelta, timezone as dt_timezone, tzinfo
-from typing import Any
+from typing import Any, TYPE_CHECKING, TypeAlias
 
 from telegram.ext import ContextTypes, Job, JobQueue
-from typing import TypeAlias
 
 CustomContext: TypeAlias = ContextTypes.DEFAULT_TYPE
-DefaultJobQueue: TypeAlias = JobQueue[ContextTypes.DEFAULT_TYPE]
+
+if TYPE_CHECKING:
+    DefaultJobQueue: TypeAlias = JobQueue[ContextTypes.DEFAULT_TYPE]
+else:
+    DefaultJobQueue = JobQueue
 
 JobCallback = Callable[[CustomContext], Coroutine[Any, Any, object]]
 

--- a/services/api/app/menu_button.py
+++ b/services/api/app/menu_button.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 from telegram import MenuButtonDefault
 
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
+from typing import TYPE_CHECKING, TypeAlias
 
-DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]
+if TYPE_CHECKING:
+    DefaultJobQueue: TypeAlias = JobQueue[ContextTypes.DEFAULT_TYPE]
+else:
+    DefaultJobQueue = JobQueue
 
 
 async def post_init(

--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import logging
 
-from telegram.ext import ContextTypes, JobQueue
-
 from sqlalchemy.orm import Session, sessionmaker
 
 from .diabetes.services.db import Reminder, User
@@ -15,7 +13,7 @@ _job_queue: DefaultJobQueue | None = None
 SessionLocal: sessionmaker[Session] | None = None
 
 
-def set_job_queue(job_queue: JobQueue[ContextTypes.DEFAULT_TYPE] | None) -> None:
+def set_job_queue(job_queue: DefaultJobQueue | None) -> None:
     """Register a shared JobQueue used to schedule reminders."""
     global _job_queue
     _job_queue = job_queue

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -10,12 +10,16 @@ from zoneinfo import ZoneInfo
 from sqlalchemy.exc import SQLAlchemyError
 from telegram import BotCommand
 from telegram.ext import Application, ContextTypes, ExtBot, JobQueue
+from typing import TYPE_CHECKING, TypeAlias
 
 from services.api.app.config import settings
 from services.api.app.diabetes.services.db import init_db
 from services.api.app.menu_button import post_init as menu_button_post_init
 
-DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]
+if TYPE_CHECKING:
+    DefaultJobQueue: TypeAlias = JobQueue[ContextTypes.DEFAULT_TYPE]
+else:
+    DefaultJobQueue = JobQueue
 logger = logging.getLogger(__name__)
 
 TELEGRAM_TOKEN = settings.telegram_token


### PR DESCRIPTION
## Summary
- avoid subscripting telegram handler classes at runtime by instantiating plain `CommandHandler`/`MessageHandler` etc.
- provide `TYPE_CHECKING` aliases for typed handler and job queue classes
- update job queue aliases across modules to prevent runtime type errors

## Testing
- `pytest -q` *(fails: Coverage failure: total of 57 is less than fail-under=85; async functions not natively supported)*
- `mypy --strict services/api/app/diabetes/handlers/registration.py services/api/app/diabetes/handlers/alert_handlers.py services/api/app/diabetes/handlers/reminder_jobs.py services/api/app/diabetes/utils/jobs.py services/api/app/menu_button.py services/api/app/reminder_events.py services/bot/main.py` *(fails: various type errors in unrelated modules)*
- `ruff check services/api/app/diabetes/handlers/registration.py services/api/app/diabetes/handlers/alert_handlers.py services/api/app/diabetes/handlers/reminder_jobs.py services/api/app/diabetes/utils/jobs.py services/api/app/menu_button.py services/api/app/reminder_events.py services/bot/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4613202d4832a80249c043b77fae7