### PR TITLE
[contracts] expand profile patch settings

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -99,11 +99,35 @@ paths:
               type: object
               properties:
                 timezone:
-                  type: string
+                  anyOf:
+                  - type: string
+                  - type: 'null'
                   title: Timezone
                 timezoneAuto:
-                  type: boolean
+                  anyOf:
+                  - type: boolean
+                  - type: 'null'
                   title: Timezone Auto
+                quietStart:
+                  anyOf:
+                  - type: string
+                  - type: 'null'
+                  title: Quiet Start
+                quietEnd:
+                  anyOf:
+                  - type: string
+                  - type: 'null'
+                  title: Quiet End
+                sosContact:
+                  anyOf:
+                  - type: string
+                  - type: 'null'
+                  title: Sos Contact
+                sosAlertsEnabled:
+                  anyOf:
+                  - type: boolean
+                  - type: 'null'
+                  title: Sos Alerts Enabled
       responses:
         '200':
           description: Successful Response

--- a/libs/py-sdk/requirements.txt
+++ b/libs/py-sdk/requirements.txt
@@ -1,2 +1,4 @@
-# Placeholder requirements for optional Python SDK.
-# Actual dependencies will be generated alongside the SDK.
+urllib3 >= 2.1.0, < 3.0.0
+python_dateutil >= 2.8.2
+pydantic >= 2
+typing-extensions >= 4.7.1

--- a/libs/ts-sdk/apis/DefaultApi.ts
+++ b/libs/ts-sdk/apis/DefaultApi.ts
@@ -74,7 +74,7 @@ export class DefaultApi extends runtime.BaseAPI {
      * Ensure a user exists in the database.
      * Create User
      */
-    async createUserUserPostRaw(requestParameters: CreateUserUserPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string; }>> {
+    async createUserUserPostRaw(requestParameters: CreateUserUserPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string | null; }>> {
         if (requestParameters['webUser'] == null) {
             throw new runtime.RequiredError(
                 'webUser',
@@ -110,7 +110,7 @@ export class DefaultApi extends runtime.BaseAPI {
      * Ensure a user exists in the database.
      * Create User
      */
-    async createUserUserPost(requestParameters: CreateUserUserPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string; }> {
+    async createUserUserPost(requestParameters: CreateUserUserPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string | null; }> {
         const response = await this.createUserUserPostRaw(requestParameters, initOverrides);
         return await response.value();
     }
@@ -254,7 +254,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Get Timezone
      */
-    async getTimezoneTimezoneGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string; }>> {
+    async getTimezoneTimezoneGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string | null; }>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -279,7 +279,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Get Timezone
      */
-    async getTimezoneTimezoneGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string; }> {
+    async getTimezoneTimezoneGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string | null; }> {
         const response = await this.getTimezoneTimezoneGetRaw(initOverrides);
         return await response.value();
     }
@@ -287,7 +287,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Get Timezones
      */
-    async getTimezonesTimezonesGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<string>>> {
+    async getTimezonesTimezonesGetRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<string | null>>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -312,7 +312,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Get Timezones
      */
-    async getTimezonesTimezonesGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<string>> {
+    async getTimezonesTimezonesGet(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<string | null>> {
         const response = await this.getTimezonesTimezonesGetRaw(initOverrides);
         return await response.value();
     }
@@ -433,7 +433,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Put Timezone
      */
-    async putTimezoneTimezonePutRaw(requestParameters: PutTimezoneTimezonePutRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string; }>> {
+    async putTimezoneTimezonePutRaw(requestParameters: PutTimezoneTimezonePutRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string | null; }>> {
         if (requestParameters['timezone'] == null) {
             throw new runtime.RequiredError(
                 'timezone',
@@ -468,7 +468,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Put Timezone
      */
-    async putTimezoneTimezonePut(requestParameters: PutTimezoneTimezonePutRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string; }> {
+    async putTimezoneTimezonePut(requestParameters: PutTimezoneTimezonePutRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string | null; }> {
         const response = await this.putTimezoneTimezonePutRaw(requestParameters, initOverrides);
         return await response.value();
     }

--- a/libs/ts-sdk/apis/HistoryApi.ts
+++ b/libs/ts-sdk/apis/HistoryApi.ts
@@ -80,7 +80,7 @@ export class HistoryApi extends runtime.BaseAPI {
      * Delete a history record after verifying ownership.
      * Delete History
      */
-    async historyIdDeleteRaw(requestParameters: HistoryIdDeleteRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string; }>> {
+    async historyIdDeleteRaw(requestParameters: HistoryIdDeleteRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string | null; }>> {
         if (requestParameters['id'] == null) {
             throw new runtime.RequiredError(
                 'id',
@@ -114,7 +114,7 @@ export class HistoryApi extends runtime.BaseAPI {
      * Delete a history record after verifying ownership.
      * Delete History
      */
-    async historyIdDelete(requestParameters: HistoryIdDeleteRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string; }> {
+    async historyIdDelete(requestParameters: HistoryIdDeleteRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string | null; }> {
         const response = await this.historyIdDeleteRaw(requestParameters, initOverrides);
         return await response.value();
     }
@@ -123,7 +123,7 @@ export class HistoryApi extends runtime.BaseAPI {
      * Save or update a history record in the database.
      * Post History
      */
-    async historyPostRaw(requestParameters: HistoryPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string; }>> {
+    async historyPostRaw(requestParameters: HistoryPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{ [key: string]: string | null; }>> {
         if (requestParameters['historyRecordSchemaInput'] == null) {
             throw new runtime.RequiredError(
                 'historyRecordSchemaInput',
@@ -159,7 +159,7 @@ export class HistoryApi extends runtime.BaseAPI {
      * Save or update a history record in the database.
      * Post History
      */
-    async historyPost(requestParameters: HistoryPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string; }> {
+    async historyPost(requestParameters: HistoryPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{ [key: string]: string | null; }> {
         const response = await this.historyPostRaw(requestParameters, initOverrides);
         return await response.value();
     }

--- a/libs/ts-sdk/models/ProfilePatchRequest.ts
+++ b/libs/ts-sdk/models/ProfilePatchRequest.ts
@@ -24,13 +24,37 @@ export interface ProfilePatchRequest {
      * @type {string}
      * @memberof ProfilePatchRequest
      */
-    timezone?: string;
+    timezone?: string | null;
     /**
      * 
      * @type {boolean}
      * @memberof ProfilePatchRequest
      */
-    timezoneAuto?: boolean;
+    timezoneAuto?: boolean | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof ProfilePatchRequest
+     */
+    quietStart?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof ProfilePatchRequest
+     */
+    quietEnd?: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof ProfilePatchRequest
+     */
+    sosContact?: string | null;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ProfilePatchRequest
+     */
+    sosAlertsEnabled?: boolean | null;
 }
 
 /**
@@ -52,6 +76,10 @@ export function ProfilePatchRequestFromJSONTyped(json: any, ignoreDiscriminator:
         
         'timezone': json['timezone'] == null ? undefined : json['timezone'],
         'timezoneAuto': json['timezoneAuto'] == null ? undefined : json['timezoneAuto'],
+        'quietStart': json['quietStart'] == null ? undefined : json['quietStart'],
+        'quietEnd': json['quietEnd'] == null ? undefined : json['quietEnd'],
+        'sosContact': json['sosContact'] == null ? undefined : json['sosContact'],
+        'sosAlertsEnabled': json['sosAlertsEnabled'] == null ? undefined : json['sosAlertsEnabled'],
     };
 }
 
@@ -68,6 +96,10 @@ export function ProfilePatchRequestToJSONTyped(value?: ProfilePatchRequest | nul
         
         'timezone': value['timezone'],
         'timezoneAuto': value['timezoneAuto'],
+        'quietStart': value['quietStart'],
+        'quietEnd': value['quietEnd'],
+        'sosContact': value['sosContact'],
+        'sosAlertsEnabled': value['sosAlertsEnabled'],
     };
 }
 

--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -1,4 +1,4 @@
-import type { ProfileSchema } from '@sdk';
+import type { ProfileSchema, ProfilePatchRequest } from '@sdk';
 import { api } from '@/api';
 
 export async function getProfile(telegramId: number) {
@@ -42,12 +42,7 @@ export async function saveProfile({
   }
 }
 
-export type PatchProfileDto = {
-  timezone?: string | null;
-  timezoneAuto?: boolean | null;
-};
-
-export async function patchProfile(payload: PatchProfileDto) {
+export async function patchProfile(payload: ProfilePatchRequest) {
   try {
     return await api.patch<unknown>('/profile', payload);
   } catch (error) {

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -81,7 +81,12 @@ describe('profile api', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     await expect(
-      patchProfile({ timezone: 'Europe/Moscow', timezoneAuto: true }),
+      patchProfile({
+        timezone: 'Europe/Moscow',
+        timezoneAuto: true,
+        quietStart: '23:00',
+        sosAlertsEnabled: false,
+      }),
     ).rejects.toThrow('Не удалось обновить профиль: fail');
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/profile',

--- a/tests/test_profile_patch_endpoint.py
+++ b/tests/test_profile_patch_endpoint.py
@@ -58,7 +58,14 @@ def test_profile_patch_returns_status_ok(
     with TestClient(server.app) as client:
         resp = client.patch(
             "/api/profile",
-            json={"timezone": "Europe/Moscow", "timezoneAuto": True},
+            json={
+                "timezone": "Europe/Moscow",
+                "timezoneAuto": True,
+                "quietStart": "22:30",
+                "quietEnd": "06:15",
+                "sosContact": "+123",
+                "sosAlertsEnabled": False,
+            },
             headers=auth_headers,
         )
     assert resp.status_code == 200
@@ -66,6 +73,12 @@ def test_profile_patch_returns_status_ok(
 
     with SessionLocal() as session:
         user = session.get(db.User, 1)
+        profile = session.get(db.Profile, 1)
         assert user is not None
+        assert profile is not None
         assert user.timezone == "Europe/Moscow"
         assert user.timezone_auto is True
+        assert profile.quiet_start.strftime("%H:%M:%S") == "22:30:00"
+        assert profile.quiet_end.strftime("%H:%M:%S") == "06:15:00"
+        assert profile.sos_contact == "+123"
+        assert profile.sos_alerts_enabled is False

--- a/tests/test_profile_patch_status.py
+++ b/tests/test_profile_patch_status.py
@@ -23,7 +23,12 @@ def test_patch_profile_returns_status_ok(monkeypatch: pytest.MonkeyPatch) -> Non
 
     with TestClient(server.app) as client:
         resp = client.patch(
-            "/api/profile", json={"timezone": "UTC", "timezoneAuto": False}
+            "/api/profile",
+            json={
+                "timezone": "UTC",
+                "timezoneAuto": False,
+                "sosAlertsEnabled": True,
+            },
         )
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- expand profile patch request with quiet hours and SOS contact fields
- regenerate SDKs and adopt `ProfilePatchRequest` in webapp
- update backend and tests for new profile settings

## Testing
- `pytest tests -q`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b5d5d29b18832a811166344d064c67