### PR TITLE
[webapp] Localize ProfileHelpSheet close label

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -197,7 +197,7 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
             <Button
               variant="ghost"
               size="icon"
-              aria-label="Закрыть"
+              aria-label={t('profileHelp.close')}
             >
               <X className="h-4 w-4" />
             </Button>

--- a/services/webapp/ui/src/locales/ru/profileHelp.ts
+++ b/services/webapp/ui/src/locales/ru/profileHelp.ts
@@ -2,6 +2,7 @@ const profileHelp = {
   help: 'Справка',
   units: 'Единицы',
   range: 'Диапазон',
+  close: 'Закрыть',
   sections: {
     targets: 'Цели сахара',
     insulin: 'Инсулин',


### PR DESCRIPTION
## Summary
- use translation string for ProfileHelpSheet close button
- add Russian locale key for close label

## Testing
- `pytest -q --cov` *(fails: KeyboardInterrupt)*
- `mypy --strict .` *(fails: KeyboardInterrupt)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6b654d234832a9fdb4a1aede556bd