### PR TITLE
[handlers] Skip scheduling for non-positive interval

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -109,6 +109,14 @@ def schedule_reminder(
                 job_kwargs=call_job_kwargs,
             )
     elif kind == "every" and interval_minutes is not None:
+        if interval_minutes <= 0:
+            logger.warning(
+                "SKIP %s kind=%s interval_min=%s",
+                name,
+                kind,
+                interval_minutes,
+            )
+            return
         job_queue.run_repeating(
             reminder_job,
             interval=timedelta(minutes=float(interval_minutes)),


### PR DESCRIPTION
## Summary
- warn and skip scheduling when reminder interval is non-positive
- test skipping schedule for zero interval

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b588440e1c832a95f0d847f78f761b