### PR TITLE
[reminders] Make notify_reminder_saved async

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -258,6 +258,7 @@ def _render_reminders(
     text = header + "\n" + "\n".join(lines)
     return text, InlineKeyboardMarkup(buttons)
 
+
 def _reschedule_job(job_queue: DefaultJobQueue, reminder: Reminder, user: User) -> None:
     """Удаляет старую задачу и создаёт новую с обновлённым временем."""
     job_name = f"reminder_{reminder.id}"
@@ -269,7 +270,12 @@ def _reschedule_job(job_queue: DefaultJobQueue, reminder: Reminder, user: User) 
 
     # пересоздать
     schedule_reminder(reminder, job_queue, user)
-    logger.info("✅ Rescheduled job %s -> %s", job_name, reminder.time or reminder.minutes_after or reminder.interval_minutes)
+    logger.info(
+        "✅ Rescheduled job %s -> %s",
+        job_name,
+        reminder.time or reminder.minutes_after or reminder.interval_minutes,
+    )
+
 
 def schedule_all(job_queue: DefaultJobQueue | None) -> None:
     if job_queue is None:
@@ -430,7 +436,7 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         await message.reply_text("⚠️ Не удалось сохранить напоминание.")
         return
 
-    reminder_events.notify_reminder_saved(reminder.id)
+    await reminder_events.notify_reminder_saved(reminder.id)
     await message.reply_text(f"Сохранено: {_describe(reminder, db_user)}")
 
 
@@ -711,7 +717,7 @@ async def reminder_webapp_save(
             else:
                 _reschedule_job(job_queue, rem, user_obj)
         else:
-            reminder_events.notify_reminder_saved(rem.id)
+            await reminder_events.notify_reminder_saved(rem.id)
 
     render_fn = cast(
         Callable[[Session, int], tuple[str, InlineKeyboardMarkup | None]],

--- a/services/api/app/routers/reminders.py
+++ b/services/api/app/routers/reminders.py
@@ -37,7 +37,7 @@ async def _post_job_queue_event(action: Literal["saved", "deleted"], rid: int) -
 async def _reschedule_job(action: Literal["saved", "deleted"], rid: int) -> None:
     if reminder_events.job_queue is not None:
         if action == "saved":
-            reminder_events.notify_reminder_saved(rid)
+            await reminder_events.notify_reminder_saved(rid)
         else:
             reminder_events.notify_reminder_deleted(rid)
     else:

--- a/tests/test_reminder_events.py
+++ b/tests/test_reminder_events.py
@@ -6,13 +6,15 @@ from typing import Any, cast
 from services.api.app import reminder_events
 
 
-def test_notify_without_job_queue_raises() -> None:
+@pytest.mark.asyncio
+async def test_notify_without_job_queue_raises() -> None:
     reminder_events.register_job_queue(None)
     with pytest.raises(RuntimeError):
-        reminder_events.notify_reminder_saved(1)
+        await reminder_events.notify_reminder_saved(1)
 
 
-def test_notify_with_job_queue(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_notify_with_job_queue(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummySession:
         def __enter__(self) -> DummySession:  # pragma: no cover - simple stub
             return self
@@ -25,5 +27,5 @@ def test_notify_with_job_queue(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(reminder_events, "SessionLocal", lambda: DummySession())
     reminder_events.register_job_queue(cast(Any, object()))
-    reminder_events.notify_reminder_saved(1)
+    await reminder_events.notify_reminder_saved(1)
     reminder_events.register_job_queue(None)


### PR DESCRIPTION
## Summary
- run reminder scheduling DB fetches in a thread pool
- await reminder scheduling in routers and handlers
- adjust reminder event tests for async behaviour

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b4a4f8c274832ab5b02285379c35c0