### PR TITLE
[ui] Remove unused menu items from Home page

### DIFF
--- a/services/webapp/ui/src/pages/Home.tsx
+++ b/services/webapp/ui/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { Clock, User, BookOpen, Star } from 'lucide-react';
+import { Star } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { MedicalHeader } from '@/components/MedicalHeader';
@@ -8,30 +8,6 @@ import { StatCard } from '@/components/StatCard';
 import { fetchDayStats, fallbackDayStats } from '@/api/stats';
 
 const menuItems = [
-  {
-    id: 'reminders',
-    title: 'Напоминания',
-    icon: Clock,
-    description: 'Настройка уведомлений',
-    route: '/reminders',
-    color: 'medical-blue'
-  },
-  {
-    id: 'profile', 
-    title: 'Мой профиль',
-    icon: User,
-    description: 'Личные настройки',
-    route: '/profile',
-    color: 'medical-teal'
-  },
-  {
-    id: 'history',
-    title: 'История',
-    icon: BookOpen,
-    description: 'Записи о сахаре',
-    route: '/history',
-    color: 'medical-success'
-  },
   {
     id: 'subscription',
     title: 'Подписка',
@@ -75,7 +51,11 @@ const Home = () => {
         </div>
 
         {/* Главное меню */}
-        <div className="grid grid-cols-2 gap-4 mb-8">
+        <div
+          className={`grid gap-4 mb-8 ${
+            menuItems.length === 1 ? 'grid-cols-1 justify-items-center' : 'grid-cols-2'
+          }`}
+        >
           {menuItems.map((item, index) => {
             const Icon = item.icon;
             return (


### PR DESCRIPTION
## Summary
- show only subscription tile on home page
- center menu grid when only one item remains

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: Table 'user_settings' is already defined)*
- `mypy --strict .` *(interrupted due to repository size)*
- `ruff check .` *(fails: F811 Redefinition of unused `UserSettings`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e069a5c0832a99424324e71b4d42