### PR TITLE
[db] add user settings model and migration

### DIFF
--- a/migrations/versions/20250901_profile_mvp.py
+++ b/migrations/versions/20250901_profile_mvp.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20250901_profile_mvp"
+down_revision: Union[str, Sequence[str], None] = "016dca0fbac4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_settings",
+        sa.Column(
+            "telegram_id",
+            sa.BigInteger(),
+            sa.ForeignKey("users.telegram_id"),
+            primary_key=True,
+        ),
+        sa.Column("icr", sa.Float(), nullable=False, server_default="1.0"),
+        sa.Column("cf", sa.Float(), nullable=False, server_default="1.0"),
+        sa.Column("target_bg", sa.Float(), nullable=False, server_default="5.5"),
+        sa.Column("low_threshold", sa.Float(), nullable=False, server_default="4.0"),
+        sa.Column("high_threshold", sa.Float(), nullable=False, server_default="8.0"),
+        sa.Column("quiet_start", sa.Time(), nullable=False, server_default="23:00:00"),
+        sa.Column("quiet_end", sa.Time(), nullable=False, server_default="07:00:00"),
+        sa.Column(
+            "sos_alerts_enabled", sa.Boolean(), nullable=False, server_default=sa.true()
+        ),
+    )
+    op.alter_column("user_settings", "icr", server_default=None)
+    op.alter_column("user_settings", "cf", server_default=None)
+    op.alter_column("user_settings", "target_bg", server_default=None)
+    op.alter_column("user_settings", "low_threshold", server_default=None)
+    op.alter_column("user_settings", "high_threshold", server_default=None)
+    op.alter_column("user_settings", "quiet_start", server_default=None)
+    op.alter_column("user_settings", "quiet_end", server_default=None)
+    op.alter_column("user_settings", "sos_alerts_enabled", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_table("user_settings")

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -336,6 +336,10 @@ class HistoryRecord(Base):
     type: Mapped[str] = mapped_column(String, nullable=False)
 
 
+# Import additional models
+from .db_models import UserSettings  # noqa: F401,E402
+
+
 # ────────────────────── инициализация ────────────────────────
 def init_db() -> None:
     """Создать таблицы, если их ещё нет (для локального запуска)."""

--- a/services/api/app/diabetes/services/db_models.py
+++ b/services/api/app/diabetes/services/db_models.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import time
+
+from sqlalchemy import BigInteger, Boolean, Float, ForeignKey, Time
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .db import Base, User
+
+
+class UserSettings(Base):
+    """Per-user configurable settings."""
+
+    __tablename__ = "user_settings"
+
+    telegram_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
+    )
+    icr: Mapped[float] = mapped_column(Float, default=1.0)
+    cf: Mapped[float] = mapped_column(Float, default=1.0)
+    target_bg: Mapped[float] = mapped_column(Float, default=5.5)
+    low_threshold: Mapped[float] = mapped_column(Float, default=4.0)
+    high_threshold: Mapped[float] = mapped_column(Float, default=8.0)
+    quiet_start: Mapped[time] = mapped_column(Time, default=time(23, 0))
+    quiet_end: Mapped[time] = mapped_column(Time, default=time(7, 0))
+    sos_alerts_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    user: Mapped[User] = relationship("User")


### PR DESCRIPTION
## Summary
- add `UserSettings` ORM model with defaults
- create Alembic migration for `user_settings` table
- register model within existing database module

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5d5c587a4832ab48db2fe2a921dde