### PR TITLE
[handlers] Skip rescheduling when user missing

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -982,7 +982,14 @@ async def reminder_action_cb(
             else:
                 with SessionLocal() as session:
                     user_obj = session.get(User, rem.telegram_id)
-                _reschedule_job(job_queue, rem, user_obj)
+                if user_obj is None:
+                    logger.warning(
+                        "User %s not found for reminder %s",
+                        rem.telegram_id,
+                        rem.id,
+                    )
+                else:
+                    _reschedule_job(job_queue, rem, user_obj)
         elif job_queue is not None:
             for job in job_queue.get_jobs_by_name(f"reminder_{rid}"):
                 job.schedule_removal()


### PR DESCRIPTION
## Summary
- warn and skip reminder rescheduling when user record is missing
- test missing-user toggle path

## Testing
- `pytest --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b51c644cd8832a9df059bdd6e7a1bd