### PR TITLE
[services.db] Remove redundant UserSettings import

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -349,7 +349,9 @@ class HistoryRecord(Base):
 
 
 # Import additional models
-from .db_models import UserSettings  # noqa: F401,E402
+# Additional models can be defined in separate modules and imported here so
+# that ``Base.metadata`` is aware of them.  Currently, all models are declared
+# in this file, so no extra imports are required.
 
 
 # ────────────────────── инициализация ────────────────────────


### PR DESCRIPTION
## Summary
- avoid redefining `UserSettings` by dropping dead import in `db.py`

## Testing
- `pytest -q --cov` *(fails: test_help_lists_reminder_commands_and_menu_button)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5e3a6bab4832a98e0784d4a996de4