### PR TITLE
[ui] Fix typos in profile page

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -448,7 +448,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
       toast({
         title: "Проверьте значения",
         description:
-          "ICR больше 8 и CF меньше 3. Пожалуйста, убедитесь в корректности введенных данных",
+          "ICR больше 8 и CF меньше 3. Пожалуйста, убедитесь в корректности введённых данных",
       });
       return;
     }
@@ -482,7 +482,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
       >
         <p>
           ICR больше 8 и CF меньше 3. Пожалуйста, убедитесь в корректности
-          введенных данных
+          введённых данных
         </p>
       </Modal>
 
@@ -739,7 +739,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
                   Максимальный болюс
                   <HelpHint label="Максимальный болюс">
-                    Максимальная доза болюсного инсулина за один раз
+                    Максимальная доза болюсного инсулина за один раз.
                   </HelpHint>
                 </label>
                 <input


### PR DESCRIPTION
## Summary
- fix typo in warning message about ICR/CF validation
- clarify max bolus hint and adjust punctuation

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b68bbf8908832a8c1e330405e7223d