### PR TITLE
[webapp] restrict insulin profile fields

### DIFF
--- a/services/webapp/ui/src/pages/Profile.test.tsx
+++ b/services/webapp/ui/src/pages/Profile.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import Profile from './Profile';
+import React from 'react';
+import { describe, it, vi, expect } from 'vitest';
+
+// mock dependencies that Profile relies on
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@/i18n', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@/hooks/useTelegram', () => ({ useTelegram: () => ({ user: undefined }) }));
+vi.mock('@/hooks/useTelegramInitData', () => ({ useTelegramInitData: () => undefined }));
+vi.mock('./resolveTelegramId', () => ({ resolveTelegramId: () => undefined }));
+vi.mock('@/features/profile/api', () => ({
+  saveProfile: vi.fn(),
+  getProfile: vi.fn(),
+  patchProfile: vi.fn(),
+}));
+vi.mock('@/api/timezones', () => ({ getTimezones: vi.fn() }));
+vi.mock('lucide-react', () => ({ Save: () => <svg /> }));
+vi.mock('@/components/MedicalHeader', () => ({ MedicalHeader: ({ children }: any) => <div>{children}</div> }));
+vi.mock('@/components/MedicalButton', () => ({ default: ({ children }: any) => <button>{children}</button> }));
+vi.mock('@/components/Modal', () => ({ default: ({ children }: any) => <div>{children}</div> }));
+vi.mock('@/components/HelpHint', () => ({ default: ({ children }: any) => <>{children}</> }));
+vi.mock('@/components/ProfileHelpSheet', () => ({ default: () => null }));
+vi.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => false }));
+vi.mock('@/components/ui/tooltip', () => ({ TooltipProvider: ({ children }: any) => <div>{children}</div> }));
+vi.mock('@/components/ui/button', () => ({ Button: ({ children }: any) => <button>{children}</button> }));
+vi.mock('@/components/ui/checkbox', () => ({ Checkbox: (props: any) => <input type="checkbox" {...props} /> }));
+
+const therapyTypes = ['tablets', 'none'] as const;
+
+describe.each(therapyTypes)('Profile for therapy type %s', (therapyType) => {
+  it('omits insulin-specific inputs', () => {
+    render(<Profile therapyType={therapyType} />);
+
+    expect(screen.queryByLabelText('profileHelp.icr.title')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('profileHelp.preBolus.title')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('profileHelp.maxBolus.title')).not.toBeInTheDocument();
+  });
+});

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -498,7 +498,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
           <main className="container mx-auto px-4 py-6">
           <div className="medical-card animate-slide-up bg-gradient-to-br from-primary/5 to-primary/10 border-primary/20">
           <div className="space-y-6">
-            {therapyType !== 'tablets' && (
+            {(therapyType === 'insulin' || therapyType === 'mixed') && (
               <>
                 {/* ICR */}
                 <div>
@@ -648,7 +648,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               <h3 className="font-semibold text-foreground">
                 Расширенные настройки болюса
               </h3>
-              {therapyType !== 'tablets' && (
+              {(therapyType === 'insulin' || therapyType === 'mixed') && (
                 <>
                   {/* DIA */}
                   <div>
@@ -783,7 +783,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   <option value="regular">Regular</option>
                 </select>
               </div>
-              {therapyType !== 'tablets' && (
+              {(therapyType === 'insulin' || therapyType === 'mixed') && (
                 <>
                   {/* Max bolus */}
                   <div>


### PR DESCRIPTION
## Summary
- gate insulin-specific Profile inputs behind explicit `insulin` or `mixed` therapy types
- add tests ensuring insulin inputs are hidden for `tablets` and `none`

## Testing
- `pnpm --filter ./services/webapp/ui exec vitest run src/pages/Profile.test.tsx --config ../../../vitest.config.ts`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`

⚠️ `pnpm --filter ./services/webapp/ui test` (JavaScript heap out of memory)

------
https://chatgpt.com/codex/tasks/task_e_68b697fe286c832ab1443ff107daeb68