### PR TITLE
[ui] respect therapy type when checking profile

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -67,23 +67,44 @@ export const parseProfile = (
     const parsed = {
       icr: 0,
       cf: 0,
-      target: 0,
-      low: 0,
-      high: 0,
+      target: Number(profile.target.replace(/,/g, '.')),
+      low: Number(profile.low.replace(/,/g, '.')),
+      high: Number(profile.high.replace(/,/g, '.')),
       dia: 0,
       preBolus: 0,
-      roundStep: 0,
+      roundStep: Number(profile.roundStep.replace(/,/g, '.')),
       carbUnit: profile.carbUnit,
       gramsPerXe: Number(profile.gramsPerXe.replace(/,/g, '.')),
       rapidInsulinType: '',
       maxBolus: 0,
-      afterMealMinutes: 0,
+      afterMealMinutes: Number(
+        profile.afterMealMinutes.replace(/,/g, '.'),
+      ),
     } satisfies ParsedProfile;
-    const numbersValid = Number.isFinite(parsed.gramsPerXe);
-    const positiveValid = parsed.gramsPerXe > 0;
+    const numbersValid =
+      [
+        parsed.target,
+        parsed.low,
+        parsed.high,
+        parsed.roundStep,
+        parsed.gramsPerXe,
+        parsed.afterMealMinutes,
+      ].every((v) => Number.isFinite(v));
+    const positiveValid =
+      parsed.target > 0 &&
+      parsed.low > 0 &&
+      parsed.high > 0 &&
+      parsed.roundStep > 0 &&
+      parsed.gramsPerXe > 0 &&
+      parsed.afterMealMinutes >= 0;
     const rangeValid =
+      parsed.low < parsed.high &&
+      parsed.low < parsed.target &&
+      parsed.target < parsed.high &&
+      parsed.roundStep <= 5 &&
       parsed.gramsPerXe >= 5 &&
       parsed.gramsPerXe <= 20 &&
+      parsed.afterMealMinutes <= 180 &&
       (parsed.carbUnit === 'g' || parsed.carbUnit === 'xe');
     return numbersValid && positiveValid && rangeValid ? parsed : null;
   }
@@ -294,20 +315,31 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
             : deviceTz;
         const timezoneAuto = data.timezoneAuto === true;
         const therapyType = data.therapyType ?? undefined;
+        const requiredFields =
+          therapyType === 'tablets' || therapyType === 'none'
+            ? [
+                target,
+                low,
+                high,
+                roundStep,
+                gramsPerXe,
+                afterMealMinutes,
+              ]
+            : [
+                icr,
+                cf,
+                target,
+                low,
+                high,
+                dia,
+                preBolus,
+                roundStep,
+                gramsPerXe,
+                maxBolus,
+                afterMealMinutes,
+              ];
 
-        const isComplete = [
-          icr,
-          cf,
-          target,
-          low,
-          high,
-          dia,
-          preBolus,
-          roundStep,
-          gramsPerXe,
-          maxBolus,
-          afterMealMinutes,
-        ].every((v) => Number(v) > 0);
+        const isComplete = requiredFields.every((v) => Number(v) > 0);
 
         const loaded: ProfileForm = {
           icr,

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -71,19 +71,28 @@ describe("parseProfile", () => {
       makeProfile({
         icr: "",
         cf: "",
-        target: "",
-        low: "",
-        high: "",
         dia: "",
         preBolus: "",
-        roundStep: "",
         rapidInsulinType: "",
         maxBolus: "",
-        afterMealMinutes: "",
       }),
       "tablets",
     );
-    expect(result).toMatchObject({ carbUnit: "g", gramsPerXe: 12 });
+    expect(result).toEqual({
+      icr: 0,
+      cf: 0,
+      target: 5,
+      low: 4,
+      high: 10,
+      dia: 0,
+      preBolus: 0,
+      roundStep: 1,
+      carbUnit: "g",
+      gramsPerXe: 12,
+      rapidInsulinType: "",
+      maxBolus: 0,
+      afterMealMinutes: 60,
+    });
   });
 
   it("handles none therapy without insulin fields", () => {
@@ -91,19 +100,62 @@ describe("parseProfile", () => {
       makeProfile({
         icr: "",
         cf: "",
-        target: "",
-        low: "",
-        high: "",
         dia: "",
         preBolus: "",
-        roundStep: "",
         rapidInsulinType: "",
         maxBolus: "",
-        afterMealMinutes: "",
       }),
       "none",
     );
-    expect(result).toMatchObject({ carbUnit: "g", gramsPerXe: 12 });
+    expect(result).toEqual({
+      icr: 0,
+      cf: 0,
+      target: 5,
+      low: 4,
+      high: 10,
+      dia: 0,
+      preBolus: 0,
+      roundStep: 1,
+      carbUnit: "g",
+      gramsPerXe: 12,
+      rapidInsulinType: "",
+      maxBolus: 0,
+      afterMealMinutes: 60,
+    });
+  });
+
+  it("rejects invalid non-insulin fields for tablet therapy", () => {
+    expect(
+      parseProfile(
+        makeProfile({
+          icr: "",
+          cf: "",
+          dia: "",
+          preBolus: "",
+          rapidInsulinType: "",
+          maxBolus: "",
+          target: "",
+        }),
+        "tablets",
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects invalid non-insulin fields for none therapy", () => {
+    expect(
+      parseProfile(
+        makeProfile({
+          icr: "",
+          cf: "",
+          dia: "",
+          preBolus: "",
+          rapidInsulinType: "",
+          maxBolus: "",
+          low: "",
+        }),
+        "none",
+      ),
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Validate non-insulin profile fields when therapy type is tablets or none
- Derive profile completeness from therapy type in profile screen
- Extend profile parsing tests for therapy-specific validation

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any. Specify a different type)*
- `pnpm --filter ./services/webapp/ui test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ab213290832aa14c9ce0fe71f240