### PR TITLE
[handlers] Clear main and snooze reminder jobs

### DIFF
--- a/tests/test_reminder_reschedule.py
+++ b/tests/test_reminder_reschedule.py
@@ -9,7 +9,9 @@ from services.api.app.diabetes.handlers import reminder_handlers, reminder_jobs
 
 
 class DummyJob:
-    def __init__(self, scheduler: "DummyScheduler", *, id: str, name: str, run_time: dt_time) -> None:
+    def __init__(
+        self, scheduler: "DummyScheduler", *, id: str, name: str, run_time: dt_time
+    ) -> None:
         self._scheduler = scheduler
         self.id = id
         self.name = name
@@ -77,7 +79,9 @@ def test_editing_reminder_replaces_job() -> None:
     user = SimpleNamespace(timezone="UTC")
 
     reminder_jobs.schedule_reminder(rem, job_queue, user)
-    assert [j.run_time for j in job_queue.get_jobs_by_name("reminder_1")] == [dt_time(8, 0)]
+    assert [j.run_time for j in job_queue.get_jobs_by_name("reminder_1")] == [
+        dt_time(8, 0)
+    ]
 
     rem.time = dt_time(9, 0)
     reminder_jobs.schedule_reminder(rem, job_queue, user)
@@ -103,13 +107,29 @@ def test_reschedule_job_helper_recreates_job() -> None:
     user = SimpleNamespace(timezone="UTC")
 
     reminder_jobs.schedule_reminder(rem, job_queue, user)
-    assert [j.run_time for j in job_queue.get_jobs_by_name("reminder_1")] == [dt_time(8, 0)]
+    assert [j.run_time for j in job_queue.get_jobs_by_name("reminder_1")] == [
+        dt_time(8, 0)
+    ]
+
+    job_queue.scheduler.add_job(
+        lambda: None,
+        trigger="cron",
+        id="reminder_1_snooze",
+        name="reminder_1_snooze",
+        replace_existing=False,
+        timezone=job_queue.scheduler.timezone,
+        kwargs={},
+        hour=0,
+        minute=0,
+    )
+    assert job_queue.get_jobs_by_name("reminder_1_snooze")
 
     rem.time = dt_time(9, 30)
     reminder_handlers._reschedule_job(job_queue, rem, user)
     jobs = job_queue.get_jobs_by_name("reminder_1")
     assert len(jobs) == 1
     assert jobs[0].run_time == dt_time(9, 30)
+    assert not job_queue.get_jobs_by_name("reminder_1_snooze")
 
 
 def test_reschedule_job_helper_handles_jobs_without_remove() -> None:

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -80,7 +80,9 @@ class DummyBot:
     async def send_message(self, chat_id: int | str, text: str, **kwargs: Any) -> None:
         self.messages.append((chat_id, text, kwargs))
 
-    async def answer_callback_query(self, callback_query_id: str, text: str | None = None, **kwargs: Any) -> None:
+    async def answer_callback_query(
+        self, callback_query_id: str, text: str | None = None, **kwargs: Any
+    ) -> None:
         self.cb_answers.append((callback_query_id, text))
 
 
@@ -131,7 +133,9 @@ class DummyScheduler:
     ) -> DummyJob:  # noqa: D401 - simplified
         if replace_existing:
             self.jobs = [j for j in self.jobs if j.id != id]
-        job = DummyJob(self, id=id, name=name, trigger=trigger, timezone=timezone, params=params)
+        job = DummyJob(
+            self, id=id, name=name, trigger=trigger, timezone=timezone, params=params
+        )
         self.jobs.append(job)
         return job
 
@@ -156,7 +160,12 @@ class DummyJobQueue:
         params: dict[str, Any] = {"when": when}
         job_id = job_kwargs["id"] if job_kwargs else name or ""  # type: ignore[assignment]
         job = DummyJob(
-            id=job_id, name=name or job_id, trigger="once", timezone=timezone or ZoneInfo("UTC"), params=params
+            self.scheduler,
+            id=job_id,
+            name=name or job_id,
+            trigger="once",
+            timezone=timezone or ZoneInfo("UTC"),
+            params=params,
         )
         self.scheduler.jobs.append(job)
         return job
@@ -381,7 +390,9 @@ def test_schedule_with_next_interval(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(handlers, "datetime", DummyDatetime)
     user = DbUser(telegram_id=1, thread_id="t", timezone="Europe/Moscow")
-    rem = Reminder(telegram_id=1, type="sugar", interval_hours=2, is_enabled=True, user=user)
+    rem = Reminder(
+        telegram_id=1, type="sugar", interval_hours=2, is_enabled=True, user=user
+    )
     icon, schedule = handlers._schedule_with_next(rem)
     assert icon == "⏱"
     assert schedule == "каждые 2 ч (next 12:00)"
@@ -437,7 +448,9 @@ def test_interval_minutes_scheduling_and_rendering(
         rem = session.get(Reminder, 1)
         user = session.get(DbUser, 1)
         assert rem is not None
-        with patch.object(job_queue.scheduler, "add_job", wraps=job_queue.scheduler.add_job) as mock_add:
+        with patch.object(
+            job_queue.scheduler, "add_job", wraps=job_queue.scheduler.add_job
+        ) as mock_add:
             handlers.schedule_reminder(rem, job_queue, user)
             mock_add.assert_called_once()
             assert mock_add.call_args.kwargs["trigger"] == "interval"
@@ -467,7 +480,9 @@ def test_schedule_with_next_invalid_timezone_logs_warning(
 
 def test_schedule_reminder_invalid_timezone_raises() -> None:
     user = DbUser(telegram_id=1, thread_id="t", timezone="Bad/Zone")
-    rem = Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user)
+    rem = Reminder(
+        id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True, user=user
+    )
     job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
     with pytest.raises(ZoneInfoNotFoundError):
         handlers.schedule_reminder(rem, job_queue, user)
@@ -640,7 +655,9 @@ def test_render_reminders_no_entries_webapp(monkeypatch: pytest.MonkeyPatch) -> 
     assert add_btn.web_app.url == config.build_ui_url("/reminders/new")
 
 
-def test_render_reminders_runtime_public_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_render_reminders_runtime_public_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -705,7 +722,9 @@ async def test_reminders_list_renders_output(
 
     monkeypatch.setattr(handlers, "SessionLocal", lambda: DummySessionCtx())
 
-    def fake_render(session: Session, user_id: int) -> tuple[str, InlineKeyboardMarkup | None]:
+    def fake_render(
+        session: Session, user_id: int
+    ) -> tuple[str, InlineKeyboardMarkup | None]:
         assert session is session_obj
         assert user_id == 1
         return "rendered", keyboard
@@ -750,7 +769,9 @@ async def test_reminders_list_shows_menu_keyboard(
 
     monkeypatch.setattr(handlers, "SessionLocal", lambda: DummySessionCtx())
 
-    def fake_render(session: Session, user_id: int) -> tuple[str, InlineKeyboardMarkup | None]:
+    def fake_render(
+        session: Session, user_id: int
+    ) -> tuple[str, InlineKeyboardMarkup | None]:
         return "rendered", None
 
     monkeypatch.setattr(handlers, "_render_reminders", fake_render)
@@ -786,7 +807,11 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
 
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
-        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True))
+        session.add(
+            Reminder(
+                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=True
+            )
+        )
         session.commit()
 
     job_queue = cast(handlers.DefaultJobQueue, DummyJobQueue())
@@ -800,6 +825,15 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
         user = session.get(DbUser, 1)
         assert rem is not None
         handlers.schedule_reminder(rem, job_queue, user)
+    job_queue.scheduler.add_job(
+        lambda: None,
+        trigger="cron",
+        id="reminder_1_snooze",
+        name="reminder_1_snooze",
+        replace_existing=False,
+        timezone=ZoneInfo("UTC"),
+        kwargs={},
+    )
 
     query = DummyCallbackQuery("rem_toggle:1", DummyMessage())
     update = make_update(callback_query=query, effective_user=make_user(1))
@@ -815,7 +849,9 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
         assert rem_db is not None
         assert not rem_db.is_enabled
     jobs: list[DummyJob] = list(job_queue.get_jobs_by_name("reminder_1"))
+    snoozes: list[DummyJob] = list(job_queue.get_jobs_by_name("reminder_1_snooze"))
     assert not jobs
+    assert not snoozes
     assert query.answers
     answer = query.answers[0]
     assert answer == "Готово ✅"
@@ -851,6 +887,15 @@ async def test_delete_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
         user = session.get(DbUser, 1)
         assert rem is not None
         handlers.schedule_reminder(rem, job_queue, user)
+    job_queue.scheduler.add_job(
+        lambda: None,
+        trigger="cron",
+        id="reminder_1_snooze",
+        name="reminder_1_snooze",
+        replace_existing=False,
+        timezone=ZoneInfo("UTC"),
+        kwargs={},
+    )
     notify_mock = AsyncMock()
     monkeypatch.setattr(handlers.reminder_events, "notify_reminder_saved", notify_mock)
 
@@ -863,14 +908,18 @@ async def test_delete_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
     with TestSession() as session:
         assert session.query(Reminder).count() == 0
     jobs: list[DummyJob] = list(job_queue.get_jobs_by_name("reminder_1"))
+    snoozes: list[DummyJob] = list(job_queue.get_jobs_by_name("reminder_1_snooze"))
     assert not jobs
+    assert not snoozes
     assert query.answers
     answer = query.answers[-1]
     assert answer == "Готово ✅"
 
 
 @pytest.mark.asyncio
-async def test_toggle_reminder_without_job_queue(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_toggle_reminder_without_job_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -879,7 +928,11 @@ async def test_toggle_reminder_without_job_queue(monkeypatch: pytest.MonkeyPatch
 
     with TestSession() as session:
         session.add(DbUser(telegram_id=1, thread_id="t"))
-        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=False))
+        session.add(
+            Reminder(
+                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=False
+            )
+        )
         session.commit()
 
     schedule_mock = MagicMock()
@@ -906,7 +959,9 @@ async def test_toggle_reminder_without_job_queue(monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.mark.asyncio
-async def test_toggle_reminder_missing_user(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+async def test_toggle_reminder_missing_user(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
@@ -914,7 +969,11 @@ async def test_toggle_reminder_missing_user(monkeypatch: pytest.MonkeyPatch, cap
     handlers.commit = commit
 
     with TestSession() as session:
-        session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=False))
+        session.add(
+            Reminder(
+                id=1, telegram_id=1, type="sugar", time=time(8, 0), is_enabled=False
+            )
+        )
         session.commit()
 
     reschedule_mock = MagicMock()
@@ -1278,7 +1337,9 @@ def client(
         yield test_client
 
 
-def test_empty_returns_200(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_empty_returns_200(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -1287,7 +1348,9 @@ def test_empty_returns_200(client: TestClient, session_factory: sessionmaker[Ses
     assert resp.json() == []
 
 
-def test_nonempty_returns_list(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_nonempty_returns_list(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(
@@ -1324,7 +1387,9 @@ def test_nonempty_returns_list(client: TestClient, session_factory: sessionmaker
     ]
 
 
-def test_get_single_reminder(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_get_single_reminder(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(
@@ -1367,7 +1432,9 @@ def test_real_404(client: TestClient) -> None:
     assert resp.json() == []
 
 
-def test_get_single_reminder_not_found(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_get_single_reminder_not_found(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -1376,7 +1443,9 @@ def test_get_single_reminder_not_found(client: TestClient, session_factory: sess
     assert resp.json() == {"detail": "reminder not found"}
 
 
-def test_post_reminder_forbidden(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_post_reminder_forbidden(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -1391,7 +1460,9 @@ def test_post_reminder_forbidden(client: TestClient, session_factory: sessionmak
     fastapi_app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
 
 
-def test_patch_reminder_forbidden(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_patch_reminder_forbidden(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(


### PR DESCRIPTION
## Summary
- ensure both main and snooze reminder jobs are cleared on reschedule, delete, toggle, and after-meal scheduling
- add helper for consistent job removal and extend tests for snooze cleanup

## Testing
- `pytest -q` *(fails: IndexError in register_handlers tests; TimeoutError in reminder_timezones tests; TypeError in reminders_button_regex; AssertionError in reminders_job_queue; AttributeError in schedule_all_queries; IndexError in sos_contact)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b541a44d00832abbf05206403a1eba