### PR TITLE
[reminders] pass naive time to run_daily

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING, TypeAlias
@@ -80,23 +81,18 @@ def schedule_reminder(rem: Reminder, job_queue: DefaultJobQueue | None, user: Us
     elif kind == "at_time" and rem.time is not None:
         mask = getattr(rem, "days_mask", 0) or 0
         days = tuple(i for i in range(7) if mask & (1 << i)) if mask else None
-        if days is None:
-            job_queue.run_daily(
-                reminder_job,
-                time=rem.time.replace(tzinfo=tz),
-                data=context,
-                name=name,
-                job_kwargs=job_kwargs,
-            )
-        else:
-            job_queue.run_daily(
-                reminder_job,
-                time=rem.time.replace(tzinfo=tz),
-                days=days,
-                data=context,
-                name=name,
-                job_kwargs=job_kwargs,
-            )
+        params = {
+            "time": rem.time,
+            "data": context,
+            "name": name,
+            "job_kwargs": job_kwargs,
+        }
+        sig = inspect.signature(job_queue.run_daily)
+        if "timezone" in sig.parameters:
+            params["timezone"] = tz
+        if days is not None and "days" in sig.parameters:
+            params["days"] = days
+        job_queue.run_daily(reminder_job, **params)
     elif kind == "every" and rem.interval_minutes is not None:
         job_queue.run_repeating(
             reminder_job,

--- a/tests/test_reminder_reschedule.py
+++ b/tests/test_reminder_reschedule.py
@@ -64,6 +64,7 @@ class DummyJobQueue:
         days: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6),
         data: dict[str, object] | None = None,
         name: str | None = None,
+        timezone: ZoneInfo | None = None,
         job_kwargs: dict[str, object] | None = None,
     ) -> DummyJob:
         params: dict[str, object] = {"hour": time.hour, "minute": time.minute}
@@ -75,7 +76,7 @@ class DummyJobQueue:
             id=name or "",
             name=name or "",
             replace_existing=bool(job_kwargs and job_kwargs.get("replace_existing")),
-            timezone=time.tzinfo or ZoneInfo("UTC"),
+            timezone=timezone or ZoneInfo("UTC"),
             kwargs={"context": data},
             **params,
         )

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -169,6 +169,7 @@ class DummyJobQueue:
         days: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6),
         data: dict[str, Any] | None = None,
         name: str | None = None,
+        timezone: tzinfo | None = None,
         job_kwargs: dict[str, Any] | None = None,
     ) -> DummyJob:
         params: dict[str, Any] = {"hour": time.hour, "minute": time.minute}
@@ -180,7 +181,7 @@ class DummyJobQueue:
             id=name or "",
             name=name or "",
             replace_existing=bool(job_kwargs and job_kwargs.get("replace_existing")),
-            timezone=getattr(time, "tzinfo", None) or ZoneInfo("UTC"),
+            timezone=timezone or ZoneInfo("UTC"),
             kwargs={"context": data},
             **params,
         )

--- a/tests/test_schedule_all_queries.py
+++ b/tests/test_schedule_all_queries.py
@@ -37,6 +37,7 @@ class DummyJobQueue:
         days: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6),
         data: dict[str, object] | None = None,
         name: str | None = None,
+        timezone: object | None = None,
         job_kwargs: dict[str, object] | None = None,
     ) -> DummyJob:
         job = DummyJob(name, data)


### PR DESCRIPTION
## Summary
- ensure reminder scheduling passes naive time to JobQueue and forwards timezone only if supported
- adapt test job queues to accept optional timezone argument

## Testing
- `ruff check services/api/app/diabetes/handlers/reminder_jobs.py tests/test_reminder_reschedule.py tests/test_reminders.py tests/test_schedule_all_queries.py`
- `mypy --strict services/api/app/diabetes/handlers/reminder_jobs.py tests/test_reminder_reschedule.py tests/test_reminders.py tests/test_schedule_all_queries.py` *(failed: Interrupted)*
- `pytest -q` *(fail: 10 failed, 752 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b563283c44832aa2c8fea0b6dd4805