### PR TITLE
[utils] Simplify job dump helper and log diagnostics

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_debug.py
+++ b/services/api/app/diabetes/handlers/reminder_debug.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
+import logging
 from telegram import Update
 from telegram.ext import Application, CommandHandler, ContextTypes
 
 from services.api.app.config import settings
+from services.api.app.diabetes.utils.jobs import dbg_jobs_dump
+
+
+logger = logging.getLogger(__name__)
 
 
 def _is_admin(update: Update) -> bool:
@@ -58,6 +63,8 @@ async def dbg_tz(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def dbg_jobs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not _is_admin(update):
         return
+    dump = dbg_jobs_dump(context.application.job_queue)
+    logger.debug("dbg_jobs_dump: %s", dump)
     text = _fmt_jobs(context.application)
     await update.effective_chat.send_message(text)
 

--- a/tests/test_reminder_debug.py
+++ b/tests/test_reminder_debug.py
@@ -106,7 +106,7 @@ async def test_dbg_jobs_admin(monkeypatch: pytest.MonkeyPatch) -> None:
             effective_chat=SimpleNamespace(send_message=send),
         ),
     )
-    context_app = SimpleNamespace()
+    context_app = SimpleNamespace(job_queue=SimpleNamespace(jobs=lambda: []))
     context = cast(
         ContextTypes.DEFAULT_TYPE,
         SimpleNamespace(application=context_app),

--- a/tests/test_remove_jobs.py
+++ b/tests/test_remove_jobs.py
@@ -85,6 +85,7 @@ def test_remove_jobs() -> None:
 
     before = dbg_jobs_dump(jq)
     assert len(before) == 6
+    assert ("reminder_1", None) in before
 
     removed = _remove_jobs(jq, "reminder_1")
 


### PR DESCRIPTION
## Summary
- document job queue utilities and expose `dbg_jobs_dump`
- simplify `dbg_jobs_dump` to return `(id, name)` tuples
- log job queue dump in `/dbg_jobs` command for easier debugging

## Testing
- `python -m pytest -q`
- `python -m mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5b0dbabdc832ab19afb9d6f56d6a8