### PR TITLE
[handlers] fix after meal job naming

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -1098,7 +1098,8 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
         minutes_after = rem.minutes_after
         if minutes_after is None:
             continue
-        removed = _remove_jobs(job_queue, f"reminder_{rem.id}")
+        name = f"reminder_{rem.id}_after"
+        removed = _remove_jobs(job_queue, name)
         if removed:
             logger.info("Removed %d job(s) for reminder %s", removed, rem.id)
         schedule_once(
@@ -1106,7 +1107,8 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
             reminder_job,
             when=timedelta(minutes=float(minutes_after)),
             data={"reminder_id": rem.id, "chat_id": user_id},
-            name=f"reminder_{rem.id}",
+            name=name,
+            job_kwargs={"id": name, "name": name, "replace_existing": True},
         )
 
 

--- a/tests/test_reminders_after_meal.py
+++ b/tests/test_reminders_after_meal.py
@@ -114,7 +114,7 @@ def test_schedule_after_meal_single_reminder() -> None:
     assert job.callback is handlers.reminder_job
     assert job.when == timedelta(minutes=30)
     assert job.data == {"reminder_id": 1, "chat_id": 1}
-    assert job.name == "reminder_1"
+    assert job.name == "reminder_1_after"
 
 
 def test_schedule_after_meal_no_duplicate_jobs() -> None:
@@ -139,10 +139,9 @@ def test_schedule_after_meal_no_duplicate_jobs() -> None:
     job_queue = cast(handlers.DefaultJobQueue, dummy_queue)
     handlers.schedule_after_meal(1, job_queue)
     handlers.schedule_after_meal(1, job_queue)
-    jobs = list(job_queue.get_jobs_by_name("reminder_1"))
-    assert len(jobs) == 2
-    assert jobs[0].removed is True
-    assert jobs[1].removed is False
+    jobs = list(job_queue.get_jobs_by_name("reminder_1_after"))
+    assert len(jobs) == 1
+    assert jobs[0].removed is False
 
 
 def test_schedule_after_meal_multiple_reminders() -> None:
@@ -178,10 +177,10 @@ def test_schedule_after_meal_multiple_reminders() -> None:
     handlers.schedule_after_meal(1, cast(handlers.DefaultJobQueue, dummy_queue))
     assert len(dummy_queue.jobs) == 2
     jobs = {job.name: job for job in dummy_queue.jobs}
-    job1 = jobs["reminder_1"]
+    job1 = jobs["reminder_1_after"]
     assert job1.when == timedelta(minutes=15)
     assert job1.data == {"reminder_id": 1, "chat_id": 1}
-    job2 = jobs["reminder_2"]
+    job2 = jobs["reminder_2_after"]
     assert job2.when == timedelta(minutes=45)
     assert job2.data == {"reminder_id": 2, "chat_id": 1}
 


### PR DESCRIPTION
## Summary
- ensure after-meal reminders use unique `_after` job name and replace existing jobs
- adjust tests for updated after-meal reminder scheduling

## Testing
- `pytest tests/test_reminders_after_meal.py::test_schedule_after_meal_single_reminder tests/test_reminders_after_meal.py::test_schedule_after_meal_no_duplicate_jobs tests/test_reminders_after_meal.py::test_schedule_after_meal_multiple_reminders --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=0 -q`
- `mypy --strict --follow-imports=skip services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders_after_meal.py`
- `ruff check services/api/app/diabetes/handlers/reminder_handlers.py tests/test_reminders_after_meal.py`


------
https://chatgpt.com/codex/tasks/task_e_68b566a1c004832a986e780e2e802e7e