### PR TITLE
[webapp] Localize insulin type options

### DIFF
--- a/services/webapp/ui/src/locales/ru/profileHelp.ts
+++ b/services/webapp/ui/src/locales/ru/profileHelp.ts
@@ -78,6 +78,12 @@ const profileHelp = {
     definition: 'Используемый тип быстродействующего инсулина',
     unit: '—',
     range: '—',
+    options: {
+      aspart: 'Аспарт',
+      lispro: 'Лиспро',
+      glulisine: 'Глулизин',
+      regular: 'Регуляр',
+    },
   },
   afterMealMinutes: {
     title: 'Минут после еды',

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -807,10 +807,18 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                       value={profile.rapidInsulinType}
                       onChange={(e) => handleInputChange('rapidInsulinType', e.target.value)}
                     >
-                      <option value="aspart">Aspart</option>
-                      <option value="lispro">Lispro</option>
-                      <option value="glulisine">Glulisine</option>
-                      <option value="regular">Regular</option>
+                      <option value="aspart">
+                        {t('profileHelp.rapidInsulinType.options.aspart')}
+                      </option>
+                      <option value="lispro">
+                        {t('profileHelp.rapidInsulinType.options.lispro')}
+                      </option>
+                      <option value="glulisine">
+                        {t('profileHelp.rapidInsulinType.options.glulisine')}
+                      </option>
+                      <option value="regular">
+                        {t('profileHelp.rapidInsulinType.options.regular')}
+                      </option>
                     </select>
                   </div>
                   {/* Max bolus */}

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -122,6 +122,25 @@ describe('Profile page', () => {
     );
   });
 
+  it('renders localized rapid insulin type options', async () => {
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
+    const { getByLabelText } = render(<Profile />);
+
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalledWith(123);
+    });
+
+    const options = Array.from(
+      (
+        getByLabelText('Тип быстрого инсулина', {
+          selector: 'select',
+        }) as HTMLSelectElement
+      ).options,
+    ).map((o) => o.text);
+
+    expect(options).toEqual(['Аспарт', 'Лиспро', 'Глулизин', 'Регуляр']);
+  });
+
   it('blocks save with invalid numeric input and shows toast', () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
 


### PR DESCRIPTION
## Summary
- add rapid insulin type option translations to ru locale
- use i18n strings for insulin type select
- test localized insulin type options on profile page

## Testing
- `pnpm --filter ./services/webapp/ui test tests/profile.test.tsx -t "renders localized rapid insulin type options"` *(fails: Found multiple elements with the placeholder text of: 12)*
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6ab2683f8832aa5669deedee06349