### PR TITLE
[api] add internal reminders router

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -34,6 +34,7 @@ from .diabetes.services.db import (
 )
 from .diabetes.services.repository import CommitError, commit
 from .legacy import router as legacy_router
+from .routers.internal_reminders import router as internal_reminders_router
 from .routers.stats import router as stats_router
 from .schemas.history import ALLOWED_HISTORY_TYPES, HistoryRecordSchema, HistoryType
 from .schemas.role import RoleSchema
@@ -379,6 +380,7 @@ async def delete_history(
 
 
 # ────────── include router ──────────
+app.include_router(internal_reminders_router)
 app.include_router(api_router, prefix="/api")
 
 # ────────── run (for local testing) ──────────

--- a/services/api/app/routers/internal_reminders.py
+++ b/services/api/app/routers/internal_reminders.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from .. import reminder_events
+
+
+class ReminderId(BaseModel):
+    id: int
+
+
+router = APIRouter(prefix="/internal/reminders")
+
+
+@router.post("/saved")
+async def reminder_saved(data: ReminderId) -> dict[str, str]:
+    await reminder_events.notify_reminder_saved(data.id)
+    return {"status": "ok"}
+
+
+@router.post("/deleted")
+async def reminder_deleted(data: ReminderId) -> dict[str, str]:
+    reminder_events.notify_reminder_deleted(data.id)
+    return {"status": "ok"}

--- a/tests/test_internal_reminders_router.py
+++ b/tests/test_internal_reminders_router.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from services.api.app import reminder_events
+from services.api.app.routers.internal_reminders import router
+
+
+def test_saved_notifies(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[int] = []
+
+    async def fake_notify(rid: int) -> None:
+        called.append(rid)
+
+    monkeypatch.setattr(reminder_events, "notify_reminder_saved", fake_notify)
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as client:
+        resp = client.post("/internal/reminders/saved", json={"id": 1})
+    assert resp.status_code == 200
+    assert called == [1]
+
+
+def test_deleted_notifies(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[int] = []
+
+    def fake_notify(rid: int) -> None:
+        called.append(rid)
+
+    monkeypatch.setattr(reminder_events, "notify_reminder_deleted", fake_notify)
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as client:
+        resp = client.post("/internal/reminders/deleted", json={"id": 2})
+    assert resp.status_code == 200
+    assert called == [2]

--- a/tests/test_legacy_reminders_auth.py
+++ b/tests/test_legacy_reminders_auth.py
@@ -48,7 +48,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]
     async def _noop(action: str, rid: int) -> None:  # pragma: no cover - simple stub
         return None
 
-    monkeypatch.setattr(reminders_router, "_reschedule_job", _noop)
+    monkeypatch.setattr(reminders_router, "_post_job_queue_event", _noop)
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
         session.commit()

--- a/tests/test_reminders_api.py
+++ b/tests/test_reminders_api.py
@@ -445,6 +445,7 @@ def test_delete_reminder_sends_event_without_job_queue(
 async def test_post_job_queue_event_logs_error(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
+    reminder_events.register_job_queue(None)
     monkeypatch.setenv("API_URL", "http://example.com")
     config.reload_settings()
 


### PR DESCRIPTION
## Summary
- add internal reminders router for saved/deleted events
- forward job queue notifications directly or via internal routes
- wire router into FastAPI app and cover with tests

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: TypeError: 'dict' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5af53d12c832a903fafc4f5d76f1f