### PR TITLE
[onboarding] Validate callback messages

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -339,11 +339,13 @@ async def onboarding_demo_next(
 ) -> int:
     """Proceed from demo to reminder suggestion."""
     query = update.callback_query
-    if query is None or query.message is None:
+    if query is None:
+        return ConversationHandler.END
+    msg = query.message
+    if not isinstance(msg, Message):
         return ConversationHandler.END
     await query.answer()
-    message = cast(Message, query.message)
-    await message.delete()
+    await msg.delete()
 
     keyboard = InlineKeyboardMarkup(
         [
@@ -353,7 +355,7 @@ async def onboarding_demo_next(
             ]
         ]
     )
-    await message.reply_text(
+    await msg.reply_text(
         "3/3. Включить напоминания о замерах сахара?",
         reply_markup=keyboard,
     )
@@ -366,10 +368,12 @@ async def onboarding_reminders(
     """Handle reminder choice and finish onboarding."""
     query = update.callback_query
     user = update.effective_user
-    if query is None or query.message is None or user is None:
+    if query is None or user is None:
+        return ConversationHandler.END
+    msg = query.message
+    if not isinstance(msg, Message):
         return ConversationHandler.END
     await query.answer()
-    message = cast(Message, query.message)
     enable = query.data == "onb_rem_yes"
     user_id = user.id
     reminders: list[Reminder] = []
@@ -406,7 +410,7 @@ async def onboarding_reminders(
             try:
                 commit(session)
             except CommitError:
-                await message.reply_text("⚠️ Не удалось сохранить настройки.")
+                await msg.reply_text("⚠️ Не удалось сохранить настройки.")
                 return ConversationHandler.END
 
     job_queue = getattr(context, "job_queue", None)
@@ -425,7 +429,7 @@ async def onboarding_reminders(
 
     logger.info("User %s reminder choice: %s", user_id, enable)
 
-    poll_msg = await message.reply_poll(
+    poll_msg = await msg.reply_poll(
         "Как вам онбординг?",
         ["👍", "🙂", "👎"],
         is_anonymous=False,
@@ -436,7 +440,7 @@ async def onboarding_reminders(
     else:
         logger.warning("Poll message missing poll object for user %s", user_id)
 
-    await message.reply_text(
+    await msg.reply_text(
         "Готово! Спасибо за настройку.", reply_markup=menu_keyboard()
     )
     return ConversationHandler.END
@@ -446,10 +450,12 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     """Skip the onboarding entirely."""
     query = update.callback_query
     user = update.effective_user
-    if query is None or query.message is None or user is None:
+    if query is None or user is None:
+        return ConversationHandler.END
+    msg = query.message
+    if not isinstance(msg, Message):
         return ConversationHandler.END
     await query.answer()
-    message = cast(Message, query.message)
 
     user_id = user.id
     with SessionLocal() as session:
@@ -459,13 +465,13 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             try:
                 commit(session)
             except CommitError:
-                await message.reply_text(
+                await msg.reply_text(
                     "⚠️ Не удалось сохранить настройки.",
                     reply_markup=menu_keyboard(),
                 )
                 return ConversationHandler.END
 
-    poll_msg = await message.reply_poll(
+    poll_msg = await msg.reply_poll(
         "Как вам онбординг?",
         ["👍", "🙂", "👎"],
         is_anonymous=False,
@@ -476,7 +482,7 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     else:
         logger.warning("Poll message missing poll object for user %s", user_id)
 
-    await message.reply_text("Пропущено.", reply_markup=menu_keyboard())
+    await msg.reply_text("Пропущено.", reply_markup=menu_keyboard())
     return ConversationHandler.END
 
 

--- a/tests/handlers/test_onboarding_handlers.py
+++ b/tests/handlers/test_onboarding_handlers.py
@@ -85,6 +85,7 @@ async def test_onboarding_skip_cancels(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
     monkeypatch.setattr(onboarding, "commit", lambda s: None)
     monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
+    monkeypatch.setattr(onboarding, "Message", DummyMessage)
 
     message = DummyMessage()
     query = DummyQuery(message, "onb_skip")

--- a/tests/test_onboarding_edge_cases.py
+++ b/tests/test_onboarding_edge_cases.py
@@ -159,6 +159,7 @@ async def test_onboarding_reminders_repeated(monkeypatch: pytest.MonkeyPatch) ->
         SimpleNamespace(user_data={}, bot_data={}, job_queue=None),
     )
 
+    monkeypatch.setattr(onboarding, "Message", DummyMessage)
     query_yes = DummyQuery(message, "onb_rem_yes")
     update_yes = cast(
         Update,
@@ -202,6 +203,7 @@ async def test_onboarding_reminders_poll_missing(
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
     monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
+    monkeypatch.setattr(onboarding, "Message", DummyMessage)
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -237,6 +239,7 @@ async def test_onboarding_skip_commit_failure(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(onboarding, "commit", fail_commit)
     monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
+    monkeypatch.setattr(onboarding, "Message", DummyMessage)
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))

--- a/tests/test_onboarding_handlers_errors.py
+++ b/tests/test_onboarding_handlers_errors.py
@@ -86,3 +86,49 @@ async def test_onboarding_target_missing_data() -> None:
         "⚠️ Не хватает данных для профиля. Пожалуйста, начните заново."
     ]
 
+
+@pytest.mark.asyncio
+async def test_onboarding_demo_next_invalid_message_type() -> None:
+    query = SimpleNamespace(message=object())
+    update = cast(Update, SimpleNamespace(callback_query=query))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}, bot_data={}),
+    )
+    state = await onboarding.onboarding_demo_next(update, context)
+    assert state == ConversationHandler.END
+
+
+@pytest.mark.asyncio
+async def test_onboarding_reminders_invalid_message_type() -> None:
+    query = SimpleNamespace(message=object(), data="onb_rem_yes")
+    update = cast(
+        Update,
+        SimpleNamespace(
+            callback_query=query, effective_user=SimpleNamespace(id=1)
+        ),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}, bot_data={}, job_queue=None),
+    )
+    state = await onboarding.onboarding_reminders(update, context)
+    assert state == ConversationHandler.END
+
+
+@pytest.mark.asyncio
+async def test_onboarding_skip_invalid_message_type() -> None:
+    query = SimpleNamespace(message=object(), data="onb_skip")
+    update = cast(
+        Update,
+        SimpleNamespace(
+            callback_query=query, effective_user=SimpleNamespace(id=1)
+        ),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}, bot_data={}),
+    )
+    state = await onboarding.onboarding_skip(update, context)
+    assert state == ConversationHandler.END
+


### PR DESCRIPTION
## Summary
- ensure onboarding callback handlers verify `query.message` is a `Message`
- cover invalid callback message types in onboarding tests

## Testing
- `pytest -q` *(fails: async plugin missing, coverage 57<85)*
- `mypy --strict .` *(fails: List item incompatible type, attribute errors)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b46186589c832aad88a41c47055541