### PR TITLE
refactor: streamline reminder GC scheduling

### DIFF
--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -66,14 +66,11 @@ def schedule_reminders_gc(jq: DefaultJobQueue) -> None:
     run_rep = getattr(jq, "run_repeating", None)
     if not callable(run_rep):
         return
-    job_kwargs = {"id": _GC_JOB_NAME, "name": _GC_JOB_NAME, "replace_existing": True}
-    call_job_kwargs = dict(job_kwargs)
-    call_job_kwargs.pop("name", None)
     run_rep(
         _reminders_gc,
         interval=timedelta(seconds=90),
         name=_GC_JOB_NAME,
-        job_kwargs=call_job_kwargs,
+        job_kwargs={"id": _GC_JOB_NAME, "replace_existing": True},
     )
 
 


### PR DESCRIPTION
## Summary
- streamline scheduling of reminder garbage collector
- cover job kwargs for GC scheduling

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5d2f4e4c8832a96f1705daf023504