### PR TITLE
[webapp] localize profile help button

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -184,7 +184,7 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
           className="gap-2"
         >
           <HelpCircle className="h-5 w-5" />
-          Справка
+          {t('profileHelp.help')}
         </Button>
       </SheetTrigger>
       <SheetContent


### PR DESCRIPTION
## Summary
- localize help sheet trigger with translation key

## Testing
- `pnpm --filter ./services/webapp/ui test` *(fails: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6b636eac0832a92c182c793966414