### PR TITLE
[handlers] Skip reminder saved event when already scheduled

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -448,8 +448,9 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     )
     if job_queue is not None and db_user is not None:
         _reschedule_job(job_queue, reminder, db_user)
+    else:
+        await reminder_events.notify_reminder_saved(reminder.id)
 
-    await reminder_events.notify_reminder_saved(reminder.id)
     await message.reply_text(f"Сохранено: {_describe(reminder, db_user)}")
 
 


### PR DESCRIPTION
## Summary
- avoid notifying reminder job queue when add_reminder schedules immediately
- test reminder notification only when scheduling deferred

## Testing
- `pytest --cov -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b51c6a2c7c832a974651873ca64e20