### PR TITLE
[ui] Localize profile tooltips

### DIFF
--- a/services/webapp/ui/src/locales/ru/profileHelp.ts
+++ b/services/webapp/ui/src/locales/ru/profileHelp.ts
@@ -67,6 +67,18 @@ const profileHelp = {
     unit: 'г или ХЕ',
     range: 'г, ХЕ',
   },
+  gramsPerXe: {
+    title: 'Граммов на 1 ХЕ',
+    definition: 'Количество граммов углеводов в одной ХЕ',
+    unit: 'г',
+    range: '5–20',
+  },
+  rapidInsulinType: {
+    title: 'Тип быстрого инсулина',
+    definition: 'Используемый тип быстродействующего инсулина',
+    unit: '—',
+    range: '—',
+  },
   afterMealMinutes: {
     title: 'Минут после еды',
     definition: 'Через сколько минут после еды напомнить о замере сахара',

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -11,6 +11,7 @@ import HelpHint from "@/components/HelpHint";
 import ProfileHelpSheet from "@/components/ProfileHelpSheet";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useTranslation } from "@/i18n";
 import {
   saveProfile,
   getProfile,
@@ -153,6 +154,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
   const { toast } = useToast();
   const { user } = useTelegram();
   const initData = useTelegramInitData();
+  const { t } = useTranslation();
   const deviceTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const [profile, setProfile] = useState<ProfileForm>({
     icr: "",
@@ -504,10 +506,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                     htmlFor="icr"
                     className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
                   >
-                    ICR (Инсулино-углеводное соотношение)
-                    <HelpHint label="ICR (Инсулино-углеводное соотношение)">
-                      Показывает, сколько граммов углеводов покрывает 1 единица
-                      быстрого инсулина
+                    {t('profileHelp.icr.title')}
+                    <HelpHint label="profileHelp.icr.title">
+                      {t('profileHelp.icr.definition')}
                     </HelpHint>
                   </label>
                   <div className="relative">
@@ -533,10 +534,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                     htmlFor="cf"
                     className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
                   >
-                    Коэффициент коррекции (КЧ)
-                    <HelpHint label="Коэффициент коррекции (КЧ)">
-                      На сколько ммоль/л снижает уровень глюкозы 1 единица
-                      быстрого инсулина
+                    {t('profileHelp.cf.title')}
+                    <HelpHint label="profileHelp.cf.title">
+                      {t('profileHelp.cf.definition')}
                     </HelpHint>
                   </label>
                   <div className="relative">
@@ -564,10 +564,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                 htmlFor="target"
                 className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
               >
-                Целевой уровень сахара
-                <HelpHint label="Целевой уровень сахара">
-                  Желаемый уровень глюкозы, к которому стремится приложение
-                  при расчётах
+                {t('profileHelp.target.title')}
+                <HelpHint label="profileHelp.target.title">
+                  {t('profileHelp.target.definition')}
                 </HelpHint>
               </label>
               <div className="relative">
@@ -594,10 +593,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   htmlFor="low"
                   className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
                 >
-                  Нижний порог
-                  <HelpHint label="Нижний порог">
-                    При достижении этого уровня бот предупредит о
-                    гипогликемии
+                  {t('profileHelp.low.title')}
+                  <HelpHint label="profileHelp.low.title">
+                    {t('profileHelp.low.definition')}
                   </HelpHint>
                 </label>
                 <div className="relative">
@@ -622,10 +620,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   htmlFor="high"
                   className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
                 >
-                  Верхний порог
-                  <HelpHint label="Верхний порог">
-                    При превышении этого уровня бот предупредит о
-                    гипергликемии
+                  {t('profileHelp.high.title')}
+                  <HelpHint label="profileHelp.high.title">
+                    {t('profileHelp.high.definition')}
                   </HelpHint>
                 </label>
                 <div className="relative">
@@ -659,9 +656,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                       htmlFor="dia"
                       className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
                     >
-                      DIA (часы)
-                      <HelpHint label="DIA (часы)">
-                        Сколько часов действует введённый инсулин
+                      {t('profileHelp.dia.title')}
+                      <HelpHint label="profileHelp.dia.title">
+                        {t('profileHelp.dia.definition')}
                       </HelpHint>
                     </label>
                     <input
@@ -681,9 +678,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                       htmlFor="preBolus"
                       className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
                     >
-                      Пре-болюс (мин)
-                      <HelpHint label="Пре-болюс (мин)">
-                        За сколько минут до еды вводить инсулин
+                      {t('profileHelp.preBolus.title')}
+                      <HelpHint label="profileHelp.preBolus.title">
+                        {t('profileHelp.preBolus.definition')}
                       </HelpHint>
                     </label>
                     <input
@@ -705,9 +702,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   htmlFor="roundStep"
                   className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
                 >
-                  Шаг округления
-                  <HelpHint label="Шаг округления">
-                    Шаг округления дозы инсулина
+                  {t('profileHelp.roundStep.title')}
+                  <HelpHint label="profileHelp.roundStep.title">
+                    {t('profileHelp.roundStep.definition')}
                   </HelpHint>
                 </label>
                 <input
@@ -727,9 +724,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   htmlFor="carbUnit"
                   className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
                 >
-                  Единица углеводов
-                  <HelpHint label="Единица углеводов">
-                    Единица измерения углеводов в расчётах
+                  {t('profileHelp.carbUnit.title')}
+                  <HelpHint label="profileHelp.carbUnit.title">
+                    {t('profileHelp.carbUnit.definition')}
                   </HelpHint>
                 </label>
                 <select
@@ -743,15 +740,15 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                 </select>
               </div>
               <div>
-                <label
-                  htmlFor="gramsPerXe"
-                  className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
-                >
-                  Граммов на 1 ХЕ
-                  <HelpHint label="Граммов на 1 ХЕ">
-                    Количество граммов углеводов в одной ХЕ
-                  </HelpHint>
-                </label>
+                  <label
+                    htmlFor="gramsPerXe"
+                    className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
+                  >
+                    {t('profileHelp.gramsPerXe.title')}
+                    <HelpHint label="profileHelp.gramsPerXe.title">
+                      {t('profileHelp.gramsPerXe.definition')}
+                    </HelpHint>
+                  </label>
                 <input
                   id="gramsPerXe"
                   type="text"
@@ -765,15 +762,15 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               </div>
               {/* Rapid insulin type */}
               <div>
-                <label
-                  htmlFor="rapidInsulinType"
-                  className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
-                >
-                  Тип быстрого инсулина
-                  <HelpHint label="Тип быстрого инсулина">
-                    Используемый тип быстродействующего инсулина
-                  </HelpHint>
-                </label>
+                  <label
+                    htmlFor="rapidInsulinType"
+                    className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
+                  >
+                    {t('profileHelp.rapidInsulinType.title')}
+                    <HelpHint label="profileHelp.rapidInsulinType.title">
+                      {t('profileHelp.rapidInsulinType.definition')}
+                    </HelpHint>
+                  </label>
                 <select
                   id="rapidInsulinType"
                   className="medical-input"
@@ -794,9 +791,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                       htmlFor="maxBolus"
                       className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
                     >
-                      Максимальный болюс
-                      <HelpHint label="Максимальный болюс">
-                        Максимальная доза болюсного инсулина за один раз.
+                      {t('profileHelp.maxBolus.title')}
+                      <HelpHint label="profileHelp.maxBolus.title">
+                        {t('profileHelp.maxBolus.definition')}
                       </HelpHint>
                     </label>
                     <input
@@ -818,9 +815,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   htmlFor="afterMealMinutes"
                   className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
                 >
-                  Минут после еды по умолчанию
-                  <HelpHint label="Минут после еды по умолчанию">
-                    Через сколько минут после еды напомнить о замере сахара
+                  {t('profileHelp.afterMealMinutes.title')}
+                  <HelpHint label="profileHelp.afterMealMinutes.title">
+                    {t('profileHelp.afterMealMinutes.definition')}
                   </HelpHint>
                 </label>
                 <input


### PR DESCRIPTION
## Summary
- translate profile page help hints using i18n
- add missing locale entries for carbohydrate ratio and insulin type

## Testing
- `pnpm --filter ./services/webapp/ui test` *(fails: JavaScript heap out of memory)*
- `pytest -q` *(fails: async def functions are not natively supported)*
- `pnpm --filter ./services/webapp/ui typecheck`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b692b0b500832abe5734896521fd17