### PR TITLE
[api] Add APScheduler dependency

### DIFF
--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -1,6 +1,7 @@
 alembic==1.14.1
 annotated-types==0.7.0
 anyio==4.9.0
+APScheduler>=3.10,<3.11
 certifi==2025.4.26
 contourpy==1.3.2
 cycler==0.12.1


### PR DESCRIPTION
## Summary
- add APScheduler dependency with range >=3.10,<3.11

## Testing
- `pytest -q --cov && mypy --strict . && ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b4726c6af4832aa8460df8fb5ddd3e