### PR TITLE
[reminders] handle disabled or after-event reminders

### DIFF
--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -51,6 +51,9 @@ async def notify_reminder_saved(reminder_id: int) -> None:
     if rem is None:
         logger.warning("Reminder %s not found for scheduling", reminder_id)
         return
+    if not rem.is_enabled or rem.kind == "after_event":
+        notify_reminder_deleted(reminder_id)
+        return
     schedule_reminder(rem, jq, user)
 
 

--- a/tests/test_reminder_events.py
+++ b/tests/test_reminder_events.py
@@ -4,6 +4,7 @@ import pytest
 from typing import Any, cast
 
 from services.api.app import reminder_events
+from services.api.app.diabetes.services.db import Reminder
 
 
 @pytest.mark.asyncio
@@ -28,4 +29,88 @@ async def test_notify_with_job_queue(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(reminder_events, "SessionLocal", lambda: DummySession())
     reminder_events.register_job_queue(cast(Any, object()))
     await reminder_events.notify_reminder_saved(1)
+    reminder_events.register_job_queue(None)
+
+
+@pytest.mark.asyncio
+async def test_notify_disabled_removes_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    rem = Reminder(id=1, telegram_id=1, type="sugar", is_enabled=False)
+
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - simple stub
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - simple stub
+            return None
+
+        def get(self, model: object, _id: object) -> Reminder | None:
+            return rem if model is Reminder else None
+
+    class DummyJob:
+        def __init__(self, queue: DummyJobQueue, name: str) -> None:
+            self.queue = queue
+            self.name = name
+
+        def schedule_removal(self) -> None:
+            self.queue.jobs.remove(self)
+
+    class DummyJobQueue:
+        def __init__(self) -> None:
+            self.jobs: list[DummyJob] = []
+
+        def get_jobs_by_name(self, name: str) -> list[DummyJob]:
+            return [job for job in self.jobs if job.name.startswith(name)]
+
+    jq = DummyJobQueue()
+    jq.jobs.append(DummyJob(jq, "reminder_1"))
+
+    monkeypatch.setattr(reminder_events, "SessionLocal", lambda: DummySession())
+    reminder_events.register_job_queue(cast(Any, jq))
+    await reminder_events.notify_reminder_saved(1)
+    assert jq.get_jobs_by_name("reminder_1") == []
+    reminder_events.register_job_queue(None)
+
+
+@pytest.mark.asyncio
+async def test_notify_after_event_removes_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    rem = Reminder(
+        id=1,
+        telegram_id=1,
+        type="sugar",
+        is_enabled=True,
+        kind="after_event",
+    )
+
+    class DummySession:
+        def __enter__(self) -> DummySession:  # pragma: no cover - simple stub
+            return self
+
+        def __exit__(self, *exc: object) -> None:  # pragma: no cover - simple stub
+            return None
+
+        def get(self, model: object, _id: object) -> Reminder | None:
+            return rem if model is Reminder else None
+
+    class DummyJob:
+        def __init__(self, queue: DummyJobQueue, name: str) -> None:
+            self.queue = queue
+            self.name = name
+
+        def schedule_removal(self) -> None:
+            self.queue.jobs.remove(self)
+
+    class DummyJobQueue:
+        def __init__(self) -> None:
+            self.jobs: list[DummyJob] = []
+
+        def get_jobs_by_name(self, name: str) -> list[DummyJob]:
+            return [job for job in self.jobs if job.name.startswith(name)]
+
+    jq = DummyJobQueue()
+    jq.jobs.append(DummyJob(jq, "reminder_1"))
+
+    monkeypatch.setattr(reminder_events, "SessionLocal", lambda: DummySession())
+    reminder_events.register_job_queue(cast(Any, jq))
+    await reminder_events.notify_reminder_saved(1)
+    assert jq.get_jobs_by_name("reminder_1") == []
     reminder_events.register_job_queue(None)


### PR DESCRIPTION
## Summary
- skip scheduling when a reminder is disabled or becomes `after_event`
- add tests ensuring jobs are removed when reminders are disabled or become after-event

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5b6425264832aacd1ad4f4a6d7e73