### PR TITLE
[handlers] refine reminder handler typing

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -7,7 +7,7 @@ import json
 import logging
 import re
 from datetime import time, timedelta, timezone
-from typing import TYPE_CHECKING, Awaitable, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from urllib.parse import parse_qsl
 
@@ -47,7 +47,7 @@ from .reminder_jobs import DefaultJobQueue, schedule_reminder
 if TYPE_CHECKING:
     from . import UserData
 
-run_db: Callable[..., Awaitable[object]] | None
+run_db: Callable[..., Awaitable[Any]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
@@ -56,7 +56,7 @@ except ImportError:  # pragma: no cover - optional db runner
     )
     run_db = None
 else:
-    run_db = cast(Callable[..., Awaitable[object]], _run_db)
+    run_db = cast(Callable[..., Awaitable[Any]], _run_db)
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +269,7 @@ def _reschedule_job(job_queue: DefaultJobQueue, reminder: Reminder, user: User) 
         job.schedule_removal()
 
     schedule_reminder(reminder, job_queue, user)
-
+    next_run: datetime.datetime | None
     next_run = None
     job = next(iter(job_queue.get_jobs_by_name(job_name)), None)
     if job is not None:


### PR DESCRIPTION
## Summary
- use `Any` for async database runner
- type next reminder job schedule

## Testing
- `pytest --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b51fb1a91c832abbe1fec6ac36025c