### PR TITLE
[reminders] preserve job name for after meal schedule

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -1134,7 +1134,7 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
             when=timedelta(minutes=float(minutes_after)),
             data={"reminder_id": rem.id, "chat_id": user_id},
             name=name,
-            job_kwargs={"id": name, "replace_existing": True},
+            job_kwargs={"id": name, "name": name, "replace_existing": True},
         )
 
 


### PR DESCRIPTION
## Summary
- preserve job name when scheduling after-meal reminders by passing name in job kwargs
- extend after-meal reminder tests to verify job name is kept

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b57d8b2fac832aaac55cb1bca72f1c