### PR TITLE
[services] remove unused db_models import

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -359,10 +359,6 @@ class HistoryRecord(Base):
     type: Mapped[str] = mapped_column(String, nullable=False)
 
 
-# Import additional models so ``Base.metadata`` is aware of them.
-from .db_models import UserSettings  # noqa: F401, E402
-
-
 # ────────────────────── инициализация ────────────────────────
 def init_db() -> None:
     """Создать таблицы, если их ещё нет (для локального запуска)."""


### PR DESCRIPTION
## Summary
- drop leftover db_models import in db module

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b5e9ff5850832a90877d7be7e1b0b4