### PR TITLE
[reminders] Reschedule jobs without duplicates

### DIFF
--- a/tests/test_add_reminder_wizard.py
+++ b/tests/test_add_reminder_wizard.py
@@ -9,6 +9,7 @@ from datetime import time
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from unittest.mock import AsyncMock
 from telegram import Update
 from telegram.ext import ContextTypes
 
@@ -96,6 +97,11 @@ async def test_webapp_save_creates_reminder(
     context = cast(
         ContextTypes.DEFAULT_TYPE, CallbackContextStub(job_queue=DummyJobQueue())
     )
+    monkeypatch.setattr(
+        handlers.reminder_events,
+        "notify_reminder_saved",
+        AsyncMock(),
+    )
     await handlers.reminder_webapp_save(update, context)
 
     with TestSession() as session:
@@ -123,6 +129,11 @@ async def test_webapp_save_creates_interval(
     )
     context = cast(
         ContextTypes.DEFAULT_TYPE, CallbackContextStub(job_queue=DummyJobQueue())
+    )
+    monkeypatch.setattr(
+        handlers.reminder_events,
+        "notify_reminder_saved",
+        AsyncMock(),
     )
     await handlers.reminder_webapp_save(update, context)
 

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 from datetime import datetime, time, timedelta, timezone, tzinfo
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from typing import Any, Callable, cast
 
 import pytest
@@ -812,6 +812,11 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
         session.commit()
 
     job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
+    monkeypatch.setattr(
+        handlers.reminder_events,
+        "notify_reminder_saved",
+        AsyncMock(),
+    )
     with TestSession() as session:
         rem = session.get(Reminder, 1)
         user = session.get(DbUser, 1)
@@ -898,6 +903,11 @@ async def test_toggle_reminder_without_job_queue(monkeypatch: pytest.MonkeyPatch
 
     schedule_mock = MagicMock()
     monkeypatch.setattr(handlers, "schedule_reminder", schedule_mock)
+    monkeypatch.setattr(
+        handlers.reminder_events,
+        "notify_reminder_saved",
+        AsyncMock(),
+    )
 
     query = DummyCallbackQuery("rem_toggle:1", DummyMessage())
     update = make_update(callback_query=query, effective_user=make_user(1))
@@ -939,6 +949,11 @@ async def test_edit_reminder(monkeypatch: pytest.MonkeyPatch) -> None:
         user = session.get(DbUser, 1)
         assert rem is not None
         handlers.schedule_reminder(rem, job_queue, user)
+    monkeypatch.setattr(
+        handlers.reminder_events,
+        "notify_reminder_saved",
+        AsyncMock(),
+    )
 
     msg = DummyMessage()
     web_app_data = MagicMock()


### PR DESCRIPTION
## Summary
- remove outdated APScheduler jobs and reschedule updated reminders
- ensure add, edit and toggle operations emit reminder_saved events
- cover rescheduling helper with unit test

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5177cd0dc832aaf36f4c68168a16a