### PR TITLE
[webapp] Localize profile warning modal

### DIFF
--- a/services/webapp/ui/src/locales/ru/profile.ts
+++ b/services/webapp/ui/src/locales/ru/profile.ts
@@ -1,6 +1,13 @@
 const profile = {
   title: 'Мой профиль',
   save: 'Сохранить настройки',
+  warning: {
+    title: 'Проверьте значения',
+    message:
+      'ICR больше 8 и CF меньше 3. Пожалуйста, убедитесь в корректности введённых данных',
+    cancel: 'Отмена',
+    confirm: 'Продолжить',
+  },
 };
 
 export default profile;

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -535,22 +535,19 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
       <Modal
         open={warningOpen}
         onClose={() => setWarningOpen(false)}
-        title="Проверьте значения"
+        title={t('profile.warning.title')}
         footer={
           <div className="flex justify-end gap-2">
             <Button variant="outline" onClick={() => setWarningOpen(false)}>
-              Отмена
+              {t('profile.warning.cancel')}
             </Button>
             <MedicalButton onClick={handleConfirmSave}>
-              Продолжить
+              {t('profile.warning.confirm')}
             </MedicalButton>
           </div>
         }
       >
-        <p>
-          ICR больше 8 и CF меньше 3. Пожалуйста, убедитесь в корректности
-          введённых данных
-        </p>
+        <p>{t('profile.warning.message')}</p>
       </Modal>
 
       <TooltipProvider>


### PR DESCRIPTION
## Summary
- wrap profile warning modal title, message, and actions in `t()`
- add Russian locale keys for profile warning dialog

## Testing
- `pytest -q --maxfail=1` (fails: async def functions are not natively supported)
- `mypy --strict .` (command interrupted)
- `ruff check .`
- `npm test` (fails: backend request failed)
- `npm run lint` (fails: 32 problems)


------
https://chatgpt.com/codex/tasks/task_e_68b6b6404e04832ab3a58a8cc6939f8a