### PR TITLE
[tests] support repeating dummy jobs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,9 @@ class _DummyBaseHandler:  # pragma: no cover - minimal stub
 dummy.BaseHandler = _DummyBaseHandler
 sys.modules.setdefault("telegram.ext._basehandler", dummy)
 
-warnings.filterwarnings("ignore", category=ResourceWarning, module=r"anyio\.streams\.memory")
+warnings.filterwarnings(
+    "ignore", category=ResourceWarning, module=r"anyio\.streams\.memory"
+)
 
 _sqlite_connections: list[sqlite3.Connection] = []
 _original_sqlite_connect: Callable[..., sqlite3.Connection] = sqlite3.connect
@@ -42,7 +44,9 @@ setattr(sqlite3, "connect", _tracking_sqlite_connect)
 
 
 _engines: list[sqlalchemy.engine.Engine] = []
-_original_create_engine: Callable[..., sqlalchemy.engine.Engine] = sqlalchemy.create_engine
+_original_create_engine: Callable[..., sqlalchemy.engine.Engine] = (
+    sqlalchemy.create_engine
+)
 
 
 def _tracking_create_engine(*args: Any, **kwargs: Any) -> sqlalchemy.engine.Engine:
@@ -109,6 +113,31 @@ class _DummyJobQueue:
         job = _DummyJob(job_id, data)
         self.scheduler.jobs.append(job)
         return job
+
+    def run_repeating(
+        self,
+        callback: Callable[..., object],
+        interval: object,
+        *,
+        data: dict[str, Any] | None = None,
+        name: str | None = None,
+        timezone: object | None = None,
+        job_kwargs: dict[str, Any] | None = None,
+    ) -> _DummyJob:
+        job_id = job_kwargs.get("id") if job_kwargs else name or ""
+        replace_existing = (
+            bool(job_kwargs.get("replace_existing")) if job_kwargs else False
+        )
+        return self.scheduler.add_job(
+            callback,
+            trigger="interval",
+            id=job_id,
+            name=job_id,
+            replace_existing=replace_existing,
+            timezone=timezone,
+            kwargs={"context": data} if data is not None else None,
+            seconds=interval,
+        )
 
     def get_jobs_by_name(self, name: str) -> list[_DummyJob]:
         return [j for j in self.scheduler.jobs if j.name == name]

--- a/tests/test_dummy_job_queue_run_repeating.py
+++ b/tests/test_dummy_job_queue_run_repeating.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tests.conftest import _DummyJobQueue
+
+
+def _callback(context: Any) -> None:
+    return None
+
+
+def test_run_repeating_schedules_job() -> None:
+    job_queue = _DummyJobQueue()
+    job_queue.run_repeating(
+        _callback,
+        interval=5,
+        data={"a": 1},
+        name="job",
+        timezone="UTC",
+    )
+    jobs = job_queue.get_jobs_by_name("job")
+    assert len(jobs) == 1
+    assert jobs[0].name == "job"
+    assert jobs[0].data == {"a": 1}


### PR DESCRIPTION
## Summary
- support repeating jobs in test dummy job queue
- cover dummy job queue repeating scheduling

## Testing
- `python -m black tests/conftest.py tests/test_dummy_job_queue_run_repeating.py`
- `ruff check tests/conftest.py tests/test_dummy_job_queue_run_repeating.py`
- `mypy --strict tests/conftest.py tests/test_dummy_job_queue_run_repeating.py`
- `pytest tests/test_dummy_job_queue_run_repeating.py -q -o addopts='--cov=tests.test_dummy_job_queue_run_repeating --cov-fail-under=85'`


------
https://chatgpt.com/codex/tasks/task_e_68b581127410832a9a00d3406e7933bc