### PR TITLE
refactor: simplify reminder scheduling

### DIFF
--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -71,11 +71,7 @@ def _setup_db() -> tuple[sessionmaker[Session], Any]:
     handlers.commit = commit
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
-        session.add(
-            Reminder(
-                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
-            )
-        )
+        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
         session.commit()
     return TestSession, engine
 
@@ -121,6 +117,7 @@ async def test_good_input_updates_and_ends(
         "notify_reminder_saved",
         AsyncMock(),
     )
+    monkeypatch.setattr(handlers, "schedule_reminder", lambda *a, **k: None)
     with no_warnings():
         await handlers.reminder_webapp_save(update, context)
     with TestSession() as session:

--- a/tests/test_reminders_after_meal.py
+++ b/tests/test_reminders_after_meal.py
@@ -1,7 +1,6 @@
 from collections.abc import Callable
 from datetime import timedelta
 from typing import Any, cast
-
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -38,8 +37,12 @@ class DummyJobQueue:
         data: dict[str, Any] | None = None,
         name: str | None = None,
         timezone: object | None = None,
+        job_kwargs: dict[str, Any] | None = None,
     ) -> DummyJob:
-        job = DummyJob(callback, when, data or {}, name or "")
+        job_id = job_kwargs.get("id") if job_kwargs else name or ""
+        if job_kwargs and job_kwargs.get("replace_existing"):
+            self.jobs = [j for j in self.jobs if j.name != job_id]
+        job = DummyJob(callback, when, data or {}, job_id)
         self.jobs.append(job)
         return job
 


### PR DESCRIPTION
## Summary
- streamline reminder scheduling to use scheduler.add_job with timezone awareness
- update dummy job queues and tests for new scheduling API

## Testing
- `ruff check . -v`
- `mypy --strict .`
- `pytest -q` *(fails: AttributeError in various tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b53a72e204832aad09e471f2c92b34