### PR TITLE
[handlers] Validate telegram_id before scheduling reminder

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -26,6 +26,9 @@ def schedule_reminder(
     if job_queue is None:
         msg = "schedule_reminder called without job_queue"
         raise RuntimeError(msg)
+    if rem.telegram_id is None:
+        msg = "schedule_reminder called without telegram_id"
+        raise ValueError(msg)
 
     # Import lazily to avoid circular imports.
     from services.api.app import reminder_events

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -214,6 +214,19 @@ def test_schedule_reminder_requires_job_queue() -> None:
         handlers.schedule_reminder(rem, None, user)
 
 
+def test_schedule_reminder_requires_telegram_id() -> None:
+    job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
+    rem = Reminder(
+        id=1,
+        telegram_id=None,
+        type="sugar",
+        time=time(8, 0),
+        is_enabled=True,
+    )
+    with pytest.raises(ValueError):
+        handlers.schedule_reminder(rem, job_queue, None)
+
+
 def test_schedule_reminder_without_user_defaults_to_moscow() -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)


### PR DESCRIPTION
## Summary
- ensure schedule_reminder errors when telegram_id is missing
- cover schedule_reminder telegram_id requirement with a test

## Testing
- `pytest tests/test_reminders.py::test_schedule_reminder_requires_telegram_id -q` *(fails: Coverage failure: total of 24 is less than fail-under=85)*
- `pytest -q` *(fails: async def functions are not natively supported; requires appropriate async plugin)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b4a4f189e0832aaba0af21c9faca7d