### PR TITLE
[tests] Add HelpHint and ProfileHelpSheet tests

### DIFF
--- a/tests/HelpHint.test.tsx
+++ b/tests/HelpHint.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+
+import HelpHint from '../services/webapp/ui/src/components/HelpHint';
+import { TooltipProvider } from '../services/webapp/ui/src/components/ui/tooltip';
+
+describe('HelpHint', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const setup = () =>
+    render(
+      <TooltipProvider delayDuration={0}>
+        <HelpHint label="ICR">Example</HelpHint>
+      </TooltipProvider>,
+    );
+
+  it('shows tooltip on focus and hides on blur', async () => {
+    setup();
+    const button = screen.getByLabelText('ICR');
+    expect(button.getAttribute('aria-label')).toBe('ICR');
+
+    fireEvent.focus(button);
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Example');
+
+    fireEvent.blur(button);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('closes tooltip on Escape key', async () => {
+    setup();
+    const button = screen.getByLabelText('ICR');
+
+    fireEvent.focus(button);
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Example');
+
+    fireEvent.keyDown(button, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+});
+

--- a/tests/ProfileHelpSheet.test.tsx
+++ b/tests/ProfileHelpSheet.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import ProfileHelpSheet from '../services/webapp/ui/src/components/ProfileHelpSheet';
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+
+describe('ProfileHelpSheet', () => {
+  it('opens and closes the help sheet', () => {
+    render(<ProfileHelpSheet />);
+    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it("hides 'Инсулин' section for tablets therapy", () => {
+    render(<ProfileHelpSheet therapyType="tablets" />);
+    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
+    expect(screen.queryByText('Инсулин')).toBeNull();
+    expect(screen.getByText('Цели сахара')).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add vitest for HelpHint tooltip focus and escape behavior
- add ProfileHelpSheet tests for sheet open/close and insulin section hiding

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `npx --prefix services/webapp/ui vitest run tests/HelpHint.test.tsx tests/ProfileHelpSheet.test.tsx --config vitest.config.ts` *(fails: Failed to resolve import 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68b6b36d4c24832abf6cca6843089a0c