### PR TITLE
[bot] Use JobQueue timezone for test job

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -133,9 +133,14 @@ def main() -> None:  # pragma: no cover
             text="🔔 Test reminder fired! JobQueue работает ✅",
         )
 
-    if application.job_queue:
-        when = datetime.now(tz=application.timezone) + timedelta(seconds=30)
-        application.job_queue.run_once(
+    if job_queue:
+        tzinfo = (
+            job_queue.scheduler.timezone
+            if job_queue.scheduler.timezone
+            else ZoneInfo("UTC")
+        )
+        when = datetime.now(tz=tzinfo) + timedelta(seconds=30)
+        job_queue.run_once(
             test_job,
             when=when,
         )


### PR DESCRIPTION
## Summary
- use JobQueue scheduler timezone when scheduling initial test job, fallback to UTC

## Testing
- `pytest -q --cov`
- `mypy --strict .` *(fails: Incompatible types in assignment, Invariant type variable in protocol, etc.)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b46189768c832a934cff89952bfc96