### PR TITLE
[events] Use helper to remove reminder jobs

### DIFF
--- a/tests/test_notify_reminder_deleted.py
+++ b/tests/test_notify_reminder_deleted.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.schedulers.base import SchedulerNotRunningError
+from telegram.ext import JobQueue
+
+from services.api.app import reminder_events
+
+
+async def dummy(_: object) -> None:
+    pass
+
+
+def test_notify_reminder_deleted_removes_jobs() -> None:
+    scheduler = BackgroundScheduler(paused=True)
+    jq = JobQueue()
+    jq.scheduler = scheduler
+    reminder_events.register_job_queue(jq)
+
+    jq.run_once(dummy, 0, name="reminder_42")
+    jq.run_once(dummy, 0, name="reminder_42_after")
+    jq.run_once(dummy, 0, name="reminder_42_snooze")
+    jq.run_once(dummy, 0, name="reminder_999")
+
+    reminder_events.notify_reminder_deleted(42)
+
+    assert not jq.get_jobs_by_name("reminder_42")
+    assert not jq.get_jobs_by_name("reminder_42_after")
+    assert not jq.get_jobs_by_name("reminder_42_snooze")
+    assert jq.get_jobs_by_name("reminder_999")
+
+    reminder_events.register_job_queue(None)
+
+    try:
+        scheduler.shutdown(wait=False)
+    except SchedulerNotRunningError:
+        pass
+    executor = getattr(jq, "executor", None) or getattr(jq, "_executor", None)
+    try:
+        executor.shutdown(wait=False)
+    except AttributeError:
+        pass


### PR DESCRIPTION
## Summary
- simplify reminder job deletion by delegating to `_remove_jobs`
- test removal of base, `_after`, and `_snooze` jobs

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5b643d800832aabb9d87cc4ea626f