### PR TITLE
[utils] add job removal test

### DIFF
--- a/tests/utils/test_jobs_remove.py
+++ b/tests/utils/test_jobs_remove.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.schedulers.base import SchedulerNotRunningError
+from telegram.ext import JobQueue
+
+from services.api.app.diabetes.utils.jobs import _remove_jobs
+
+
+async def dummy(_: object) -> None:
+    pass
+
+
+def test_jobs_remove() -> None:
+    scheduler = BackgroundScheduler(paused=True)
+    jq = JobQueue()
+    jq.scheduler = scheduler
+
+    jq.run_once(dummy, 0, name="reminder_42")
+    jq.run_once(dummy, 0, name="reminder_42_after")
+    jq.run_once(dummy, 0, name="reminder_42_snooze")
+    jq.run_once(dummy, 0, name="reminder_999")
+
+    removed = _remove_jobs(jq, "reminder_42")
+    assert removed == 3
+    assert not jq.get_jobs_by_name("reminder_42")
+    assert jq.get_jobs_by_name("reminder_999")
+
+    removed = _remove_jobs(jq, "reminder_42")
+    assert removed == 0
+
+    try:
+        scheduler.shutdown(wait=False)
+    except SchedulerNotRunningError:
+        pass
+    executor = getattr(jq, "executor", None) or getattr(jq, "_executor", None)
+    try:
+        executor.shutdown(wait=False)
+    except AttributeError:
+        pass


### PR DESCRIPTION
## Summary
- add regression test for job cleanup logic

## Testing
- `ruff check tests/utils/test_jobs_remove.py`
- `mypy --strict tests/utils/test_jobs_remove.py`
- `pytest -k test_jobs_remove -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b5add28404832a94e3cb065659b46b