### PR TITLE
[reminders] remove name from job_kwargs

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -1108,7 +1108,7 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
             when=timedelta(minutes=float(minutes_after)),
             data={"reminder_id": rem.id, "chat_id": user_id},
             name=name,
-            job_kwargs={"id": name, "name": name, "replace_existing": True},
+            job_kwargs={"id": name, "replace_existing": True},
         )
 
 

--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -68,11 +68,7 @@ def schedule_reminder(
     context: dict[str, object] = {"reminder_id": rem.id, "chat_id": rem.telegram_id}
 
 
-    job_kwargs: dict[str, object] = {
-        "id": name,
-        "name": name,
-        "replace_existing": True,
-    }
+    job_kwargs: dict[str, object] = {"id": name, "replace_existing": True}
 
     if kind == "after_event":
         logger.info("Skip scheduling %s: 'after_event' is scheduled on trigger.", name)


### PR DESCRIPTION
## Summary
- avoid duplicating scheduler job name in job_kwargs for reminder jobs

## Testing
- `pytest tests/test_reminders_after_meal.py::test_schedule_after_meal_single_reminder tests/test_reminders_after_meal.py::test_schedule_after_meal_no_duplicate_jobs tests/test_reminders_after_meal.py::test_schedule_after_meal_multiple_reminders tests/test_reminders_after_meal.py::test_schedule_after_meal_no_enabled_reminders tests/test_reminders_after_meal.py::test_schedule_after_meal_no_timezone_kwarg tests/test_reminders.py::test_schedule_reminder_replaces_existing_job tests/test_reminders.py::test_schedule_reminder_requires_job_queue tests/test_reminders.py::test_schedule_reminder_requires_telegram_id tests/test_reminders.py::test_schedule_reminder_without_user_defaults_to_utc tests/test_reminders.py::test_schedule_reminder_uses_user_timezone_when_queue_has_none --cov-fail-under=0 -q`
- `mypy --strict services/api/app/diabetes/handlers/reminder_jobs.py services/api/app/diabetes/handlers/reminder_handlers.py`
- `ruff check services/api/app/diabetes/handlers/reminder_jobs.py services/api/app/diabetes/handlers/reminder_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b56dd2d9d4832aa12dfda75a32918b