### PR TITLE
webapp: skip grams per XE when using grams

### DIFF
--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -60,6 +60,32 @@ describe("parseProfile", () => {
     expect(result).toBeNull();
   });
 
+  it("skips gramsPerXe validation when carb unit is grams", () => {
+    const result = parseProfile(makeProfile({ gramsPerXe: "", carbUnit: "g" }));
+    expect(result).toEqual({
+      icr: 1,
+      cf: 2,
+      target: 5,
+      low: 4,
+      high: 10,
+      dia: 7,
+      preBolus: 10,
+      roundStep: 1,
+      carbUnit: "g",
+      gramsPerXe: 0,
+      rapidInsulinType: "lispro",
+      maxBolus: 20,
+      afterMealMinutes: 60,
+    });
+  });
+
+  it("validates gramsPerXe when carb unit is XE", () => {
+    const result = parseProfile(
+      makeProfile({ gramsPerXe: "", carbUnit: "xe" }),
+    );
+    expect(result).toBeNull();
+  });
+
   it("returns null when low/high bounds are invalid", () => {
     expect(parseProfile(makeProfile({ low: "8", high: "6" }))).toBeNull();
     expect(parseProfile(makeProfile({ target: "3" }))).toBeNull();

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -162,6 +162,20 @@ describe('Profile page', () => {
     );
   });
 
+  it('toggles grams per XE input with carb unit', async () => {
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
+    const { queryByLabelText, getByDisplayValue } = render(<Profile />);
+
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalledWith(123);
+    });
+
+    expect(queryByLabelText('Граммов на 1 ХЕ')).toBeNull();
+    const select = getByDisplayValue('г') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'xe' } });
+    expect(queryByLabelText('Граммов на 1 ХЕ')).not.toBeNull();
+  });
+
   it('blocks save when target is out of range and shows toast', () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
 
@@ -353,7 +367,7 @@ describe('Profile page', () => {
   it('submits advanced bolus fields and sends patch only for changes', async () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
     (saveProfile as vi.Mock).mockResolvedValue(undefined);
-    const { getByText, getByPlaceholderText, getAllByPlaceholderText, getByDisplayValue } =
+    const { getByText, getByPlaceholderText, getByDisplayValue, getByLabelText } =
       render(<Profile />);
     await waitFor(() => {
       expect((getByPlaceholderText('4') as HTMLInputElement).value).toBe('4');
@@ -361,14 +375,16 @@ describe('Profile page', () => {
     fireEvent.change(getByPlaceholderText('4'), { target: { value: '5' } });
     fireEvent.change(getByPlaceholderText('15'), { target: { value: '20' } });
     fireEvent.change(getByPlaceholderText('0.5'), { target: { value: '1' } });
-    fireEvent.change(getAllByPlaceholderText('12')[1], { target: { value: '15' } });
+    const carbSelect = getByDisplayValue('г') as HTMLSelectElement;
+    fireEvent.change(carbSelect, { target: { value: 'xe' } });
+    fireEvent.change(getByLabelText('Граммов на 1 ХЕ'), {
+      target: { value: '15' },
+    });
     fireEvent.change(getByPlaceholderText('10'), { target: { value: '12' } });
     fireEvent.change(getByPlaceholderText('120'), { target: { value: '90' } });
     fireEvent.change(getByDisplayValue('aspart'), {
       target: { value: 'lispro' },
     });
-    const carbSelect = getByDisplayValue('г') as HTMLSelectElement;
-    fireEvent.change(carbSelect, { target: { value: 'xe' } });
 
     fireEvent.click(getByText('Сохранить настройки'));
 


### PR DESCRIPTION
## Summary
- Hide grams-per-XE field when carb unit is grams
- Skip grams-per-XE validation in profile parsing unless carb unit is XE
- Update profile tests for grams-per-XE toggling

## Testing
- `NODE_OPTIONS=--max_old_space_size=4096 pnpm --filter ./services/webapp/ui test`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6c09b85e0832ab0f4116ed63d8ce4