### PR TITLE
[contracts] add sos fields to profile settings

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -733,6 +733,15 @@ components:
           - g
           - xe
           title: Carb Units
+        sosContact:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Sos Contact
+        sosAlertsEnabled:
+          type: boolean
+          title: Sos Alerts Enabled
+          default: true
       type: object
       title: ProfileSettingsIn
     ProfileSettingsOut:
@@ -744,6 +753,7 @@ components:
       - dia
       - roundStep
       - carbUnits
+      - sosAlertsEnabled
       title: ProfileSettingsOut
     ProfileSchema:
       properties:

--- a/libs/py-sdk/requirements.txt
+++ b/libs/py-sdk/requirements.txt
@@ -1,2 +1,4 @@
-# Placeholder requirements for optional Python SDK.
-# Actual dependencies will be generated alongside the SDK.
+urllib3 >= 2.1.0, < 3.0.0
+python_dateutil >= 2.8.2
+pydantic >= 2
+typing-extensions >= 4.7.1

--- a/libs/ts-sdk/models/ProfileSettingsIn.ts
+++ b/libs/ts-sdk/models/ProfileSettingsIn.ts
@@ -49,6 +49,18 @@ export interface ProfileSettingsIn {
      * @memberof ProfileSettingsIn
      */
     carbUnits?: ProfileSettingsInCarbUnitsEnum;
+    /**
+     * 
+     * @type {string}
+     * @memberof ProfileSettingsIn
+     */
+    sosContact?: string | null;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ProfileSettingsIn
+     */
+    sosAlertsEnabled?: boolean;
 }
 
 
@@ -84,6 +96,8 @@ export function ProfileSettingsInFromJSONTyped(json: any, ignoreDiscriminator: b
         'dia': json['dia'] == null ? undefined : json['dia'],
         'roundStep': json['roundStep'] == null ? undefined : json['roundStep'],
         'carbUnits': json['carbUnits'] == null ? undefined : json['carbUnits'],
+        'sosContact': json['sosContact'] == null ? undefined : json['sosContact'],
+        'sosAlertsEnabled': json['sosAlertsEnabled'] == null ? undefined : json['sosAlertsEnabled'],
     };
 }
 
@@ -103,6 +117,8 @@ export function ProfileSettingsInToJSONTyped(value?: ProfileSettingsIn | null, i
         'dia': value['dia'],
         'roundStep': value['roundStep'],
         'carbUnits': value['carbUnits'],
+        'sosContact': value['sosContact'],
+        'sosAlertsEnabled': value['sosAlertsEnabled'],
     };
 }
 

--- a/libs/ts-sdk/models/ProfileSettingsOut.ts
+++ b/libs/ts-sdk/models/ProfileSettingsOut.ts
@@ -49,6 +49,18 @@ export interface ProfileSettingsOut {
      * @memberof ProfileSettingsOut
      */
     carbUnits: ProfileSettingsOutCarbUnitsEnum;
+    /**
+     * 
+     * @type {string}
+     * @memberof ProfileSettingsOut
+     */
+    sosContact?: string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ProfileSettingsOut
+     */
+    sosAlertsEnabled: boolean;
 }
 
 
@@ -71,6 +83,7 @@ export function instanceOfProfileSettingsOut(value: object): value is ProfileSet
     if (!('dia' in value) || value['dia'] === undefined) return false;
     if (!('roundStep' in value) || value['roundStep'] === undefined) return false;
     if (!('carbUnits' in value) || value['carbUnits'] === undefined) return false;
+    if (!('sosAlertsEnabled' in value) || value['sosAlertsEnabled'] === undefined) return false;
     return true;
 }
 
@@ -89,6 +102,8 @@ export function ProfileSettingsOutFromJSONTyped(json: any, ignoreDiscriminator: 
         'dia': json['dia'],
         'roundStep': json['roundStep'],
         'carbUnits': json['carbUnits'],
+        'sosContact': json['sosContact'] == null ? undefined : json['sosContact'],
+        'sosAlertsEnabled': json['sosAlertsEnabled'],
     };
 }
 
@@ -108,6 +123,8 @@ export function ProfileSettingsOutToJSONTyped(value?: ProfileSettingsOut | null,
         'dia': value['dia'],
         'roundStep': value['roundStep'],
         'carbUnits': value['carbUnits'],
+        'sosContact': value['sosContact'],
+        'sosAlertsEnabled': value['sosAlertsEnabled'],
     };
 }
 

--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -185,6 +185,10 @@ def patch_user_settings(
     user = session.get(User, user_id)
     if not user:
         return False, False
+    profile = session.get(Profile, user_id)
+    if profile is None:
+        profile = Profile(telegram_id=user_id)
+        session.add(profile)
     if data.timezone is not None:
         user.timezone = data.timezone
     if data.timezoneAuto is not None:
@@ -195,6 +199,10 @@ def patch_user_settings(
         user.round_step = data.roundStep
     if data.carbUnits is not None:
         user.carb_units = data.carbUnits
+    if data.sosContact is not None:
+        profile.sos_contact = data.sosContact
+    if data.sosAlertsEnabled is not None:
+        profile.sos_alerts_enabled = data.sosAlertsEnabled
     if user.timezone_auto and device_tz and user.timezone != device_tz:
         user.timezone = device_tz
     try:

--- a/services/api/app/diabetes/schemas/profile.py
+++ b/services/api/app/diabetes/schemas/profile.py
@@ -29,6 +29,16 @@ class ProfileSettingsIn(BaseModel):
         alias="carbUnits",
         validation_alias=AliasChoices("carbUnits", "carb_units"),
     )
+    sosContact: str | None = Field(
+        default=None,
+        alias="sosContact",
+        validation_alias=AliasChoices("sosContact", "sos_contact"),
+    )
+    sosAlertsEnabled: bool | None = Field(
+        default=None,
+        alias="sosAlertsEnabled",
+        validation_alias=AliasChoices("sosAlertsEnabled", "sos_alerts_enabled"),
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -49,3 +59,5 @@ class ProfileSettingsOut(ProfileSettingsIn):
     dia: float
     roundStep: float = Field(alias="roundStep")
     carbUnits: CarbUnits = Field(alias="carbUnits")
+    sosContact: str | None = Field(default=None, alias="sosContact")
+    sosAlertsEnabled: bool = Field(alias="sosAlertsEnabled")

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -60,6 +60,11 @@ async def patch_user_settings(
             user = User(telegram_id=telegram_id, thread_id="api")
             cast(Session, session).add(user)
 
+        profile = cast(Profile | None, session.get(Profile, telegram_id))
+        if profile is None:
+            profile = Profile(telegram_id=telegram_id)
+            cast(Session, session).add(profile)
+
         if data.timezone is not None:
             user.timezone = data.timezone
         if data.timezoneAuto is not None:
@@ -70,6 +75,10 @@ async def patch_user_settings(
             user.round_step = data.roundStep
         if data.carbUnits is not None:
             user.carb_units = data.carbUnits
+        if data.sosContact is not None:
+            profile.sos_contact = data.sosContact
+        if data.sosAlertsEnabled is not None:
+            profile.sos_alerts_enabled = data.sosAlertsEnabled
 
         if user.timezone_auto and device_tz and user.timezone != device_tz:
             user.timezone = device_tz
@@ -85,6 +94,8 @@ async def patch_user_settings(
             dia=user.dia,
             roundStep=user.round_step,
             carbUnits=CarbUnits(user.carb_units),
+            sosContact=profile.sos_contact,
+            sosAlertsEnabled=profile.sos_alerts_enabled,
         )
 
     return await db.run_db(_patch, sessionmaker=db.SessionLocal)

--- a/tests/handlers/profile/test_api.py
+++ b/tests/handlers/profile/test_api.py
@@ -270,6 +270,8 @@ def test_profile_patch_updates_timezone(
         data = resp.json()
         assert data["timezone"] == "Europe/Moscow"
         assert data["timezoneAuto"] is False
+        assert data["sosAlertsEnabled"] is True
+        assert data["sosContact"] is None
     with session_factory() as session:
         user = session.get(User, 1)
         assert user is not None
@@ -294,6 +296,8 @@ def test_profile_patch_auto_device_timezone(
         data = resp.json()
         assert data["timezone"] == "Europe/Moscow"
         assert data["timezoneAuto"] is True
+        assert data["sosAlertsEnabled"] is True
+        assert data["sosContact"] is None
     with session_factory() as session:
         user = session.get(User, 1)
         assert user is not None

--- a/tests/test_profile_patch_endpoint.py
+++ b/tests/test_profile_patch_endpoint.py
@@ -75,6 +75,8 @@ def test_profile_patch_returns_settings(
     assert data["dia"] == 6
     assert data["roundStep"] == 1
     assert data["carbUnits"] == "xe"
+    assert data["sosAlertsEnabled"] is True
+    assert data["sosContact"] is None
 
     with SessionLocal() as session:
         user = session.get(db.User, 1)
@@ -84,6 +86,10 @@ def test_profile_patch_returns_settings(
         assert user.dia == 6
         assert user.round_step == 1
         assert user.carb_units == "xe"
+        prof = session.get(db.Profile, 1)
+        assert prof is not None
+        assert prof.sos_alerts_enabled is True
+        assert prof.sos_contact is None
 
 
 def test_profile_patch_partial_update(
@@ -99,6 +105,8 @@ def test_profile_patch_partial_update(
         assert data["dia"] == 5
         assert data["roundStep"] == 0.5
         assert data["carbUnits"] == "g"
+        assert data["sosAlertsEnabled"] is True
+        assert data["sosContact"] is None
 
     with SessionLocal() as session:
         user = session.get(db.User, 1)
@@ -106,3 +114,7 @@ def test_profile_patch_partial_update(
         assert user.dia == 5
         assert user.round_step == 0.5
         assert user.carb_units == "g"
+        prof = session.get(db.Profile, 1)
+        assert prof is not None
+        assert prof.sos_alerts_enabled is True
+        assert prof.sos_contact is None

--- a/tests/test_profile_patch_status.py
+++ b/tests/test_profile_patch_status.py
@@ -30,5 +30,7 @@ def test_patch_profile_returns_status_ok(monkeypatch: pytest.MonkeyPatch) -> Non
         data = resp.json()
         assert data["timezone"] == "UTC"
         assert data["timezoneAuto"] is False
+        assert data["sosAlertsEnabled"] is True
+        assert data["sosContact"] is None
 
     server.app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- extend profile settings with `sosContact` and `sosAlertsEnabled`
- regenerate TS and Python SDKs
- update profile settings patch handling and tests

## Testing
- `pnpm --filter "./services/webapp/ui" test`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5da643020832a9822953d7fe734d8