### PR TITLE
[ui] Add label to ProfileHelpSheet help button

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -1,24 +1,24 @@
-import { useState } from 'react';
+import { useState } from "react";
 import {
   Sheet,
   SheetTrigger,
   SheetContent,
   SheetHeader,
   SheetTitle,
-} from '@/components/ui/sheet';
+} from "@/components/ui/sheet";
 import {
   Accordion,
   AccordionItem,
   AccordionTrigger,
   AccordionContent,
-} from '@/components/ui/accordion';
-import { Button } from '@/components/ui/button';
-import { HelpCircle } from 'lucide-react';
-import { useIsMobile } from '@/hooks/use-mobile';
-import { useTranslation } from '@/i18n';
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { HelpCircle } from "lucide-react";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { useTranslation } from "@/i18n";
 
 interface ProfileHelpSheetProps {
-  therapyType?: 'insulin' | 'tablets' | 'none' | 'mixed';
+  therapyType?: "insulin" | "tablets" | "none" | "mixed";
 }
 
 interface HelpItem {
@@ -37,104 +37,104 @@ interface HelpSection {
 
 const sections: HelpSection[] = [
   {
-    key: 'targets',
-    titleKey: 'profileHelp.sections.targets',
+    key: "targets",
+    titleKey: "profileHelp.sections.targets",
     items: [
       {
-        key: 'target',
-        titleKey: 'profileHelp.target.title',
-        definitionKey: 'profileHelp.target.definition',
-        unitKey: 'profileHelp.target.unit',
-        rangeKey: 'profileHelp.target.range',
+        key: "target",
+        titleKey: "profileHelp.target.title",
+        definitionKey: "profileHelp.target.definition",
+        unitKey: "profileHelp.target.unit",
+        rangeKey: "profileHelp.target.range",
       },
       {
-        key: 'low',
-        titleKey: 'profileHelp.low.title',
-        definitionKey: 'profileHelp.low.definition',
-        unitKey: 'profileHelp.low.unit',
-        rangeKey: 'profileHelp.low.range',
+        key: "low",
+        titleKey: "profileHelp.low.title",
+        definitionKey: "profileHelp.low.definition",
+        unitKey: "profileHelp.low.unit",
+        rangeKey: "profileHelp.low.range",
       },
       {
-        key: 'high',
-        titleKey: 'profileHelp.high.title',
-        definitionKey: 'profileHelp.high.definition',
-        unitKey: 'profileHelp.high.unit',
-        rangeKey: 'profileHelp.high.range',
+        key: "high",
+        titleKey: "profileHelp.high.title",
+        definitionKey: "profileHelp.high.definition",
+        unitKey: "profileHelp.high.unit",
+        rangeKey: "profileHelp.high.range",
       },
     ],
   },
   {
-    key: 'insulin',
-    titleKey: 'profileHelp.sections.insulin',
+    key: "insulin",
+    titleKey: "profileHelp.sections.insulin",
     items: [
       {
-        key: 'icr',
-        titleKey: 'profileHelp.icr.title',
-        definitionKey: 'profileHelp.icr.definition',
-        unitKey: 'profileHelp.icr.unit',
-        rangeKey: 'profileHelp.icr.range',
+        key: "icr",
+        titleKey: "profileHelp.icr.title",
+        definitionKey: "profileHelp.icr.definition",
+        unitKey: "profileHelp.icr.unit",
+        rangeKey: "profileHelp.icr.range",
       },
       {
-        key: 'cf',
-        titleKey: 'profileHelp.cf.title',
-        definitionKey: 'profileHelp.cf.definition',
-        unitKey: 'profileHelp.cf.unit',
-        rangeKey: 'profileHelp.cf.range',
+        key: "cf",
+        titleKey: "profileHelp.cf.title",
+        definitionKey: "profileHelp.cf.definition",
+        unitKey: "profileHelp.cf.unit",
+        rangeKey: "profileHelp.cf.range",
       },
       {
-        key: 'dia',
-        titleKey: 'profileHelp.dia.title',
-        definitionKey: 'profileHelp.dia.definition',
-        unitKey: 'profileHelp.dia.unit',
-        rangeKey: 'profileHelp.dia.range',
+        key: "dia",
+        titleKey: "profileHelp.dia.title",
+        definitionKey: "profileHelp.dia.definition",
+        unitKey: "profileHelp.dia.unit",
+        rangeKey: "profileHelp.dia.range",
       },
       {
-        key: 'preBolus',
-        titleKey: 'profileHelp.preBolus.title',
-        definitionKey: 'profileHelp.preBolus.definition',
-        unitKey: 'profileHelp.preBolus.unit',
-        rangeKey: 'profileHelp.preBolus.range',
+        key: "preBolus",
+        titleKey: "profileHelp.preBolus.title",
+        definitionKey: "profileHelp.preBolus.definition",
+        unitKey: "profileHelp.preBolus.unit",
+        rangeKey: "profileHelp.preBolus.range",
       },
       {
-        key: 'maxBolus',
-        titleKey: 'profileHelp.maxBolus.title',
-        definitionKey: 'profileHelp.maxBolus.definition',
-        unitKey: 'profileHelp.maxBolus.unit',
-        rangeKey: 'profileHelp.maxBolus.range',
+        key: "maxBolus",
+        titleKey: "profileHelp.maxBolus.title",
+        definitionKey: "profileHelp.maxBolus.definition",
+        unitKey: "profileHelp.maxBolus.unit",
+        rangeKey: "profileHelp.maxBolus.range",
       },
     ],
   },
   {
-    key: 'other',
-    titleKey: 'profileHelp.sections.other',
+    key: "other",
+    titleKey: "profileHelp.sections.other",
     items: [
       {
-        key: 'roundStep',
-        titleKey: 'profileHelp.roundStep.title',
-        definitionKey: 'profileHelp.roundStep.definition',
-        unitKey: 'profileHelp.roundStep.unit',
-        rangeKey: 'profileHelp.roundStep.range',
+        key: "roundStep",
+        titleKey: "profileHelp.roundStep.title",
+        definitionKey: "profileHelp.roundStep.definition",
+        unitKey: "profileHelp.roundStep.unit",
+        rangeKey: "profileHelp.roundStep.range",
       },
       {
-        key: 'carbUnit',
-        titleKey: 'profileHelp.carbUnit.title',
-        definitionKey: 'profileHelp.carbUnit.definition',
-        unitKey: 'profileHelp.carbUnit.unit',
-        rangeKey: 'profileHelp.carbUnit.range',
+        key: "carbUnit",
+        titleKey: "profileHelp.carbUnit.title",
+        definitionKey: "profileHelp.carbUnit.definition",
+        unitKey: "profileHelp.carbUnit.unit",
+        rangeKey: "profileHelp.carbUnit.range",
       },
       {
-        key: 'afterMealMinutes',
-        titleKey: 'profileHelp.afterMealMinutes.title',
-        definitionKey: 'profileHelp.afterMealMinutes.definition',
-        unitKey: 'profileHelp.afterMealMinutes.unit',
-        rangeKey: 'profileHelp.afterMealMinutes.range',
+        key: "afterMealMinutes",
+        titleKey: "profileHelp.afterMealMinutes.title",
+        definitionKey: "profileHelp.afterMealMinutes.definition",
+        unitKey: "profileHelp.afterMealMinutes.unit",
+        rangeKey: "profileHelp.afterMealMinutes.range",
       },
       {
-        key: 'timezone',
-        titleKey: 'profileHelp.timezone.title',
-        definitionKey: 'profileHelp.timezone.definition',
-        unitKey: 'profileHelp.timezone.unit',
-        rangeKey: 'profileHelp.timezone.range',
+        key: "timezone",
+        titleKey: "profileHelp.timezone.title",
+        definitionKey: "profileHelp.timezone.definition",
+        unitKey: "profileHelp.timezone.unit",
+        rangeKey: "profileHelp.timezone.range",
       },
     ],
   },
@@ -146,27 +146,29 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
   const { t } = useTranslation();
 
   const filtered =
-    therapyType === 'tablets' || therapyType === 'none'
-      ? sections.filter((s) => s.key !== 'insulin')
+    therapyType === "tablets" || therapyType === "none"
+      ? sections.filter((s) => s.key !== "insulin")
       : sections;
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>
         <Button
-          aria-label={t('profileHelp.help')}
-          variant="ghost"
-          size="icon"
+          aria-label={t("profileHelp.help")}
+          variant="outline"
+          size="sm"
+          className="gap-2"
         >
           <HelpCircle className="h-5 w-5" />
+          Справка
         </Button>
       </SheetTrigger>
       <SheetContent
-        side={isMobile ? 'bottom' : 'right'}
+        side={isMobile ? "bottom" : "right"}
         className="max-h-screen overflow-y-auto"
       >
         <SheetHeader>
-          <SheetTitle>{t('profileHelp.help')}</SheetTitle>
+          <SheetTitle>{t("profileHelp.help")}</SheetTitle>
         </SheetHeader>
         <Accordion type="single" collapsible className="w-full">
           {filtered.map((section) => (
@@ -181,7 +183,8 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
                         {t(item.definitionKey)}
                       </p>
                       <p className="text-sm text-muted-foreground">
-                        {t('profileHelp.units')}: {t(item.unitKey)}; {t('profileHelp.range')}: {t(item.rangeKey)}
+                        {t("profileHelp.units")}: {t(item.unitKey)};{" "}
+                        {t("profileHelp.range")}: {t(item.rangeKey)}
                       </p>
                     </li>
                   ))}
@@ -196,4 +199,3 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
 };
 
 export default ProfileHelpSheet;
-


### PR DESCRIPTION
## Summary
- switch ProfileHelpSheet help button to `outline` variant and `sm` size
- add visible "Справка" label and spacing

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: existing lint errors)*
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui exec vitest run tests/ProfileHelpSheet.test.tsx`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6b0e775dc832a8dea374386ef0a41