### PR TITLE
[ui] limit profile fields to insulin or mixed therapy

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -207,6 +207,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     therapyTypeProp,
   );
 
+  const isInsulinTherapy =
+    therapyType === 'insulin' || therapyType === 'mixed';
+
   const [warningOpen, setWarningOpen] = useState(false);
   const [pendingProfile, setPendingProfile] = useState<
     (
@@ -526,7 +529,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
           <main className="container mx-auto px-4 py-6">
           <div className="medical-card animate-slide-up bg-gradient-to-br from-primary/5 to-primary/10 border-primary/20">
           <div className="space-y-6">
-            {(therapyType === 'insulin' || therapyType === 'mixed') && (
+            {isInsulinTherapy && (
               <>
                 {/* ICR */}
                 <div>
@@ -676,7 +679,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               <h3 className="font-semibold text-foreground">
                 Расширенные настройки болюса
               </h3>
-              {(therapyType === 'insulin' || therapyType === 'mixed') && (
+              {isInsulinTherapy && (
                 <>
                   {/* DIA */}
                   <div>
@@ -788,7 +791,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   placeholder="12"
                 />
               </div>
-              {(therapyType === 'insulin' || therapyType === 'mixed') && (
+              {isInsulinTherapy && (
                 <>
                   {/* Rapid insulin type */}
                   <div>

--- a/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
+++ b/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
@@ -10,19 +10,15 @@ vi.mock('@/hooks/use-mobile', () => ({
 }));
 
 describe('ProfileHelpSheet', () => {
-  it('hides insulin section for tablet therapy', () => {
-    render(<ProfileHelpSheet therapyType="tablets" />);
-    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
-    expect(screen.queryByText('Инсулин')).toBeNull();
-    expect(screen.getByText('Цели сахара')).toBeTruthy();
-  });
-
-  it('hides insulin section for none therapy', () => {
-    render(<ProfileHelpSheet therapyType="none" />);
-    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
-    expect(screen.queryByText('Инсулин')).toBeNull();
-    expect(screen.getByText('Цели сахара')).toBeTruthy();
-  });
+  it.each(['none', 'tablets'] as const)(
+    'hides insulin section for %s therapy',
+    (therapy) => {
+      render(<ProfileHelpSheet therapyType={therapy} />);
+      fireEvent.click(screen.getAllByLabelText('Справка')[0]);
+      expect(screen.queryByText('Инсулин')).toBeNull();
+      expect(screen.getByText('Цели сахара')).toBeTruthy();
+    },
+  );
 
   it('closes on Escape key', () => {
     render(<ProfileHelpSheet />);

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -212,7 +212,9 @@ describe('Profile page', () => {
     });
   });
 
-  it.each(['tablets', 'none'] as const)(
+  const nonInsulinTherapies: Array<'none' | 'tablets'> = ['none', 'tablets'];
+
+  it.each(nonInsulinTherapies)(
     'hides insulin fields for %s therapy',
     async (therapy) => {
       (resolveTelegramId as vi.Mock).mockReturnValue(123);


### PR DESCRIPTION
## Summary
- gate insulin-related profile sections behind `insulin` or `mixed` therapy
- cover tablet and none therapies in profile and help sheet tests

## Testing
- `npm test` *(fails: FATAL ERROR: Reached heap limit)*
- `npm run lint` *(fails: Unexpected any)*
- `npm run typecheck`
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6ab11ae2c832a985d982691e30288