### PR TITLE
[handlers] Simplify onboarding message checks

### DIFF
--- a/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
+++ b/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
@@ -1,7 +1,7 @@
 import re
 from typing import Callable, Coroutine, Optional
 
-from telegram import Update
+from telegram import CallbackQuery, Update
 from telegram.ext import BaseHandler, ContextTypes
 
 CallbackQueryHandlerCallback = Callable[
@@ -25,9 +25,9 @@ class CallbackQueryNoWarnHandler(
             re.compile(pattern) if pattern else None
         )
 
-    def check_update(self, update: object) -> Optional[Update]:
+    def check_update(self, update: object) -> Optional[CallbackQuery]:
         if isinstance(update, Update) and update.callback_query:
             data = update.callback_query.data or ""
             if self.pattern is None or self.pattern.match(data):
-                return update
+                return update.callback_query
         return None

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -17,12 +17,7 @@ import logging
 from pathlib import Path
 from typing import cast
 
-from telegram import (
-    InlineKeyboardButton,
-    InlineKeyboardMarkup,
-    Message,
-    Update,
-)
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
 from telegram.ext import (
     CommandHandler,
     ContextTypes,
@@ -371,8 +366,9 @@ async def onboarding_reminders(
     if query is None or user is None or not hasattr(query, "answer"):
         return ConversationHandler.END
     msg = query.message
-    if msg is None or not hasattr(msg, "reply_poll") or not hasattr(msg, "reply_text"):
+    if msg is None:
         return ConversationHandler.END
+    msg = cast(Message, msg)
     await query.answer()
     enable = query.data == "onb_rem_yes"
     user_id = user.id
@@ -440,9 +436,7 @@ async def onboarding_reminders(
     else:
         logger.warning("Poll message missing poll object for user %s", user_id)
 
-    await msg.reply_text(
-        "Готово! Спасибо за настройку.", reply_markup=menu_keyboard()
-    )
+    await msg.reply_text("Готово! Спасибо за настройку.", reply_markup=menu_keyboard())
     return ConversationHandler.END
 
 
@@ -450,11 +444,12 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     """Skip the onboarding entirely."""
     query = update.callback_query
     user = update.effective_user
-    if query is None or user is None:
+    if query is None or user is None or not hasattr(query, "answer"):
         return ConversationHandler.END
     msg = query.message
-    if not isinstance(msg, Message):
+    if msg is None:
         return ConversationHandler.END
+    msg = cast(Message, msg)
     await query.answer()
 
     user_id = user.id

--- a/tests/handlers/test_onboarding_handlers.py
+++ b/tests/handlers/test_onboarding_handlers.py
@@ -85,7 +85,6 @@ async def test_onboarding_skip_cancels(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
     monkeypatch.setattr(onboarding, "commit", lambda s: None)
     monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
-    monkeypatch.setattr(onboarding, "Message", DummyMessage)
 
     message = DummyMessage()
     query = DummyQuery(message, "onb_skip")

--- a/tests/test_onboarding_edge_cases.py
+++ b/tests/test_onboarding_edge_cases.py
@@ -159,7 +159,6 @@ async def test_onboarding_reminders_repeated(monkeypatch: pytest.MonkeyPatch) ->
         SimpleNamespace(user_data={}, bot_data={}, job_queue=None),
     )
 
-    monkeypatch.setattr(onboarding, "Message", DummyMessage)
     query_yes = DummyQuery(message, "onb_rem_yes")
     update_yes = cast(
         Update,
@@ -203,7 +202,6 @@ async def test_onboarding_reminders_poll_missing(
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
     monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
-    monkeypatch.setattr(onboarding, "Message", DummyMessage)
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -234,12 +232,12 @@ async def test_onboarding_skip_commit_failure(monkeypatch: pytest.MonkeyPatch) -
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
+
     def fail_commit(session: object) -> None:
         raise onboarding.CommitError
 
     monkeypatch.setattr(onboarding, "commit", fail_commit)
     monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
-    monkeypatch.setattr(onboarding, "Message", DummyMessage)
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))


### PR DESCRIPTION
## Summary
- Drop Message isinstance checks in onboarding_reminders/onboarding_skip and handle None directly
- Return callback query in CallbackQueryNoWarnHandler.check_update
- Align onboarding tests with new message handling

## Testing
- `pytest tests/test_onboarding* tests/handlers/test_onboarding_handlers.py -q --cov-fail-under=0`
- `pytest -q`
- `mypy --strict .`
- `ruff check services/api/app/diabetes/handlers/onboarding_handlers.py services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py tests/test_onboarding_edge_cases.py tests/handlers/test_onboarding_handlers.py`

------
https://chatgpt.com/codex/tasks/task_e_68b46bd1fed8832a9dc1e2adba284a38