### PR TITLE
[ui] handle tablet therapy in profile parsing

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -59,22 +59,50 @@ type ParsedProfile = {
   afterMealMinutes: number;
 };
 
-export const parseProfile = (profile: ProfileForm): ParsedProfile | null => {
+export const parseProfile = (
+  profile: ProfileForm,
+  therapyType?: TherapyType,
+): ParsedProfile | null => {
+  if (therapyType === 'tablets' || therapyType === 'none') {
+    const parsed = {
+      icr: 0,
+      cf: 0,
+      target: 0,
+      low: 0,
+      high: 0,
+      dia: 0,
+      preBolus: 0,
+      roundStep: 0,
+      carbUnit: profile.carbUnit,
+      gramsPerXe: Number(profile.gramsPerXe.replace(/,/g, '.')),
+      rapidInsulinType: '',
+      maxBolus: 0,
+      afterMealMinutes: 0,
+    } satisfies ParsedProfile;
+    const numbersValid = Number.isFinite(parsed.gramsPerXe);
+    const positiveValid = parsed.gramsPerXe > 0;
+    const rangeValid =
+      parsed.gramsPerXe >= 5 &&
+      parsed.gramsPerXe <= 20 &&
+      (parsed.carbUnit === 'g' || parsed.carbUnit === 'xe');
+    return numbersValid && positiveValid && rangeValid ? parsed : null;
+  }
+
   const parsed = {
-    icr: Number(profile.icr.replace(/,/g, ".")),
-    cf: Number(profile.cf.replace(/,/g, ".")),
-    target: Number(profile.target.replace(/,/g, ".")),
-    low: Number(profile.low.replace(/,/g, ".")),
-    high: Number(profile.high.replace(/,/g, ".")),
-    dia: Number(profile.dia.replace(/,/g, ".")),
-    preBolus: Number(profile.preBolus.replace(/,/g, ".")),
-    roundStep: Number(profile.roundStep.replace(/,/g, ".")),
+    icr: Number(profile.icr.replace(/,/g, '.')),
+    cf: Number(profile.cf.replace(/,/g, '.')),
+    target: Number(profile.target.replace(/,/g, '.')),
+    low: Number(profile.low.replace(/,/g, '.')),
+    high: Number(profile.high.replace(/,/g, '.')),
+    dia: Number(profile.dia.replace(/,/g, '.')),
+    preBolus: Number(profile.preBolus.replace(/,/g, '.')),
+    roundStep: Number(profile.roundStep.replace(/,/g, '.')),
     carbUnit: profile.carbUnit,
-    gramsPerXe: Number(profile.gramsPerXe.replace(/,/g, ".")),
+    gramsPerXe: Number(profile.gramsPerXe.replace(/,/g, '.')),
     rapidInsulinType: profile.rapidInsulinType,
-    maxBolus: Number(profile.maxBolus.replace(/,/g, ".")),
-    afterMealMinutes: Number(profile.afterMealMinutes.replace(/,/g, ".")),
-  };
+    maxBolus: Number(profile.maxBolus.replace(/,/g, '.')),
+    afterMealMinutes: Number(profile.afterMealMinutes.replace(/,/g, '.')),
+  } satisfies ParsedProfile;
   const numbersValid =
     [
       parsed.icr,
@@ -432,7 +460,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
       return;
     }
 
-    const parsed = parseProfile(profile);
+    const parsed = parseProfile(profile, therapyType);
     if (!parsed) {
       toast({
         title: "Ошибка",

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -1,127 +1,164 @@
 import { describe, it, expect } from "vitest";
 import { parseProfile, shouldWarnProfile } from "../src/pages/Profile";
 
+const makeProfile = (overrides: Record<string, string | boolean> = {}) => ({
+  icr: "1",
+  cf: "2",
+  target: "5",
+  low: "4",
+  high: "10",
+  timezone: "",
+  timezoneAuto: false,
+  dia: "7",
+  preBolus: "10",
+  roundStep: "1",
+  carbUnit: "g",
+  gramsPerXe: "12",
+  rapidInsulinType: "lispro",
+  maxBolus: "20",
+  afterMealMinutes: "60",
+  ...overrides,
+});
+
 describe("parseProfile", () => {
   it("returns parsed numbers for valid input", () => {
-    const result = parseProfile({
-      icr: "1",
-      cf: "2",
-      target: "5",
-      low: "4",
-      high: "10",
-      timezone: "",
-      timezoneAuto: false,
+    const result = parseProfile(makeProfile());
+    expect(result).toEqual({
+      icr: 1,
+      cf: 2,
+      target: 5,
+      low: 4,
+      high: 10,
+      dia: 7,
+      preBolus: 10,
+      roundStep: 1,
+      carbUnit: "g",
+      gramsPerXe: 12,
+      rapidInsulinType: "lispro",
+      maxBolus: 20,
+      afterMealMinutes: 60,
     });
-    expect(result).toEqual({ icr: 1, cf: 2, target: 5, low: 4, high: 10 });
   });
 
   it("returns null when any value is non-positive or invalid", () => {
-    expect(
-      parseProfile({
-        icr: "0",
-        cf: "2",
-        target: "5",
-        low: "4",
-        high: "10",
-        timezone: "",
-        timezoneAuto: false,
-      }),
-    ).toBeNull();
-    expect(
-      parseProfile({
-        icr: "1",
-        cf: "-1",
-        target: "5",
-        low: "4",
-        high: "10",
-        timezone: "",
-        timezoneAuto: false,
-      }),
-    ).toBeNull();
-    expect(
-      parseProfile({
-        icr: "a",
-        cf: "2",
-        target: "5",
-        low: "4",
-        high: "10",
-        timezone: "",
-        timezoneAuto: false,
-      }),
-    ).toBeNull();
+    expect(parseProfile(makeProfile({ icr: "0" }))).toBeNull();
+    expect(parseProfile(makeProfile({ cf: "-1" }))).toBeNull();
+    expect(parseProfile(makeProfile({ icr: "a" }))).toBeNull();
   });
 
   it("parses comma decimal numbers", () => {
-    const result = parseProfile({
-      icr: "1,5",
-      cf: "2,5",
-      target: "5,5",
-      low: "4",
-      high: "10",
-      timezone: "",
-      timezoneAuto: false,
-    });
-    expect(result).toEqual({ icr: 1.5, cf: 2.5, target: 5.5, low: 4, high: 10 });
+    const result = parseProfile(
+      makeProfile({ icr: "1,5", cf: "2,5", target: "5,5" }),
+    );
+    expect(result?.icr).toBe(1.5);
+    expect(result?.cf).toBe(2.5);
+    expect(result?.target).toBe(5.5);
   });
 
   it("returns null for multiple commas", () => {
-    const result = parseProfile({
-      icr: "1,2,3",
-      cf: "2",
-      target: "5",
-      low: "4",
-      high: "10",
-      timezone: "",
-      timezoneAuto: false,
-    });
+    const result = parseProfile(makeProfile({ icr: "1,2,3" }));
     expect(result).toBeNull();
   });
 
   it("returns null when low/high bounds are invalid", () => {
-    expect(
-      parseProfile({
-        icr: "1",
-        cf: "2",
-        target: "5",
-        low: "8",
-        high: "6",
-        timezone: "",
-        timezoneAuto: false,
-      }),
-    ).toBeNull();
-    expect(
-      parseProfile({
-        icr: "1",
-        cf: "2",
-        target: "3",
-        low: "4",
-        high: "10",
-        timezone: "",
-        timezoneAuto: false,
-      }),
-    ).toBeNull();
-    expect(
-      parseProfile({
-        icr: "1",
-        cf: "2",
-        target: "12",
-        low: "4",
-        high: "10",
-        timezone: "",
-        timezoneAuto: false,
-      }),
-    ).toBeNull();
+    expect(parseProfile(makeProfile({ low: "8", high: "6" }))).toBeNull();
+    expect(parseProfile(makeProfile({ target: "3" }))).toBeNull();
+    expect(parseProfile(makeProfile({ target: "12" }))).toBeNull();
   });
 
+  it("handles tablet therapy without insulin fields", () => {
+    const result = parseProfile(
+      makeProfile({
+        icr: "",
+        cf: "",
+        target: "",
+        low: "",
+        high: "",
+        dia: "",
+        preBolus: "",
+        roundStep: "",
+        rapidInsulinType: "",
+        maxBolus: "",
+        afterMealMinutes: "",
+      }),
+      "tablets",
+    );
+    expect(result).toMatchObject({ carbUnit: "g", gramsPerXe: 12 });
+  });
+
+  it("handles none therapy without insulin fields", () => {
+    const result = parseProfile(
+      makeProfile({
+        icr: "",
+        cf: "",
+        target: "",
+        low: "",
+        high: "",
+        dia: "",
+        preBolus: "",
+        roundStep: "",
+        rapidInsulinType: "",
+        maxBolus: "",
+        afterMealMinutes: "",
+      }),
+      "none",
+    );
+    expect(result).toMatchObject({ carbUnit: "g", gramsPerXe: 12 });
+  });
+});
+
+describe("shouldWarnProfile", () => {
   it("detects suspicious profile values", () => {
     expect(
-      shouldWarnProfile({ icr: 9, cf: 2, target: 5, low: 4, high: 10 }),
+      shouldWarnProfile({
+        icr: 9,
+        cf: 2,
+        target: 5,
+        low: 4,
+        high: 10,
+        dia: 1,
+        preBolus: 0,
+        roundStep: 1,
+        carbUnit: "g",
+        gramsPerXe: 10,
+        rapidInsulinType: "a",
+        maxBolus: 1,
+        afterMealMinutes: 0,
+      }),
     ).toBe(true);
     expect(
-      shouldWarnProfile({ icr: 8, cf: 2, target: 5, low: 4, high: 10 }),
+      shouldWarnProfile({
+        icr: 8,
+        cf: 2,
+        target: 5,
+        low: 4,
+        high: 10,
+        dia: 1,
+        preBolus: 0,
+        roundStep: 1,
+        carbUnit: "g",
+        gramsPerXe: 10,
+        rapidInsulinType: "a",
+        maxBolus: 1,
+        afterMealMinutes: 0,
+      }),
     ).toBe(false);
     expect(
-      shouldWarnProfile({ icr: 9, cf: 3, target: 5, low: 4, high: 10 }),
+      shouldWarnProfile({
+        icr: 9,
+        cf: 3,
+        target: 5,
+        low: 4,
+        high: 10,
+        dia: 1,
+        preBolus: 0,
+        roundStep: 1,
+        carbUnit: "g",
+        gramsPerXe: 10,
+        rapidInsulinType: "a",
+        maxBolus: 1,
+        afterMealMinutes: 0,
+      }),
     ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- support therapyType in profile parsing, skipping insulin-only fields for tablets/none
- pass therapyType through save handler
- test parseProfile with tablet and none therapies

## Testing
- `pnpm --filter ./services/webapp/ui test tests/parseProfile.test.ts`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui lint` *(fails: An interface declaring no members is equivalent to its supertype)*

------
https://chatgpt.com/codex/tasks/task_e_68b69801d65c832a99e2857111c36b57