### PR TITLE
[handlers] Use type-only import for UserData

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -7,7 +7,7 @@ import json
 import logging
 import re
 from datetime import time, timedelta, timezone
-from typing import Awaitable, Callable, Literal, cast
+from typing import TYPE_CHECKING, Awaitable, Callable, Literal, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from urllib.parse import parse_qsl
 
@@ -43,7 +43,9 @@ from services.api.app.diabetes.utils.jobs import schedule_once
 from services.api.app.diabetes.utils.ui import menu_keyboard
 from services.api.app.diabetes.schemas.reminders import ScheduleKind
 from .reminder_jobs import DefaultJobQueue, schedule_reminder
-from . import UserData
+
+if TYPE_CHECKING:
+    from . import UserData
 
 run_db: Callable[..., Awaitable[object]] | None
 try:
@@ -789,7 +791,7 @@ async def reminder_job(context: ContextTypes.DEFAULT_TYPE) -> None:
     job = context.job
     if job is None or job.data is None:
         return
-    data = cast(UserData, job.data)
+    data = cast("UserData", job.data)
     rid = data.get("reminder_id")
     chat_id = data.get("chat_id")
     if rid is None or chat_id is None:


### PR DESCRIPTION
## Summary
- use TYPE_CHECKING for UserData to avoid runtime import

## Testing
- `pytest --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b51c6c5998832aa55a92a91f73766e