### PR TITLE
[services] export UserSettings model

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -339,10 +339,8 @@ class HistoryRecord(Base):
     type: Mapped[str] = mapped_column(String, nullable=False)
 
 
-# Import additional models
-# Additional models can be defined in separate modules and imported here so
-# that ``Base.metadata`` is aware of them.  Currently, all models are declared
-# in this file, so no extra imports are required.
+# Import additional models so ``Base.metadata`` is aware of them.
+from .db_models import UserSettings  # noqa: F401, E402
 
 
 # ────────────────────── инициализация ────────────────────────


### PR DESCRIPTION
## Summary
- expose `UserSettings` via `services.db` to satisfy imports

## Testing
- `pytest -q --cov` (fails: async def functions are not natively supported)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5e70ac3a8832aac41c02e9d26dd00