### PR TITLE
[api] Guard fallback for UI dist build

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -95,11 +95,8 @@ api_router.include_router(legacy_router)
 
 # ────────── статические файлы UI ──────────
 BASE_DIR = Path(__file__).resolve().parents[2] / "webapp"
-UI_DIR = (
-    (BASE_DIR / "ui" / "dist")
-    if (BASE_DIR / "ui" / "dist").exists()
-    else (BASE_DIR / "ui")
-)
+DIST_DIR = BASE_DIR / "ui" / "dist"
+UI_DIR = DIST_DIR if (DIST_DIR / "index.html").exists() else BASE_DIR / "ui"
 UI_DIR = UI_DIR.resolve()
 
 


### PR DESCRIPTION
## Summary
- Serve `services/webapp/ui/dist` only when `dist/index.html` exists; otherwise fall back to `services/webapp/ui`

## Testing
- `ruff check services/api/app/main.py tests/test_ui_routes.py tests/test_webapp_server.py tests/test_ui_reminders_smoke.py`
- `mypy --strict services/api/app/main.py tests/test_ui_routes.py tests/test_webapp_server.py tests/test_ui_reminders_smoke.py`
- `pytest --no-cov tests/test_ui_routes.py tests/test_webapp_server.py tests/test_ui_reminders_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68b519793d20832ab13f4300143c74a2