### PR TITLE
[ui] extend profile help sections

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -96,6 +96,13 @@ const sections: HelpSection[] = [
         rangeKey: 'profileHelp.preBolus.range',
       },
       {
+        key: 'rapidInsulinType',
+        titleKey: 'profileHelp.rapidInsulinType.title',
+        definitionKey: 'profileHelp.rapidInsulinType.definition',
+        unitKey: 'profileHelp.rapidInsulinType.unit',
+        rangeKey: 'profileHelp.rapidInsulinType.range',
+      },
+      {
         key: 'maxBolus',
         titleKey: 'profileHelp.maxBolus.title',
         definitionKey: 'profileHelp.maxBolus.definition',
@@ -123,6 +130,13 @@ const sections: HelpSection[] = [
         rangeKey: 'profileHelp.carbUnit.range',
       },
       {
+        key: 'gramsPerXe',
+        titleKey: 'profileHelp.gramsPerXe.title',
+        definitionKey: 'profileHelp.gramsPerXe.definition',
+        unitKey: 'profileHelp.gramsPerXe.unit',
+        rangeKey: 'profileHelp.gramsPerXe.range',
+      },
+      {
         key: 'afterMealMinutes',
         titleKey: 'profileHelp.afterMealMinutes.title',
         definitionKey: 'profileHelp.afterMealMinutes.definition',
@@ -145,10 +159,19 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
   const isMobile = useIsMobile();
   const { t } = useTranslation();
 
-  const filtered =
-    therapyType === 'tablets' || therapyType === 'none'
-      ? sections.filter((s) => s.key !== 'insulin')
-      : sections;
+  const filtered = sections
+    .map((section) => ({
+      ...section,
+      items:
+        therapyType === 'tablets' || therapyType === 'none'
+          ? section.items.filter((item) => item.key !== 'rapidInsulinType')
+          : section.items,
+    }))
+    .filter((section) =>
+      therapyType === 'tablets' || therapyType === 'none'
+        ? section.key !== 'insulin'
+        : true,
+    );
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>

--- a/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
+++ b/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
@@ -16,9 +16,11 @@ describe('ProfileHelpSheet', () => {
       render(<ProfileHelpSheet therapyType={therapy} />);
       fireEvent.click(screen.getAllByLabelText('Справка')[0]);
       expect(screen.queryByText('Инсулин')).toBeNull();
+      expect(screen.queryByText('Тип быстрого инсулина')).toBeNull();
       expect(screen.getByText('Цели сахара')).toBeTruthy();
     },
   );
+
 
   it('closes on Escape key', () => {
     render(<ProfileHelpSheet />);


### PR DESCRIPTION
## Summary
- mention grams per XE and rapid insulin type in profile help
- hide rapid insulin type hints for non-insulin therapies
- cover insulin section filtering in tests

## Testing
- `pnpm --filter ./services/webapp/ui exec vitest run tests/ProfileHelpSheet.test.tsx`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6b0ef3790832aab1cd92d91c99ed9