### PR TITLE
[handlers] refine reminders rendering

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -176,14 +176,14 @@ def _render_reminders(
     user = session.query(User).filter_by(telegram_id=user_id).first()
     limit = _limit_for(user)
     active_count = sum(1 for r in rems if r.is_enabled)
-    header = f"Ваши напоминания  ({active_count} / {limit} 🔔)"
+    header = f"Ваши напоминания ({active_count} / {limit} 🔔)"
     if active_count > limit:
         header += " ⚠️"
 
-    webapp_enabled: bool = bool(config.get_settings().public_origin)
+    webapp_enabled: bool = bool(settings.public_origin)
 
-    origin = settings.public_origin.rstrip("/")
-    base_url = settings.ui_base_url.strip("/")
+    origin = (settings.public_origin or "").rstrip("/")
+    base_url = (getattr(settings, "ui_base_url", "") or "").strip("/")
 
     def build_url(path: str) -> str:
         rel = path.lstrip("/")


### PR DESCRIPTION
## Summary
- fix reminder list header and URL setup when public_origin is missing
- cover reminder rendering for missing public_origin and header format

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b57d8d3e74832a994076d2b837c5ba