### PR TITLE
[utils] hard remove jobs by base name

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -813,16 +813,8 @@ async def delete_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             return
     job_queue: DefaultJobQueue | None = cast(DefaultJobQueue | None, context.job_queue)
     if job_queue is not None:
-        removed_main = _remove_jobs(job_queue, f"reminder_{rid}")
-        removed_snooze = _remove_jobs(job_queue, f"reminder_{rid}_snooze")
-        removed_after = _remove_jobs(job_queue, f"reminder_{rid}_after")
-        logger.info(
-            "Removed jobs for %s: main=%d, snooze=%d, after=%d",
-            rid,
-            removed_main,
-            removed_snooze,
-            removed_after,
-        )
+        removed = _remove_jobs(job_queue, f"reminder_{rid}")
+        logger.info("Removed jobs for %s: %d", rid, removed)
     if message:
         await message.reply_text("Удалено")
     if job_queue is None:
@@ -1045,16 +1037,8 @@ async def reminder_action_cb(
                     rid,
                 )
         elif job_queue is not None:
-            removed_main = _remove_jobs(job_queue, f"reminder_{rid}")
-            removed_snooze = _remove_jobs(job_queue, f"reminder_{rid}_snooze")
-            removed_after = _remove_jobs(job_queue, f"reminder_{rid}_after")
-            logger.info(
-                "Removed jobs for %s: main=%d, snooze=%d, after=%d",
-                rid,
-                removed_main,
-                removed_snooze,
-                removed_after,
-            )
+            removed = _remove_jobs(job_queue, f"reminder_{rid}")
+            logger.info("Removed jobs for %s: %d", rid, removed)
             logger.debug(
                 "Job queue present; suppressed reminder_saved event for %s",
                 rid,
@@ -1064,16 +1048,8 @@ async def reminder_action_cb(
             logger.debug("Sent reminder_saved event for %s", rid)
     else:  # del
         if job_queue is not None:
-            removed_main = _remove_jobs(job_queue, f"reminder_{rid}")
-            removed_snooze = _remove_jobs(job_queue, f"reminder_{rid}_snooze")
-            removed_after = _remove_jobs(job_queue, f"reminder_{rid}_after")
-            logger.info(
-                "Removed jobs for %s: main=%d, snooze=%d, after=%d",
-                rid,
-                removed_main,
-                removed_snooze,
-                removed_after,
-            )
+            removed = _remove_jobs(job_queue, f"reminder_{rid}")
+            logger.info("Removed jobs for %s: %d", rid, removed)
             logger.debug(
                 "Job queue present; suppressed reminder_saved event for %s",
                 rid,
@@ -1124,17 +1100,18 @@ def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None
         minutes_after = rem.minutes_after
         if minutes_after is None:
             continue
-        name = f"reminder_{rem.id}_after"
+        name = f"reminder_{rem.id}"
         removed = _remove_jobs(job_queue, name)
         if removed:
             logger.info("Removed %d job(s) for reminder %s", removed, rem.id)
+        after_name = f"{name}_after"
         schedule_once(
             job_queue,
             reminder_job,
             when=timedelta(minutes=float(minutes_after)),
             data={"reminder_id": rem.id, "chat_id": user_id},
-            name=name,
-            job_kwargs={"id": name, "name": name, "replace_existing": True},
+            name=after_name,
+            job_kwargs={"id": after_name, "name": after_name, "replace_existing": True},
         )
 
 

--- a/tests/test_remove_jobs.py
+++ b/tests/test_remove_jobs.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from services.api.app.diabetes.utils.jobs import _remove_jobs
+
+
+class RemovableJob:
+    def __init__(self, name: str) -> None:
+        self.id = name
+        self.name = name
+        self.removed = False
+
+    def remove(self) -> None:  # pragma: no cover - simple
+        self.removed = True
+
+
+class NonRemovableJob:
+    def __init__(self, name: str) -> None:
+        self.id = name
+        self.name = name
+
+
+class SchedulableJob:
+    def __init__(self, name: str) -> None:
+        self.id = name
+        self.name = name
+        self.scheduled = False
+
+    def schedule_removal(self) -> None:  # pragma: no cover - simple
+        self.scheduled = True
+
+
+class DummyScheduler:
+    def __init__(self, jobs: dict[str, object]) -> None:
+        self.jobs = jobs
+        self.removed: list[str] = []
+
+    def get_job(self, job_id: str) -> object | None:
+        return self.jobs.get(job_id)
+
+    def remove_job(self, job_id: str) -> None:
+        if job_id in self.jobs:
+            self.removed.append(job_id)
+            del self.jobs[job_id]
+        else:  # pragma: no cover - defensive
+            raise KeyError(job_id)
+
+
+class DummyQueue:
+    def __init__(self, jobs: list[object], scheduler: DummyScheduler) -> None:
+        self._jobs = jobs
+        self.scheduler = scheduler
+
+    def get_jobs_by_name(self, name: str) -> list[object]:
+        return [j for j in self._jobs if getattr(j, "name", None) == name]
+
+    def jobs(self) -> list[object]:
+        return list(self._jobs)
+
+
+def test_remove_jobs_covers_variants() -> None:
+    job1 = RemovableJob("reminder_1")
+    job2 = NonRemovableJob("reminder_1_after")
+    job3 = SchedulableJob("reminder_1_snooze_extra")
+    scheduler = DummyScheduler({job1.id: job1, job2.id: job2, job3.id: job3})
+    queue = DummyQueue([job1, job2, job3], scheduler)
+
+    removed = _remove_jobs(cast(Any, queue), "reminder_1")
+
+    assert removed == 3
+    assert job1.removed is True
+    assert "reminder_1_after" not in scheduler.jobs
+    assert job3.scheduled is True or job3.id not in scheduler.jobs


### PR DESCRIPTION
## Summary
- hard remove APScheduler jobs by base name with suffix variants
- collapse reminder job cleanup to single call
- add unit test for aggressive job removal

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5a3c1ca04832a8f928a5b81d51c66