### PR TITLE
tests: update menu references

### DIFF
--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -6,7 +6,6 @@ from telegram import Update
 from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.common_handlers as handlers
-from services.api.app.diabetes.utils.ui import REMINDERS_BUTTON_TEXT
 
 
 class DummyMessage:
@@ -82,7 +81,6 @@ async def test_help_lists_reminder_commands_and_menu_button() -> None:
     assert "/reminders - список напоминаний\n" in text
     assert "/addreminder" not in text
     assert "/delreminder" not in text
-    assert f"{REMINDERS_BUTTON_TEXT}\n" in text
 
 
 @pytest.mark.asyncio

--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -3,7 +3,7 @@ import re
 from typing import cast
 
 from telegram.ext import ApplicationBuilder, MessageHandler, filters
-from services.api.app.diabetes.utils.ui import menu_keyboard, REMINDERS_BUTTON_TEXT
+from services.api.app.diabetes.utils.ui import REMINDERS_BUTTON_TEXT
 import services.api.app.diabetes.handlers.registration as handlers
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
@@ -12,9 +12,6 @@ def test_reminders_button_matches_regex() -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-
-    button_texts = [btn.text for row in menu_keyboard().keyboard for btn in row]
-    assert REMINDERS_BUTTON_TEXT in button_texts
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
     handlers.register_handlers(app)


### PR DESCRIPTION
## Summary
- adjust menu keyboard tests for simplified menu structure
- drop obsolete menu button checks in help command
- streamline reminders button regex test

## Testing
- `pytest tests/test_menu_keyboard_webapp.py tests/test_help_command.py tests/test_reminders_button_regex.py -q` *(fails: Table 'user_settings' is already defined for this MetaData instance)*
- `mypy --strict tests/test_menu_keyboard_webapp.py tests/test_help_command.py tests/test_reminders_button_regex.py`
- `ruff check tests/test_menu_keyboard_webapp.py tests/test_help_command.py tests/test_reminders_button_regex.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5e0669790832abd3696ceb104cb2d