### PR TITLE
[reminders] Log rescheduled jobs

### DIFF
--- a/tests/test_reminder_reschedule.py
+++ b/tests/test_reminder_reschedule.py
@@ -49,6 +49,12 @@ class DummyScheduler:
     def remove_job(self, job_id: str) -> None:
         self.jobs = [j for j in self.jobs if j.id != job_id]
 
+    def get_job(self, job_id: str) -> DummyJob | None:
+        for job in self.jobs:
+            if job.id == job_id:
+                return job
+        return None
+
 
 class DummyJobQueue:
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- log removal and rescheduling of reminder jobs with emojis
- use scheduler.get_job to report next run time
- add scheduler.get_job to test job queue

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5c08a30f8832abed12174e64eaa67