### PR TITLE
[reminders] Add AfterEventDelay component

### DIFF
--- a/services/webapp/ui/src/features/reminders/components/AfterEventDelay.tsx
+++ b/services/webapp/ui/src/features/reminders/components/AfterEventDelay.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+const PRESETS = [60, 90, 120, 150, 180, 240];
+
+export interface AfterEventDelayProps {
+  value: number | undefined;
+  onChange: (value: number | undefined) => void;
+  error?: string;
+}
+
+const AfterEventDelay: React.FC<AfterEventDelayProps> = ({
+  value,
+  onChange,
+  error,
+}) => {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    const num = val === "" ? undefined : Number(val);
+    onChange(Number.isNaN(num) ? undefined : num);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-sm font-medium text-foreground">
+          Задержка после еды (мин)
+        </label>
+        <p className="text-xs text-muted-foreground mt-1">
+          Сработает после записи приёма пищи в «Истории»
+        </p>
+      </div>
+      <input
+        type="number"
+        min={5}
+        max={480}
+        step={5}
+        aria-label="Задержка после еды (мин)"
+        className="medical-input"
+        value={value ?? ""}
+        onChange={handleInputChange}
+      />
+      {error && <p className="text-xs text-destructive mt-1">{error}</p>}
+      <p className="text-xs text-muted-foreground">
+        Рекомендации: 60–90 — промежуточная; 120 — основная; 180–240 — поздняя
+      </p>
+      <div className="flex gap-2 flex-wrap">
+        {PRESETS.map((m) => (
+          <button
+            key={m}
+            type="button"
+            aria-pressed={value === m}
+            onClick={() => onChange(m)}
+            className={cn(
+              "px-3 py-1 rounded-lg border transition-colors",
+              value === m
+                ? "bg-primary text-primary-foreground border-primary shadow-soft"
+                : "border-border bg-background text-foreground hover:bg-secondary"
+            )}
+          >
+            {m}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AfterEventDelay;
+

--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useRemindersApi } from "../api/reminders"; // ваш хук, возвращающий DefaultApi
 import { DayOfWeekPicker } from "../components/DayOfWeekPicker";
 import { DaysPresets } from "../components/DaysPresets";
+import AfterEventDelay from "../components/AfterEventDelay";
 import {
   buildReminderPayload,
   ReminderFormValues,
@@ -66,7 +67,6 @@ export default function RemindersCreate() {
 
   const presetsTime = ["07:30", "12:30", "22:00"];
   const presetsEvery = [60, 120, 180, 1440];
-  const presetsAfter = [90, 120, 150];
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -273,37 +273,11 @@ export default function RemindersCreate() {
           )}
 
           {form.kind === "after_event" && (
-            <div className="space-y-3">
-              <label className="block text-sm font-medium text-foreground">
-                Задержка после еды (мин)
-              </label>
-              <input
-                type="number"
-                min={1}
-                className={`medical-input ${errors.minutesAfter ? "border-destructive focus:border-destructive" : ""}`}
-                value={form.minutesAfter ?? ""}
-                onChange={(e) =>
-                  onChange("minutesAfter", Number(e.target.value || 0))
-                }
-              />
-              {errors.minutesAfter && (
-                <p className="text-xs text-destructive mt-1">
-                  {errors.minutesAfter}
-                </p>
-              )}
-              <div className="flex gap-2 flex-wrap">
-                {presetsAfter.map((m) => (
-                  <button
-                    key={m}
-                    type="button"
-                    className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-colors"
-                    onClick={() => onChange("minutesAfter", m)}
-                  >
-                    {m} мин
-                  </button>
-                ))}
-              </div>
-            </div>
+            <AfterEventDelay
+              value={form.minutesAfter}
+              onChange={(v) => onChange("minutesAfter", v)}
+              error={errors.minutesAfter}
+            />
           )}
 
           {/* Дни недели */}

--- a/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
@@ -4,6 +4,7 @@ import type { ReminderSchema } from "@sdk";
 import { useRemindersApi } from "../api/reminders";
 import { DayOfWeekPicker } from "../components/DayOfWeekPicker";
 import { DaysPresets } from "../components/DaysPresets";
+import AfterEventDelay from "../components/AfterEventDelay";
 import {
   buildReminderPayload,
   ReminderFormValues,
@@ -113,7 +114,6 @@ export default function RemindersEdit() {
 
   const presetsTime = ["07:30", "12:30", "22:00"];
   const presetsEvery = [60, 120, 180, 1440];
-  const presetsAfter = [90, 120, 150];
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -302,38 +302,11 @@ export default function RemindersEdit() {
           )}
 
           {form.kind === "after_event" && (
-            <div className="space-y-3">
-              <label className="block text-sm font-medium text-foreground">
-                Через сколько минут после еды
-              </label>
-              <input
-                type="number"
-                className={`medical-input ${
-                  errors.minutesAfter
-                    ? "border-destructive focus:border-destructive"
-                    : ""
-                }`}
-                value={form.minutesAfter?.toString() || ""}
-                onChange={(e) => onChange("minutesAfter", Number(e.target.value))}
-              />
-              {errors.minutesAfter && (
-                <p className="text-xs text-destructive mt-1">
-                  {errors.minutesAfter}
-                </p>
-              )}
-              <div className="flex gap-2 flex-wrap">
-                {presetsAfter.map((t) => (
-                  <button
-                    key={t}
-                    type="button"
-                    className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-colors"
-                    onClick={() => onChange("minutesAfter", t)}
-                  >
-                    {t}
-                  </button>
-                ))}
-              </div>
-            </div>
+            <AfterEventDelay
+              value={form.minutesAfter}
+              onChange={(v) => onChange("minutesAfter", v)}
+              error={errors.minutesAfter}
+            />
           )}
 
           {/* Дни недели */}

--- a/services/webapp/ui/tests/AfterEventDelay.test.tsx
+++ b/services/webapp/ui/tests/AfterEventDelay.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import AfterEventDelay from "../src/features/reminders/components/AfterEventDelay";
+
+const renderWithState = (initial?: number) => {
+  const Wrapper: React.FC = () => {
+    const [value, setValue] = React.useState<number | undefined>(initial);
+    return <AfterEventDelay value={value} onChange={setValue} />;
+  };
+  return render(<Wrapper />);
+};
+
+afterEach(() => cleanup());
+
+describe("AfterEventDelay", () => {
+  it("renders number input with constraints", () => {
+    const { getByLabelText } = render(
+      <AfterEventDelay value={60} onChange={() => {}} />
+    );
+    const input = getByLabelText(
+      "Задержка после еды (мин)"
+    ) as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.min).toBe("5");
+    expect(input.max).toBe("480");
+    expect(input.step).toBe("5");
+  });
+
+  it("activates preset and updates value on click", () => {
+    const onChange = vi.fn();
+    const { getByRole } = render(
+      <AfterEventDelay value={60} onChange={onChange} />
+    );
+    const preset90 = getByRole("button", { name: "90" });
+    fireEvent.click(preset90);
+    expect(onChange).toHaveBeenCalledWith(90);
+  });
+
+  it("deactivates preset when manual input differs", () => {
+    const { getByLabelText, getByRole } = renderWithState(60);
+    const input = getByLabelText("Задержка после еды (мин)") as HTMLInputElement;
+    const preset60 = getByRole("button", { name: "60" });
+    expect(preset60.getAttribute("aria-pressed")).toBe("true");
+    fireEvent.change(input, { target: { value: "65" } });
+    expect(preset60.getAttribute("aria-pressed")).toBe("false");
+  });
+});
+


### PR DESCRIPTION
## Summary
- add reusable `AfterEventDelay` component with presets and hints
- replace duplicated delay inputs in reminder create/edit pages
- cover component with unit tests

## Testing
- `pnpm exec eslint src/features/reminders/components/AfterEventDelay.tsx src/features/reminders/pages/RemindersCreate.tsx src/features/reminders/pages/RemindersEdit.tsx tests/AfterEventDelay.test.tsx`
- `pnpm test tests/AfterEventDelay.test.tsx`
- `pnpm typecheck`
- `pnpm lint` *(fails: An interface declaring no members is equivalent to its supertype, Unexpected any ...)*
- `pnpm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d79abf94832aa3392e8d04aca287