### PR TITLE
[bot] Graceful JobQueue shutdown

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -149,7 +149,11 @@ def main() -> None:  # pragma: no cover
             when=when,
         )
 
-    application.run_polling()
+    try:
+        application.run_polling()
+    finally:
+        if getattr(job_queue.scheduler, "running", False):
+            job_queue.scheduler.shutdown()
 
 
 __all__ = ["main", "error_handler", "settings", "TELEGRAM_TOKEN"]


### PR DESCRIPTION
## Summary
- ensure JobQueue stops via scheduler.shutdown in main bot entry point

## Testing
- `pytest -q` *(fails: tests/test_onboarding_flow.py::test_onboarding_flow - AssertionError: assert -1 == 5)*
- `mypy --strict .` *(fails: Argument 2 to "__init__" of "BaseHandler" has incompatible type ...)*
- `ruff check .`
- `systemctl stop diabetes-bot` *(fails: System has not been booted with systemd as init system)*

------
https://chatgpt.com/codex/tasks/task_e_68b468fa930c832abf6a3e7703d5062b