### PR TITLE
tests: check reminder job queue usage

### DIFF
--- a/tests/test_reminders_job_queue.py
+++ b/tests/test_reminders_job_queue.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app import reminder_events
+from services.api.app.diabetes.handlers import reminder_handlers
+from services.api.app.diabetes.services.db import Base, User
+from services.api.app.routers import reminders as reminders_router
+from services.api.app.services import reminders
+from services.api.app.telegram_auth import require_tg_user
+
+
+class DummyJob:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.removed = False
+
+    def schedule_removal(self) -> None:  # pragma: no cover - trivial
+        self.removed = True
+
+
+class DummyJobQueue:
+    def __init__(self) -> None:
+        self.jobs: list[DummyJob] = []
+
+    def run_daily(
+        self,
+        callback: Any,
+        time: Any,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        **kwargs: Any,
+    ) -> DummyJob:
+        job = DummyJob(name or "")
+        self.jobs.append(job)
+        return job
+
+    def run_repeating(
+        self,
+        callback: Any,
+        interval: Any,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        **kwargs: Any,
+    ) -> DummyJob:
+        job = DummyJob(name or "")
+        self.jobs.append(job)
+        return job
+
+    def get_jobs_by_name(self, name: str) -> list[DummyJob]:
+        return [job for job in self.jobs if job.name == name]
+
+
+@pytest.fixture()
+def session_factory() -> Generator[sessionmaker[Session], None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    try:
+        yield TestSession
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture()
+def client(
+    session_factory: sessionmaker[Session],
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[TestClient, None, None]:
+    monkeypatch.setattr(reminders, "SessionLocal", session_factory)
+    monkeypatch.setattr(reminder_events, "SessionLocal", session_factory)
+    monkeypatch.setattr(reminder_handlers, "SessionLocal", session_factory)
+    monkeypatch.setattr(
+        reminders,
+        "compute_next",
+        lambda rem, tz: datetime(2023, 1, 1, tzinfo=timezone.utc),
+    )
+    app = FastAPI()
+    app.include_router(reminders_router.router, prefix="/api")
+    app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_post_reminder_uses_job_queue(
+    client: TestClient,
+    session_factory: sessionmaker[Session],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with session_factory() as session:
+        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.commit()
+
+    fake_queue = DummyJobQueue()
+    monkeypatch.setattr(reminder_events, "job_queue", fake_queue)
+    spy = AsyncMock(wraps=reminder_events.notify_reminder_saved)
+    monkeypatch.setattr(reminder_events, "notify_reminder_saved", spy)
+
+    resp = client.post(
+        "/api/reminders",
+        json={"telegramId": 1, "type": "sugar", "time": "08:00", "isEnabled": True},
+    )
+    assert resp.status_code == 200
+    rid = resp.json()["id"]
+    spy.assert_awaited_once_with(rid)
+    assert fake_queue.get_jobs_by_name(f"reminder_{rid}")
+
+    reminder_events.job_queue = None
+


### PR DESCRIPTION
## Summary
- add job queue scheduling test for reminders API

## Testing
- `python -m pytest tests/test_reminders_job_queue.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b4e8943c832a8dc98d466976c633