### PR TITLE
[jobs] Add job queue dump helper

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_debug.py
+++ b/services/api/app/diabetes/handlers/reminder_debug.py
@@ -1,6 +1,7 @@
 # services/api/app/diabetes/handlers/reminder_debug.py
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
@@ -8,6 +9,10 @@ from telegram import Update
 from telegram.ext import Application, CommandHandler, ContextTypes
 
 from services.api.app.config import settings
+from services.api.app.diabetes.utils.jobs import dbg_jobs_dump
+
+
+logger = logging.getLogger(__name__)
 
 
 def _is_admin(update: Update) -> bool:
@@ -58,6 +63,9 @@ async def dbg_tz(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def dbg_jobs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not _is_admin(update):
         return
+    job_queue = getattr(context.application, "job_queue", None)
+    if job_queue is not None:
+        logger.debug("JobQueue dump: %s", dbg_jobs_dump(job_queue))
     text = _fmt_jobs(context.application)
     await update.effective_chat.send_message(text)
 

--- a/tests/test_dbg_jobs_dump.py
+++ b/tests/test_dbg_jobs_dump.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import cast
+
+from services.api.app.diabetes.utils.jobs import DefaultJobQueue, dbg_jobs_dump
+
+
+class _Job:
+    def __init__(self, job_id: str | None, name: str | None) -> None:
+        self.id = job_id
+        self.name = name
+
+
+class _JobQueue:
+    def __init__(self, jobs: list[_Job]) -> None:
+        self._jobs = jobs
+
+    def jobs(self) -> list[_Job]:
+        return list(self._jobs)
+
+
+def test_dbg_jobs_dump() -> None:
+    jq = cast(DefaultJobQueue, _JobQueue([_Job("1", "a"), _Job(None, "b")]))
+    assert dbg_jobs_dump(jq) == [("1", "a"), (None, "b")]


### PR DESCRIPTION
## Summary
- add dbg_jobs_dump to inspect JobQueue jobs
- log job ids in /dbg_jobs debug command
- cover dbg_jobs_dump utility with unit tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5adbe30f0832a94501c6f2bfb3205