### PR TITLE
tests: add profile settings API and bolus utility coverage

### DIFF
--- a/services/api/app/schemas/__init__.py
+++ b/services/api/app/schemas/__init__.py
@@ -3,6 +3,7 @@ from .history import HistoryRecordSchema
 from .profile import ProfileSchema
 from .reminders import ReminderSchema
 from .timezone import TimezoneSchema
+from .profile_settings import ProfileSettings, ProfileSettingsPatch
 
 __all__ = [
     "CommandSchema",
@@ -10,4 +11,6 @@ __all__ = [
     "ProfileSchema",
     "ReminderSchema",
     "TimezoneSchema",
+    "ProfileSettings",
+    "ProfileSettingsPatch",
 ]

--- a/services/api/app/schemas/profile_settings.py
+++ b/services/api/app/schemas/profile_settings.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ProfileSettings(BaseModel):
+    grams_per_xe: int = Field(alias="gramsPerXe")
+    round_step: float = Field(alias="roundStep")
+    max_bolus: float = Field(alias="maxBolus")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="after")
+    def validate_values(self) -> "ProfileSettings":
+        if self.grams_per_xe not in (10, 12):
+            raise ValueError("grams_per_xe must be 10 or 12")
+        if self.round_step not in (0.5, 1.0):
+            raise ValueError("round_step must be 0.5 or 1.0")
+        if not (0.5 <= self.max_bolus <= 25.0):
+            raise ValueError("max_bolus out of range")
+        return self
+
+
+class ProfileSettingsPatch(BaseModel):
+    grams_per_xe: int | None = Field(default=None, alias="gramsPerXe")
+    round_step: float | None = Field(default=None, alias="roundStep")
+    max_bolus: float | None = Field(default=None, alias="maxBolus")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @model_validator(mode="after")
+    def validate_values(self) -> "ProfileSettingsPatch":
+        if self.grams_per_xe is not None and self.grams_per_xe not in (10, 12):
+            raise ValueError("grams_per_xe must be 10 or 12")
+        if self.round_step is not None and self.round_step not in (0.5, 1.0):
+            raise ValueError("round_step must be 0.5 or 1.0")
+        if self.max_bolus is not None and not (0.5 <= self.max_bolus <= 25.0):
+            raise ValueError("max_bolus out of range")
+        return self

--- a/tests/test_calc_bolus_extended.py
+++ b/tests/test_calc_bolus_extended.py
@@ -1,0 +1,30 @@
+from services.api.app.diabetes.utils.functions import (
+    PatientProfile,
+    calc_bolus_extended,
+)
+
+
+def test_rounding_steps() -> None:
+    profile = PatientProfile(icr=9.0, cf=50.0, target_bg=5.5)
+    dose_half = calc_bolus_extended(15, 6, profile, round_step=0.5)
+    dose_full = calc_bolus_extended(15, 6, profile, round_step=1.0)
+    assert dose_half == 1.5
+    assert dose_full == 2.0
+
+
+def test_unit_conversion() -> None:
+    profile = PatientProfile(icr=9.0, cf=50.0, target_bg=5.5)
+    dose_10 = calc_bolus_extended(
+        1, 5.5, profile, unit="xe", grams_per_xe=10, round_step=0.5
+    )
+    dose_12 = calc_bolus_extended(
+        1, 5.5, profile, unit="xe", grams_per_xe=12, round_step=0.5
+    )
+    assert dose_10 == 1.0
+    assert dose_12 == 1.5
+
+
+def test_max_bolus_cap() -> None:
+    profile = PatientProfile(icr=1.0, cf=1.0, target_bg=5.0)
+    dose = calc_bolus_extended(500, 20, profile, round_step=1.0, max_bolus=10.0)
+    assert dose == 10.0

--- a/tests/test_profile_settings_api.py
+++ b/tests/test_profile_settings_api.py
@@ -1,0 +1,47 @@
+import pytest
+from fastapi.testclient import TestClient
+
+import services.api.app.main as server
+
+
+def auth_override() -> dict[str, int]:
+    return {"id": 1}
+
+
+@pytest.fixture(autouse=True)
+def override_auth() -> None:
+    server.app.dependency_overrides[server.require_tg_user] = auth_override
+    yield
+    server.app.dependency_overrides.clear()
+
+
+def test_profile_settings_serialization() -> None:
+    with TestClient(server.app) as client:
+        resp = client.get("/api/profile/settings")
+    assert resp.status_code == 200
+    assert resp.json() == {"gramsPerXe": 12, "roundStep": 1.0, "maxBolus": 25.0}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"gramsPerXe": 11},
+        {"roundStep": 0.7},
+        {"maxBolus": 30.0},
+        {"maxBolus": 0.4},
+    ],
+)
+def test_profile_settings_validation(payload: dict[str, float]) -> None:
+    with TestClient(server.app) as client:
+        resp = client.patch("/api/profile/settings", json=payload)
+    assert resp.status_code == 422
+
+
+def test_profile_settings_patch_updates() -> None:
+    with TestClient(server.app) as client:
+        patch = {"gramsPerXe": 10, "roundStep": 0.5, "maxBolus": 20.0}
+        resp = client.patch("/api/profile/settings", json=patch)
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+        resp = client.get("/api/profile/settings")
+    assert resp.json() == patch


### PR DESCRIPTION
## Summary
- expand bolus calculations with rounding, unit conversion and max cap helper
- add profile settings schema and API endpoints with validation
- cover profile settings API and bolus utility with tests

## Testing
- `ruff check services/api/app/main.py services/api/app/schemas/profile_settings.py`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68b5d5d14a28832aa59d017b71344888