### PR TITLE
[jobs] use scheduling helpers for reminders

### DIFF
--- a/tests/test_add_reminder_wizard.py
+++ b/tests/test_add_reminder_wizard.py
@@ -105,6 +105,28 @@ class DummyJobQueue:
             minutes=minutes,
         )
 
+    def run_once(
+        self,
+        callback: Callable[..., Any],
+        when: Any,
+        *,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        timezone: object | None = None,
+        job_kwargs: dict[str, Any] | None = None,
+    ) -> Any:
+        params = {"when": when}
+        return self.scheduler.add_job(
+            callback,
+            trigger="once",
+            id=name or "",
+            name=name or "",
+            replace_existing=bool(job_kwargs and job_kwargs.get("replace_existing")),
+            timezone=timezone or ZoneInfo("UTC"),
+            kwargs={"context": data},
+            **params,
+        )
+
     def get_jobs_by_name(self, name: str) -> list[Any]:
         return [j for j in self.scheduler.jobs if j["name"] == name]
 
@@ -140,8 +162,12 @@ async def test_webapp_save_creates_reminder(
         session.commit()
 
     msg = DummyMessage(json.dumps({"type": "sugar", "value": "08:00"}))
-    update = cast(Update, UpdateStub(effective_message=msg, effective_user=DummyUser(id=1)))
-    context = cast(ContextTypes.DEFAULT_TYPE, CallbackContextStub(job_queue=DummyJobQueue()))
+    update = cast(
+        Update, UpdateStub(effective_message=msg, effective_user=DummyUser(id=1))
+    )
+    context = cast(
+        ContextTypes.DEFAULT_TYPE, CallbackContextStub(job_queue=DummyJobQueue())
+    )
     monkeypatch.setattr(
         handlers.reminder_events,
         "notify_reminder_saved",
@@ -169,8 +195,12 @@ async def test_webapp_save_creates_interval(
         session.commit()
 
     msg = DummyMessage(json.dumps({"type": "sugar", "value": "2h"}))
-    update = cast(Update, UpdateStub(effective_message=msg, effective_user=DummyUser(id=1)))
-    context = cast(ContextTypes.DEFAULT_TYPE, CallbackContextStub(job_queue=DummyJobQueue()))
+    update = cast(
+        Update, UpdateStub(effective_message=msg, effective_user=DummyUser(id=1))
+    )
+    context = cast(
+        ContextTypes.DEFAULT_TYPE, CallbackContextStub(job_queue=DummyJobQueue())
+    )
     monkeypatch.setattr(
         handlers.reminder_events,
         "notify_reminder_saved",

--- a/tests/test_reminder_limit_free_vs_pro.py
+++ b/tests/test_reminder_limit_free_vs_pro.py
@@ -55,6 +55,7 @@ async def test_reminder_limit_free_vs_pro(
     context: Any = SimpleNamespace(
         job_queue=SimpleNamespace(
             run_daily=lambda *a, **k: None,
+            run_once=lambda *a, **k: None,
             run_repeating=lambda *a, **k: None,
             get_jobs_by_name=lambda name: [],
         )

--- a/tests/test_reminders_api.py
+++ b/tests/test_reminders_api.py
@@ -58,6 +58,28 @@ class DummyJobQueue:
     def __init__(self) -> None:
         self.scheduler = DummyScheduler()
 
+    def run_once(
+        self,
+        callback: Callable[..., Any],
+        when: Any,
+        *,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        timezone: object | None = None,
+        job_kwargs: dict[str, Any] | None = None,
+    ) -> DummyJob:
+        params: dict[str, Any] = {"when": when}
+        return self.scheduler.add_job(
+            callback,
+            trigger="once",
+            id=name or "",
+            name=name or "",
+            replace_existing=bool(job_kwargs and job_kwargs.get("replace_existing")),
+            timezone=timezone or ZoneInfo("UTC"),
+            kwargs={"context": data},
+            **params,
+        )
+
     def run_daily(
         self,
         callback: Callable[..., Any],
@@ -161,7 +183,9 @@ def client_with_job_queue(
     reminder_events.register_job_queue(None)
 
 
-def test_empty_returns_200(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_empty_returns_200(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()
@@ -170,7 +194,9 @@ def test_empty_returns_200(client: TestClient, session_factory: sessionmaker[Ses
     assert resp.json() == []
 
 
-def test_nonempty_returns_list(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_nonempty_returns_list(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(
@@ -208,7 +234,9 @@ def test_nonempty_returns_list(client: TestClient, session_factory: sessionmaker
     ]
 
 
-def test_get_single_reminder(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_get_single_reminder(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
         session.add(
@@ -258,7 +286,9 @@ def test_mismatched_telegram_id_returns_404(client: TestClient) -> None:
     assert resp.json() == {"detail": "reminder not found"}
 
 
-def test_get_single_reminder_not_found(client: TestClient, session_factory: sessionmaker[Session]) -> None:
+def test_get_single_reminder_not_found(
+    client: TestClient, session_factory: sessionmaker[Session]
+) -> None:
     with session_factory() as session:
         session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()

--- a/tests/test_reminders_job_queue.py
+++ b/tests/test_reminders_job_queue.py
@@ -57,6 +57,18 @@ class DummyJobQueue:
         self.jobs.append(job)
         return job
 
+    def run_once(
+        self,
+        callback: Any,
+        when: Any,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        **kwargs: Any,
+    ) -> DummyJob:
+        job = DummyJob(name or "")
+        self.jobs.append(job)
+        return job
+
     def get_jobs_by_name(self, name: str) -> list[DummyJob]:
         return [job for job in self.jobs if job.name == name]
 
@@ -120,4 +132,3 @@ def test_post_reminder_uses_job_queue(
     assert fake_queue.get_jobs_by_name(f"reminder_{rid}")
 
     reminder_events.job_queue = None
-


### PR DESCRIPTION
## Summary
- schedule reminders with `schedule_daily`/`schedule_once` instead of direct JobQueue calls
- update tests and dummy job queues for new scheduling helpers

## Testing
- `ruff check services/api/app/diabetes/handlers/reminder_jobs.py tests/test_reminders.py tests/test_add_reminder_wizard.py tests/test_reminder_limit_free_vs_pro.py tests/test_reminders_api.py tests/test_reminders_job_queue.py`
- `mypy --strict services/api/app/diabetes/handlers/reminder_jobs.py tests/test_reminders.py tests/test_add_reminder_wizard.py tests/test_reminder_limit_free_vs_pro.py tests/test_reminders_api.py tests/test_reminders_job_queue.py`
- `pytest -q` *(fails: apscheduler.scheduler.BaseScheduler missing timezone)*
- `pytest tests/test_reminders.py::test_interval_minutes_scheduling_and_rendering tests/test_reminders_after_meal.py::test_schedule_reminder_after_meal -q`


------
https://chatgpt.com/codex/tasks/task_e_68b56dd6cca8832a93aa3986975f6217