### PR TITLE
[ui] Hide unit/range when unavailable in ProfileHelpSheet

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -201,17 +201,25 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
               <AccordionTrigger>{t(section.titleKey)}</AccordionTrigger>
               <AccordionContent>
                 <ul className="space-y-3">
-                  {section.items.map((item) => (
-                    <li key={item.key}>
-                      <p className="font-medium">{t(item.titleKey)}</p>
-                      <p className="text-sm text-muted-foreground">
-                        {t(item.definitionKey)}
-                      </p>
-                      <p className="text-sm text-muted-foreground">
-                        {t('profileHelp.units')}: {t(item.unitKey)}; {t('profileHelp.range')}: {t(item.rangeKey)}
-                      </p>
-                    </li>
-                  ))}
+                  {section.items.map((item) => {
+                    const unit = t(item.unitKey);
+                    const range = t(item.rangeKey);
+
+                    return (
+                      <li key={item.key}>
+                        <p className="font-medium">{t(item.titleKey)}</p>
+                        <p className="text-sm text-muted-foreground">
+                          {t(item.definitionKey)}
+                        </p>
+                        {unit !== '—' && range !== '—' && (
+                          <p className="text-sm text-muted-foreground">
+                            {t('profileHelp.units')}: {unit};{' '}
+                            {t('profileHelp.range')}: {range}
+                          </p>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </AccordionContent>
             </AccordionItem>

--- a/tests/ProfileHelpSheet.test.tsx
+++ b/tests/ProfileHelpSheet.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
 import ProfileHelpSheet from '../services/webapp/ui/src/components/ProfileHelpSheet';
@@ -22,6 +22,17 @@ describe('ProfileHelpSheet', () => {
     fireEvent.click(screen.getAllByLabelText('Справка')[0]);
     expect(screen.queryByText('Инсулин')).toBeNull();
     expect(screen.getByText('Цели сахара')).toBeTruthy();
+  });
+
+  it('omits unit and range for rapid insulin type', () => {
+    render(<ProfileHelpSheet />);
+    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Инсулин' }));
+    const item = screen.getByText('Тип быстрого инсулина').closest('li');
+    expect(item).not.toBeNull();
+    const utils = within(item as HTMLElement);
+    expect(utils.queryByText(/Единицы/)).toBeNull();
+    expect(utils.queryByText(/Диапазон/)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Render unit and range info only when translations exist
- Test ProfileHelpSheet omits unit and range for rapid insulin type

## Testing
- `pnpm --filter ./services/webapp/ui exec vitest run tests/ProfileHelpSheet.test.tsx --config vitest.config.ts`
- `mypy --strict .`
- `ruff check .`
- `pytest -q --cov` *(fails: unrecognized arguments --cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c61af918832ab045a0c914df90ca