### PR TITLE
[ui] test after event delay input

### DIFF
--- a/services/webapp/ui/src/features/reminders/components/AfterEventDelay.tsx
+++ b/services/webapp/ui/src/features/reminders/components/AfterEventDelay.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+interface Props {
+  value?: number;
+  onChange: (minutes: number) => void;
+  presets?: number[];
+}
+
+const DEFAULT_PRESETS = [60, 90, 120];
+
+export default function AfterEventDelay({
+  value,
+  onChange,
+  presets = DEFAULT_PRESETS,
+}: Props) {
+  return (
+    <div className="space-y-3">
+      <label className="block text-sm font-medium text-foreground">
+        Задержка после события (мин)
+      </label>
+      <input
+        type="number"
+        min={1}
+        className="medical-input"
+        value={value ?? ""}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+      <div className="flex gap-2 flex-wrap">
+        {presets.map((m) => (
+          <button
+            key={m}
+            type="button"
+            aria-pressed={value === m}
+            className={`px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-colors ${
+              value === m ? "bg-secondary" : ""
+            }`}
+            onClick={() => onChange(m)}
+          >
+            {m} мин
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/services/webapp/ui/tests/AfterEventDelay.test.tsx
+++ b/services/webapp/ui/tests/AfterEventDelay.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import AfterEventDelay from '../src/features/reminders/components/AfterEventDelay';
+
+function Wrapper({ onChange }: { onChange: (v: number) => void }) {
+  const [value, setValue] = React.useState<number | undefined>();
+  const handleChange = (v: number) => {
+    onChange(v);
+    setValue(v);
+  };
+  return <AfterEventDelay value={value} onChange={handleChange} />;
+}
+
+describe('AfterEventDelay', () => {
+  afterEach(() => cleanup());
+
+  it('calls onChange with preset value and activates button', () => {
+    const onChange = vi.fn();
+    const { getByRole } = render(<Wrapper onChange={onChange} />);
+    const preset = getByRole('button', { name: /60/ });
+    fireEvent.click(preset);
+    expect(onChange).toHaveBeenCalledWith(60);
+    expect(preset.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('clears preset active state when manual value entered', () => {
+    const onChange = vi.fn();
+    const { getByRole } = render(<Wrapper onChange={onChange} />);
+    const preset = getByRole('button', { name: /60/ });
+    fireEvent.click(preset);
+    const input = getByRole('spinbutton') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '65' } });
+    expect(onChange).toHaveBeenLastCalledWith(65);
+    expect(input.value).toBe('65');
+    expect(preset.getAttribute('aria-pressed')).toBe('false');
+  });
+});

--- a/services/webapp/ui/tests/reminderKindSwitch.test.tsx
+++ b/services/webapp/ui/tests/reminderKindSwitch.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../src/features/reminders/api/reminders', () => ({
+  useRemindersApi: () => ({ remindersPost: vi.fn() })
+}));
+vi.mock('../src/hooks/useTelegramInitData', () => ({
+  useTelegramInitData: () => null,
+}));
+vi.mock('../src/hooks/useTelegram', () => ({
+  useTelegram: () => ({ user: { id: 1 }, sendData: vi.fn() })
+}));
+vi.mock('../src/shared/toast', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() })
+}));
+vi.mock('../src/api/mock-server', () => ({
+  mockApi: { createReminder: vi.fn() }
+}));
+vi.mock('../src/features/reminders/api/buildPayload', () => ({
+  buildReminderPayload: (x: any) => x
+}));
+vi.mock('../src/features/reminders/logic/validate', () => ({
+  validate: () => ({}),
+  hasErrors: () => false
+}));
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+describe('RemindersCreate kind switch', () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('clears minutesAfter when switching to at_time', async () => {
+    const { default: RemindersCreate } = await import('../src/features/reminders/pages/RemindersCreate');
+    const { getByRole, queryByRole } = render(<RemindersCreate />);
+
+    fireEvent.click(getByRole('button', { name: 'После события' }));
+    fireEvent.click(getByRole('button', { name: /90/ }));
+
+    const input = getByRole('spinbutton') as HTMLInputElement;
+    expect(input.value).not.toBe('');
+
+    fireEvent.click(getByRole('button', { name: 'Время' }));
+
+    expect(queryByRole('spinbutton')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add AfterEventDelay component with presets and active state
- test AfterEventDelay preset clicks and manual input
- ensure minutesAfter resets when switching reminder kind

## Testing
- `npm --prefix services/webapp/ui test`
- `pytest`
- `mypy --strict .`
- `ruff check .`
- `npm --prefix services/webapp/ui run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b5d7a363e4832aa65854bb2e232159