### PR TITLE
[reminders] suppress reminder events when job queue present

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -446,7 +446,13 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     )
     if job_queue is not None and db_user is not None:
         schedule_reminder(reminder, job_queue, db_user)
-    await reminder_events.notify_reminder_saved(reminder.id)
+        logger.info(
+            "Job queue present, skipping reminder saved event for %s",
+            reminder.id,
+        )
+    else:
+        logger.info("Sending reminder saved event for %s", reminder.id)
+        await reminder_events.notify_reminder_saved(reminder.id)
     await message.reply_text(f"Сохранено: {_describe(reminder, db_user)}")
 
 
@@ -726,8 +732,13 @@ async def reminder_webapp_save(
                 )
             else:
                 _reschedule_job(job_queue, rem, user_obj)
-
-        await reminder_events.notify_reminder_saved(rem.id)
+            logger.info(
+                "Job queue present, skipping reminder saved event for %s",
+                rem.id,
+            )
+        else:
+            logger.info("Sending reminder saved event for %s", rem.id)
+            await reminder_events.notify_reminder_saved(rem.id)
 
     render_fn = cast(
         Callable[[Session, int], tuple[str, InlineKeyboardMarkup | None]],
@@ -780,7 +791,11 @@ async def delete_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             job.schedule_removal()
     if message:
         await message.reply_text("Удалено")
-    await reminder_events.notify_reminder_saved(rid)
+    if job_queue is None:
+        logger.info("Sending reminder saved event for %s", rid)
+        await reminder_events.notify_reminder_saved(rid)
+    else:
+        logger.info("Job queue present, skipping reminder saved event for %s", rid)
 
 
 async def reminder_job(context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -991,12 +1006,16 @@ async def reminder_action_cb(
         elif job_queue is not None:
             for job in job_queue.get_jobs_by_name(f"reminder_{rid}"):
                 job.schedule_removal()
-        await reminder_events.notify_reminder_saved(rid)
     else:  # del
         if job_queue is not None:
             for job in job_queue.get_jobs_by_name(f"reminder_{rid}"):
                 job.schedule_removal()
+
+    if job_queue is None:
+        logger.info("Sending reminder saved event for %s", rid)
         await reminder_events.notify_reminder_saved(rid)
+    else:
+        logger.info("Job queue present, skipping reminder saved event for %s", rid)
 
     render_fn = cast(
         Callable[[Session, int], tuple[str, InlineKeyboardMarkup | None]],

--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -247,6 +247,7 @@ async def test_add_reminder_saves_time_and_description(
     await reminder_handlers.add_reminder(update, context)
 
     assert message.texts == ["Сохранено: 🔔 Замерить сахар ⏰ 09:00 (next 09:00)"]
+    reminder_handlers.reminder_events.notify_reminder_saved.assert_awaited_once_with(1)
 
     with TestSession() as session:
         rem_db = session.query(Reminder).one()
@@ -254,7 +255,7 @@ async def test_add_reminder_saves_time_and_description(
 
 
 @pytest.mark.asyncio
-async def test_add_reminder_notifies_when_scheduled(
+async def test_add_reminder_schedules_without_notify(
     reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     engine = create_engine("sqlite:///:memory:")
@@ -287,7 +288,7 @@ async def test_add_reminder_notifies_when_scheduled(
     await reminder_handlers.add_reminder(update, context)
 
     schedule_mock.assert_called_once()
-    notify_mock.assert_awaited_once_with(1)
+    notify_mock.assert_not_awaited()
     assert message.texts == ["Сохранено: desc"]
 
 
@@ -330,7 +331,7 @@ async def test_add_reminder_ignores_disabled(
 
 
 @pytest.mark.asyncio
-async def test_delete_reminder_notifies(
+async def test_delete_reminder_no_notify_with_job_queue(
     reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     engine = create_engine("sqlite:///:memory:")
@@ -361,6 +362,44 @@ async def test_delete_reminder_notifies(
     update = make_update(message=message, effective_user=make_user(1))
     job_queue = DummyJobQueue()
     context = make_context(args=["1"], job_queue=job_queue)
+
+    await reminder_handlers.delete_reminder(update, context)
+
+    assert message.texts == ["Удалено"]
+    notify_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_reminder_notifies_without_job_queue(
+    reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(reminder_handlers, "SessionLocal", TestSession)
+    monkeypatch.setattr(reminder_handlers, "commit", commit)
+
+    with TestSession() as session:
+        session.add(DbUser(telegram_id=1, thread_id="t"))
+        session.add(
+            Reminder(
+                id=1,
+                telegram_id=1,
+                type="sugar",
+                time=time(8, 0),
+                kind="at_time",
+            )
+        )
+        session.commit()
+
+    notify_mock = AsyncMock()
+    monkeypatch.setattr(
+        reminder_handlers.reminder_events, "notify_reminder_saved", notify_mock
+    )
+
+    message = DummyMessage()
+    update = make_update(message=message, effective_user=make_user(1))
+    context = make_context(args=["1"], job_queue=None)
 
     await reminder_handlers.delete_reminder(update, context)
 
@@ -469,6 +508,8 @@ async def test_reminder_webapp_save_clears_interval_params(
     context = make_context()
 
     await reminder_handlers.reminder_webapp_save(update, context)
+
+    reminder_handlers.reminder_events.notify_reminder_saved.assert_awaited_once_with(1)
 
     with TestSession() as session:
         rem_db = session.get(Reminder, 1)


### PR DESCRIPTION
## Summary
- broadcast reminder_saved only when no local job queue is available
- reschedule/removal handled locally without emitting events
- extend tests for job queue/no queue scenarios

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b52a3da950832ab7177d2776931c96