### PR TITLE
[handlers] Add runtime message checks

### DIFF
--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -95,9 +95,8 @@ async def handle_cancel_entry(
     user_data.pop("pending_entry", None)
     await query.edit_message_text("❌ Запись отменена.")
     message = query.message
-    if message is None:
+    if not isinstance(message, Message):
         return
-    message = cast(Message, message)
     await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
 
 
@@ -141,9 +140,8 @@ async def handle_edit_or_delete(
         return
     user_data = cast(UserData, user_data_raw)
     message = query.message
-    if message is None:
+    if not isinstance(message, Message):
         return
-    message = cast(Message, message)
     user_data["edit_entry"] = {
         "id": entry_id,
         "chat_id": message.chat_id,
@@ -187,9 +185,8 @@ async def handle_edit_field(
         "dose": "Введите дозу инсулина (ед.).",
     }.get(field, "Введите значение")
     message = query.message
-    if message is None:
+    if not isinstance(message, Message):
         return
-    message = cast(Message, message)
     await message.reply_text(prompt, reply_markup=ForceReply(selective=True))
 
 

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-from telegram import Message, Update
+from telegram import Chat, Message, Update
 from telegram.ext import CallbackContext, ContextTypes
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -16,13 +16,18 @@ os.environ.setdefault("DB_PASSWORD", "test")
 from services.api.app.diabetes.services.db import Base, User, Entry
 
 
-class DummyMessage:
+class DummyMessage(Message):
+    __slots__ = ("replies", "kwargs")
+
     def __init__(self, text: str = "", chat_id: int = 1, message_id: int = 1) -> None:
-        self.text: str = text
-        self.chat_id: int = chat_id
-        self.message_id: int = message_id
-        self.replies: list[str] = []
-        self.kwargs: list[dict[str, Any]] = []
+        super().__init__(
+            message_id=message_id,
+            date=datetime.datetime.now(),
+            chat=Chat(id=chat_id, type="private"),
+            text=text,
+        )
+        object.__setattr__(self, "replies", [])
+        object.__setattr__(self, "kwargs", [])
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -1,16 +1,24 @@
+import datetime
 import logging
 from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-from telegram import Update
+from telegram import Chat, Message, Update
 from telegram.ext import CallbackContext
 
 
-class DummyMessage:
+class DummyMessage(Message):
+    __slots__ = ("replies", "kwargs")
+
     def __init__(self) -> None:
-        self.replies: list[str] = []
-        self.kwargs: list[dict[str, Any]] = []
+        super().__init__(
+            message_id=1,
+            date=datetime.datetime.now(),
+            chat=Chat(id=1, type="private"),
+        )
+        object.__setattr__(self, "replies", [])
+        object.__setattr__(self, "kwargs", [])
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -4,7 +4,13 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
+from telegram import (
+    Chat,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Message,
+    Update,
+)
 from telegram.ext import CallbackContext, ContextTypes
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
@@ -16,13 +22,18 @@ from services.api.app.diabetes.handlers import UserData
 import services.api.app.diabetes.handlers.gpt_handlers as gpt_handlers
 
 
-class DummyMessage:
+class DummyMessage(Message):
+    __slots__ = ("replies", "kwargs")
+
     def __init__(self, text: str = "", chat_id: int = 1, message_id: int = 1) -> None:
-        self.text: str = text
-        self.chat_id: int = chat_id
-        self.message_id: int = message_id
-        self.replies: list[str] = []
-        self.kwargs: list[dict[str, Any]] = []
+        super().__init__(
+            message_id=message_id,
+            date=datetime.datetime.now(),
+            chat=Chat(id=chat_id, type="private"),
+            text=text,
+        )
+        object.__setattr__(self, "replies", [])
+        object.__setattr__(self, "kwargs", [])
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)


### PR DESCRIPTION
## Summary
- add runtime Message checks before using message APIs in router handlers
- adjust tests to use Message subclass stubs

## Testing
- `pytest -q --cov`
- `mypy --strict .` *(fails: Invariant type variable "U" used in protocol where covariant one is expected)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b46184cf44832a9e1be684be48a753