### PR TITLE
[bot] make timezone configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ sudo apt install python3.12 python3.12-venv
 Приложение автоматически загружает переменные окружения из этого файла в корне проекта.
 
 - обязательные значения: `TELEGRAM_TOKEN` (токен бота), `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
-- дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `VITE_API_BASE`, `VITE_BASE_URL`, `UI_BASE_URL`, `UVICORN_WORKERS`
+- дополнительные: `LOG_LEVEL` или `DEBUG`, `WEBAPP_URL`, `VITE_API_BASE`, `VITE_BASE_URL`, `UI_BASE_URL`, `UVICORN_WORKERS`, `BOT_TZ`
+- `BOT_TZ` задаёт часовой пояс бота (IANA‑строка, по умолчанию `UTC`)
 - для появления кнопки «Определить автоматически» при выборе часового пояса нужно задать `PUBLIC_ORIGIN` (и оставить `UI_BASE_URL` ненулевым)
 - при необходимости настройте прокси для OpenAI через переменные окружения
 Переменная `VITE_API_BASE` задаёт базовый URL API для WebApp и используется SDK‑клиентом.

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -36,3 +36,4 @@ FONT_DIR=infra/fonts
 
 # Telegram
 TELEGRAM_TOKEN=your-telegram-bot-token
+BOT_TZ=UTC

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -61,6 +61,7 @@ class Settings(BaseSettings):
     font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
     telegram_token: Optional[str] = Field(default=None, alias="TELEGRAM_TOKEN")
     admin_id: Optional[int] = Field(default=None, alias="ADMIN_ID")
+    bot_timezone: str = Field(default="UTC", alias="BOT_TZ")
 
     @field_validator("log_level", mode="before")
     @classmethod

--- a/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
+++ b/services/api/app/diabetes/handlers/callbackquery_no_warn_handler.py
@@ -1,7 +1,7 @@
 import re
 from typing import Callable, Coroutine, Optional
 
-from telegram import Update
+from telegram import CallbackQuery, Update
 from telegram.ext import BaseHandler, ContextTypes
 
 CallbackQueryHandlerCallback = Callable[
@@ -25,9 +25,9 @@ class CallbackQueryNoWarnHandler(
             re.compile(pattern) if pattern else None
         )
 
-    def check_update(self, update: object) -> Optional[Update]:
+    def check_update(self, update: object) -> Optional[CallbackQuery]:
         if isinstance(update, Update) and update.callback_query:
             data = update.callback_query.data or ""
             if self.pattern is None or self.pattern.match(data):
-                return update
+                return update.callback_query
         return None

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -3,6 +3,7 @@ Bot entry point and configuration.
 """
 
 import logging
+import os
 import sys
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
@@ -95,7 +96,8 @@ def main() -> None:  # pragma: no cover
         .token(BOT_TOKEN)
         .post_init(post_init)  # registers post-init handler
     )
-    timezone = ZoneInfo("Europe/Moscow")
+    tz_name = os.getenv("BOT_TZ", settings.bot_timezone)
+    timezone = ZoneInfo(tz_name)
     if hasattr(builder, "timezone"):
         builder = builder.timezone(timezone)
     elif hasattr(builder, "job_queue"):

--- a/tests/test_bot_timezone.py
+++ b/tests/test_bot_timezone.py
@@ -1,0 +1,129 @@
+"""Tests for bot timezone configuration."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from zoneinfo import ZoneInfo
+
+import pytest
+
+
+def _run_bot(monkeypatch: pytest.MonkeyPatch) -> tuple[ZoneInfo, ZoneInfo]:
+    """Import ``bot.main`` and return scheduler and app timezones."""
+
+    bot = importlib.import_module("services.bot.main")
+    monkeypatch.setattr(bot.settings, "telegram_token", "token")
+    monkeypatch.setattr(bot.settings, "admin_id", 1, raising=False)
+    monkeypatch.setattr(bot, "TELEGRAM_TOKEN", "token")
+    monkeypatch.setattr(bot, "init_db", lambda: None)
+
+    class DummyJobQueue:
+        class _Scheduler:
+            def __init__(self) -> None:
+                self.timezone: ZoneInfo | None = None
+                self.running = False
+
+            def configure(self, *, timezone: ZoneInfo) -> None:  # noqa: D401
+                self.timezone = timezone
+
+        def __init__(self) -> None:
+            self.scheduler = self._Scheduler()
+
+        def run_once(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def get_jobs_by_name(self, name: str) -> list[object]:  # pragma: no cover - compat
+            return []
+
+        def run_repeating(self, *args: object, **kwargs: object) -> None:  # pragma: no cover
+            return None
+
+        def jobs(self) -> list[object]:  # pragma: no cover - compat
+            return []
+
+    class DummyBot:
+        def set_my_commands(self, commands: list[tuple[str, str]]) -> None:  # pragma: no cover
+            return None
+
+    class DummyApp:
+        def __init__(self) -> None:
+            self.bot = DummyBot()
+            self.job_queue = DummyJobQueue()
+            self.timezone: ZoneInfo | None = None
+
+        def add_error_handler(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def add_handler(self, *args: object, **kwargs: object) -> None:  # pragma: no cover
+            return None
+
+        def run_polling(self) -> None:  # pragma: no cover - compat
+            return None
+
+    built_app = DummyApp()
+
+    class DummyBuilder:
+        def __init__(self) -> None:
+            self._tz: ZoneInfo | None = None
+
+        def token(self, _: str) -> "DummyBuilder":
+            return self
+
+        def post_init(self, _: object) -> "DummyBuilder":
+            return self
+
+        def timezone(self, tz: ZoneInfo) -> "DummyBuilder":
+            self._tz = tz
+            return self
+
+        def build(self) -> DummyApp:
+            built_app.timezone = self._tz
+            return built_app
+
+    class DummyApplication:
+        @staticmethod
+        def builder() -> DummyBuilder:
+            return DummyBuilder()
+
+        def __class_getitem__(cls, _: object) -> type["DummyApplication"]:  # pragma: no cover
+            return cls
+
+    monkeypatch.setattr(bot, "Application", DummyApplication)
+    monkeypatch.setattr(bot, "register_handlers", lambda app: None, raising=False)
+
+    bot.main()
+
+    assert built_app.job_queue.scheduler.timezone is not None
+    assert built_app.timezone is not None
+    return built_app.job_queue.scheduler.timezone, built_app.timezone
+
+
+def test_timezone_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default timezone is UTC when ``BOT_TZ`` is unset."""
+
+    monkeypatch.setenv("DB_PASSWORD", "pwd")
+    monkeypatch.delenv("BOT_TZ", raising=False)
+    for mod in ["services.api.app.config", "services.bot.main"]:
+        sys.modules.pop(mod, None)
+
+    sched_tz, app_tz = _run_bot(monkeypatch)
+
+    assert sched_tz == ZoneInfo("UTC")
+    assert app_tz == ZoneInfo("UTC")
+
+
+def test_timezone_custom(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Custom timezone from ``BOT_TZ`` is respected."""
+
+    monkeypatch.setenv("DB_PASSWORD", "pwd")
+    monkeypatch.setenv("BOT_TZ", "Asia/Tokyo")
+    for mod in ["services.api.app.config", "services.bot.main"]:
+        sys.modules.pop(mod, None)
+
+    sched_tz, app_tz = _run_bot(monkeypatch)
+
+    tokyo = ZoneInfo("Asia/Tokyo")
+    assert sched_tz == tokyo
+    assert app_tz == tokyo
+


### PR DESCRIPTION
## Summary
- allow setting bot timezone via `BOT_TZ` environment variable
- document `BOT_TZ` and provide example
- test default and custom timezone configurations
- fix `CallbackQueryNoWarnHandler` to return callback query object

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b46c5a1dc4832aa177a66cccba7da6