### PR TITLE
[reminders] Use job scheduling helpers

### DIFF
--- a/tests/test_add_reminder_wizard.py
+++ b/tests/test_add_reminder_wizard.py
@@ -84,6 +84,28 @@ class DummyJobQueue:
             **params,
         )
 
+    def run_once(
+        self,
+        callback: Callable[..., Any],
+        when: Any,
+        *,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        timezone: object | None = None,
+        job_kwargs: dict[str, Any] | None = None,
+    ) -> Any:
+        params = {"when": when}
+        return self.scheduler.add_job(
+            callback,
+            trigger="date",
+            id=name or "",
+            name=name or "",
+            replace_existing=bool(job_kwargs and job_kwargs.get("replace_existing")),
+            timezone=timezone or ZoneInfo("UTC"),
+            kwargs={"context": data},
+            **params,
+        )
+
     def run_repeating(
         self,
         callback: Callable[..., Any],
@@ -140,8 +162,12 @@ async def test_webapp_save_creates_reminder(
         session.commit()
 
     msg = DummyMessage(json.dumps({"type": "sugar", "value": "08:00"}))
-    update = cast(Update, UpdateStub(effective_message=msg, effective_user=DummyUser(id=1)))
-    context = cast(ContextTypes.DEFAULT_TYPE, CallbackContextStub(job_queue=DummyJobQueue()))
+    update = cast(
+        Update, UpdateStub(effective_message=msg, effective_user=DummyUser(id=1))
+    )
+    context = cast(
+        ContextTypes.DEFAULT_TYPE, CallbackContextStub(job_queue=DummyJobQueue())
+    )
     monkeypatch.setattr(
         handlers.reminder_events,
         "notify_reminder_saved",
@@ -169,8 +195,12 @@ async def test_webapp_save_creates_interval(
         session.commit()
 
     msg = DummyMessage(json.dumps({"type": "sugar", "value": "2h"}))
-    update = cast(Update, UpdateStub(effective_message=msg, effective_user=DummyUser(id=1)))
-    context = cast(ContextTypes.DEFAULT_TYPE, CallbackContextStub(job_queue=DummyJobQueue()))
+    update = cast(
+        Update, UpdateStub(effective_message=msg, effective_user=DummyUser(id=1))
+    )
+    context = cast(
+        ContextTypes.DEFAULT_TYPE, CallbackContextStub(job_queue=DummyJobQueue())
+    )
     monkeypatch.setattr(
         handlers.reminder_events,
         "notify_reminder_saved",


### PR DESCRIPTION
## Summary
- centralize reminder scheduling via `schedule_daily`/`schedule_once`
- adjust tests for new scheduling interface

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b578cbe390832a95943446aff8cade