### PR TITLE
tests: update menu after button removal

### DIFF
--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -6,7 +6,6 @@ from telegram import Update
 from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.common_handlers as handlers
-from services.api.app.diabetes.utils.ui import REMINDERS_BUTTON_TEXT
 
 
 class DummyMessage:
@@ -82,7 +81,6 @@ async def test_help_lists_reminder_commands_and_menu_button() -> None:
     assert "/reminders - список напоминаний\n" in text
     assert "/addreminder" not in text
     assert "/delreminder" not in text
-    assert f"{REMINDERS_BUTTON_TEXT}\n" in text
 
 
 @pytest.mark.asyncio

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -1,0 +1,12 @@
+import services.api.app.diabetes.handlers.common_handlers as handlers
+import services.api.app.diabetes.utils.ui as ui
+
+
+def test_menu_keyboard_webapp_layout() -> None:
+    keyboard_texts = [[btn.text for btn in row] for row in handlers.menu_keyboard().keyboard]
+    assert keyboard_texts == [
+        [ui.PHOTO_BUTTON_TEXT, ui.SUGAR_BUTTON_TEXT],
+        [ui.DOSE_BUTTON_TEXT, ui.REPORT_BUTTON_TEXT],
+        [ui.QUICK_INPUT_BUTTON_TEXT, ui.HELP_BUTTON_TEXT],
+        [ui.SOS_BUTTON_TEXT],
+    ]

--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -3,7 +3,7 @@ import re
 from typing import cast
 
 from telegram.ext import ApplicationBuilder, MessageHandler, filters
-from services.api.app.diabetes.utils.ui import menu_keyboard, REMINDERS_BUTTON_TEXT
+from services.api.app.diabetes.utils.ui import REMINDERS_BUTTON_TEXT
 import services.api.app.diabetes.handlers.registration as handlers
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 
@@ -12,9 +12,6 @@ def test_reminders_button_regex_matches_text() -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
-
-    button_texts = [btn.text for row in menu_keyboard().keyboard for btn in row]
-    assert REMINDERS_BUTTON_TEXT not in button_texts
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
     handlers.register_handlers(app)


### PR DESCRIPTION
## Summary
- drop references to removed menu buttons from help and reminders tests
- check reminders button regex only
- cover webapp menu layout with current buttons

## Testing
- `ruff check tests/test_menu_keyboard_webapp.py tests/test_help_command.py tests/test_reminders_button_regex.py tests/test_menu_keyboard.py`
- `mypy --strict tests/test_menu_keyboard_webapp.py tests/test_help_command.py tests/test_reminders_button_regex.py tests/test_menu_keyboard.py`
- `pytest tests/test_menu_keyboard_webapp.py tests/test_help_command.py tests/test_reminders_button_regex.py tests/test_menu_keyboard.py -q` *(fails: sqlalchemy.exc.InvalidRequestError: Table 'user_settings' is already defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e22dc4c0832a8bf165a24c87842b