### PR TITLE
[handlers] centralize reminder job scheduling

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-import inspect
 import logging
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, TypeAlias, cast
+from typing import TYPE_CHECKING, TypeAlias
 from zoneinfo import ZoneInfo
 
 from telegram.ext import ContextTypes, JobQueue
 
 from services.api.app.diabetes.services.db import Reminder, User
-from services.api.app.diabetes.utils.jobs import schedule_once
+from services.api.app.diabetes.utils.jobs import schedule_daily, schedule_once
 
 logger = logging.getLogger(__name__)
 
@@ -83,59 +82,38 @@ def schedule_reminder(
     elif kind == "at_time" and rem.time is not None:
         mask = getattr(rem, "days_mask", 0) or 0
         days = tuple(i for i in range(7) if mask & (1 << i)) if mask else None
-        run_daily = job_queue.run_daily
-        sig = inspect.signature(run_daily)
-        job_kwargs_cast = cast(dict[str, Any], job_kwargs)
-        if days is not None and "days" in sig.parameters:
-            if "timezone" in sig.parameters:
-                cast(Any, run_daily)(
-                    reminder_job,
-                    time=rem.time,
-                    days=days,
-                    data=context,
-                    name=name,
-                    job_kwargs=job_kwargs_cast,
-                    timezone=tz,
-                )
-            else:
-                run_daily(
-                    reminder_job,
-                    time=rem.time,
-                    days=days,
-                    data=context,
-                    name=name,
-                    job_kwargs=job_kwargs_cast,
-                )
-        else:
-            if "timezone" in sig.parameters:
-                cast(Any, run_daily)(
-                    reminder_job,
-                    time=rem.time,
-                    data=context,
-                    name=name,
-                    job_kwargs=job_kwargs_cast,
-                    timezone=tz,
-                )
-            else:
-                run_daily(
-                    reminder_job,
-                    time=rem.time,
-                    data=context,
-                    name=name,
-                    job_kwargs=job_kwargs_cast,
-                )
+        schedule_daily(
+            job_queue,
+            reminder_job,
+            time=rem.time,
+            data=context,
+            name=name,
+            timezone=tz,
+            days=days,
+            job_kwargs=job_kwargs,
+        )
     elif kind == "every" and rem.interval_minutes is not None:
-        run_repeating = getattr(job_queue, "run_repeating", None)
-        if run_repeating is not None:
-            cast(Any, run_repeating)(
+        if hasattr(job_queue, "run_once"):
+            schedule_once(
+                job_queue,
                 reminder_job,
-                interval=timedelta(minutes=int(rem.interval_minutes)),
+                when=timedelta(minutes=int(rem.interval_minutes)),
                 data=context,
                 name=name,
                 job_kwargs=job_kwargs,
             )
         else:
-            logger.warning("Job queue lacks run_repeating; skipping %s", name)
+            run_repeating = getattr(job_queue, "run_repeating", None)
+            if run_repeating is not None:
+                run_repeating(
+                    reminder_job,
+                    interval=timedelta(minutes=int(rem.interval_minutes)),
+                    data=context,
+                    name=name,
+                    job_kwargs=job_kwargs,
+                )
+            else:
+                logger.warning("Job queue lacks run_once and run_repeating; skipping %s", name)
 
     job = next(iter(job_queue.get_jobs_by_name(name)), None)
     next_run = None

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -496,13 +496,12 @@ def test_interval_minutes_scheduling_and_rendering(
         rem = session.get(Reminder, 1)
         user = session.get(DbUser, 1)
         assert rem is not None
-        with patch.object(
-            job_queue.scheduler, "add_job", wraps=job_queue.scheduler.add_job
-        ) as mock_add:
+        with patch.object(job_queue, "run_once", wraps=job_queue.run_once) as mock_once:
             handlers.schedule_reminder(rem, job_queue, user)
-            mock_add.assert_called_once()
-            assert mock_add.call_args.kwargs["trigger"] == "interval"
-            assert mock_add.call_args.kwargs["minutes"] == 30
+            mock_once.assert_called_once()
+            when = mock_once.call_args.kwargs["when"]
+            assert isinstance(when, timedelta)
+            assert when == timedelta(minutes=30)
         text, _ = handlers._render_reminders(session, 1)
     assert "⏱ Интервал" in text
     assert "каждые 30 мин" in text


### PR DESCRIPTION
## Summary
- use `schedule_daily`/`schedule_once` helpers in reminder job scheduling
- fall back to `run_repeating` if `run_once` is unavailable
- update interval reminder test for new scheduling helper

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b57617de08832a9c793f36f44b851d