### PR TITLE
[ui] Add close button to profile help sheet

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -5,6 +5,7 @@ import {
   SheetContent,
   SheetHeader,
   SheetTitle,
+  SheetClose,
 } from '@/components/ui/sheet';
 import {
   Accordion,
@@ -13,7 +14,7 @@ import {
   AccordionContent,
 } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
-import { HelpCircle } from 'lucide-react';
+import { HelpCircle, X } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useTranslation } from '@/i18n';
 
@@ -165,8 +166,17 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
         side={isMobile ? 'bottom' : 'right'}
         className="max-h-screen overflow-y-auto"
       >
-        <SheetHeader>
+        <SheetHeader className="flex-row items-center justify-between">
           <SheetTitle>{t('profileHelp.help')}</SheetTitle>
+          <SheetClose asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Закрыть"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </SheetClose>
         </SheetHeader>
         <Accordion type="single" collapsible className="w-full">
           {filtered.map((section) => (

--- a/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
+++ b/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
@@ -28,6 +28,16 @@ describe('ProfileHelpSheet', () => {
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 
+  it('renders focusable close button', () => {
+    render(<ProfileHelpSheet />);
+    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
+    const closeBtn = screen.getByLabelText('Закрыть');
+    closeBtn.focus();
+    expect(document.activeElement).toBe(closeBtn);
+    fireEvent.click(closeBtn);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
   it('uses bottom sheet on mobile', () => {
     (mobileHook.useIsMobile as unknown as vi.Mock).mockReturnValue(true);
     render(<ProfileHelpSheet />);


### PR DESCRIPTION
## Summary
- add X icon close button to profile help sheet header
- test close button focus and closing

## Testing
- `pnpm --filter vite_react_shadcn_ts test`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `pnpm exec eslint src/components/ProfileHelpSheet.tsx tests/ProfileHelpSheet.test.tsx`
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b6b0f3f064832a90d58060e4a18c27