### PR TITLE
[handlers] Handle missing messages in onboarding callbacks

### DIFF
--- a/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
+++ b/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
@@ -10,7 +10,7 @@ CallbackQueryHandlerCallback = Callable[
 
 
 class CallbackQueryNoWarnHandler(
-    BaseHandler[CallbackQuery, ContextTypes.DEFAULT_TYPE, int | None]
+    BaseHandler[Update, ContextTypes.DEFAULT_TYPE, int | None]
 ):
     """Handle callback queries without triggering ConversationHandler warnings."""
 

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -24,6 +24,7 @@ from telegram import (
     Update,
 )
 from telegram.ext import (
+    BaseHandler,
     CommandHandler,
     ContextTypes,
     ConversationHandler,
@@ -371,8 +372,9 @@ async def onboarding_reminders(
     if query is None or user is None:
         return ConversationHandler.END
     msg = query.message
-    if not isinstance(msg, Message):
+    if msg is None:
         return ConversationHandler.END
+    msg = cast(Message, msg)
     await query.answer()
     enable = query.data == "onb_rem_yes"
     user_id = user.id
@@ -453,8 +455,9 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     if query is None or user is None:
         return ConversationHandler.END
     msg = query.message
-    if not isinstance(msg, Message):
+    if msg is None:
         return ConversationHandler.END
+    msg = cast(Message, msg)
     await query.answer()
 
     user_id = user.id
@@ -522,32 +525,56 @@ onboarding_conv = ConversationHandler(
     states={
         ONB_PROFILE_ICR: [
             MessageHandler(filters.TEXT & ~filters.COMMAND, onboarding_icr),
-            CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
+            cast(
+                BaseHandler[Update, ContextTypes.DEFAULT_TYPE, object],
+                CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
+            ),
         ],
         ONB_PROFILE_CF: [
             MessageHandler(filters.TEXT & ~filters.COMMAND, onboarding_cf),
-            CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
+            cast(
+                BaseHandler[Update, ContextTypes.DEFAULT_TYPE, object],
+                CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
+            ),
         ],
         ONB_PROFILE_TARGET: [
             MessageHandler(filters.TEXT & ~filters.COMMAND, onboarding_target),
-            CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
+            cast(
+                BaseHandler[Update, ContextTypes.DEFAULT_TYPE, object],
+                CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
+            ),
         ],
         ONB_PROFILE_TZ: [
             MessageHandler(
                 (filters.TEXT & ~filters.COMMAND) | filters.StatusUpdate.WEB_APP_DATA,
                 onboarding_timezone,
             ),
-            CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
+            cast(
+                BaseHandler[Update, ContextTypes.DEFAULT_TYPE, object],
+                CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
+            ),
         ],
         ONB_DEMO: [
-            CallbackQueryNoWarnHandler(onboarding_demo_next, pattern="^onb_next$"),
-            CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
+            cast(
+                BaseHandler[Update, ContextTypes.DEFAULT_TYPE, object],
+                CallbackQueryNoWarnHandler(onboarding_demo_next, pattern="^onb_next$"),
+            ),
+            cast(
+                BaseHandler[Update, ContextTypes.DEFAULT_TYPE, object],
+                CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
+            ),
         ],
         ONB_REMINDERS: [
-            CallbackQueryNoWarnHandler(
-                onboarding_reminders, pattern="^onb_rem_(yes|no)$"
+            cast(
+                BaseHandler[Update, ContextTypes.DEFAULT_TYPE, object],
+                CallbackQueryNoWarnHandler(
+                    onboarding_reminders, pattern="^onb_rem_(yes|no)$"
+                ),
             ),
-            CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
+            cast(
+                BaseHandler[Update, ContextTypes.DEFAULT_TYPE, object],
+                CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
+            ),
         ],
     },
     fallbacks=[

--- a/tests/test_onboarding_flow.py
+++ b/tests/test_onboarding_flow.py
@@ -66,6 +66,8 @@ async def test_onboarding_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(gpt_client, "create_thread", fake_create_thread)
 
+    monkeypatch.setattr(onboarding, "Message", DummyMessage)
+
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/tests/test_onboarding_handlers_errors.py
+++ b/tests/test_onboarding_handlers_errors.py
@@ -100,8 +100,12 @@ async def test_onboarding_demo_next_invalid_message_type() -> None:
 
 
 @pytest.mark.asyncio
-async def test_onboarding_reminders_invalid_message_type() -> None:
-    query = SimpleNamespace(message=object(), data="onb_rem_yes")
+async def test_onboarding_reminders_missing_message() -> None:
+    class DummyQuery(SimpleNamespace):
+        async def answer(self) -> None:
+            pass
+
+    query = DummyQuery(message=None, data="onb_rem_yes")
     update = cast(
         Update,
         SimpleNamespace(
@@ -117,8 +121,12 @@ async def test_onboarding_reminders_invalid_message_type() -> None:
 
 
 @pytest.mark.asyncio
-async def test_onboarding_skip_invalid_message_type() -> None:
-    query = SimpleNamespace(message=object(), data="onb_skip")
+async def test_onboarding_skip_missing_message() -> None:
+    class DummyQuery(SimpleNamespace):
+        async def answer(self) -> None:
+            pass
+
+    query = DummyQuery(message=None, data="onb_skip")
     update = cast(
         Update,
         SimpleNamespace(


### PR DESCRIPTION
## Summary
- guard onboarding reminder and skip handlers against missing callback messages
- fix CallbackQueryNoWarnHandler base typing for mypy
- adjust onboarding tests for new message handling

## Testing
- `pytest -o addopts='' tests/test_onboarding* tests/handlers/test_onboarding_handlers.py tests/test_photo_fallbacks.py tests/test_register_handlers.py -q`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b468914f3c832a81b771fee2bd91af