### PR TITLE
[handlers] respect reminder days mask

### DIFF
--- a/services/api/app/diabetes/utils/jobs.py
+++ b/services/api/app/diabetes/utils/jobs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Iterable
 from datetime import (
     datetime,
     time as dt_time,
@@ -72,6 +72,7 @@ def schedule_daily(
     data: dict[str, object] | None = None,
     name: str | None = None,
     timezone: tzinfo | None = None,
+    days: Iterable[int] | None = None,
 ) -> Job[CustomContext]:
     """Schedule ``callback`` to run daily at ``time``.
 
@@ -106,6 +107,9 @@ def schedule_daily(
         "data": data,
         "name": name,
     }
-    if "timezone" in inspect.signature(job_queue.run_daily).parameters:
+    sig = inspect.signature(job_queue.run_daily)
+    if "timezone" in sig.parameters:
         params["timezone"] = tz
+    if days is not None and "days" in sig.parameters:
+        params["days"] = tuple(days)
     return job_queue.run_daily(callback, **params)

--- a/tests/test_schedule_daily.py
+++ b/tests/test_schedule_daily.py
@@ -157,3 +157,9 @@ def test_schedule_daily_converts_time(queue_cls: type[object]) -> None:
     t = dt_time(12, 0, tzinfo=tokyo)
     schedule_daily(queue, dummy_cb, time=t)
     assert queue.args.time == dt_time(6, 0)
+
+
+def test_schedule_daily_forwards_days() -> None:
+    jq = QueueWithTimezone()
+    schedule_daily(jq, dummy_cb, time=dt_time(1, 0), days=(0, 2, 4))
+    assert jq.args.days == (0, 2, 4)


### PR DESCRIPTION
## Summary
- Handle optional days_mask in reminder scheduling and pass allowed weekdays to the job queue
- Support weekday filtering in `schedule_daily`
- Add regression tests for day-masked reminders and job scheduling

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b4a4d2f3a0832aab47dfa2dbbfb587