### PR TITLE
[ui] add HelpHint component

### DIFF
--- a/services/webapp/ui/src/components/HelpHint.tsx
+++ b/services/webapp/ui/src/components/HelpHint.tsx
@@ -1,0 +1,40 @@
+import { useState, type KeyboardEvent } from 'react';
+import { HelpCircle } from 'lucide-react';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+interface HelpHintProps {
+  label: string;
+  className?: string;
+  side?: React.ComponentProps<typeof TooltipContent>['side'];
+}
+
+const HelpHint = ({ label, className, side }: HelpHintProps) => {
+  const [open, setOpen] = useState(false);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Escape') {
+      setOpen(false);
+      event.currentTarget.blur();
+    }
+  };
+
+  return (
+    <Tooltip open={open} onOpenChange={setOpen}>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onKeyDown={handleKeyDown}
+          className={cn('flex h-4 w-4 items-center justify-center text-muted-foreground', className)}
+          aria-label={label}
+        >
+          <HelpCircle className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side={side}>{label}</TooltipContent>
+    </Tooltip>
+  );
+};
+
+export default HelpHint;

--- a/services/webapp/ui/src/components/index.ts
+++ b/services/webapp/ui/src/components/index.ts
@@ -4,3 +4,4 @@ export { default as MedicalButton } from './MedicalButton';
 export { default as ThemeToggle } from './ThemeToggle';
 export { default as Sheet } from './Sheet';
 export { default as TimeInput } from './TimeInput';
+export { default as HelpHint } from './HelpHint';


### PR DESCRIPTION
## Summary
- add HelpHint tooltip component
- export HelpHint from component index

## Testing
- `pnpm lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any)*
- `pnpm typecheck`
- `pnpm test` *(fails: JavaScript heap out of memory)*
- `pytest -q` *(fails: async functions require plugins)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b672c6a540832a97420fc29ebe3b98