### PR TITLE
[services] remove duplicate UserSettings model

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -202,15 +202,6 @@ class Profile(Base):
     user: Mapped[User] = relationship("User")
 
 
-class UserSettings(Base):
-    __tablename__ = "user_settings"
-    telegram_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
-    )
-    default_after_meal_minutes: Mapped[Optional[int]] = mapped_column(Integer)
-    user: Mapped[User] = relationship("User")
-
-
 class Entry(Base):
     __tablename__ = "entries"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)


### PR DESCRIPTION
## Summary
- remove inline UserSettings mapping and re-export model from db_models
- require explicit minutes for after-meal reminders in tests

## Testing
- `pytest tests/test_reminder_handlers.py::test_add_reminder_after_meal_requires_value tests/test_reminder_handlers.py::test_reminder_webapp_save_minutes_after_required -q --no-cov`
- `mypy --strict services/api/app/diabetes/services/db.py services/api/app/diabetes/services/db_models.py tests/test_reminder_handlers.py`
- `ruff check services/api/app/diabetes/services/db.py services/api/app/diabetes/services/db_models.py tests/test_reminder_handlers.py`
- `DATABASE_URL=sqlite:///:memory: make migrate` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e3bd5e80832aa0696607ab27d00b