### PR TITLE
[webapp] Localize profile help hints

### DIFF
--- a/services/webapp/ui/src/locales/ru/profileHelp.ts
+++ b/services/webapp/ui/src/locales/ru/profileHelp.ts
@@ -49,6 +49,12 @@ const profileHelp = {
     unit: 'мин',
     range: '0–60',
   },
+  rapidInsulinType: {
+    title: 'Тип быстрого инсулина',
+    definition: 'Используемый тип быстродействующего инсулина',
+    unit: '—',
+    range: 'Aspart, Lispro, Glulisine, Regular',
+  },
   maxBolus: {
     title: 'Максимальный болюс',
     definition: 'Максимальная доза болюсного инсулина за один раз',
@@ -66,6 +72,12 @@ const profileHelp = {
     definition: 'Единица измерения углеводов в расчётах',
     unit: 'г или ХЕ',
     range: 'г, ХЕ',
+  },
+  gramsPerXe: {
+    title: 'Граммов на 1 ХЕ',
+    definition: 'Количество граммов углеводов в одной ХЕ',
+    unit: 'г/ХЕ',
+    range: '5–20',
   },
   afterMealMinutes: {
     title: 'Минут после еды',

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -11,6 +11,7 @@ import HelpHint from "@/components/HelpHint";
 import ProfileHelpSheet from "@/components/ProfileHelpSheet";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useTranslation } from "@/i18n";
 import {
   saveProfile,
   getProfile,
@@ -151,6 +152,7 @@ interface ProfileProps {
 const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { t } = useTranslation();
   const { user } = useTelegram();
   const initData = useTelegramInitData();
   const deviceTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -499,10 +501,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
             {/* ICR */}
             <div>
               <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                ICR (Инсулино-углеводное соотношение)
-                <HelpHint label="ICR (Инсулино-углеводное соотношение)">
-                  Показывает, сколько граммов углеводов покрывает 1 единица
-                  быстрого инсулина
+                {t('profileHelp.icr.title')}
+                <HelpHint label="profileHelp.icr.title">
+                  {t('profileHelp.icr.definition')}
                 </HelpHint>
               </label>
               <div className="relative">
@@ -524,10 +525,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
             {/* Коэффициент коррекции */}
             <div>
               <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                Коэффициент коррекции (КЧ)
-                <HelpHint label="Коэффициент коррекции (КЧ)">
-                  На сколько ммоль/л снижает уровень глюкозы 1 единица
-                  быстрого инсулина
+                {t('profileHelp.cf.title')}
+                <HelpHint label="profileHelp.cf.title">
+                  {t('profileHelp.cf.definition')}
                 </HelpHint>
               </label>
               <div className="relative">
@@ -549,10 +549,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
             {/* Целевой сахар */}
             <div>
               <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                Целевой уровень сахара
-                <HelpHint label="Целевой уровень сахара">
-                  Желаемый уровень глюкозы, к которому стремится приложение
-                  при расчётах
+                {t('profileHelp.target.title')}
+                <HelpHint label="profileHelp.target.title">
+                  {t('profileHelp.target.definition')}
                 </HelpHint>
               </label>
               <div className="relative">
@@ -575,10 +574,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                  Нижний порог
-                  <HelpHint label="Нижний порог">
-                    При достижении этого уровня бот предупредит о
-                    гипогликемии
+                  {t('profileHelp.low.title')}
+                  <HelpHint label="profileHelp.low.title">
+                    {t('profileHelp.low.definition')}
                   </HelpHint>
                 </label>
                 <div className="relative">
@@ -599,10 +597,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
 
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                  Верхний порог
-                  <HelpHint label="Верхний порог">
-                    При превышении этого уровня бот предупредит о
-                    гипергликемии
+                  {t('profileHelp.high.title')}
+                  <HelpHint label="profileHelp.high.title">
+                    {t('profileHelp.high.definition')}
                   </HelpHint>
                 </label>
                 <div className="relative">
@@ -630,9 +627,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               {/* DIA */}
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                  DIA (часы)
-                  <HelpHint label="DIA (часы)">
-                    Сколько часов действует введённый инсулин
+                  {t('profileHelp.dia.title')}
+                  <HelpHint label="profileHelp.dia.title">
+                    {t('profileHelp.dia.definition')}
                   </HelpHint>
                 </label>
                 <input
@@ -648,9 +645,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               {/* Pre-bolus */}
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                  Пре-болюс (мин)
-                  <HelpHint label="Пре-болюс (мин)">
-                    За сколько минут до еды вводить инсулин
+                  {t('profileHelp.preBolus.title')}
+                  <HelpHint label="profileHelp.preBolus.title">
+                    {t('profileHelp.preBolus.definition')}
                   </HelpHint>
                 </label>
                 <input
@@ -666,9 +663,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               {/* Round step */}
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                  Шаг округления
-                  <HelpHint label="Шаг округления">
-                    Шаг округления дозы инсулина
+                  {t('profileHelp.roundStep.title')}
+                  <HelpHint label="profileHelp.roundStep.title">
+                    {t('profileHelp.roundStep.definition')}
                   </HelpHint>
                 </label>
                 <input
@@ -684,9 +681,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               {/* Carb unit and grams per XE */}
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                  Единица углеводов
-                  <HelpHint label="Единица углеводов">
-                    Единица измерения углеводов в расчётах
+                  {t('profileHelp.carbUnit.title')}
+                  <HelpHint label="profileHelp.carbUnit.title">
+                    {t('profileHelp.carbUnit.definition')}
                   </HelpHint>
                 </label>
                 <select
@@ -700,9 +697,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               </div>
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                  Граммов на 1 ХЕ
-                  <HelpHint label="Граммов на 1 ХЕ">
-                    Количество граммов углеводов в одной ХЕ
+                  {t('profileHelp.gramsPerXe.title')}
+                  <HelpHint label="profileHelp.gramsPerXe.title">
+                    {t('profileHelp.gramsPerXe.definition')}
                   </HelpHint>
                 </label>
                 <input
@@ -718,9 +715,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               {/* Rapid insulin type */}
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                  Тип быстрого инсулина
-                  <HelpHint label="Тип быстрого инсулина">
-                    Используемый тип быстродействующего инсулина
+                  {t('profileHelp.rapidInsulinType.title')}
+                  <HelpHint label="profileHelp.rapidInsulinType.title">
+                    {t('profileHelp.rapidInsulinType.definition')}
                   </HelpHint>
                 </label>
                 <select
@@ -737,9 +734,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               {/* Max bolus */}
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                  Максимальный болюс
-                  <HelpHint label="Максимальный болюс">
-                    Максимальная доза болюсного инсулина за один раз
+                  {t('profileHelp.maxBolus.title')}
+                  <HelpHint label="profileHelp.maxBolus.title">
+                    {t('profileHelp.maxBolus.definition')}
                   </HelpHint>
                 </label>
                 <input
@@ -755,9 +752,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               {/* Default after-meal minutes */}
               <div>
                 <label className="flex items-center gap-2 text-sm font-medium text-foreground mb-2">
-                  Минут после еды по умолчанию
-                  <HelpHint label="Минут после еды по умолчанию">
-                    Через сколько минут после еды напомнить о замере сахара
+                  {t('profileHelp.afterMealMinutes.title')}
+                  <HelpHint label="profileHelp.afterMealMinutes.title">
+                    {t('profileHelp.afterMealMinutes.definition')}
                   </HelpHint>
                 </label>
                 <input


### PR DESCRIPTION
## Summary
- localize all Profile `<HelpHint>` labels and tooltips via `useTranslation`
- add missing Russian locale keys for rapid insulin type and grams per XE

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `npm test` *(fails: JavaScript heap out of memory)*
- `npm run lint` *(fails: ESLint errors)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b68baed2e4832ab8ee25cd77e442f9