### PR TITLE
[reminders] Document notify_reminder_saved usage

### DIFF
--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -26,9 +26,10 @@ def register_job_queue(jq: DefaultJobQueue | None) -> None:
 async def notify_reminder_saved(reminder_id: int) -> None:
     """Send reminder to the job queue for scheduling.
 
-    Performs database access in a thread pool to avoid blocking the
-    event loop. Raises :class:`RuntimeError` if the job queue is not
-    configured.
+    Performs database access in a thread pool to avoid blocking the event loop.
+    This coroutine must be awaited or scheduled via ``asyncio.create_task`` so
+    that the reminder is actually enqueued. Raises :class:`RuntimeError` if the
+    job queue is not configured.
     """
     jq = job_queue
     if jq is None:


### PR DESCRIPTION
## Summary
- clarify that `notify_reminder_saved` must be awaited or scheduled with `asyncio.create_task`

## Testing
- `pytest --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b51c718640832a9d8461c2da2448cb