### PR TITLE
[reminders] reschedule job on edit

### DIFF
--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -807,7 +807,9 @@ async def test_edit_reminder(monkeypatch: pytest.MonkeyPatch) -> None:
     jobs: list[DummyJob] = list(job_queue.get_jobs_by_name("reminder_1"))
     assert len(jobs) == 2
     assert jobs[0].removed is True
-    assert jobs[1].removed is False
+    active_job = jobs[1]
+    assert active_job.removed is False
+    assert active_job.time == time(9, 0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- reschedule reminder job via context JobQueue after webapp save
- ensure dummy job time updated in tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b49f0a23f8832a864577d0cd9f7b81