### PR TITLE
[db] add dia field to users

### DIFF
--- a/services/api/alembic/versions/20250904_add_dia_to_users.py
+++ b/services/api/alembic/versions/20250904_add_dia_to_users.py
@@ -1,0 +1,29 @@
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250904_add_dia_to_users"
+down_revision: Union[str, Sequence[str], None] = "016dca0fbac4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = [col["name"] for col in inspector.get_columns("users")]
+    if "dia" not in columns:
+        op.add_column(
+            "users",
+            sa.Column("dia", sa.Float(), nullable=False, server_default="4.0"),
+        )
+        op.alter_column("users", "dia", server_default=None)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = [col["name"] for col in inspector.get_columns("users")]
+    if "dia" in columns:
+        op.drop_column("users", "dia")

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -157,7 +157,9 @@ class User(Base):
     plan: Mapped[str] = mapped_column(String, default="free")
     timezone: Mapped[str] = mapped_column(String, default="UTC")
     timezone_auto: Mapped[bool] = mapped_column(Boolean, default=True)
-    dia: Mapped[float] = mapped_column(Float, default=4.0)
+    dia: Mapped[float] = mapped_column(
+        Float, default=4.0, server_default=sa.text("4.0")
+    )
     round_step: Mapped[float] = mapped_column(Float, default=0.5)
     carb_units: Mapped[str] = mapped_column(String, default="g")
     org_id: Mapped[Optional[int]] = mapped_column(Integer)


### PR DESCRIPTION
## Summary
- add dia column to SQLAlchemy User model
- add Alembic migration to persist dia on users table

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `DATABASE_URL=sqlite:///tmp.db alembic -c services/api/alembic.ini upgrade head` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f108c188832a8d9dcef01b621818