### PR TITLE
[ui] hide rapid insulin type for tablets

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -763,31 +763,33 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   placeholder="12"
                 />
               </div>
-              {/* Rapid insulin type */}
-              <div>
-                <label
-                  htmlFor="rapidInsulinType"
-                  className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
-                >
-                  Тип быстрого инсулина
-                  <HelpHint label="Тип быстрого инсулина">
-                    Используемый тип быстродействующего инсулина
-                  </HelpHint>
-                </label>
-                <select
-                  id="rapidInsulinType"
-                  className="medical-input"
-                  value={profile.rapidInsulinType}
-                  onChange={(e) => handleInputChange('rapidInsulinType', e.target.value)}
-                >
-                  <option value="aspart">Aspart</option>
-                  <option value="lispro">Lispro</option>
-                  <option value="glulisine">Glulisine</option>
-                  <option value="regular">Regular</option>
-                </select>
-              </div>
               {therapyType !== 'tablets' && (
                 <>
+                  {/* Rapid insulin type */}
+                  <div>
+                    <label
+                      htmlFor="rapidInsulinType"
+                      className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
+                    >
+                      Тип быстрого инсулина
+                      <HelpHint label="Тип быстрого инсулина">
+                        Используемый тип быстродействующего инсулина
+                      </HelpHint>
+                    </label>
+                    <select
+                      id="rapidInsulinType"
+                      className="medical-input"
+                      value={profile.rapidInsulinType}
+                      onChange={(e) =>
+                        handleInputChange('rapidInsulinType', e.target.value)
+                      }
+                    >
+                      <option value="aspart">Aspart</option>
+                      <option value="lispro">Lispro</option>
+                      <option value="glulisine">Glulisine</option>
+                      <option value="regular">Regular</option>
+                    </select>
+                  </div>
                   {/* Max bolus */}
                   <div>
                     <label

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -240,6 +240,7 @@ describe('Profile page', () => {
     expect(queryByLabelText(/Коэффициент коррекции/)).toBeNull();
     expect(queryByLabelText(/DIA/)).toBeNull();
     expect(queryByLabelText(/Пре-болюс/)).toBeNull();
+    expect(queryByLabelText(/Тип быстрого инсулина/)).toBeNull();
     expect(queryByLabelText(/Максимальный болюс/)).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- conditionally show rapid insulin type and max bolus when therapyType isn't `tablets`
- verify rapid insulin type hidden for tablet therapy in profile tests

## Testing
- `pnpm --filter ./services/webapp/ui test` *(fails: tests/parseProfile.test.ts (6 tests | 5 failed) etc.)*
- `pytest` *(fails: async def functions are not natively supported; 434 failed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b691c6a2f8832a93ff0927545fd8a6