### PR TITLE
[ui] Add translation hooks for help components

### DIFF
--- a/services/webapp/ui/src/components/HelpHint.tsx
+++ b/services/webapp/ui/src/components/HelpHint.tsx
@@ -3,6 +3,7 @@ import { HelpCircle } from 'lucide-react';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+import { useTranslation } from '@/i18n';
 
 interface HelpHintProps {
   label: string;
@@ -11,6 +12,7 @@ interface HelpHintProps {
 }
 
 const HelpHint = ({ label, className, side }: HelpHintProps) => {
+  const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
@@ -27,12 +29,12 @@ const HelpHint = ({ label, className, side }: HelpHintProps) => {
           type="button"
           onKeyDown={handleKeyDown}
           className={cn('flex h-4 w-4 items-center justify-center text-muted-foreground', className)}
-          aria-label={label}
+          aria-label={t(label)}
         >
           <HelpCircle className="h-4 w-4" aria-hidden="true" />
         </button>
       </TooltipTrigger>
-      <TooltipContent side={side}>{label}</TooltipContent>
+      <TooltipContent side={side}>{t(label)}</TooltipContent>
     </Tooltip>
   );
 };

--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -15,6 +15,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { HelpCircle } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { useTranslation } from '@/i18n';
 
 interface ProfileHelpSheetProps {
   therapyType?: string;
@@ -59,6 +60,7 @@ const sections = [
 const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
   const [open, setOpen] = useState(false);
   const isMobile = useIsMobile();
+  const { t } = useTranslation();
 
   const filtered =
     therapyType === 'tablets'
@@ -69,7 +71,7 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>
         <Button
-          aria-label="Справка"
+          aria-label={t('Справка')}
           variant="ghost"
           size="icon"
         >
@@ -81,13 +83,13 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
         className="max-h-screen overflow-y-auto"
       >
         <SheetHeader>
-          <SheetTitle>Справка</SheetTitle>
+          <SheetTitle>{t('Справка')}</SheetTitle>
         </SheetHeader>
         <Accordion type="single" collapsible className="w-full">
           {filtered.map((section) => (
             <AccordionItem key={section.key} value={section.key}>
-              <AccordionTrigger>{section.title}</AccordionTrigger>
-              <AccordionContent>{section.content}</AccordionContent>
+              <AccordionTrigger>{t(section.title)}</AccordionTrigger>
+              <AccordionContent>{t(section.content)}</AccordionContent>
             </AccordionItem>
           ))}
         </Accordion>

--- a/services/webapp/ui/src/i18n.ts
+++ b/services/webapp/ui/src/i18n.ts
@@ -1,0 +1,8 @@
+import ru from './locales/ru';
+
+const dictionary: Record<string, string> = ru;
+
+export function useTranslation() {
+  const t = (key: string): string => dictionary[key] ?? key;
+  return { t };
+}

--- a/services/webapp/ui/src/locales/ru.ts
+++ b/services/webapp/ui/src/locales/ru.ts
@@ -1,0 +1,2 @@
+const ru: Record<string, string> = {};
+export default ru;


### PR DESCRIPTION
## Summary
- wrap HelpHint tooltip and labels with `t`
- translate ProfileHelpSheet strings via new `useTranslation`
- scaffold `useTranslation` hook and empty locale dictionary

## Testing
- `pnpm --filter ./services/webapp/ui typecheck`
- `pytest -q tests/test_timezones_api.py` *(fails: coverage 24% < 85%)*
- `mypy --strict services/webapp/ui/src/components/HelpHint.tsx services/webapp/ui/src/components/ProfileHelpSheet.tsx services/webapp/ui/src/i18n.ts` *(fails: invalid syntax in .tsx)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b679081b38832abe6cea0efe7bfc81