### PR TITLE
[ui] Allow multiple ProfileHelpSheet sections

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -168,7 +168,7 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
         <SheetHeader>
           <SheetTitle>{t('profileHelp.help')}</SheetTitle>
         </SheetHeader>
-        <Accordion type="single" collapsible className="w-full">
+        <Accordion type="multiple" className="w-full">
           {filtered.map((section) => (
             <AccordionItem key={section.key} value={section.key}>
               <AccordionTrigger>{t(section.titleKey)}</AccordionTrigger>

--- a/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
+++ b/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
@@ -35,4 +35,15 @@ describe('ProfileHelpSheet', () => {
     const content = screen.getByRole('dialog');
     expect(content.className).toContain('bottom-0');
   });
+
+  it('allows multiple sections to be expanded', () => {
+    render(<ProfileHelpSheet />);
+    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Цели сахара' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Прочее' }));
+
+    expect(screen.getByText('Целевой уровень сахара')).toBeTruthy();
+    expect(screen.getByText('Шаг округления')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- allow multiple sections in profile help to expand concurrently
- test multiple section expansion

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any)*
- `pnpm --filter ./services/webapp/ui test tests/ProfileHelpSheet.test.tsx`
- `pytest -q` *(fails: unrecognized arguments: --cov=services.api.app.diabetes)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6b0ebe468832ab05b4a02bbca2921