### PR TITLE
[reminders] use schedule_reminder in add_reminder

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -447,7 +447,7 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         DefaultJobQueue | None, context.job_queue
     )
     if job_queue is not None and db_user is not None:
-        _reschedule_job(job_queue, reminder, db_user)
+        schedule_reminder(reminder, job_queue, db_user)
 
     await reminder_events.notify_reminder_saved(reminder.id)
     await message.reply_text(f"Сохранено: {_describe(reminder, db_user)}")


### PR DESCRIPTION
## Summary
- use `schedule_reminder` directly when adding reminders

## Testing
- `pytest --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b51c5da480832a99f9a14515c3bda6