### PR TITLE
[reminders] use profile default after meal minutes

### DIFF
--- a/services/webapp/ui/src/features/profile/hooks.ts
+++ b/services/webapp/ui/src/features/profile/hooks.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { getProfile } from "./api";
+
+export function useDefaultAfterMealMinutes(telegramId: number | null | undefined) {
+  const [value, setValue] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!telegramId) return;
+    getProfile(telegramId)
+      .then((profile) => {
+        const minutes =
+          (profile as any).default_after_meal_minutes ??
+          (profile as any).defaultAfterMealMinutes;
+        if (typeof minutes === "number") {
+          setValue(minutes);
+        }
+      })
+      .catch((err) => {
+        console.warn("Failed to load profile:", err);
+      });
+  }, [telegramId]);
+
+  return value;
+}
+

--- a/services/webapp/ui/src/features/reminders/components/Templates.tsx
+++ b/services/webapp/ui/src/features/reminders/components/Templates.tsx
@@ -1,41 +1,57 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useRemindersApi } from "../api/reminders";
 import { buildReminderPayload } from "../api/buildPayload";
 import { mockApi } from "../../../api/mock-server";
 import { useToast } from "../../../shared/toast";
+import { useDefaultAfterMealMinutes } from "../../profile/hooks";
 
-export function Templates({ 
-  telegramId, 
-  onCreated 
-}: { 
-  telegramId: number; 
-  onCreated: () => void 
+export function Templates({
+  telegramId,
+  onCreated
+}: {
+  telegramId: number;
+  onCreated: () => void
 }) {
   const api = useRemindersApi();
   const toast = useToast();
-  
-  const templates = [
-    {
-      title: "Сахар утром 07:30",
-      emoji: "🩸",
-      dto: { telegramId, type: "sugar", kind: "at_time", time: "07:30", isEnabled: true }
-    },
-    {
-      title: "После еды 120 мин", 
-      emoji: "🍽️",
-      dto: { telegramId, type: "after_meal", kind: "after_event", minutesAfter: 120, isEnabled: true }
-    },
-    {
-      title: "Длинный инсулин 22:00",
-      emoji: "💉", 
-      dto: { telegramId, type: "insulin_long", kind: "at_time", time: "22:00", isEnabled: true }
-    },
-    {
-      title: "Короткий инсулин",
-      emoji: "💊",
-      dto: { telegramId, type: "insulin_short", kind: "every", intervalMinutes: 180, isEnabled: true }
-    }
-  ] as const;
+  const defaultAfterMeal = useDefaultAfterMealMinutes(telegramId);
+  const templates = useMemo(
+    () => [
+      {
+        title: "Сахар утром 07:30",
+        emoji: "🩸",
+        dto: { telegramId, type: "sugar", kind: "at_time", time: "07:30", isEnabled: true },
+      },
+      {
+        title: `После еды ${defaultAfterMeal ?? 120} мин`,
+        emoji: "🍽️",
+        dto: {
+          telegramId,
+          type: "after_meal",
+          kind: "after_event",
+          minutesAfter: defaultAfterMeal ?? 120,
+          isEnabled: true,
+        },
+      },
+      {
+        title: "Длинный инсулин 22:00",
+        emoji: "💉",
+        dto: { telegramId, type: "insulin_long", kind: "at_time", time: "22:00", isEnabled: true },
+      },
+      {
+        title: "Короткий инсулин",
+        emoji: "💊",
+        dto: {
+          telegramId,
+          type: "insulin_short",
+          kind: "every",
+          intervalMinutes: 180,
+          isEnabled: true,
+        },
+      },
+    ] as const,
+    [telegramId, defaultAfterMeal],
+  );
   
   const create = async (dto: any) => {
     try {

--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -16,6 +16,7 @@ import { getTelegramUserId } from "../../../shared/telegram";
 import { mockApi } from "../../../api/mock-server";
 import { useToast } from "../../../shared/toast";
 import TimeInput from "@/components/TimeInput";
+import { useDefaultAfterMealMinutes } from "../../profile/hooks";
 
 const TYPE_OPTIONS: { value: ReminderType; label: string }[] = [
   { value: "sugar", label: "Измерение сахара" },
@@ -46,6 +47,7 @@ export default function RemindersCreate() {
   const nav = useNavigate();
   const toast = useToast();
   const isDev = process.env.NODE_ENV === "development";
+  const defaultAfterMeal = useDefaultAfterMealMinutes(telegramId);
 
   const [form, setForm] = useState<ReminderFormValues>({
     telegramId,
@@ -66,7 +68,13 @@ export default function RemindersCreate() {
 
   const presetsTime = ["07:30", "12:30", "22:00"];
   const presetsEvery = [60, 120, 180, 1440];
-  const presetsAfter = [90, 120, 150];
+  const presetsAfter = useMemo(() => {
+    const base = [90, 120, 150];
+    if (defaultAfterMeal && !base.includes(defaultAfterMeal)) {
+      return [defaultAfterMeal, ...base];
+    }
+    return base;
+  }, [defaultAfterMeal]);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -141,7 +149,7 @@ export default function RemindersCreate() {
       if (k === "at_time") base.time = "07:30";
       if (k === "every") base.intervalMinutes = 60;
       if (k === "after_event") {
-        base.minutesAfter = 120;
+        base.minutesAfter = defaultAfterMeal ?? 120;
         base.type = "after_meal";
       }
       return base;

--- a/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
@@ -17,6 +17,7 @@ import { mockApi } from "../../../api/mock-server";
 import { useToast } from "../../../shared/toast";
 import { useTelegram } from "@/hooks/useTelegram";
 import TimeInput from "@/components/TimeInput";
+import { useDefaultAfterMealMinutes } from "../../profile/hooks";
 
 const TYPE_OPTIONS: { value: ReminderType; label: string }[] = [
   { value: "sugar", label: "Измерение сахара" },
@@ -71,9 +72,19 @@ export default function RemindersEdit() {
   const { id } = useParams<{ id: string }>();
   const nav = useNavigate();
   const toast = useToast();
-
+  const defaultAfterMeal = useDefaultAfterMealMinutes(telegramId);
   const [form, setForm] = useState<ReminderFormValues | null>(null);
   const [saving, setSaving] = useState(false);
+
+  const presetsTime = ["07:30", "12:30", "22:00"];
+  const presetsEvery = [60, 120, 180, 1440];
+  const presetsAfter = useMemo(() => {
+    const base = [90, 120, 150];
+    if (defaultAfterMeal && !base.includes(defaultAfterMeal)) {
+      return [defaultAfterMeal, ...base];
+    }
+    return base;
+  }, [defaultAfterMeal]);
 
   useEffect(() => {
     async function load() {
@@ -110,10 +121,6 @@ export default function RemindersEdit() {
     k: K,
     v: ReminderFormValues[K],
   ) => setForm((s) => (s ? { ...s, [k]: v } : s));
-
-  const presetsTime = ["07:30", "12:30", "22:00"];
-  const presetsEvery = [60, 120, 180, 1440];
-  const presetsAfter = [90, 120, 150];
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -165,7 +172,7 @@ export default function RemindersEdit() {
       if (k === "at_time") base.time = "07:30";
       if (k === "every") base.intervalMinutes = 60;
       if (k === "after_event") {
-        base.minutesAfter = 120;
+        base.minutesAfter = defaultAfterMeal ?? 120;
         base.type = "after_meal";
       }
       return base;

--- a/services/webapp/ui/tests/mockApi.test.tsx
+++ b/services/webapp/ui/tests/mockApi.test.tsx
@@ -34,6 +34,9 @@ vi.mock('../src/features/reminders/logic/validate', () => ({
   validate: () => ({}),
   hasErrors: () => false
 }));
+vi.mock('../src/features/profile/hooks', () => ({
+  useDefaultAfterMealMinutes: () => 120
+}));
 vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn()
 }));

--- a/services/webapp/ui/tests/reminders.api.test.ts
+++ b/services/webapp/ui/tests/reminders.api.test.ts
@@ -74,6 +74,9 @@ describe('RemindersEdit', () => {
     vi.doMock('../src/shared/toast', () => ({
       useToast: () => ({ success: vi.fn(), error: vi.fn() }),
     }));
+    vi.doMock('../src/features/profile/hooks', () => ({
+      useDefaultAfterMealMinutes: () => 120,
+    }));
     vi.doMock('../src/hooks/useTelegram', () => ({
       useTelegram: () => ({ user: { id: 1 }, sendData: vi.fn() }),
     }));

--- a/services/webapp/ui/tests/reminders.default.test.tsx
+++ b/services/webapp/ui/tests/reminders.default.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, vi, afterEach, expect } from 'vitest';
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('default after meal minutes', () => {
+  it('preselects profile default in RemindersCreate', async () => {
+    vi.stubGlobal('Telegram', { WebApp: { platform: 'ios' } });
+    vi.doMock('react-input-mask', () => ({
+      default: ({ children, ...rest }: any) =>
+        typeof children === 'function'
+          ? children({ ...rest })
+          : React.createElement('input', rest, children),
+    }));
+    vi.doMock('../src/features/reminders/api/reminders', () => ({
+      useRemindersApi: () => ({ remindersPost: vi.fn() }),
+    }));
+    vi.doMock('../src/shared/toast', () => ({
+      useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+    }));
+    vi.doMock('../src/hooks/useTelegram', () => ({
+      useTelegram: () => ({ user: { id: 1 }, sendData: vi.fn() }),
+    }));
+    vi.doMock('../src/hooks/useTelegramInitData', () => ({
+      useTelegramInitData: () => null,
+    }));
+    vi.doMock('../src/features/profile/hooks', () => ({
+      useDefaultAfterMealMinutes: () => 150,
+    }));
+    vi.doMock('../src/features/reminders/logic/validate', () => ({
+      validate: () => ({}),
+      hasErrors: () => false,
+    }));
+    vi.doMock('react-router-dom', () => ({
+      useNavigate: () => vi.fn(),
+    }));
+
+    const { default: RemindersCreate } = await import(
+      '../src/features/reminders/pages/RemindersCreate'
+    );
+    const { container, getByText } = render(
+      React.createElement(RemindersCreate),
+    );
+    fireEvent.click(getByText('После события'));
+    await waitFor(() => {
+      const input = container.querySelector(
+        'input[type="number"]',
+      ) as HTMLInputElement;
+      expect(input.value).toBe('150');
+    });
+    getByText('150 мин');
+  });
+
+  it('uses profile default in Templates', async () => {
+    vi.doMock('../src/features/reminders/api/reminders', () => ({
+      useRemindersApi: () => ({ remindersPost: vi.fn() }),
+    }));
+    vi.doMock('../src/shared/toast', () => ({
+      useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+    }));
+    vi.doMock('../src/features/profile/hooks', () => ({
+      useDefaultAfterMealMinutes: () => 110,
+    }));
+    vi.doMock('../src/api/mock-server', () => ({
+      mockApi: {},
+    }));
+
+    const { Templates } = await import(
+      '../src/features/reminders/components/Templates'
+    );
+    const { getByText } = render(
+      React.createElement(Templates, { telegramId: 1, onCreated: vi.fn() }),
+    );
+    getByText('После еды 110 мин');
+  });
+});
+


### PR DESCRIPTION
## Summary
- fetch default_after_meal_minutes from profile
- preselect profile delay in reminders create/edit and templates
- cover defaults with UI tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d5cf8064832ab4bc1723a07ab018