### PR TITLE
[ui] default HelpHint tooltip side

### DIFF
--- a/services/webapp/ui/src/components/HelpHint.tsx
+++ b/services/webapp/ui/src/components/HelpHint.tsx
@@ -17,7 +17,12 @@ interface HelpHintProps {
   side?: React.ComponentProps<typeof TooltipContent>['side'];
 }
 
-const HelpHint = ({ label, children, className, side }: HelpHintProps) => {
+const HelpHint = ({
+  label,
+  children,
+  className,
+  side = 'right',
+}: HelpHintProps) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 


### PR DESCRIPTION
## Summary
- default `side` prop of `HelpHint` to `'right'`

## Testing
- `pnpm --filter ./services/webapp/ui test tests/HelpHint.test.tsx`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6c6155b68832aa8e2e7509b6ef4a4