### PR TITLE
[utils] Extract remove_jobs and ensure unique scheduling

### DIFF
--- a/services/api/app/diabetes/utils/jobs.py
+++ b/services/api/app/diabetes/utils/jobs.py
@@ -9,7 +9,7 @@ from datetime import (
     timezone as dt_timezone,
     tzinfo,
 )
-from typing import Any, TYPE_CHECKING, TypeAlias
+from typing import Any, TYPE_CHECKING, TypeAlias, cast
 
 from telegram.ext import ContextTypes, Job, JobQueue
 
@@ -21,6 +21,44 @@ else:
     DefaultJobQueue = JobQueue
 
 JobCallback = Callable[[CustomContext], Coroutine[Any, Any, object]]
+
+
+def _remove_jobs(job_queue: DefaultJobQueue, job_name: str) -> int:
+    """Best-effort removal of jobs from the queue.
+
+    Tries ``job.remove()`` first, then falls back to direct scheduler removal,
+    and finally schedules the job for removal. Returns the number of jobs
+    processed.
+    """
+    removed = 0
+    for job in job_queue.get_jobs_by_name(job_name):
+        remover = cast(Callable[[], None] | None, getattr(job, "remove", None))
+        if remover is not None:
+            try:
+                remover()
+                removed += 1
+                continue
+            except Exception:  # pragma: no cover - defensive
+                pass
+        scheduler = getattr(job_queue, "scheduler", None)
+        remove_job = (
+            cast(Callable[[object], None] | None, getattr(scheduler, "remove_job", None))
+            if scheduler is not None
+            else None
+        )
+        job_id = getattr(job, "id", None)
+        if remove_job is not None and job_id is not None:
+            try:
+                remove_job(job_id)
+                removed += 1
+                continue
+            except Exception:  # pragma: no cover - defensive
+                pass
+        schedule_removal = cast(Callable[[], None] | None, getattr(job, "schedule_removal", None))
+        if schedule_removal is not None:
+            schedule_removal()
+            removed += 1
+    return removed
 
 
 def schedule_once(
@@ -113,3 +151,12 @@ def schedule_daily(
     if days is not None and "days" in sig.parameters:
         params["days"] = tuple(days)
     return job_queue.run_daily(callback, **params)
+
+
+__all__ = [
+    "DefaultJobQueue",
+    "JobCallback",
+    "schedule_once",
+    "schedule_daily",
+    "_remove_jobs",
+]


### PR DESCRIPTION
## Summary
- move _remove_jobs helper to shared jobs util
- reuse _remove_jobs in reminder scheduling and ensure APScheduler jobs use replace_existing

## Testing
- `ruff check .`
- `mypy --strict services/api/app/diabetes/utils/jobs.py services/api/app/diabetes/handlers/reminder_handlers.py services/api/app/diabetes/handlers/reminder_jobs.py --follow-imports=skip`
- `pytest tests/test_reminders.py::test_schedule_reminder_replaces_existing_job tests/test_reminder_reschedule.py tests/test_reminders_job_queue.py -q -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68b533052cf0832abb33b72c26d84d85