### PR TITLE
[handlers] Simplify reminder rescheduling

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -264,11 +264,7 @@ def _reschedule_job(job_queue: DefaultJobQueue, reminder: Reminder, user: User) 
     job_name = f"reminder_{reminder.id}"
 
     for job in job_queue.get_jobs_by_name(job_name):
-        remover = getattr(job, "remove", None)
-        if callable(remover):
-            remover()
-        else:
-            job.schedule_removal()  # type: ignore[no-untyped-call]
+        job.schedule_removal()
 
     schedule_reminder(reminder, job_queue, user)
 

--- a/tests/test_reminder_reschedule.py
+++ b/tests/test_reminder_reschedule.py
@@ -17,6 +17,9 @@ class DummyJob:
     def remove(self) -> None:
         self._queue._jobs.remove(self)
 
+    def schedule_removal(self) -> None:
+        self.remove()
+
 
 class DummyJobQueue:
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- simplify reminder job rescheduling to always use schedule_removal
- adjust reminder reschedule test dummy job

## Testing
- `pytest --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b51c509b64832aa4bb86cad6124d56