### PR TITLE
[handlers] relax onboarding message guard

### DIFF
--- a/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
+++ b/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
@@ -1,16 +1,16 @@
 import re
 from typing import Callable, Coroutine, Optional
 
-from telegram import CallbackQuery, Update
+from telegram import Update
 from telegram.ext import BaseHandler, ContextTypes
 
 CallbackQueryHandlerCallback = Callable[
-    [Update, ContextTypes.DEFAULT_TYPE], Coroutine[object, object, int | None]
+    [Update, ContextTypes.DEFAULT_TYPE], Coroutine[object, object, object]
 ]
 
 
 class CallbackQueryNoWarnHandler(
-    BaseHandler[CallbackQuery, ContextTypes.DEFAULT_TYPE, int | None]
+    BaseHandler[Update, ContextTypes.DEFAULT_TYPE, object]
 ):
     """Handle callback queries without triggering ConversationHandler warnings."""
 
@@ -25,9 +25,9 @@ class CallbackQueryNoWarnHandler(
             re.compile(pattern) if pattern else None
         )
 
-    def check_update(self, update: object) -> Optional[CallbackQuery]:
+    def check_update(self, update: object) -> Optional[Update]:
         if isinstance(update, Update) and update.callback_query:
             data = update.callback_query.data or ""
             if self.pattern is None or self.pattern.match(data):
-                return update.callback_query
+                return update
         return None

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -339,10 +339,10 @@ async def onboarding_demo_next(
 ) -> int:
     """Proceed from demo to reminder suggestion."""
     query = update.callback_query
-    if query is None:
+    if query is None or not hasattr(query, "answer"):
         return ConversationHandler.END
     msg = query.message
-    if not isinstance(msg, Message):
+    if msg is None or not hasattr(msg, "delete") or not hasattr(msg, "reply_text"):
         return ConversationHandler.END
     await query.answer()
     await msg.delete()
@@ -368,10 +368,10 @@ async def onboarding_reminders(
     """Handle reminder choice and finish onboarding."""
     query = update.callback_query
     user = update.effective_user
-    if query is None or user is None:
+    if query is None or user is None or not hasattr(query, "answer"):
         return ConversationHandler.END
     msg = query.message
-    if not isinstance(msg, Message):
+    if msg is None or not hasattr(msg, "reply_poll") or not hasattr(msg, "reply_text"):
         return ConversationHandler.END
     await query.answer()
     enable = query.data == "onb_rem_yes"


### PR DESCRIPTION
## Summary
- loosen onboarding_demo_next to only check for missing callback query or message rather than enforcing telegram.Message
- add attribute guards in onboarding demo and reminders steps
- adjust CallbackQueryNoWarnHandler generics to accept Update and satisfy mypy

## Testing
- `pytest tests/test_onboarding_flow.py::test_onboarding_flow -q` *(fails: coverage total of 32 is less than fail-under=85)*
- `pytest -q --cov --cov-report=term --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b468903430832a987c01a68b2e53ec