### PR TITLE
[db] Register SQLite datetime adapters

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -271,8 +271,8 @@ def _reschedule_job(job_queue: DefaultJobQueue, reminder: Reminder, user: User) 
     next_run: datetime.datetime | None = None
     scheduler = getattr(job_queue, "scheduler", None)
     job = (
-        job_queue.scheduler.get_job(job_id=base)  # type: ignore[attr-defined]
-        if scheduler is not None
+        scheduler.get_job(job_id=base)  # type: ignore[attr-defined]
+        if getattr(scheduler, "get_job", None) is not None
         else None
     )
     if job is not None:

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sqlite3
 import threading
 from datetime import date, datetime, time
 from typing import Callable, Iterable, Optional, Protocol, TypeVar
@@ -39,6 +40,23 @@ from sqlalchemy.orm import (
 from services.api.app.config import get_db_password, settings
 
 logger = logging.getLogger(__name__)
+
+
+def _register_sqlite_adapters() -> None:
+    """Register adapters and converters for SQLite datetime handling."""
+
+    sqlite3.register_adapter(datetime, lambda val: val.isoformat(sep=" "))
+    sqlite3.register_adapter(date, lambda val: val.isoformat())
+    sqlite3.register_adapter(time, lambda val: val.isoformat())
+
+    sqlite3.register_converter(
+        "timestamp", lambda b: datetime.fromisoformat(b.decode())
+    )
+    sqlite3.register_converter("date", lambda b: date.fromisoformat(b.decode()))
+    sqlite3.register_converter("time", lambda b: time.fromisoformat(b.decode()))
+
+
+_register_sqlite_adapters()
 
 
 # ────────────────── подключение к Postgres ──────────────────


### PR DESCRIPTION
## Summary
- register custom SQLite adapters/converters for date, time and datetime
- guard reminder rescheduling against missing `scheduler.get_job`

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b5c415db98832aa4945e625f1366dc