### PR TITLE
[bot] Register job queue before scheduling reminders

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -32,7 +32,7 @@ def schedule_reminder(
     from services.api.app import reminder_events
     from . import reminder_handlers
 
-    reminder_events.set_job_queue(job_queue)
+    reminder_events.register_job_queue(job_queue)
     reminder_job = reminder_handlers.reminder_job
     SessionLocal = reminder_handlers.SessionLocal
 

--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -9,14 +9,16 @@ from .diabetes.handlers.reminder_jobs import DefaultJobQueue, schedule_reminder
 
 logger = logging.getLogger(__name__)
 
-_job_queue: DefaultJobQueue | None = None
+# Shared job queue used across the application. It is configured during
+# application startup via :func:`register_job_queue`.
+job_queue: DefaultJobQueue | None = None
 SessionLocal: sessionmaker[Session] | None = None
 
 
-def set_job_queue(job_queue: DefaultJobQueue | None) -> None:
+def register_job_queue(jq: DefaultJobQueue | None) -> None:
     """Register a shared JobQueue used to schedule reminders."""
-    global _job_queue
-    _job_queue = job_queue
+    global job_queue
+    job_queue = jq
 
 
 def notify_reminder_saved(reminder_id: int) -> None:
@@ -24,7 +26,7 @@ def notify_reminder_saved(reminder_id: int) -> None:
 
     Raises RuntimeError if the job queue is not configured.
     """
-    jq = _job_queue
+    jq = job_queue
     if jq is None:
         msg = "notify_reminder_saved called without job_queue"
         raise RuntimeError(msg)
@@ -46,7 +48,7 @@ def notify_reminder_deleted(reminder_id: int) -> None:
 
     Raises RuntimeError if the job queue is not configured.
     """
-    jq = _job_queue
+    jq = job_queue
     if jq is None:
         msg = "notify_reminder_deleted called without job_queue"
         raise RuntimeError(msg)
@@ -54,4 +56,4 @@ def notify_reminder_deleted(reminder_id: int) -> None:
         job.schedule_removal()
 
 
-__all__ = ["set_job_queue", "notify_reminder_saved", "notify_reminder_deleted"]
+__all__ = ["register_job_queue", "notify_reminder_saved", "notify_reminder_deleted"]

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -120,7 +120,7 @@ def main() -> None:  # pragma: no cover
 
     from services.api.app import reminder_events
 
-    reminder_events.set_job_queue(job_queue)
+    reminder_events.register_job_queue(application.job_queue)
 
     from services.api.app.diabetes.handlers.registration import register_handlers
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,9 +117,9 @@ def _dummy_job_queue() -> Iterator[None]:
     from services.api.app import reminder_events
 
     jq = _DummyJobQueue()
-    reminder_events.set_job_queue(cast(Any, jq))
+    reminder_events.register_job_queue(cast(Any, jq))
     yield
-    reminder_events.set_job_queue(None)
+    reminder_events.register_job_queue(None)
 
 # Avoid real database initialization during tests
 db_module.init_db = lambda: None

--- a/tests/test_reminder_events.py
+++ b/tests/test_reminder_events.py
@@ -1,9 +1,29 @@
+from __future__ import annotations
+
 import pytest
+from typing import Any, cast
 
 from services.api.app import reminder_events
 
 
 def test_notify_without_job_queue_raises() -> None:
-    reminder_events.set_job_queue(None)
+    reminder_events.register_job_queue(None)
     with pytest.raises(RuntimeError):
         reminder_events.notify_reminder_saved(1)
+
+
+def test_notify_with_job_queue(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - simple stub
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - simple stub
+            return None
+
+        def get(self, *args: object, **kwargs: object) -> None:  # pragma: no cover
+            return None
+
+    monkeypatch.setattr(reminder_events, "SessionLocal", lambda: DummySession())
+    reminder_events.register_job_queue(cast(Any, object()))
+    reminder_events.notify_reminder_saved(1)
+    reminder_events.register_job_queue(None)

--- a/tests/test_reminders_api.py
+++ b/tests/test_reminders_api.py
@@ -105,13 +105,13 @@ def client_with_job_queue(
         lambda rem, tz: datetime(2023, 1, 1, tzinfo=timezone.utc),
     )
     job_queue = DummyJobQueue()
-    reminder_events.set_job_queue(cast(Any, job_queue))
+    reminder_events.register_job_queue(cast(Any, job_queue))
     app = FastAPI()
     app.include_router(router, prefix="/api")
     app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
     with TestClient(app) as test_client:
         yield test_client, job_queue
-    reminder_events.set_job_queue(None)
+    reminder_events.register_job_queue(None)
 
 
 def test_empty_returns_200(


### PR DESCRIPTION
## Summary
- expose a shared `job_queue` and `register_job_queue()` in `reminder_events`
- register the application's job queue before any reminders are scheduled
- update reminder scheduling utilities and tests for the new API

## Testing
- `pytest -q --cov` *(fails: test_onboarding_flow)*
- `mypy --strict .` *(fails: found 10 errors in 2 files)*
- `ruff check services/api/app/reminder_events.py services/bot/main.py services/api/app/diabetes/handlers/reminder_jobs.py tests/conftest.py tests/test_reminder_events.py tests/test_reminders_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68b468f79d68832aba6bb3219e411326