### PR TITLE
[reminders] Use kind for reminder scheduling

### DIFF
--- a/tests/test_reminder_timezones.py
+++ b/tests/test_reminder_timezones.py
@@ -30,9 +30,7 @@ class _BaseQueue:
     def get_jobs_by_name(self, name: str) -> list[_FakeJob]:
         return self.jobs.get(name, [])
 
-    def _schedule(
-        self, callback, delay: float, data: dict[str, object] | None, name: str | None
-    ) -> _FakeJob:
+    def _schedule(self, callback, delay: float, data: dict[str, object] | None, name: str | None) -> _FakeJob:
         job = _FakeJob(name or "")
         self.jobs.setdefault(name or "", []).append(job)
         asyncio.get_event_loop().create_task(self._run(callback, delay, data))
@@ -135,6 +133,7 @@ async def test_daily_reminder_respects_timezone(queue_cls: QueueType) -> None:
             interval_hours=None,
             interval_minutes=None,
             minutes_after=None,
+            kind="at_time",
             is_enabled=True,
         )
         user = SimpleNamespace(timezone="Asia/Tokyo")
@@ -181,6 +180,7 @@ async def test_after_meal_reminder_respects_timezone(queue_cls: QueueType) -> No
                 interval_minutes=None,
                 minutes_after=0.01,
                 is_enabled=True,
+                kind="after_event",
             )
             return [rem]
 

--- a/tests/test_reminders_after_meal.py
+++ b/tests/test_reminders_after_meal.py
@@ -50,9 +50,7 @@ class DummyJobQueue:
 def make_session() -> sessionmaker[Session]:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
-    return sessionmaker(
-        bind=engine, autoflush=False, autocommit=False, expire_on_commit=False
-    )
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
 
 
 def test_schedule_reminder_after_meal() -> None:
@@ -65,6 +63,7 @@ def test_schedule_reminder_after_meal() -> None:
             id=1,
             telegram_id=1,
             type="after_meal",
+            kind="after_event",
             minutes_after=30,
             is_enabled=True,
             user=user,
@@ -97,6 +96,7 @@ def test_schedule_after_meal_single_reminder() -> None:
                 id=1,
                 telegram_id=1,
                 type="after_meal",
+                kind="after_event",
                 minutes_after=30,
                 is_enabled=True,
                 user=user,
@@ -125,6 +125,7 @@ def test_schedule_after_meal_no_duplicate_jobs() -> None:
                 id=1,
                 telegram_id=1,
                 type="after_meal",
+                kind="after_event",
                 minutes_after=30,
                 is_enabled=True,
                 user=user,
@@ -153,6 +154,7 @@ def test_schedule_after_meal_multiple_reminders() -> None:
                     id=1,
                     telegram_id=1,
                     type="after_meal",
+                    kind="after_event",
                     minutes_after=15,
                     is_enabled=True,
                     user=user,
@@ -161,6 +163,7 @@ def test_schedule_after_meal_multiple_reminders() -> None:
                     id=2,
                     telegram_id=1,
                     type="after_meal",
+                    kind="after_event",
                     minutes_after=45,
                     is_enabled=True,
                     user=user,
@@ -191,6 +194,7 @@ def test_schedule_after_meal_no_enabled_reminders() -> None:
                 id=1,
                 telegram_id=1,
                 type="after_meal",
+                kind="after_event",
                 minutes_after=30,
                 is_enabled=False,
                 user=user,
@@ -232,6 +236,7 @@ def test_schedule_after_meal_no_timezone_kwarg() -> None:
                 id=1,
                 telegram_id=1,
                 type="after_meal",
+                kind="after_event",
                 minutes_after=30,
                 is_enabled=True,
                 user=user,

--- a/tests/test_schedule_all_queries.py
+++ b/tests/test_schedule_all_queries.py
@@ -92,6 +92,7 @@ def test_schedule_all_uses_constant_queries() -> None:
                     telegram_id=1,
                     type="sugar",
                     time=time(8, 0),
+                    kind="at_time",
                     is_enabled=True,
                 )
             )


### PR DESCRIPTION
## Summary
- branch schedule_reminder on reminder.kind for at-time, repeating, or event-based jobs
- add kind field to tests and after-meal reminders

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b4a87db494832aabab6a577814b629