### PR TITLE
[handlers] Apply default after-meal reminder time

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -199,6 +199,15 @@ class Profile(Base):
     user: Mapped[User] = relationship("User")
 
 
+class UserSettings(Base):
+    __tablename__ = "user_settings"
+    telegram_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
+    )
+    default_after_meal_minutes: Mapped[Optional[int]] = mapped_column(Integer)
+    user: Mapped[User] = relationship("User")
+
+
 class Entry(Base):
     __tablename__ = "entries"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)


### PR DESCRIPTION
## Summary
- load default `after_meal` minutes from `UserSettings` when missing
- support default for web app reminder save
- cover defaults with new tests

## Testing
- `pytest tests/test_reminder_handlers.py -q` *(fails: Coverage failure: total of 26 is less than fail-under=85)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5d5d4f8c4832aaa521abe61baad60