### PR TITLE
[reminders] hide days selection for after-event schedule

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/buildPayload.ts
+++ b/services/webapp/ui/src/features/reminders/api/buildPayload.ts
@@ -49,7 +49,9 @@ export function buildReminderPayload(v: ReminderFormValues): ReminderSchema {
     kind: values.kind,
     isEnabled: values.isEnabled ?? true,
     title: generateTitle(values),
-    ...(values.daysOfWeek ? { daysOfWeek: new Set(values.daysOfWeek) } : {}),
+    ...(values.daysOfWeek && values.kind !== "after_event"
+      ? { daysOfWeek: new Set(values.daysOfWeek) }
+      : {}),
   };
 
   // Backend only supports one of: time, intervalMinutes, minutesAfter

--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useRemindersApi } from "../api/reminders"; // ваш хук, возвращающий DefaultApi
 import { DayOfWeekPicker } from "../components/DayOfWeekPicker";
@@ -55,6 +55,7 @@ export default function RemindersCreate() {
     isEnabled: true,
   });
   const [loading, setLoading] = useState(false);
+  const savedDaysRef = useRef<number[] | undefined>();
 
   const errors = validate(form);
   const formHasErrors = hasErrors(errors);
@@ -141,8 +142,12 @@ export default function RemindersCreate() {
       if (k === "at_time") base.time = "07:30";
       if (k === "every") base.intervalMinutes = 60;
       if (k === "after_event") {
+        savedDaysRef.current = s.daysOfWeek;
         base.minutesAfter = 120;
         base.type = "after_meal";
+        base.daysOfWeek = undefined;
+      } else {
+        base.daysOfWeek = s.kind === "after_event" ? savedDaysRef.current : s.daysOfWeek;
       }
       return base;
     });
@@ -306,22 +311,23 @@ export default function RemindersCreate() {
             </div>
           )}
 
-          {/* Дни недели */}
-          <div>
-            <label className="block text-sm font-medium text-foreground mb-2">
-              Дни недели (опционально)
-            </label>
-            <div className="space-y-3">
-              <DaysPresets
-                value={form.daysOfWeek}
-                onChange={(v) => onChange("daysOfWeek", v)}
-              />
-              <DayOfWeekPicker
-                value={form.daysOfWeek}
-                onChange={(v) => onChange("daysOfWeek", v)}
-              />
+          {form.kind !== "after_event" && (
+            <div>
+              <label className="block text-sm font-medium text-foreground mb-2">
+                Дни недели (опционально)
+              </label>
+              <div className="space-y-3">
+                <DaysPresets
+                  value={form.daysOfWeek}
+                  onChange={(v) => onChange("daysOfWeek", v)}
+                />
+                <DayOfWeekPicker
+                  value={form.daysOfWeek}
+                  onChange={(v) => onChange("daysOfWeek", v)}
+                />
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Название (необяз.) */}
           <div>

--- a/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import type { ReminderSchema } from "@sdk";
 import { useRemindersApi } from "../api/reminders";
@@ -74,6 +74,7 @@ export default function RemindersEdit() {
 
   const [form, setForm] = useState<ReminderFormValues | null>(null);
   const [saving, setSaving] = useState(false);
+  const savedDaysRef = useRef<number[] | undefined>();
 
   useEffect(() => {
     async function load() {
@@ -165,8 +166,12 @@ export default function RemindersEdit() {
       if (k === "at_time") base.time = "07:30";
       if (k === "every") base.intervalMinutes = 60;
       if (k === "after_event") {
+        savedDaysRef.current = s.daysOfWeek;
         base.minutesAfter = 120;
         base.type = "after_meal";
+        base.daysOfWeek = undefined;
+      } else {
+        base.daysOfWeek = s.kind === "after_event" ? savedDaysRef.current : s.daysOfWeek;
       }
       return base;
     });
@@ -336,22 +341,23 @@ export default function RemindersEdit() {
             </div>
           )}
 
-          {/* Дни недели */}
-          <div>
-            <label className="block text-sm font-medium text-foreground mb-2">
-              Дни недели (опционально)
-            </label>
-            <div className="space-y-3">
-              <DaysPresets
-                value={form.daysOfWeek}
-                onChange={(v) => onChange("daysOfWeek", v)}
-              />
-              <DayOfWeekPicker
-                value={form.daysOfWeek}
-                onChange={(v) => onChange("daysOfWeek", v)}
-              />
+          {form.kind !== "after_event" && (
+            <div>
+              <label className="block text-sm font-medium text-foreground mb-2">
+                Дни недели (опционально)
+              </label>
+              <div className="space-y-3">
+                <DaysPresets
+                  value={form.daysOfWeek}
+                  onChange={(v) => onChange("daysOfWeek", v)}
+                />
+                <DayOfWeekPicker
+                  value={form.daysOfWeek}
+                  onChange={(v) => onChange("daysOfWeek", v)}
+                />
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Название (необяз.) */}
           <div>

--- a/services/webapp/ui/tests/buildPayload.test.ts
+++ b/services/webapp/ui/tests/buildPayload.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { buildReminderPayload } from "../src/features/reminders/api/buildPayload";
+
+describe("buildReminderPayload daysOfWeek handling", () => {
+  it("omits daysOfWeek for after_event", () => {
+    const payload = buildReminderPayload({
+      telegramId: 1,
+      type: "after_meal",
+      kind: "after_event",
+      minutesAfter: 30,
+      daysOfWeek: [1, 2, 3],
+    });
+    expect(payload.daysOfWeek).toBeUndefined();
+  });
+
+  it("includes daysOfWeek for regular kinds", () => {
+    const payload = buildReminderPayload({
+      telegramId: 1,
+      type: "sugar",
+      kind: "at_time",
+      time: "08:00",
+      daysOfWeek: [1, 2],
+    });
+    expect(payload.daysOfWeek).toEqual(new Set([1, 2]));
+  });
+});


### PR DESCRIPTION
## Summary
- reset and restore daysOfWeek when switching reminder kind
- show weekdays picker only for time/every modes
- skip daysOfWeek in payload for after-event reminders
- add tests for daysOfWeek omission

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: async def functions are not natively supported, 427 failed)*
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui lint` *(fails: 28 problems (16 errors, 12 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b5d79da1b4832ab566b0d212e1c136