### PR TITLE
[webapp] add profile help sheet component

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import {
+  Sheet,
+  SheetTrigger,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '@/components/ui/accordion';
+import { Button } from '@/components/ui/button';
+import { HelpCircle } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-mobile';
+
+interface ProfileHelpSheetProps {
+  therapyType?: string;
+}
+
+const sections = [
+  {
+    key: 'icr',
+    title: 'ICR (Инсулино-углеводное соотношение)',
+    content:
+      'Показывает, сколько граммов углеводов покрывает 1 единица быстрого инсулина',
+  },
+  {
+    key: 'cf',
+    title: 'Коэффициент коррекции (КЧ)',
+    content:
+      'На сколько ммоль/л снижает уровень глюкозы 1 единица быстрого инсулина',
+  },
+  {
+    key: 'target',
+    title: 'Целевой уровень сахара',
+    content:
+      'Желаемый уровень глюкозы, к которому стремится приложение при расчётах',
+  },
+  {
+    key: 'low',
+    title: 'Нижний порог',
+    content: 'При достижении этого уровня бот предупредит о гипогликемии',
+  },
+  {
+    key: 'high',
+    title: 'Верхний порог',
+    content: 'При превышении этого уровня бот предупредит о гипергликемии',
+  },
+  {
+    key: 'dia',
+    title: 'DIA (длительность действия инсулина)',
+    content: 'Сколько часов действует введённый инсулин',
+  },
+];
+
+const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
+  const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
+
+  const filtered =
+    therapyType === 'tablets'
+      ? sections.filter((s) => !['icr', 'cf', 'dia'].includes(s.key))
+      : sections;
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button
+          aria-label="Справка"
+          variant="ghost"
+          size="icon"
+        >
+          <HelpCircle className="h-5 w-5" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side={isMobile ? 'bottom' : 'right'}
+        className="max-h-screen overflow-y-auto"
+      >
+        <SheetHeader>
+          <SheetTitle>Справка</SheetTitle>
+        </SheetHeader>
+        <Accordion type="single" collapsible className="w-full">
+          {filtered.map((section) => (
+            <AccordionItem key={section.key} value={section.key}>
+              <AccordionTrigger>{section.title}</AccordionTrigger>
+              <AccordionContent>{section.content}</AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+export default ProfileHelpSheet;

--- a/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
+++ b/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import ProfileHelpSheet from '../src/components/ProfileHelpSheet';
+import * as mobileHook from '@/hooks/use-mobile';
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: vi.fn(() => false),
+}));
+
+describe('ProfileHelpSheet', () => {
+  it('hides insulin sections for tablet therapy', () => {
+    render(<ProfileHelpSheet therapyType="tablets" />);
+    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
+    expect(screen.queryByText(/ICR/)).toBeNull();
+    expect(screen.queryByText(/Коэффициент коррекции/)).toBeNull();
+    expect(screen.queryByText(/DIA/)).toBeNull();
+    expect(screen.getByText(/Целевой уровень сахара/)).toBeTruthy();
+  });
+
+  it('closes on Escape key', () => {
+    render(<ProfileHelpSheet />);
+    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('uses bottom sheet on mobile', () => {
+    (mobileHook.useIsMobile as unknown as vi.Mock).mockReturnValue(true);
+    render(<ProfileHelpSheet />);
+    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
+    const content = screen.getByRole('dialog');
+    expect(content.className).toContain('bottom-0');
+  });
+});


### PR DESCRIPTION
## Summary
- add ProfileHelpSheet component with shadcn Sheet, Accordion, and Button
- hide insulin-related sections for tablet therapy
- support Esc close and mobile bottom sheet

## Testing
- `pnpm lint` (fails: @typescript-eslint/no-empty-object-type, etc.)
- `pnpm typecheck`
- `pnpm test`
- `pytest -q` (fails: unrecognized arguments: --cov=...)
- `mypy --strict .` (interrupted)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b672c6c62c832abff27ef996d80f6f