### PR TITLE
[utils] harden job removal routines

### DIFF
--- a/tests/test_remove_jobs.py
+++ b/tests/test_remove_jobs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from services.api.app.diabetes.utils.jobs import _remove_jobs
+from services.api.app.diabetes.utils.jobs import _remove_jobs, dbg_jobs_dump
 
 
 class _Job:
@@ -83,8 +83,12 @@ def test_remove_jobs() -> None:
         ]
     )
 
+    before = dbg_jobs_dump(jq)
+    assert len(before) == 6
+
     removed = _remove_jobs(jq, "reminder_1")
 
     assert removed == 6
+    assert dbg_jobs_dump(jq) == []
     assert jq.get_jobs_by_name("reminder_1") == []
     assert jq.jobs() == []


### PR DESCRIPTION
## Summary
- broaden `_remove_jobs` to purge scheduler, named, and lingering jobs and log count
- add `dbg_jobs_dump` helper for inspecting the queue
- test job removal and dump behaviour

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5adce8ef4832aa00989893e08ae97