### PR TITLE
[webapp] Restrict insulin settings to insulin or mixed therapy types

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -498,7 +498,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
           <main className="container mx-auto px-4 py-6">
           <div className="medical-card animate-slide-up bg-gradient-to-br from-primary/5 to-primary/10 border-primary/20">
           <div className="space-y-6">
-            {therapyType !== 'tablets' && (
+            {(therapyType === 'insulin' || therapyType === 'mixed') && (
               <>
                 {/* ICR */}
                 <div>
@@ -648,7 +648,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               <h3 className="font-semibold text-foreground">
                 Расширенные настройки болюса
               </h3>
-              {therapyType !== 'tablets' && (
+              {(therapyType === 'insulin' || therapyType === 'mixed') && (
                 <>
                   {/* DIA */}
                   <div>
@@ -760,7 +760,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   placeholder="12"
                 />
               </div>
-              {therapyType !== 'tablets' && (
+              {(therapyType === 'insulin' || therapyType === 'mixed') && (
                 <>
                   {/* Rapid insulin type */}
                   <div>

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -56,6 +56,7 @@ describe('Profile page', () => {
       defaultAfterMealMinutes: 120,
       timezone: 'Europe/Moscow',
       timezoneAuto: false,
+      therapyType: 'insulin',
     });
     const realDTF = Intl.DateTimeFormat;
     const realResolved = realDTF.prototype.resolvedOptions;
@@ -211,38 +212,41 @@ describe('Profile page', () => {
     });
   });
 
-  it('hides insulin fields for tablet therapy', async () => {
-    (resolveTelegramId as vi.Mock).mockReturnValue(123);
-    (getProfile as vi.Mock).mockResolvedValueOnce({
-      telegramId: 123,
-      icr: 12,
-      cf: 2.5,
-      target: 6,
-      low: 4,
-      high: 10,
-      dia: 4,
-      preBolus: 15,
-      roundStep: 0.5,
-      carbUnit: 'g',
-      gramsPerXe: 12,
-      rapidInsulinType: 'aspart',
-      maxBolus: 10,
-      defaultAfterMealMinutes: 120,
-      timezone: 'Europe/Moscow',
-      timezoneAuto: false,
-      therapyType: 'tablets',
-    });
-    const { queryByLabelText } = render(<Profile therapyType="tablets" />);
-    await waitFor(() => {
-      expect(getProfile).toHaveBeenCalled();
-    });
-    expect(queryByLabelText(/ICR/)).toBeNull();
-    expect(queryByLabelText(/Коэффициент коррекции/)).toBeNull();
-    expect(queryByLabelText(/DIA/)).toBeNull();
-    expect(queryByLabelText(/Пре-болюс/)).toBeNull();
-    expect(queryByLabelText(/Тип быстрого инсулина/)).toBeNull();
-    expect(queryByLabelText(/Максимальный болюс/)).toBeNull();
-  });
+  it.each(['tablets', 'none'] as const)(
+    'hides insulin fields for %s therapy',
+    async (therapy) => {
+      (resolveTelegramId as vi.Mock).mockReturnValue(123);
+      (getProfile as vi.Mock).mockResolvedValueOnce({
+        telegramId: 123,
+        icr: 12,
+        cf: 2.5,
+        target: 6,
+        low: 4,
+        high: 10,
+        dia: 4,
+        preBolus: 15,
+        roundStep: 0.5,
+        carbUnit: 'g',
+        gramsPerXe: 12,
+        rapidInsulinType: 'aspart',
+        maxBolus: 10,
+        defaultAfterMealMinutes: 120,
+        timezone: 'Europe/Moscow',
+        timezoneAuto: false,
+        therapyType: therapy,
+      });
+      const { queryByLabelText } = render(<Profile therapyType={therapy} />);
+      await waitFor(() => {
+        expect(getProfile).toHaveBeenCalled();
+      });
+      expect(queryByLabelText(/ICR/)).toBeNull();
+      expect(queryByLabelText(/Коэффициент коррекции/)).toBeNull();
+      expect(queryByLabelText(/DIA/)).toBeNull();
+      expect(queryByLabelText(/Пре-болюс/)).toBeNull();
+      expect(queryByLabelText(/Тип быстрого инсулина/)).toBeNull();
+      expect(queryByLabelText(/Максимальный болюс/)).toBeNull();
+    },
+  );
 
   it('renders advanced bolus fields', async () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
@@ -326,6 +330,7 @@ describe('Profile page', () => {
       defaultAfterMealMinutes: 120,
       timezone: 'Europe/Moscow',
       timezoneAuto: true,
+      therapyType: 'insulin',
     });
 
     render(<Profile />);
@@ -358,6 +363,7 @@ describe('Profile page', () => {
       defaultAfterMealMinutes: 120,
       timezone: 'Europe/Moscow',
       timezoneAuto: false,
+      therapyType: 'insulin',
     });
 
     const { getByLabelText, getByText, getByPlaceholderText } = render(<Profile />);
@@ -397,6 +403,7 @@ describe('Profile page', () => {
       rapidInsulinType: 'aspart',
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
+      therapyType: 'insulin',
     });
 
     const { getByPlaceholderText } = render(<Profile />);
@@ -421,6 +428,7 @@ describe('Profile page', () => {
       rapidInsulinType: 'aspart',
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
+      therapyType: 'insulin',
     });
 
     const { getByPlaceholderText } = render(<Profile />);
@@ -458,6 +466,7 @@ describe('Profile page', () => {
       rapidInsulinType: 'aspart',
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
+      therapyType: 'insulin',
     });
 
     const { getByPlaceholderText } = render(<Profile />);


### PR DESCRIPTION
## Summary
- show insulin-specific profile inputs only for insulin or mixed therapy
- adjust profile tests for therapy types and add coverage for `none`

## Testing
- `pnpm --filter "./services/webapp/ui" test`
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b69c1bb8dc832a9cf4743a2425d4cb