### PR TITLE
[tests] Implement dummy job queue run_repeating

### DIFF
--- a/tests/test_dummy_job_queue.py
+++ b/tests/test_dummy_job_queue.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import timezone
+from unittest.mock import patch
+
+from tests.conftest import _DummyJobQueue
+
+
+def test_run_repeating_schedules_job() -> None:
+    jq = _DummyJobQueue()
+    with patch.object(jq.scheduler, "add_job", wraps=jq.scheduler.add_job) as spy:
+        jq.run_repeating(
+            lambda: None,
+            interval=5,
+            data={"a": 1},
+            name="test",
+            timezone=timezone.utc,
+        )
+    spy.assert_called_once()
+    assert spy.call_args.kwargs["trigger"] == "interval"
+    jobs = jq.get_jobs_by_name("test")
+    assert len(jobs) == 1
+    assert jobs[0].data == {"a": 1}


### PR DESCRIPTION
## Summary
- use `_DummyScheduler.add_job` for dummy `run_repeating` with interval trigger
- allow `timezone` arg for dummy `run_repeating`
- add test for scheduling and retrieving repeating jobs

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b583b6aeac832a9a8a796c60315da3