### PR TITLE
[handlers] simplify onboarding message checks

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -86,12 +86,8 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
             try:
                 thread_id = await create_thread()
             except OpenAIError as exc:  # pragma: no cover - network errors
-                logger.exception(
-                    "Failed to create thread for user %s: %s", user_id, exc
-                )
-                await message.reply_text(
-                    "⚠️ Не удалось инициализировать профиль. Попробуйте позже."
-                )
+                logger.exception("Failed to create thread for user %s: %s", user_id, exc)
+                await message.reply_text("⚠️ Не удалось инициализировать профиль. Попробуйте позже.")
                 return ConversationHandler.END
             user_obj = User(telegram_id=user_id, thread_id=thread_id)
             session.add(user_obj)
@@ -104,9 +100,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         if user_obj.onboarding_complete:
             greeting = f"👋 Привет, {first_name}!" if first_name else "👋 Привет!"
             greeting += " Рада видеть тебя. Надеюсь, у тебя сегодня всё отлично."
-            await message.reply_text(
-                f"{greeting}\n\n📋 Выберите действие:", reply_markup=menu_keyboard()
-            )
+            await message.reply_text(f"{greeting}\n\n📋 Выберите действие:", reply_markup=menu_keyboard())
             return ConversationHandler.END
 
     await message.reply_text(
@@ -119,9 +113,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
 def _skip_markup() -> InlineKeyboardMarkup:
     """Markup containing a single *skip* button."""
 
-    return InlineKeyboardMarkup(
-        [[InlineKeyboardButton("Пропустить", callback_data="onb_skip")]]
-    )
+    return InlineKeyboardMarkup([[InlineKeyboardButton("Пропустить", callback_data="onb_skip")]])
 
 
 async def onboarding_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -141,9 +133,7 @@ async def onboarding_icr(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await message.reply_text("Введите ИКХ числом.", reply_markup=_skip_markup())
         return ONB_PROFILE_ICR
     if icr <= 0:
-        await message.reply_text(
-            "ИКХ должен быть больше 0.", reply_markup=_skip_markup()
-        )
+        await message.reply_text("ИКХ должен быть больше 0.", reply_markup=_skip_markup())
         return ONB_PROFILE_ICR
     user_data["profile_icr"] = icr
     await message.reply_text(
@@ -170,9 +160,7 @@ async def onboarding_cf(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         await message.reply_text("Введите КЧ числом.", reply_markup=_skip_markup())
         return ONB_PROFILE_CF
     if cf <= 0:
-        await message.reply_text(
-            "КЧ должен быть больше 0.", reply_markup=_skip_markup()
-        )
+        await message.reply_text("КЧ должен быть больше 0.", reply_markup=_skip_markup())
         return ONB_PROFILE_CF
     user_data["profile_cf"] = cf
     await message.reply_text(
@@ -197,22 +185,16 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     try:
         target = float(message.text.replace(",", "."))
     except ValueError:
-        await message.reply_text(
-            "Введите целевой сахар числом.", reply_markup=_skip_markup()
-        )
+        await message.reply_text("Введите целевой сахар числом.", reply_markup=_skip_markup())
         return ONB_PROFILE_TARGET
     if target <= 0:
-        await message.reply_text(
-            "Целевой сахар должен быть больше 0.", reply_markup=_skip_markup()
-        )
+        await message.reply_text("Целевой сахар должен быть больше 0.", reply_markup=_skip_markup())
         return ONB_PROFILE_TARGET
 
     icr = user_data.pop("profile_icr", None)
     cf = user_data.pop("profile_cf", None)
     if icr is None or cf is None:
-        await message.reply_text(
-            "⚠️ Не хватает данных для профиля. Пожалуйста, начните заново."
-        )
+        await message.reply_text("⚠️ Не хватает данных для профиля. Пожалуйста, начните заново.")
         return ConversationHandler.END
     user_id = user.id
 
@@ -240,9 +222,7 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             "Введите ваш часовой пояс (например Europe/Moscow). "
             "Автоматическое определение недоступно, укажите его вручную."
         )
-    keyboard_buttons.append(
-        InlineKeyboardButton("Пропустить", callback_data="onb_skip")
-    )
+    keyboard_buttons.append(InlineKeyboardButton("Пропустить", callback_data="onb_skip"))
     await message.reply_text(
         prompt,
         reply_markup=InlineKeyboardMarkup([keyboard_buttons]),
@@ -250,9 +230,7 @@ async def onboarding_target(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     return ONB_PROFILE_TZ
 
 
-async def onboarding_timezone(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def onboarding_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle user timezone (text or WebApp) and proceed to demo."""
 
     message = update.message
@@ -315,9 +293,7 @@ async def onboarding_timezone(
                 await message.reply_text("⚠️ Не удалось сохранить часовой пояс.")
                 return ConversationHandler.END
 
-    keyboard = InlineKeyboardMarkup(
-        [[InlineKeyboardButton("Далее", callback_data="onb_next")]]
-    )
+    keyboard = InlineKeyboardMarkup([[InlineKeyboardButton("Далее", callback_data="onb_next")]])
     try:
         with DEMO_PHOTO_PATH.open("rb") as photo:
             await message.reply_photo(
@@ -334,9 +310,7 @@ async def onboarding_timezone(
     return ONB_DEMO
 
 
-async def onboarding_demo_next(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def onboarding_demo_next(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Proceed from demo to reminder suggestion."""
     query = update.callback_query
     if query is None or not hasattr(query, "answer"):
@@ -362,17 +336,16 @@ async def onboarding_demo_next(
     return ONB_REMINDERS
 
 
-async def onboarding_reminders(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def onboarding_reminders(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle reminder choice and finish onboarding."""
     query = update.callback_query
     user = update.effective_user
     if query is None or user is None or not hasattr(query, "answer"):
         return ConversationHandler.END
     msg = query.message
-    if msg is None or not hasattr(msg, "reply_poll") or not hasattr(msg, "reply_text"):
+    if msg is None:
         return ConversationHandler.END
+    msg = cast(Message, msg)
     await query.answer()
     enable = query.data == "onb_rem_yes"
     user_id = user.id
@@ -382,11 +355,7 @@ async def onboarding_reminders(
         if user_obj:
             user_obj.onboarding_complete = True
             if enable:
-                reminders = (
-                    session.query(Reminder)
-                    .filter_by(telegram_id=user_id, type="sugar")
-                    .all()
-                )
+                reminders = session.query(Reminder).filter_by(telegram_id=user_id, type="sugar").all()
                 if not reminders:
                     reminders = [
                         Reminder(
@@ -400,11 +369,7 @@ async def onboarding_reminders(
                     for rem in reminders:
                         rem.is_enabled = True
             else:
-                reminders = (
-                    session.query(Reminder)
-                    .filter_by(telegram_id=user_id, type="sugar")
-                    .all()
-                )
+                reminders = session.query(Reminder).filter_by(telegram_id=user_id, type="sugar").all()
                 for rem in reminders:
                     rem.is_enabled = False
             try:
@@ -440,9 +405,7 @@ async def onboarding_reminders(
     else:
         logger.warning("Poll message missing poll object for user %s", user_id)
 
-    await msg.reply_text(
-        "Готово! Спасибо за настройку.", reply_markup=menu_keyboard()
-    )
+    await msg.reply_text("Готово! Спасибо за настройку.", reply_markup=menu_keyboard())
     return ConversationHandler.END
 
 
@@ -450,11 +413,12 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     """Skip the onboarding entirely."""
     query = update.callback_query
     user = update.effective_user
-    if query is None or user is None:
+    if query is None or user is None or not hasattr(query, "answer"):
         return ConversationHandler.END
     msg = query.message
-    if not isinstance(msg, Message):
+    if msg is None:
         return ConversationHandler.END
+    msg = cast(Message, msg)
     await query.answer()
 
     user_id = user.id
@@ -486,9 +450,7 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return ConversationHandler.END
 
 
-async def onboarding_poll_answer(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> None:
+async def onboarding_poll_answer(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Log poll answers from onboarding feedback."""
     poll_answer = update.poll_answer
     if poll_answer is None:
@@ -544,9 +506,7 @@ onboarding_conv = ConversationHandler(
             CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
         ],
         ONB_REMINDERS: [
-            CallbackQueryNoWarnHandler(
-                onboarding_reminders, pattern="^onb_rem_(yes|no)$"
-            ),
+            CallbackQueryNoWarnHandler(onboarding_reminders, pattern="^onb_rem_(yes|no)$"),
             CallbackQueryNoWarnHandler(onboarding_skip, pattern="^onb_skip$"),
         ],
     },


### PR DESCRIPTION
## Summary
- Avoid `isinstance` checks and work directly with Telegram message objects in onboarding reminder and skip handlers

## Testing
- `pytest --no-cov tests/handlers/test_onboarding_handlers.py tests/test_onboarding_edge_cases.py tests/test_onboarding_demo_photo_missing.py tests/test_onboarding_start_command.py tests/test_onboarding_timezone_error.py tests/test_onboarding_handlers_errors.py tests/test_onboarding_flow.py -q`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b472380630832aa45a8a7cd8ced0df