### PR TITLE
[reminders] run GC job immediately

### DIFF
--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -70,12 +70,15 @@ def schedule_reminders_gc(jq: DefaultJobQueue) -> None:
     run_rep = getattr(jq, "run_repeating", None)
     if not callable(run_rep):
         return
-    run_rep(
+    job = run_rep(
         _reminders_gc,
         interval=timedelta(seconds=90),
+        first=timedelta(seconds=0),
         name=_GC_JOB_NAME,
         job_kwargs={"id": _GC_JOB_NAME, "replace_existing": True},
     )
+    next_run = getattr(job, "next_run_time", None)
+    logger.info("🧹 scheduled %s -> next_run=%s", _GC_JOB_NAME, next_run)
 
 
 async def notify_reminder_saved(reminder_id: int) -> None:


### PR DESCRIPTION
## Summary
- schedule reminder GC to run instantly on startup and log its next run
- cover reminder GC schedule with tests verifying next-run timing

## Testing
- `pytest tests/test_reminder_events.py -q` *(fails: Coverage failure: total of 25 is less than fail-under=85)*
- `pytest tests/test_reminder_events.py::test_schedule_reminders_gc_next_run_updates_every_90_seconds -q -o addopts='' -p no:cov`
- `mypy --strict services/api/app/reminder_events.py tests/test_reminder_events.py` *(fails: Interrupted)*
- `ruff check services/api/app/reminder_events.py tests/test_reminder_events.py`


------
https://chatgpt.com/codex/tasks/task_e_68b66b11dacc832aa9132bd98221c98b