### PR TITLE
[webapp] validate profile fields for tablets and none

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -67,23 +67,42 @@ export const parseProfile = (
     const parsed = {
       icr: 0,
       cf: 0,
-      target: 0,
-      low: 0,
-      high: 0,
+      target: Number(profile.target.replace(/,/g, '.')),
+      low: Number(profile.low.replace(/,/g, '.')),
+      high: Number(profile.high.replace(/,/g, '.')),
       dia: 0,
       preBolus: 0,
-      roundStep: 0,
+      roundStep: Number(profile.roundStep.replace(/,/g, '.')),
       carbUnit: profile.carbUnit,
       gramsPerXe: Number(profile.gramsPerXe.replace(/,/g, '.')),
       rapidInsulinType: '',
       maxBolus: 0,
-      afterMealMinutes: 0,
+      afterMealMinutes: Number(profile.afterMealMinutes.replace(/,/g, '.')),
     } satisfies ParsedProfile;
-    const numbersValid = Number.isFinite(parsed.gramsPerXe);
-    const positiveValid = parsed.gramsPerXe > 0;
+    const numbersValid =
+      [
+        parsed.target,
+        parsed.low,
+        parsed.high,
+        parsed.roundStep,
+        parsed.gramsPerXe,
+        parsed.afterMealMinutes,
+      ].every((v) => Number.isFinite(v));
+    const positiveValid =
+      parsed.target > 0 &&
+      parsed.low > 0 &&
+      parsed.high > 0 &&
+      parsed.roundStep > 0 &&
+      parsed.gramsPerXe > 0 &&
+      parsed.afterMealMinutes >= 0;
     const rangeValid =
+      parsed.low < parsed.high &&
+      parsed.low < parsed.target &&
+      parsed.target < parsed.high &&
+      parsed.roundStep <= 5 &&
       parsed.gramsPerXe >= 5 &&
       parsed.gramsPerXe <= 20 &&
+      parsed.afterMealMinutes <= 180 &&
       (parsed.carbUnit === 'g' || parsed.carbUnit === 'xe');
     return numbersValid && positiveValid && rangeValid ? parsed : null;
   }

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -66,44 +66,97 @@ describe("parseProfile", () => {
     expect(parseProfile(makeProfile({ target: "12" }))).toBeNull();
   });
 
-  it("handles tablet therapy without insulin fields", () => {
+  it("parses tablet therapy profile skipping insulin fields", () => {
     const result = parseProfile(
       makeProfile({
         icr: "",
         cf: "",
-        target: "",
-        low: "",
-        high: "",
         dia: "",
         preBolus: "",
-        roundStep: "",
         rapidInsulinType: "",
         maxBolus: "",
-        afterMealMinutes: "",
       }),
       "tablets",
     );
-    expect(result).toMatchObject({ carbUnit: "g", gramsPerXe: 12 });
+    expect(result).toEqual({
+      icr: 0,
+      cf: 0,
+      target: 5,
+      low: 4,
+      high: 10,
+      dia: 0,
+      preBolus: 0,
+      roundStep: 1,
+      carbUnit: "g",
+      gramsPerXe: 12,
+      rapidInsulinType: "",
+      maxBolus: 0,
+      afterMealMinutes: 60,
+    });
   });
 
-  it("handles none therapy without insulin fields", () => {
+  it("parses none therapy profile skipping insulin fields", () => {
     const result = parseProfile(
       makeProfile({
         icr: "",
         cf: "",
-        target: "",
-        low: "",
-        high: "",
         dia: "",
         preBolus: "",
-        roundStep: "",
         rapidInsulinType: "",
         maxBolus: "",
-        afterMealMinutes: "",
       }),
       "none",
     );
-    expect(result).toMatchObject({ carbUnit: "g", gramsPerXe: 12 });
+    expect(result).toEqual({
+      icr: 0,
+      cf: 0,
+      target: 5,
+      low: 4,
+      high: 10,
+      dia: 0,
+      preBolus: 0,
+      roundStep: 1,
+      carbUnit: "g",
+      gramsPerXe: 12,
+      rapidInsulinType: "",
+      maxBolus: 0,
+      afterMealMinutes: 60,
+    });
+  });
+
+  it("validates required fields for tablet therapy", () => {
+    expect(
+      parseProfile(
+        makeProfile({
+          icr: "",
+          cf: "",
+          dia: "",
+          preBolus: "",
+          rapidInsulinType: "",
+          maxBolus: "",
+          low: "8",
+          high: "6",
+        }),
+        "tablets",
+      ),
+    ).toBeNull();
+  });
+
+  it("validates required fields for none therapy", () => {
+    expect(
+      parseProfile(
+        makeProfile({
+          icr: "",
+          cf: "",
+          dia: "",
+          preBolus: "",
+          rapidInsulinType: "",
+          maxBolus: "",
+          target: "3",
+        }),
+        "none",
+      ),
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure profile parsing for tablet and none therapies validates target, range, and meal fields
- test tablet and no-therapy profile parsing and validation paths

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6ab182df8832abb0412aeddbe8473