### PR TITLE
webapp: refine profile completeness check

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -317,7 +317,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
         const timezoneAuto = data.timezoneAuto === true;
         const therapyType = data.therapyType ?? undefined;
 
-        const isComplete = [
+        const insulinRequiredComplete = [
           icr,
           cf,
           target,
@@ -330,6 +330,20 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
           maxBolus,
           afterMealMinutes,
         ].every((v) => Number(v) > 0);
+
+        const nonInsulinComplete = [
+          target,
+          low,
+          high,
+          roundStep,
+          gramsPerXe,
+          afterMealMinutes,
+        ].every((v) => Number(v) > 0);
+
+        const isComplete =
+          therapyType === "tablets" || therapyType === "none"
+            ? nonInsulinComplete
+            : insulinRequiredComplete;
 
         const loaded: ProfileForm = {
           icr,

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -269,6 +269,61 @@ describe('Profile page', () => {
     },
   );
 
+  it.each(nonInsulinTherapies)(
+    'does not show toast when insulin fields missing for %s therapy',
+    async (therapy) => {
+      (resolveTelegramId as vi.Mock).mockReturnValue(123);
+      (getProfile as vi.Mock).mockResolvedValueOnce({
+        telegramId: 123,
+        target: 6,
+        low: 4,
+        high: 10,
+        roundStep: 1,
+        carbUnit: 'g',
+        gramsPerXe: 12,
+        defaultAfterMealMinutes: 120,
+        timezone: 'Europe/Moscow',
+        timezoneAuto: false,
+        therapyType: therapy,
+      });
+      render(<Profile therapyType={therapy} />);
+      await waitFor(() => {
+        expect(getProfile).toHaveBeenCalled();
+      });
+      expect(toast).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(nonInsulinTherapies)(
+    'shows toast when non-insulin fields missing for %s therapy',
+    async (therapy) => {
+      (resolveTelegramId as vi.Mock).mockReturnValue(123);
+      (getProfile as vi.Mock).mockResolvedValueOnce({
+        telegramId: 123,
+        low: 4,
+        high: 10,
+        roundStep: 1,
+        carbUnit: 'g',
+        gramsPerXe: 12,
+        defaultAfterMealMinutes: 120,
+        timezone: 'Europe/Moscow',
+        timezoneAuto: false,
+        therapyType: therapy,
+      });
+      render(<Profile therapyType={therapy} />);
+      await waitFor(() => {
+        expect(getProfile).toHaveBeenCalled();
+      });
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Ошибка',
+          description: 'Профиль заполнен не полностью',
+          variant: 'destructive',
+        }),
+      );
+    },
+  );
+
   it('renders advanced bolus fields', async () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
     const { getByPlaceholderText } = render(<Profile />);


### PR DESCRIPTION
## Summary
- adjust profile completeness logic to depend on therapy type
- test profile loading for non-insulin therapies

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter vite_react_shadcn_ts test`


------
https://chatgpt.com/codex/tasks/task_e_68b6adf92fa8832aaf1306382210ff45