### PR TITLE
[ui] Simplify ProfileHelpSheet filtering

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -160,19 +160,10 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
   const isMobile = useIsMobile();
   const { t } = useTranslation();
 
-  const filtered = sections
-    .map((section) => ({
-      ...section,
-      items:
-        therapyType === 'tablets' || therapyType === 'none'
-          ? section.items.filter((item) => item.key !== 'rapidInsulinType')
-          : section.items,
-    }))
-    .filter((section) =>
-      therapyType === 'tablets' || therapyType === 'none'
-        ? section.key !== 'insulin'
-        : true,
-    );
+  const filtered =
+    therapyType === 'tablets' || therapyType === 'none'
+      ? sections.filter((section) => section.key !== 'insulin')
+      : sections;
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
## Summary
- drop rapidInsulinType item filtering from ProfileHelpSheet
- rely on therapy type to exclude insulin section entirely

## Testing
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui exec vitest run tests/ProfileHelpSheet.test.tsx`
- `pytest -q` *(fails: async functions not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6b658b7bc832a8fc88fb58feebff8