### PR TITLE
[reminder] Use JobQueue scheduling

### DIFF
--- a/tests/test_reminder_reschedule.py
+++ b/tests/test_reminder_reschedule.py
@@ -56,6 +56,23 @@ class DummyJobQueue:
         self.scheduler = DummyScheduler(tz)
         self.application = SimpleNamespace(timezone=tz, scheduler=self.scheduler)
 
+    def run_daily(
+        self,
+        callback: Callable[..., object],
+        time: dt_time,
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+        timezone: object | None = None,
+        days: tuple[int, ...] | None = None,
+        job_kwargs: dict[str, object] | None = None,
+    ) -> DummyJob:
+        job_id = job_kwargs["id"] if job_kwargs else name or ""
+        if job_kwargs and job_kwargs.get("replace_existing"):
+            self.scheduler.jobs = [j for j in self.scheduler.jobs if j.id != job_id]
+        job = DummyJob(self.scheduler, id=job_id, name=name or job_id, run_time=time)
+        self.scheduler.jobs.append(job)
+        return job
+
     def get_jobs_by_name(self, name: str) -> list[DummyJob]:
         return [j for j in self.scheduler.jobs if j.name == name]
 

--- a/tests/test_reminders_api.py
+++ b/tests/test_reminders_api.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Generator
-from datetime import datetime, time, timezone
+from datetime import datetime, time, timezone, timedelta
 from typing import Any, cast
 
 import httpx
@@ -56,6 +56,39 @@ class DummyScheduler:
 class DummyJobQueue:
     def __init__(self) -> None:
         self.scheduler = DummyScheduler()
+
+    def run_daily(
+        self,
+        callback: Any,
+        time: time,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        timezone: object | None = None,
+        days: tuple[int, ...] | None = None,
+        job_kwargs: dict[str, Any] | None = None,
+    ) -> DummyJob:
+        job_id = job_kwargs["id"] if job_kwargs else name or ""
+        if job_kwargs and job_kwargs.get("replace_existing"):
+            self.scheduler.jobs = [j for j in self.scheduler.jobs if j.name != job_id]
+        job = DummyJob(job_id, data)
+        self.scheduler.jobs.append(job)
+        return job
+
+    def run_repeating(
+        self,
+        callback: Any,
+        interval: timedelta,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        first: object | None = None,
+        job_kwargs: dict[str, Any] | None = None,
+    ) -> DummyJob:
+        job_id = job_kwargs["id"] if job_kwargs else name or ""
+        if job_kwargs and job_kwargs.get("replace_existing"):
+            self.scheduler.jobs = [j for j in self.scheduler.jobs if j.name != job_id]
+        job = DummyJob(job_id, data)
+        self.scheduler.jobs.append(job)
+        return job
 
     def get_jobs_by_name(self, name: str) -> list[DummyJob]:
         return [j for j in self.scheduler.jobs if j.name == name]


### PR DESCRIPTION
## Summary
- use PTB JobQueue run_daily with days tuple instead of APScheduler string
- schedule repeating reminders with JobQueue.run_repeating
- adjust tests for new JobQueue API

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b541a292b0832a8112efb8a4ff0d50