### PR TITLE
[ui] localize profile timezone and units

### DIFF
--- a/services/webapp/ui/src/locales/ru/profileHelp.ts
+++ b/services/webapp/ui/src/locales/ru/profileHelp.ts
@@ -90,6 +90,7 @@ const profileHelp = {
     definition: 'Часовой пояс по стандарту IANA',
     unit: 'UTC±ч:м',
     range: 'UTC−12:00 — UTC+14:00',
+    auto: 'Определять автоматически',
   },
 };
 

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -523,7 +523,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                       placeholder="12"
                     />
                     <span className="absolute right-3 top-3 text-muted-foreground text-sm">
-                      г/ед.
+                      {t('profileHelp.icr.unit')}
                     </span>
                   </div>
                 </div>
@@ -551,7 +551,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                       placeholder="2.5"
                     />
                     <span className="absolute right-3 top-3 text-muted-foreground text-sm">
-                      ммоль/л
+                      {t('profileHelp.cf.unit')}
                     </span>
                   </div>
                 </div>
@@ -581,7 +581,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   placeholder="6.0"
                 />
                 <span className="absolute right-3 top-3 text-muted-foreground text-sm">
-                  ммоль/л
+                  {t('profileHelp.target.unit')}
                 </span>
               </div>
             </div>
@@ -610,7 +610,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                     placeholder="4.0"
                   />
                   <span className="absolute right-3 top-3 text-muted-foreground text-xs">
-                    ммоль/л
+                    {t('profileHelp.low.unit')}
                   </span>
                 </div>
               </div>
@@ -637,7 +637,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                     placeholder="10.0"
                   />
                   <span className="absolute right-3 top-3 text-muted-foreground text-xs">
-                    ммоль/л
+                    {t('profileHelp.high.unit')}
                   </span>
                 </div>
               </div>
@@ -837,9 +837,12 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
             <div>
               <label
                 htmlFor="timezone"
-                className="block text-sm font-medium text-foreground mb-2"
+                className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
               >
-                Часовой пояс
+                {t('profileHelp.timezone.title')}
+                <HelpHint label="profileHelp.timezone.title">
+                  {t('profileHelp.timezone.definition')}
+                </HelpHint>
               </label>
               <input
                 id="timezone"
@@ -891,7 +894,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   }}
                 />
                 <label htmlFor="timezone-auto" className="text-sm text-foreground">
-                  Определять автоматически
+                  {t('profileHelp.timezone.auto')}
                 </label>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- localize profile field units with translation keys
- add timezone help hint and auto-detect translation

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: 32 problems)*
- `pnpm --filter ./services/webapp/ui test` *(fails: parseProfile and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b6980afa94832abc883d0c1aa14339