### PR TITLE
[handlers] refactor reminder job scheduling

### DIFF
--- a/tests/test_reminder_edit_block_leak.py
+++ b/tests/test_reminder_edit_block_leak.py
@@ -45,8 +45,11 @@ class DummyJobQueue:
         self,
         callback: Callable[..., Any],
         time: Any,
+        *,
+        days: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6),
         data: dict[str, Any] | None = None,
         name: str | None = None,
+        job_kwargs: dict[str, Any] | None = None,
     ) -> None:
         pass
 
@@ -54,8 +57,10 @@ class DummyJobQueue:
         self,
         callback: Callable[..., Any],
         interval: Any,
+        *,
         data: dict[str, Any] | None = None,
         name: str | None = None,
+        job_kwargs: dict[str, Any] | None = None,
     ) -> None:
         pass
 

--- a/tests/test_reminder_reschedule.py
+++ b/tests/test_reminder_reschedule.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import time as dt_time
+from datetime import time as dt_time, timedelta
 from types import SimpleNamespace
 from typing import Callable
 from zoneinfo import ZoneInfo
@@ -55,6 +55,51 @@ class DummyJobQueue:
         tz = ZoneInfo("UTC")
         self.scheduler = DummyScheduler(tz)
         self.application = SimpleNamespace(timezone=tz, scheduler=self.scheduler)
+
+    def run_daily(
+        self,
+        callback: Callable[..., object],
+        time: dt_time,
+        *,
+        days: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6),
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+        job_kwargs: dict[str, object] | None = None,
+    ) -> DummyJob:
+        params: dict[str, object] = {"hour": time.hour, "minute": time.minute}
+        if days != (0, 1, 2, 3, 4, 5, 6):
+            params["day_of_week"] = ",".join(str(d) for d in days)
+        return self.scheduler.add_job(
+            callback,
+            trigger="cron",
+            id=name or "",
+            name=name or "",
+            replace_existing=bool(job_kwargs and job_kwargs.get("replace_existing")),
+            timezone=time.tzinfo or ZoneInfo("UTC"),
+            kwargs={"context": data},
+            **params,
+        )
+
+    def run_repeating(
+        self,
+        callback: Callable[..., object],
+        interval: timedelta,
+        *,
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+        job_kwargs: dict[str, object] | None = None,
+    ) -> DummyJob:
+        minutes = int(interval.total_seconds() / 60)
+        return self.scheduler.add_job(
+            callback,
+            trigger="interval",
+            id=name or "",
+            name=name or "",
+            replace_existing=bool(job_kwargs and job_kwargs.get("replace_existing")),
+            timezone=ZoneInfo("UTC"),
+            kwargs={"context": data},
+            minutes=minutes,
+        )
 
     def get_jobs_by_name(self, name: str) -> list[DummyJob]:
         return [j for j in self.scheduler.jobs if j.name == name]

--- a/tests/test_reminder_timezones.py
+++ b/tests/test_reminder_timezones.py
@@ -86,6 +86,7 @@ class JobQueueV20(_BaseQueue):
         data: dict[str, object] | None = None,
         name: str | None = None,
         timezone: ZoneInfo | None = None,
+        job_kwargs: dict[str, object] | None = None,
     ) -> _FakeJob:
         delay = when.total_seconds()
         return self._schedule(callback, delay, data, name)
@@ -98,6 +99,8 @@ class JobQueueV20(_BaseQueue):
         data: dict[str, object] | None = None,
         name: str | None = None,
         timezone: ZoneInfo,
+        days: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6),
+        job_kwargs: dict[str, object] | None = None,
     ) -> _FakeJob:
         now = dt.datetime.now(timezone)
         target = dt.datetime.combine(now.date(), time, tzinfo=timezone)
@@ -115,6 +118,7 @@ class JobQueueV21(_BaseQueue):
         when: dt.timedelta,
         data: dict[str, object] | None = None,
         name: str | None = None,
+        job_kwargs: dict[str, object] | None = None,
     ) -> _FakeJob:
         delay = when.total_seconds()
         return self._schedule(callback, delay, data, name)
@@ -126,6 +130,8 @@ class JobQueueV21(_BaseQueue):
         time: dt.time,
         data: dict[str, object] | None = None,
         name: str | None = None,
+        days: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6),
+        job_kwargs: dict[str, object] | None = None,
     ) -> _FakeJob:
         tz = self.application.timezone
         now = dt.datetime.now(tz)

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -161,6 +161,53 @@ class DummyJobQueue:
         self.scheduler.jobs.append(job)
         return job
 
+    def run_daily(
+        self,
+        callback: Callable[..., Any],
+        time: Any,
+        *,
+        days: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6),
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        job_kwargs: dict[str, Any] | None = None,
+    ) -> DummyJob:
+        params: dict[str, Any] = {"hour": time.hour, "minute": time.minute}
+        if days != (0, 1, 2, 3, 4, 5, 6):
+            params["day_of_week"] = ",".join(str(d) for d in days)
+        job = self.scheduler.add_job(
+            callback,
+            trigger="cron",
+            id=name or "",
+            name=name or "",
+            replace_existing=bool(job_kwargs and job_kwargs.get("replace_existing")),
+            timezone=getattr(time, "tzinfo", None) or ZoneInfo("UTC"),
+            kwargs={"context": data},
+            **params,
+        )
+        return job
+
+    def run_repeating(
+        self,
+        callback: Callable[..., Any],
+        interval: Any,
+        *,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        job_kwargs: dict[str, Any] | None = None,
+    ) -> DummyJob:
+        minutes = int(interval.total_seconds() / 60)
+        job = self.scheduler.add_job(
+            callback,
+            trigger="interval",
+            id=name or "",
+            name=name or "",
+            replace_existing=bool(job_kwargs and job_kwargs.get("replace_existing")),
+            timezone=self.timezone or ZoneInfo("UTC"),
+            kwargs={"context": data},
+            minutes=minutes,
+        )
+        return job
+
     def get_jobs_by_name(self, name: str) -> list[DummyJob]:
         return [j for j in self.scheduler.jobs if j.name == name]
 

--- a/tests/test_schedule_all_queries.py
+++ b/tests/test_schedule_all_queries.py
@@ -33,8 +33,11 @@ class DummyJobQueue:
         self,
         callback: Callable[..., object],
         time: object,
+        *,
+        days: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6),
         data: dict[str, object] | None = None,
         name: str | None = None,
+        job_kwargs: dict[str, object] | None = None,
     ) -> DummyJob:
         job = DummyJob(name, data)
         self._jobs.append(job)
@@ -46,6 +49,7 @@ class DummyJobQueue:
         interval: object,
         data: dict[str, object] | None = None,
         name: str | None = None,
+        job_kwargs: dict[str, object] | None = None,
     ) -> DummyJob:
         job = DummyJob(name, data)
         self._jobs.append(job)
@@ -58,6 +62,7 @@ class DummyJobQueue:
         data: dict[str, object] | None = None,
         name: str | None = None,
         timezone: object | None = None,
+        job_kwargs: dict[str, object] | None = None,
     ) -> DummyJob:
         job = DummyJob(name, data)
         self._jobs.append(job)


### PR DESCRIPTION
## Summary
- refactor reminder scheduler to use job queue run_daily/run_repeating
- pass job data through `data` and log next run
- update tests and stubs for new scheduling API

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict services/api/app/diabetes/handlers/reminder_jobs.py`
- `ruff check services/api/app/diabetes/handlers/reminder_jobs.py tests/test_add_reminder_wizard.py tests/test_reminder_edit_block_leak.py tests/test_reminder_reschedule.py tests/test_reminder_timezones.py tests/test_reminders.py tests/test_reminders_api.py tests/test_schedule_all_queries.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5419e6a60832ab0786bd890c1baea