### PR TITLE
[ui] embed TooltipProvider in HelpHint

### DIFF
--- a/services/webapp/ui/src/App.tsx
+++ b/services/webapp/ui/src/App.tsx
@@ -2,7 +2,6 @@
 import React from "react"
 import { Toaster } from "@/components/ui/toaster"
 import { Toaster as Sonner } from "@/components/ui/sonner"
-import { TooltipProvider } from "@/components/ui/tooltip"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { BrowserRouter, Routes, Route } from "react-router-dom"
 import { useTelegram } from "@/hooks/useTelegram"
@@ -59,15 +58,13 @@ const baseName = import.meta.env.BASE_URL.replace(/\/$/, "") || "/"
 const App = () => (
   <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
     <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <ToastProvider>
-          <Toaster />
-          <Sonner />
-          <BrowserRouter basename={baseName}>
-            <AppContent />
-          </BrowserRouter>
-        </ToastProvider>
-      </TooltipProvider>
+      <ToastProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter basename={baseName}>
+          <AppContent />
+        </BrowserRouter>
+      </ToastProvider>
     </QueryClientProvider>
   </ThemeProvider>
 )

--- a/services/webapp/ui/src/components/HelpHint.tsx
+++ b/services/webapp/ui/src/components/HelpHint.tsx
@@ -1,7 +1,12 @@
 import { useState, type KeyboardEvent, type ReactNode } from 'react';
 import { HelpCircle } from 'lucide-react';
 
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { useTranslation } from '@/i18n';
 
@@ -24,22 +29,24 @@ const HelpHint = ({ label, children, className, side }: HelpHintProps) => {
   };
 
   return (
-    <Tooltip open={open} onOpenChange={setOpen}>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          onKeyDown={handleKeyDown}
-          className={cn(
-            'flex h-4 w-4 items-center justify-center text-muted-foreground',
-            className,
-          )}
-          aria-label={t(label ?? 'profileHelp.help')}
-        >
-          <HelpCircle className="h-4 w-4" aria-hidden="true" />
-        </button>
-      </TooltipTrigger>
-      <TooltipContent side={side}>{children}</TooltipContent>
-    </Tooltip>
+    <TooltipProvider delayDuration={150}>
+      <Tooltip open={open} onOpenChange={setOpen}>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onKeyDown={handleKeyDown}
+            className={cn(
+              'flex h-4 w-4 items-center justify-center text-muted-foreground',
+              className,
+            )}
+            aria-label={t(label ?? 'profileHelp.help')}
+          >
+            <HelpCircle className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side={side}>{children}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };
 

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -10,7 +10,6 @@ import Modal from "@/components/Modal";
 import HelpHint from "@/components/HelpHint";
 import ProfileHelpSheet from "@/components/ProfileHelpSheet";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { useTranslation } from "@/i18n";
 import {
   saveProfile,
@@ -553,21 +552,20 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
         </p>
       </Modal>
 
-      <TooltipProvider>
-        <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
-          <ProfileFormHeader
-            onBack={() => navigate("/")}
-            therapyType={therapyType}
-          />
+      <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
+        <ProfileFormHeader
+          onBack={() => navigate("/")}
+          therapyType={therapyType}
+        />
 
-          <main className="container mx-auto px-4 py-6">
-          <div className="medical-card animate-slide-up bg-gradient-to-br from-primary/5 to-primary/10 border-primary/20">
-          <div className="space-y-6">
-            {isInsulinTherapy && (
-              <>
-                {/* ICR */}
-                <div>
-                  <label
+        <main className="container mx-auto px-4 py-6">
+        <div className="medical-card animate-slide-up bg-gradient-to-br from-primary/5 to-primary/10 border-primary/20">
+        <div className="space-y-6">
+          {isInsulinTherapy && (
+            <>
+              {/* ICR */}
+              <div>
+                <label
                     htmlFor="icr"
                     className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
                   >
@@ -987,7 +985,6 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
 
       </main>
     </div>
-    </TooltipProvider>
     </>
   );
 };

--- a/services/webapp/ui/tests/HelpHint.test.tsx
+++ b/services/webapp/ui/tests/HelpHint.test.tsx
@@ -3,19 +3,13 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 
 import HelpHint from '../src/components/HelpHint';
-import { TooltipProvider } from '../src/components/ui/tooltip';
 
 describe('HelpHint', () => {
   afterEach(() => {
     cleanup();
   });
 
-  const setup = () =>
-    render(
-      <TooltipProvider delayDuration={0}>
-        <HelpHint label="ICR">Example</HelpHint>
-      </TooltipProvider>,
-    );
+  const setup = () => render(<HelpHint label="ICR">Example</HelpHint>);
 
   it('shows tooltip on focus and hides on blur', async () => {
     setup();

--- a/tests/HelpHint.test.tsx
+++ b/tests/HelpHint.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { describe, it, expect, afterEach } from 'vitest';
 
 import HelpHint from '../services/webapp/ui/src/components/HelpHint';
-import { TooltipProvider } from '../services/webapp/ui/src/components/ui/tooltip';
 
 describe('HelpHint', () => {
   afterEach(() => {
@@ -11,11 +10,7 @@ describe('HelpHint', () => {
   });
 
   const setup = () =>
-    render(
-      <TooltipProvider delayDuration={0}>
-        <HelpHint label="ICR">Example</HelpHint>
-      </TooltipProvider>,
-    );
+    render(<HelpHint label="ICR">Example</HelpHint>);
 
   it('shows tooltip on focus and hides on blur', async () => {
     setup();


### PR DESCRIPTION
## Summary
- wrap HelpHint with TooltipProvider (delay 150ms)
- remove redundant TooltipProvider wrappers from App, Profile, and tests

## Testing
- `pnpm --filter ./services/webapp/ui test tests/HelpHint.test.tsx`
- `pnpm --filter ./services/webapp/ui exec vitest run ../../tests/HelpHint.test.tsx --root ../.. --config vitest.config.ts` *(fail: config resolution)*
- `pytest -q --cov` *(fail: async tests require plugin)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6b64eca04832a86bfa054977b08e4