### PR TITLE
[reminders] remove stale jobs before rescheduling

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -38,7 +38,11 @@ def schedule_reminder(rem: Reminder, job_queue: DefaultJobQueue | None, user: Us
 
     name = f"reminder_{rem.id}"
     for job in job_queue.get_jobs_by_name(name):
-        job.schedule_removal()
+        remover = getattr(job, "remove", None)
+        if callable(remover):
+            remover()
+        else:
+            job_queue.scheduler.remove_job(job.id)
     if not rem.is_enabled:
         logger.debug(
             "Reminder %s disabled, skipping (type=%s, time=%s, interval=%s, minutes_after=%s)",

--- a/tests/test_reminder_reschedule.py
+++ b/tests/test_reminder_reschedule.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import time as dt_time
+from types import SimpleNamespace
+from typing import Callable
+from zoneinfo import ZoneInfo
+
+from services.api.app.diabetes.handlers import reminder_jobs
+
+
+class DummyJob:
+    def __init__(self, queue: "DummyJobQueue", name: str | None, run_time: dt_time) -> None:
+        self._queue = queue
+        self.name = name
+        self.run_time = run_time
+
+    def remove(self) -> None:
+        self._queue._jobs.remove(self)
+
+
+class DummyJobQueue:
+    def __init__(self) -> None:
+        tz = ZoneInfo("UTC")
+        scheduler = SimpleNamespace(timezone=tz)
+        self.application = SimpleNamespace(timezone=tz, scheduler=scheduler)
+        self.scheduler = scheduler
+        self._jobs: list[DummyJob] = []
+
+    def run_daily(
+        self,
+        callback: Callable[..., object],
+        *,
+        time: dt_time,
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+        timezone: ZoneInfo | None = None,
+        days: tuple[int, ...] | None = None,
+    ) -> DummyJob:
+        job = DummyJob(self, name, time)
+        self._jobs.append(job)
+        return job
+
+    def get_jobs_by_name(self, name: str) -> list[DummyJob]:
+        return [j for j in self._jobs if j.name == name]
+
+
+def test_editing_reminder_replaces_job() -> None:
+    job_queue = DummyJobQueue()
+    rem = SimpleNamespace(
+        id=1,
+        telegram_id=1,
+        type="sugar",
+        time=dt_time(8, 0),
+        interval_hours=None,
+        interval_minutes=None,
+        minutes_after=None,
+        kind="at_time",
+        is_enabled=True,
+        days_mask=0,
+    )
+    user = SimpleNamespace(timezone="UTC")
+
+    reminder_jobs.schedule_reminder(rem, job_queue, user)
+    assert [j.run_time for j in job_queue.get_jobs_by_name("reminder_1")] == [dt_time(8, 0)]
+
+    rem.time = dt_time(9, 0)
+    reminder_jobs.schedule_reminder(rem, job_queue, user)
+    jobs = job_queue.get_jobs_by_name("reminder_1")
+    assert len(jobs) == 1
+    assert jobs[0].run_time == dt_time(9, 0)


### PR DESCRIPTION
## Summary
- remove old reminder jobs immediately instead of scheduling their removal
- adjust reminder tests to expect immediate job deletion
- add regression test ensuring rescheduled reminders appear only once

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b515442810832ab4de75e04cd269e1