### PR TITLE
[migrations] Add round_step and carb_units to users

### DIFF
--- a/services/api/alembic/versions/20250905_add_round_step_carb_units_to_users.py
+++ b/services/api/alembic/versions/20250905_add_round_step_carb_units_to_users.py
@@ -1,0 +1,37 @@
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250905_add_round_step_carb_units_to_users"
+down_revision: Union[str, Sequence[str], None] = "20250904_add_dia_to_users"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = [col["name"] for col in inspector.get_columns("users")]
+    if "round_step" not in columns:
+        op.add_column(
+            "users",
+            sa.Column("round_step", sa.Float(), nullable=False, server_default="0.5"),
+        )
+        op.alter_column("users", "round_step", server_default=None)
+    if "carb_units" not in columns:
+        op.add_column(
+            "users",
+            sa.Column("carb_units", sa.String(), nullable=False, server_default="'g'"),
+        )
+        op.alter_column("users", "carb_units", server_default=None)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = [col["name"] for col in inspector.get_columns("users")]
+    if "round_step" in columns:
+        op.drop_column("users", "round_step")
+    if "carb_units" in columns:
+        op.drop_column("users", "carb_units")


### PR DESCRIPTION
## Summary
- add `round_step` and `carb_units` columns to `users`

## Testing
- `PYTHONPATH=/workspace/saharlight-ux DATABASE_URL=sqlite:///alembic.db alembic -c services/api/alembic.ini upgrade head` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*
- `PYTHONPATH=/workspace/saharlight-ux pytest -q --cov` *(fails: async def functions are not natively supported)*
- `PYTHONPATH=/workspace/saharlight-ux mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b66365818c832ab4a5c96c2392ea85