### PR TITLE
[utils] Harden job removal

### DIFF
--- a/services/api/app/diabetes/utils/jobs.py
+++ b/services/api/app/diabetes/utils/jobs.py
@@ -160,44 +160,91 @@ def schedule_daily(
     return cast(Job[CustomContext], result)
 
 
-def _remove_jobs(job_queue: DefaultJobQueue, base: str) -> int:
-    """Best-effort removal of jobs with the given base name.
+def _safe_remove(job: object) -> bool:
+    """Remove ``job`` using all available strategies.
 
-    Removes jobs named ``base`` as well as related jobs like
-    ``f"{base}_snooze"`` and ``f"{base}_after"``. Tries ``job.remove()``
-    first, then falls back to direct scheduler removal, and finally
-    schedules the job for removal. Returns the number of jobs processed.
+    Tries ``job.remove()``, falling back to ``scheduler.remove_job`` and
+    finally ``job.schedule_removal``. Returns ``True`` if any strategy
+    succeeds.
     """
+    remover = cast(Callable[[], None] | None, getattr(job, "remove", None))
+    if remover is not None:
+        try:
+            remover()
+            return True
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+    queue = getattr(job, "queue", None)
+    scheduler = getattr(queue, "scheduler", None)
+    remove_job = cast(Callable[[object], None] | None, getattr(scheduler, "remove_job", None))
+    job_id = getattr(job, "id", None)
+    if remove_job is not None and job_id is not None:
+        try:
+            remove_job(job_id)
+            return True
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+    schedule_removal = cast(Callable[[], None] | None, getattr(job, "schedule_removal", None))
+    if schedule_removal is not None:
+        try:
+            schedule_removal()
+            return True
+        except Exception:  # pragma: no cover - defensive
+            pass
+    return False
+
+
+def _remove_jobs(job_queue: DefaultJobQueue, base_name: str) -> int:
+    """Remove jobs matching ``base_name`` and related suffixes.
+
+    Hard removal is required as APScheduler may keep stale jobs even when
+    the job queue loses track of them. Leftover jobs could fire after
+    restart, so we aggressively remove them. Returns the number of jobs
+    removed.
+    """
+    names = {base_name, f"{base_name}_after", f"{base_name}_snooze"}
     removed = 0
-    for suffix in ("", "_snooze", "_after"):
-        name = f"{base}{suffix}"
-        for job in job_queue.get_jobs_by_name(name):
-            remover = cast(Callable[[], None] | None, getattr(job, "remove", None))
-            if remover is not None:
-                try:
-                    remover()
-                    removed += 1
-                    continue
-                except Exception:  # pragma: no cover - defensive
-                    pass
-            scheduler = getattr(job_queue, "scheduler", None)
-            remove_job = (
-                cast(Callable[[object], None] | None, getattr(scheduler, "remove_job", None))
-                if scheduler is not None
-                else None
-            )
-            job_id = getattr(job, "id", None)
-            if remove_job is not None and job_id is not None:
-                try:
-                    remove_job(job_id)
-                    removed += 1
-                    continue
-                except Exception:  # pragma: no cover - defensive
-                    pass
-            schedule_removal = cast(
-                Callable[[], None] | None, getattr(job, "schedule_removal", None)
-            )
-            if schedule_removal is not None:
-                schedule_removal()
+
+    scheduler = getattr(job_queue, "scheduler", None)
+    get_job = cast(
+        Callable[[str], object | None] | None, getattr(scheduler, "get_job", None)
+    )
+    remove_job_direct = cast(
+        Callable[[str], None] | None, getattr(scheduler, "remove_job", None)
+    )
+
+    for name in names:
+        for q_job in job_queue.get_jobs_by_name(name):
+            if _safe_remove(q_job):
                 removed += 1
+
+    if get_job is not None:
+        for name in names:
+            s_job = get_job(name)
+            if s_job is not None:
+                if _safe_remove(s_job):
+                    removed += 1
+            elif remove_job_direct is not None:
+                try:
+                    remove_job_direct(name)
+                except Exception:  # pragma: no cover - defensive
+                    pass
+
+    jobs_method = cast(Callable[[], Iterable[object]] | None, getattr(job_queue, "jobs", None))
+    all_jobs = list(jobs_method()) if jobs_method is not None else []
+    for any_job in all_jobs:
+        jname = getattr(any_job, "name", None)
+        jid = getattr(any_job, "id", None)
+        for n in names:
+            if (
+                isinstance(jname, str) and (jname == n or jname.startswith(n))
+            ) or (
+                isinstance(jid, str) and (jid == n or jid.startswith(n))
+            ):
+                if _safe_remove(any_job):
+                    removed += 1
+                break
+
     return removed


### PR DESCRIPTION
## Summary
- add `_safe_remove` helper to aggressively cancel lingering jobs
- extend `_remove_jobs` to clean scheduler and scan queues by base name
- cover new removal paths in unit tests

## Testing
- `pytest tests/test_remove_jobs.py -q --no-cov`
- `mypy --strict services/api/app/diabetes/utils/jobs.py tests/test_remove_jobs.py`
- `ruff check services/api/app/diabetes/utils/jobs.py tests/test_remove_jobs.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5a7cf9074832a863ec087e34957ec