### PR TITLE
[webapp] add tests for HelpHint tooltip

### DIFF
--- a/services/webapp/ui/tests/HelpHint.test.tsx
+++ b/services/webapp/ui/tests/HelpHint.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+
+import HelpHint from '../src/components/HelpHint';
+import { TooltipProvider } from '../src/components/ui/tooltip';
+
+describe('HelpHint', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const setup = () =>
+    render(
+      <TooltipProvider delayDuration={0}>
+        <HelpHint label="ICR">Example</HelpHint>
+      </TooltipProvider>,
+    );
+
+  it('shows tooltip on focus and hides on blur', async () => {
+    setup();
+    const button = screen.getByLabelText('ICR');
+    expect(button.getAttribute('aria-label')).toBe('ICR');
+
+    fireEvent.focus(button);
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Example');
+
+    fireEvent.blur(button);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('closes tooltip on Escape key', async () => {
+    setup();
+    const button = screen.getByLabelText('ICR');
+
+    fireEvent.focus(button);
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Example');
+
+    fireEvent.keyDown(button, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add HelpHint tooltip behaviour tests

## Testing
- `pnpm test tests/HelpHint.test.tsx`
- `pnpm test` *(fails: parseProfile tests throw `Cannot read properties of undefined (reading 'replace')`)*
- `pytest -q --cov --cov-fail-under=85` *(fails: pytest: error: unrecognized arguments: --cov=services.api.app.diabetes ...)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b691cc478c832aac1ed4ad562e4094