### PR TITLE
[webapp] remove obsolete profile help

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -848,25 +848,6 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
           </div>
         </div>
 
-        {/* Дополнительная информация */}
-        <div className="mt-6 medical-card bg-gradient-to-br from-accent/5 to-accent/10 border-accent/20">
-          <h3 className="font-semibold text-foreground mb-3">Справка</h3>
-          <div className="space-y-3 text-sm text-muted-foreground">
-            <p>
-              <strong className="text-foreground">ICR</strong> - показывает,
-              сколько граммов углеводов покрывает 1 единица быстрого инсулина
-            </p>
-            <p>
-              <strong className="text-foreground">КЧ</strong> - показывает, на
-              сколько ммоль/л снижает уровень глюкозы 1 единица быстрого
-              инсулина
-            </p>
-            <p>
-              Эти параметры индивидуальны и должны быть определены совместно с
-              вашим врачом
-            </p>
-          </div>
-        </div>
       </main>
     </div>
     </TooltipProvider>


### PR DESCRIPTION
## Summary
- remove redundant help card from profile page

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b68bb68514832aa94f7450f010ae09