### PR TITLE
[ui] Hide rapid insulin type for tablet therapy

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -760,31 +760,31 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   placeholder="12"
                 />
               </div>
-              {/* Rapid insulin type */}
-              <div>
-                  <label
-                    htmlFor="rapidInsulinType"
-                    className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
-                  >
-                    {t('profileHelp.rapidInsulinType.title')}
-                    <HelpHint label="profileHelp.rapidInsulinType.title">
-                      {t('profileHelp.rapidInsulinType.definition')}
-                    </HelpHint>
-                  </label>
-                <select
-                  id="rapidInsulinType"
-                  className="medical-input"
-                  value={profile.rapidInsulinType}
-                  onChange={(e) => handleInputChange('rapidInsulinType', e.target.value)}
-                >
-                  <option value="aspart">Aspart</option>
-                  <option value="lispro">Lispro</option>
-                  <option value="glulisine">Glulisine</option>
-                  <option value="regular">Regular</option>
-                </select>
-              </div>
               {therapyType !== 'tablets' && (
                 <>
+                  {/* Rapid insulin type */}
+                  <div>
+                    <label
+                      htmlFor="rapidInsulinType"
+                      className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
+                    >
+                      {t('profileHelp.rapidInsulinType.title')}
+                      <HelpHint label="profileHelp.rapidInsulinType.title">
+                        {t('profileHelp.rapidInsulinType.definition')}
+                      </HelpHint>
+                    </label>
+                    <select
+                      id="rapidInsulinType"
+                      className="medical-input"
+                      value={profile.rapidInsulinType}
+                      onChange={(e) => handleInputChange('rapidInsulinType', e.target.value)}
+                    >
+                      <option value="aspart">Aspart</option>
+                      <option value="lispro">Lispro</option>
+                      <option value="glulisine">Glulisine</option>
+                      <option value="regular">Regular</option>
+                    </select>
+                  </div>
                   {/* Max bolus */}
                   <div>
                     <label

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -240,6 +240,7 @@ describe('Profile page', () => {
     expect(queryByLabelText(/Коэффициент коррекции/)).toBeNull();
     expect(queryByLabelText(/DIA/)).toBeNull();
     expect(queryByLabelText(/Пре-болюс/)).toBeNull();
+    expect(queryByLabelText(/Тип быстрого инсулина/)).toBeNull();
     expect(queryByLabelText(/Максимальный болюс/)).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- conditionally render rapid insulin type and max bolus fields only when therapy is not tablets
- test that rapid insulin type field is hidden for tablet therapy

## Testing
- `pnpm --filter ./services/webapp/ui test` *(fails: parseProfile and other existing tests fail)*
- `pytest -q` *(fails: missing pypdf dependency, keyboard interrupt)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b69690d5cc832aa2e3e83cf488516f