### PR TITLE
[reminders] omit daysOfWeek for after_event

### DIFF
--- a/services/webapp/ui/src/features/reminders/api/buildPayload.test.ts
+++ b/services/webapp/ui/src/features/reminders/api/buildPayload.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildReminderPayload } from "./buildPayload";
+
+import type { ReminderFormValues } from "./buildPayload";
+
+describe("buildReminderPayload", () => {
+  it("omits daysOfWeek for after_event reminders", () => {
+    const input: ReminderFormValues = {
+      telegramId: 1,
+      type: "after_meal",
+      kind: "after_event",
+      minutesAfter: 15,
+      daysOfWeek: [1, 2, 3],
+    };
+
+    const result = buildReminderPayload(input);
+
+    expect(result).toHaveProperty("minutesAfter", 15);
+    expect(result).not.toHaveProperty("daysOfWeek");
+  });
+});
+

--- a/services/webapp/ui/src/features/reminders/api/buildPayload.ts
+++ b/services/webapp/ui/src/features/reminders/api/buildPayload.ts
@@ -49,7 +49,9 @@ export function buildReminderPayload(v: ReminderFormValues): ReminderSchema {
     kind: values.kind,
     isEnabled: values.isEnabled ?? true,
     title: generateTitle(values),
-    ...(values.daysOfWeek ? { daysOfWeek: new Set(values.daysOfWeek) } : {}),
+    ...(values.kind !== "after_event" && values.daysOfWeek
+      ? { daysOfWeek: new Set(values.daysOfWeek) }
+      : {}),
   };
 
   // Backend only supports one of: time, intervalMinutes, minutesAfter


### PR DESCRIPTION
## Summary
- skip `daysOfWeek` when scheduling `after_event` reminders
- add test ensuring `after_event` reminders include `minutesAfter` but no `daysOfWeek`

## Testing
- `npm test`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5d79fa554832aa04624d59a0197f8