### PR TITLE
[ui] localize profile page title and save button

### DIFF
--- a/services/webapp/ui/src/locales/ru.ts
+++ b/services/webapp/ui/src/locales/ru.ts
@@ -1,6 +1,8 @@
+import profile from './ru/profile';
 import profileHelp from './ru/profileHelp';
 
 const ru = {
+  profile,
   profileHelp,
 };
 

--- a/services/webapp/ui/src/locales/ru/profile.ts
+++ b/services/webapp/ui/src/locales/ru/profile.ts
@@ -1,0 +1,6 @@
+const profile = {
+  title: 'Мой профиль',
+  save: 'Сохранить настройки',
+};
+
+export default profile;

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -177,10 +177,11 @@ const ProfileFormHeader = ({
   therapyType,
 }: ProfileFormHeaderProps) => {
   const isMobile = useIsMobile();
+  const { t } = useTranslation();
 
   return (
     <>
-      <MedicalHeader title="Мой профиль" showBack onBack={onBack}>
+      <MedicalHeader title={t('profile.title')} showBack onBack={onBack}>
         {!isMobile && <ProfileHelpSheet therapyType={therapyType} />}
       </MedicalHeader>
       {isMobile && (
@@ -979,7 +980,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               size="lg"
             >
               <Save className="w-4 h-4" />
-              Сохранить настройки
+              {t('profile.save')}
             </MedicalButton>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace hard-coded profile title and save button with i18n keys
- add Russian locale strings for profile title and save

## Testing
- `pnpm --filter ./services/webapp/ui lint` (fails: ESLint errors in existing files)
- `pnpm --filter ./services/webapp/ui test` (fails: JavaScript heap out of memory)
- `pnpm --filter ./services/webapp/ui typecheck`
- `pytest -q --cov` (fails: pytest-cov plugin missing)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6b0f51144832a98060d174b8400e3