### PR TITLE
[ui] Adapt HelpHint to accept label and children

### DIFF
--- a/services/webapp/ui/src/components/HelpHint.tsx
+++ b/services/webapp/ui/src/components/HelpHint.tsx
@@ -1,4 +1,4 @@
-import { useState, type KeyboardEvent } from 'react';
+import { useState, type KeyboardEvent, type ReactNode } from 'react';
 import { HelpCircle } from 'lucide-react';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -6,12 +6,13 @@ import { cn } from '@/lib/utils';
 import { useTranslation } from '@/i18n';
 
 interface HelpHintProps {
-  label: string;
+  label?: string;
+  children: ReactNode;
   className?: string;
   side?: React.ComponentProps<typeof TooltipContent>['side'];
 }
 
-const HelpHint = ({ label, className, side }: HelpHintProps) => {
+const HelpHint = ({ label, children, className, side }: HelpHintProps) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
@@ -28,13 +29,16 @@ const HelpHint = ({ label, className, side }: HelpHintProps) => {
         <button
           type="button"
           onKeyDown={handleKeyDown}
-          className={cn('flex h-4 w-4 items-center justify-center text-muted-foreground', className)}
-          aria-label={t(label)}
+          className={cn(
+            'flex h-4 w-4 items-center justify-center text-muted-foreground',
+            className,
+          )}
+          aria-label={t(label ?? 'Справка')}
         >
           <HelpCircle className="h-4 w-4" aria-hidden="true" />
         </button>
       </TooltipTrigger>
-      <TooltipContent side={side}>{t(label)}</TooltipContent>
+      <TooltipContent side={side}>{children}</TooltipContent>
     </Tooltip>
   );
 };

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -478,7 +478,10 @@ const Profile = () => {
             <div>
               <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                 ICR (Инсулино-углеводное соотношение)
-                <HelpHint label="Показывает, сколько граммов углеводов покрывает 1 единица быстрого инсулина" />
+                <HelpHint label="ICR (Инсулино-углеводное соотношение)">
+                  Показывает, сколько граммов углеводов покрывает 1 единица
+                  быстрого инсулина
+                </HelpHint>
               </label>
               <div className="relative">
                 <input
@@ -500,7 +503,10 @@ const Profile = () => {
             <div>
               <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                 Коэффициент коррекции (КЧ)
-                <HelpHint label="На сколько ммоль/л снижает уровень глюкозы 1 единица быстрого инсулина" />
+                <HelpHint label="Коэффициент коррекции (КЧ)">
+                  На сколько ммоль/л снижает уровень глюкозы 1 единица
+                  быстрого инсулина
+                </HelpHint>
               </label>
               <div className="relative">
                 <input
@@ -522,7 +528,10 @@ const Profile = () => {
             <div>
               <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                 Целевой уровень сахара
-                <HelpHint label="Желаемый уровень глюкозы, к которому стремится приложение при расчётах" />
+                <HelpHint label="Целевой уровень сахара">
+                  Желаемый уровень глюкозы, к которому стремится приложение
+                  при расчётах
+                </HelpHint>
               </label>
               <div className="relative">
                 <input
@@ -545,7 +554,10 @@ const Profile = () => {
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                   Нижний порог
-                  <HelpHint label="При достижении этого уровня бот предупредит о гипогликемии" />
+                  <HelpHint label="Нижний порог">
+                    При достижении этого уровня бот предупредит о
+                    гипогликемии
+                  </HelpHint>
                 </label>
                 <div className="relative">
                   <input
@@ -566,7 +578,10 @@ const Profile = () => {
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                   Верхний порог
-                  <HelpHint label="При превышении этого уровня бот предупредит о гипергликемии" />
+                  <HelpHint label="Верхний порог">
+                    При превышении этого уровня бот предупредит о
+                    гипергликемии
+                  </HelpHint>
                 </label>
                 <div className="relative">
                   <input
@@ -594,7 +609,9 @@ const Profile = () => {
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                   DIA (часы)
-                  <HelpHint label="Сколько часов действует введённый инсулин" />
+                  <HelpHint label="DIA (часы)">
+                    Сколько часов действует введённый инсулин
+                  </HelpHint>
                 </label>
                 <input
                   type="text"
@@ -610,7 +627,9 @@ const Profile = () => {
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                   Пре-болюс (мин)
-                  <HelpHint label="За сколько минут до еды вводить инсулин" />
+                  <HelpHint label="Пре-болюс (мин)">
+                    За сколько минут до еды вводить инсулин
+                  </HelpHint>
                 </label>
                 <input
                   type="text"
@@ -626,7 +645,9 @@ const Profile = () => {
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                   Шаг округления
-                  <HelpHint label="Шаг округления дозы инсулина" />
+                  <HelpHint label="Шаг округления">
+                    Шаг округления дозы инсулина
+                  </HelpHint>
                 </label>
                 <input
                   type="text"
@@ -642,7 +663,9 @@ const Profile = () => {
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                   Единица углеводов
-                  <HelpHint label="Единица измерения углеводов в расчётах" />
+                  <HelpHint label="Единица углеводов">
+                    Единица измерения углеводов в расчётах
+                  </HelpHint>
                 </label>
                 <select
                   className="medical-input"
@@ -656,7 +679,9 @@ const Profile = () => {
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                   Граммов на 1 ХЕ
-                  <HelpHint label="Количество граммов углеводов в одной ХЕ" />
+                  <HelpHint label="Граммов на 1 ХЕ">
+                    Количество граммов углеводов в одной ХЕ
+                  </HelpHint>
                 </label>
                 <input
                   type="text"
@@ -672,7 +697,9 @@ const Profile = () => {
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                   Тип быстрого инсулина
-                  <HelpHint label="Используемый тип быстродействующего инсулина" />
+                  <HelpHint label="Тип быстрого инсулина">
+                    Используемый тип быстродействующего инсулина
+                  </HelpHint>
                 </label>
                 <select
                   className="medical-input"
@@ -689,7 +716,9 @@ const Profile = () => {
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                   Максимальный болюс
-                  <HelpHint label="Максимальная доза болюсного инсулина за один раз" />
+                  <HelpHint label="Максимальный болюс">
+                    Максимальная доза болюсного инсулина за один раз
+                  </HelpHint>
                 </label>
                 <input
                   type="text"
@@ -705,7 +734,9 @@ const Profile = () => {
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                   Минут после еды по умолчанию
-                  <HelpHint label="Через сколько минут после еды напомнить о замере сахара" />
+                  <HelpHint label="Минут после еды по умолчанию">
+                    Через сколько минут после еды напомнить о замере сахара
+                  </HelpHint>
                 </label>
                 <input
                   type="text"


### PR DESCRIPTION
## Summary
- refactor HelpHint to take optional `label` and tooltip `children`
- update Profile page HelpHint usages with field labels and hint texts

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: React fast refresh warnings, many @typescript-eslint errors)*
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test` *(incomplete: requires manual termination, see logs)*
- `pytest -q --cov` *(fails: unrecognized arguments, missing plugin?)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b684370b70832ab075e52a47c40fcd