### PR TITLE
[ui] hide insulin section for tablets or none

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -146,7 +146,7 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
   const { t } = useTranslation();
 
   const filtered =
-    therapyType === 'tablets'
+    therapyType === 'tablets' || therapyType === 'none'
       ? sections.filter((s) => s.key !== 'insulin')
       : sections;
 

--- a/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
+++ b/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
@@ -17,6 +17,13 @@ describe('ProfileHelpSheet', () => {
     expect(screen.getByText('Цели сахара')).toBeTruthy();
   });
 
+  it('hides insulin section for none therapy', () => {
+    render(<ProfileHelpSheet therapyType="none" />);
+    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
+    expect(screen.queryByText('Инсулин')).toBeNull();
+    expect(screen.getByText('Цели сахара')).toBeTruthy();
+  });
+
   it('closes on Escape key', () => {
     render(<ProfileHelpSheet />);
     fireEvent.click(screen.getAllByLabelText('Справка')[0]);


### PR DESCRIPTION
## Summary
- Hide insulin help section for tablet or none therapy types
- Test that no insulin help is shown when therapyType is none

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test` *(fails: Test Files 3 failed | 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b697ffafe8832a8e8b1aeec7bc99f5