### PR TITLE
[ui] use RapidInsulin union type

### DIFF
--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -17,7 +17,7 @@ const makeProfile = (
   roundStep: "1",
   carbUnit: "g",
   gramsPerXe: "12",
-  rapidInsulinType: "lispro" as RapidInsulin,
+  rapidInsulinType: "lispro",
   maxBolus: "20",
   afterMealMinutes: "60",
   ...overrides,

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -31,12 +31,7 @@ vi.mock('../src/pages/resolveTelegramId', () => ({
 }));
 
 import Profile from '../src/pages/Profile';
-import {
-  saveProfile,
-  getProfile,
-  patchProfile,
-  type RapidInsulin,
-} from '../src/features/profile/api';
+import { saveProfile, getProfile, patchProfile } from '../src/features/profile/api';
 import { resolveTelegramId } from '../src/pages/resolveTelegramId';
 import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
 
@@ -56,7 +51,7 @@ describe('Profile page', () => {
       roundStep: 0.5,
       carbUnit: 'g',
       gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
+      rapidInsulinType: 'aspart',
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
       timezone: 'Europe/Moscow',
@@ -268,7 +263,7 @@ describe('Profile page', () => {
         roundStep: 0.5,
         carbUnit: 'g',
         gramsPerXe: 12,
-        rapidInsulinType: 'aspart' as RapidInsulin,
+        rapidInsulinType: 'aspart',
         maxBolus: 10,
         defaultAfterMealMinutes: 120,
         timezone: 'Europe/Moscow',
@@ -400,7 +395,7 @@ describe('Profile page', () => {
         roundStep: 1,
         carbUnit: 'xe',
         gramsPerXe: 15,
-        rapidInsulinType: 'lispro' as RapidInsulin,
+        rapidInsulinType: 'lispro',
         maxBolus: 12,
         defaultAfterMealMinutes: 90,
       });
@@ -422,7 +417,7 @@ describe('Profile page', () => {
       roundStep: 0.5,
       carbUnit: 'g',
       gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
+      rapidInsulinType: 'aspart',
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
       timezone: 'Europe/Moscow',
@@ -455,7 +450,7 @@ describe('Profile page', () => {
       roundStep: 0.5,
       carbUnit: 'g',
       gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
+      rapidInsulinType: 'aspart',
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
       timezone: 'Europe/Moscow',
@@ -497,7 +492,7 @@ describe('Profile page', () => {
       roundStep: 0.5,
       carbUnit: 'g',
       gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
+      rapidInsulinType: 'aspart',
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
       therapyType: 'insulin',
@@ -522,7 +517,7 @@ describe('Profile page', () => {
       roundStep: 0.5,
       carbUnit: 'g',
       gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
+      rapidInsulinType: 'aspart',
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
       therapyType: 'insulin',
@@ -560,7 +555,7 @@ describe('Profile page', () => {
       roundStep: 0.5,
       carbUnit: 'g',
       gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
+      rapidInsulinType: 'aspart',
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
       therapyType: 'insulin',


### PR DESCRIPTION
## Summary
- define RapidInsulin union for rapid insulin options
- type profile form and parsing with RapidInsulin
- update tests to rely on RapidInsulin without casts

## Testing
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test`


------
https://chatgpt.com/codex/tasks/task_e_68b6caa690c0832aa1250ba8ba57868b