### PR TITLE
[ui] restructure help sheet

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -21,39 +21,128 @@ interface ProfileHelpSheetProps {
   therapyType?: string;
 }
 
-const sections = [
+interface HelpItem {
+  key: string;
+  title: string;
+  definition: string;
+  unit: string;
+  range: string;
+}
+
+interface HelpSection {
+  key: string;
+  title: string;
+  items: HelpItem[];
+}
+
+const sections: HelpSection[] = [
   {
-    key: 'icr',
-    title: 'ICR (Инсулино-углеводное соотношение)',
-    content:
-      'Показывает, сколько граммов углеводов покрывает 1 единица быстрого инсулина',
+    key: 'targets',
+    title: 'Цели сахара',
+    items: [
+      {
+        key: 'target',
+        title: 'Целевой уровень сахара',
+        definition:
+          'Желаемый уровень глюкозы, к которому стремится приложение при расчётах',
+        unit: 'ммоль/л',
+        range: '4.0–7.0',
+      },
+      {
+        key: 'low',
+        title: 'Нижний порог',
+        definition:
+          'При достижении этого уровня бот предупредит о гипогликемии',
+        unit: 'ммоль/л',
+        range: '3.0–4.5',
+      },
+      {
+        key: 'high',
+        title: 'Верхний порог',
+        definition:
+          'При превышении этого уровня бот предупредит о гипергликемии',
+        unit: 'ммоль/л',
+        range: '7.0–15.0',
+      },
+    ],
   },
   {
-    key: 'cf',
-    title: 'Коэффициент коррекции (КЧ)',
-    content:
-      'На сколько ммоль/л снижает уровень глюкозы 1 единица быстрого инсулина',
+    key: 'insulin',
+    title: 'Инсулин',
+    items: [
+      {
+        key: 'icr',
+        title: 'ICR (Инсулино-углеводное соотношение)',
+        definition:
+          'Показывает, сколько граммов углеводов покрывает 1 единица быстрого инсулина',
+        unit: 'г/Ед',
+        range: '1–50',
+      },
+      {
+        key: 'cf',
+        title: 'Коэффициент коррекции (КЧ)',
+        definition:
+          'На сколько ммоль/л снижает уровень глюкозы 1 единица быстрого инсулина',
+        unit: 'ммоль/л',
+        range: '0.1–10',
+      },
+      {
+        key: 'dia',
+        title: 'DIA (длительность действия инсулина)',
+        definition: 'Сколько часов действует введённый инсулин',
+        unit: 'ч',
+        range: '1–12',
+      },
+      {
+        key: 'preBolus',
+        title: 'Пре-болюс',
+        definition: 'За сколько минут до еды вводить инсулин',
+        unit: 'мин',
+        range: '0–60',
+      },
+      {
+        key: 'maxBolus',
+        title: 'Максимальный болюс',
+        definition: 'Максимальная доза болюсного инсулина за один раз',
+        unit: 'Ед',
+        range: '1–25',
+      },
+    ],
   },
   {
-    key: 'target',
-    title: 'Целевой уровень сахара',
-    content:
-      'Желаемый уровень глюкозы, к которому стремится приложение при расчётах',
-  },
-  {
-    key: 'low',
-    title: 'Нижний порог',
-    content: 'При достижении этого уровня бот предупредит о гипогликемии',
-  },
-  {
-    key: 'high',
-    title: 'Верхний порог',
-    content: 'При превышении этого уровня бот предупредит о гипергликемии',
-  },
-  {
-    key: 'dia',
-    title: 'DIA (длительность действия инсулина)',
-    content: 'Сколько часов действует введённый инсулин',
+    key: 'other',
+    title: 'Прочее',
+    items: [
+      {
+        key: 'roundStep',
+        title: 'Шаг округления',
+        definition: 'Шаг округления дозы инсулина',
+        unit: 'Ед',
+        range: '0.1–5',
+      },
+      {
+        key: 'carbUnit',
+        title: 'Единица углеводов',
+        definition: 'Единица измерения углеводов в расчётах',
+        unit: 'г или ХЕ',
+        range: 'г, ХЕ',
+      },
+      {
+        key: 'afterMealMinutes',
+        title: 'Минут после еды',
+        definition:
+          'Через сколько минут после еды напомнить о замере сахара',
+        unit: 'мин',
+        range: '0–180',
+      },
+      {
+        key: 'timezone',
+        title: 'Часовой пояс',
+        definition: 'Часовой пояс по стандарту IANA',
+        unit: 'UTC±ч:м',
+        range: 'UTC−12:00 — UTC+14:00',
+      },
+    ],
   },
 ];
 
@@ -64,7 +153,7 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
 
   const filtered =
     therapyType === 'tablets'
-      ? sections.filter((s) => !['icr', 'cf', 'dia'].includes(s.key))
+      ? sections.filter((s) => s.key !== 'insulin')
       : sections;
 
   return (
@@ -89,7 +178,21 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
           {filtered.map((section) => (
             <AccordionItem key={section.key} value={section.key}>
               <AccordionTrigger>{t(section.title)}</AccordionTrigger>
-              <AccordionContent>{t(section.content)}</AccordionContent>
+              <AccordionContent>
+                <ul className="space-y-3">
+                  {section.items.map((item) => (
+                    <li key={item.key}>
+                      <p className="font-medium">{t(item.title)}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {t(item.definition)}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        {t('Единицы')}: {item.unit}; {t('Диапазон')}: {item.range}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              </AccordionContent>
             </AccordionItem>
           ))}
         </Accordion>
@@ -99,3 +202,4 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
 };
 
 export default ProfileHelpSheet;
+

--- a/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
+++ b/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
@@ -10,13 +10,11 @@ vi.mock('@/hooks/use-mobile', () => ({
 }));
 
 describe('ProfileHelpSheet', () => {
-  it('hides insulin sections for tablet therapy', () => {
+  it('hides insulin section for tablet therapy', () => {
     render(<ProfileHelpSheet therapyType="tablets" />);
     fireEvent.click(screen.getAllByLabelText('Справка')[0]);
-    expect(screen.queryByText(/ICR/)).toBeNull();
-    expect(screen.queryByText(/Коэффициент коррекции/)).toBeNull();
-    expect(screen.queryByText(/DIA/)).toBeNull();
-    expect(screen.getByText(/Целевой уровень сахара/)).toBeTruthy();
+    expect(screen.queryByText('Инсулин')).toBeNull();
+    expect(screen.getByText('Цели сахара')).toBeTruthy();
   });
 
   it('closes on Escape key', () => {


### PR DESCRIPTION
## Summary
- group profile help into "Цели сахара", "Инсулин" и "Прочее" with detailed items
- document pre-bolus, max bolus, rounding step, carb units, after-meal minutes and timezone
- hide insulin section when therapyType is `tablets`

## Testing
- `npm test`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `ruff check .`
- `mypy --strict .` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b6842dd6cc832a8ca67ab12b38dd15