### PR TITLE
[reminders] validate minutesAfter bounds

### DIFF
--- a/services/webapp/ui/src/features/reminders/logic/validate.test.ts
+++ b/services/webapp/ui/src/features/reminders/logic/validate.test.ts
@@ -20,4 +20,32 @@ describe("validate", () => {
     const errors = validate({ ...base, time: "7:30" });
     expect(errors.time).toBe("Формат HH:MM");
   });
+
+  const afterBase: ReminderFormValues = {
+    telegramId: 1,
+    type: "after_meal",
+    kind: "after_event",
+    minutesAfter: 60,
+    isEnabled: true,
+  };
+
+  it("accepts valid minutesAfter", () => {
+    const errors = validate(afterBase);
+    expect(errors.minutesAfter).toBeUndefined();
+  });
+
+  it("rejects minutesAfter below minimum", () => {
+    const errors = validate({ ...afterBase, minutesAfter: 3 });
+    expect(errors.minutesAfter).toBe("Минуты 5..480");
+  });
+
+  it("rejects minutesAfter above maximum", () => {
+    const errors = validate({ ...afterBase, minutesAfter: 500 });
+    expect(errors.minutesAfter).toBe("Минуты 5..480");
+  });
+
+  it("rejects minutesAfter not divisible by 5", () => {
+    const errors = validate({ ...afterBase, minutesAfter: 7 });
+    expect(errors.minutesAfter).toBe("Кратно 5");
+  });
 });

--- a/services/webapp/ui/src/features/reminders/logic/validate.ts
+++ b/services/webapp/ui/src/features/reminders/logic/validate.ts
@@ -13,8 +13,15 @@ export function validate(v: ReminderFormValues): FormErrors {
     e.intervalMinutes = "Минуты ≥ 1";
   }
   
-  if (v.kind === "after_event" && (!v.minutesAfter || v.minutesAfter < 1)) {
-    e.minutesAfter = "Минуты ≥ 1";
+  if (v.kind === "after_event") {
+    const m = v.minutesAfter;
+    if (m === undefined) {
+      e.minutesAfter = "Укажите минуты";
+    } else if (m < 5 || m > 480) {
+      e.minutesAfter = "Минуты 5..480";
+    } else if (m % 5 !== 0) {
+      e.minutesAfter = "Кратно 5";
+    }
   }
   
   return e;


### PR DESCRIPTION
## Summary
- validate minutesAfter is defined, within 5..480 and divisible by 5
- add reminder validation tests for minutesAfter edge cases

## Testing
- `pnpm --filter ./services/webapp/ui exec eslint src/features/reminders/logic/validate.ts src/features/reminders/logic/validate.test.ts`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui exec vitest run src/features/reminders/logic/validate.test.ts`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5d7a15144832abc60106e10030d40