### PR TITLE
[reminders] extract after-event delay component

### DIFF
--- a/services/webapp/ui/src/features/reminders/components/AfterEventDelay.tsx
+++ b/services/webapp/ui/src/features/reminders/components/AfterEventDelay.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+
+interface AfterEventDelayProps {
+  value?: number;
+  onChange: (v?: number) => void;
+  error?: string;
+}
+
+export default function AfterEventDelay({
+  value,
+  onChange,
+  error,
+}: AfterEventDelayProps) {
+  const presets = [60, 90, 120, 150, 180, 240];
+  const activePreset = presets.includes(value ?? 0) ? value : undefined;
+
+  const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = Number(e.target.value);
+    onChange(Number.isNaN(v) ? undefined : v);
+  };
+
+  return (
+    <div className="space-y-3">
+      <label className="block text-sm font-medium text-foreground">
+        <span className="flex items-center gap-2">
+          <span>Задержка после еды (мин)</span>
+          <span className="text-xs text-muted-foreground">
+            Сработает после записи приёма пищи в «Истории»
+          </span>
+        </span>
+      </label>
+      <input
+        type="number"
+        min={5}
+        max={480}
+        step={5}
+        aria-label="Задержка после еды (мин)"
+        className={`medical-input ${
+          error ? "border-destructive focus:border-destructive" : ""
+        }`}
+        value={value ?? ""}
+        onChange={handleInput}
+      />
+      {error && (
+        <p className="text-xs text-destructive mt-1">{error}</p>
+      )}
+        <p className="text-xs text-muted-foreground">
+          Рекомендации: 60–90 — промежуточная; 120 — основная;
+          180–240 — поздняя
+        </p>
+      <div className="flex gap-2 flex-wrap">
+        {presets.map((m) => {
+          const active = activePreset === m;
+          return (
+            <button
+              key={m}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onChange(m)}
+                className={`px-3 py-1 rounded-lg border text-sm font-medium
+                transition-all duration-200 ${
+                  active
+                    ? "bg-primary text-primary-foreground border-primary shadow-soft"
+                    : "border-border bg-background text-foreground " +
+                      "hover:bg-secondary " +
+                      "hover:border-primary/20"
+                }`}
+            >
+              {m} мин
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+

--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useRemindersApi } from "../api/reminders"; // ваш хук, возвращающий DefaultApi
 import { DayOfWeekPicker } from "../components/DayOfWeekPicker";
 import { DaysPresets } from "../components/DaysPresets";
+import AfterEventDelay from "../components/AfterEventDelay";
 import {
   buildReminderPayload,
   ReminderFormValues,
@@ -68,13 +69,6 @@ export default function RemindersCreate() {
 
   const presetsTime = ["07:30", "12:30", "22:00"];
   const presetsEvery = [60, 120, 180, 1440];
-  const presetsAfter = useMemo(() => {
-    const base = [90, 120, 150];
-    if (defaultAfterMeal && !base.includes(defaultAfterMeal)) {
-      return [defaultAfterMeal, ...base];
-    }
-    return base;
-  }, [defaultAfterMeal]);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -280,39 +274,13 @@ export default function RemindersCreate() {
             </div>
           )}
 
-          {form.kind === "after_event" && (
-            <div className="space-y-3">
-              <label className="block text-sm font-medium text-foreground">
-                Задержка после еды (мин)
-              </label>
-              <input
-                type="number"
-                min={1}
-                className={`medical-input ${errors.minutesAfter ? "border-destructive focus:border-destructive" : ""}`}
-                value={form.minutesAfter ?? ""}
-                onChange={(e) =>
-                  onChange("minutesAfter", Number(e.target.value || 0))
-                }
+            {form.kind === "after_event" && (
+              <AfterEventDelay
+                value={form.minutesAfter}
+                onChange={(v) => onChange("minutesAfter", v)}
+                error={errors.minutesAfter}
               />
-              {errors.minutesAfter && (
-                <p className="text-xs text-destructive mt-1">
-                  {errors.minutesAfter}
-                </p>
-              )}
-              <div className="flex gap-2 flex-wrap">
-                {presetsAfter.map((m) => (
-                  <button
-                    key={m}
-                    type="button"
-                    className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-colors"
-                    onClick={() => onChange("minutesAfter", m)}
-                  >
-                    {m} мин
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
+            )}
 
           {/* Дни недели */}
           <div>

--- a/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
@@ -4,6 +4,7 @@ import type { ReminderSchema } from "@sdk";
 import { useRemindersApi } from "../api/reminders";
 import { DayOfWeekPicker } from "../components/DayOfWeekPicker";
 import { DaysPresets } from "../components/DaysPresets";
+import AfterEventDelay from "../components/AfterEventDelay";
 import {
   buildReminderPayload,
   ReminderFormValues,
@@ -78,13 +79,6 @@ export default function RemindersEdit() {
 
   const presetsTime = ["07:30", "12:30", "22:00"];
   const presetsEvery = [60, 120, 180, 1440];
-  const presetsAfter = useMemo(() => {
-    const base = [90, 120, 150];
-    if (defaultAfterMeal && !base.includes(defaultAfterMeal)) {
-      return [defaultAfterMeal, ...base];
-    }
-    return base;
-  }, [defaultAfterMeal]);
 
   useEffect(() => {
     async function load() {
@@ -309,38 +303,11 @@ export default function RemindersEdit() {
           )}
 
           {form.kind === "after_event" && (
-            <div className="space-y-3">
-              <label className="block text-sm font-medium text-foreground">
-                Через сколько минут после еды
-              </label>
-              <input
-                type="number"
-                className={`medical-input ${
-                  errors.minutesAfter
-                    ? "border-destructive focus:border-destructive"
-                    : ""
-                }`}
-                value={form.minutesAfter?.toString() || ""}
-                onChange={(e) => onChange("minutesAfter", Number(e.target.value))}
-              />
-              {errors.minutesAfter && (
-                <p className="text-xs text-destructive mt-1">
-                  {errors.minutesAfter}
-                </p>
-              )}
-              <div className="flex gap-2 flex-wrap">
-                {presetsAfter.map((t) => (
-                  <button
-                    key={t}
-                    type="button"
-                    className="px-3 py-1 rounded-lg border border-border bg-background text-foreground hover:bg-secondary transition-colors"
-                    onClick={() => onChange("minutesAfter", t)}
-                  >
-                    {t}
-                  </button>
-                ))}
-              </div>
-            </div>
+            <AfterEventDelay
+              value={form.minutesAfter}
+              onChange={(v) => onChange("minutesAfter", v)}
+              error={errors.minutesAfter}
+            />
           )}
 
           {/* Дни недели */}


### PR DESCRIPTION
## Summary
- add reusable `AfterEventDelay` with presets and hints
- refactor reminder create/edit pages to use new component

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'telegram')*
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named "fastapi.middleware.cors")*
- `ruff check .` *(fails: F811 Redefinition of unused `UserSettings`)*
- `pnpm --filter ./services/webapp/ui test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dacd7638832a9b95dffcb8c96d18