### PR TITLE
[handlers] update help text for menu buttons

### DIFF
--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -38,10 +38,10 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "🔔 Безопасность:\n"
         "• Пороги низкого и высокого сахара\n"
         "• SOS-уведомления\n"
-        "• ⏰ Напоминания\n"
+        "• Напоминания (команда /reminders)\n"
         "• FAQ по гипогликемии: /hypoalert\n"
         "Настройки: /profile → «🔔 Безопасность»\n\n"
-        "⏰ Напоминания:\n"
+        "Напоминания (команда /reminders):\n"
         "• Сахар — напомнит измерить уровень сахара\n"
         "• Длинный инсулин — напомнит о базальном уколе\n"
         "• Лекарство — принять таблетки\n"
@@ -53,10 +53,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "📷 Фото еды\n"
         "🩸 Уровень сахара\n"
         "💉 Доза инсулина\n"
-        "📊 История\n"
         "📈 Отчёт\n"
-        "📄 Мой профиль\n"
-        "⏰ Напоминания\n"
         "ℹ️ Помощь"
     )
     message = update.message


### PR DESCRIPTION
## Summary
- revise help text to reflect removal of certain menu buttons

## Testing
- `pytest -q --cov` *(failed: Table 'user_settings' is already defined)*
- `mypy --strict .`
- `ruff check .` *(failed: F811 Redefinition of unused `UserSettings`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e0639138832a965667f9fd80904f