### PR TITLE
[webapp] test rapid insulin type

### DIFF
--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -2,9 +2,27 @@ import { describe, it, expect } from "vitest";
 import { parseProfile, shouldWarnProfile } from "../src/pages/Profile";
 import type { RapidInsulin } from "../src/features/profile/api";
 
+type TestProfileForm = {
+  icr: string;
+  cf: string;
+  target: string;
+  low: string;
+  high: string;
+  timezone: string;
+  timezoneAuto: boolean;
+  dia: string;
+  preBolus: string;
+  roundStep: string;
+  carbUnit: "g" | "xe";
+  gramsPerXe: string;
+  rapidInsulinType: RapidInsulin;
+  maxBolus: string;
+  afterMealMinutes: string;
+};
+
 const makeProfile = (
-  overrides: Record<string, string | boolean | RapidInsulin> = {},
-) => ({
+  overrides: Partial<TestProfileForm> = {},
+): TestProfileForm => ({
   icr: "1",
   cf: "2",
   target: "5",
@@ -17,7 +35,7 @@ const makeProfile = (
   roundStep: "1",
   carbUnit: "g",
   gramsPerXe: "12",
-  rapidInsulinType: "lispro" as RapidInsulin,
+  rapidInsulinType: "lispro",
   maxBolus: "20",
   afterMealMinutes: "60",
   ...overrides,

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -31,12 +31,11 @@ vi.mock('../src/pages/resolveTelegramId', () => ({
 }));
 
 import Profile from '../src/pages/Profile';
-import {
-  saveProfile,
-  getProfile,
-  patchProfile,
-  type RapidInsulin,
-} from '../src/features/profile/api';
+import { saveProfile, getProfile, patchProfile } from '../src/features/profile/api';
+import type { RapidInsulin } from '../src/features/profile/api';
+
+const ASPART: RapidInsulin = 'aspart';
+const LISPRO: RapidInsulin = 'lispro';
 import { resolveTelegramId } from '../src/pages/resolveTelegramId';
 import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
 
@@ -56,7 +55,7 @@ describe('Profile page', () => {
       roundStep: 0.5,
       carbUnit: 'g',
       gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
+      rapidInsulinType: ASPART,
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
       timezone: 'Europe/Moscow',
@@ -268,7 +267,7 @@ describe('Profile page', () => {
         roundStep: 0.5,
         carbUnit: 'g',
         gramsPerXe: 12,
-        rapidInsulinType: 'aspart' as RapidInsulin,
+        rapidInsulinType: ASPART,
         maxBolus: 10,
         defaultAfterMealMinutes: 120,
         timezone: 'Europe/Moscow',
@@ -400,7 +399,7 @@ describe('Profile page', () => {
         roundStep: 1,
         carbUnit: 'xe',
         gramsPerXe: 15,
-        rapidInsulinType: 'lispro' as RapidInsulin,
+        rapidInsulinType: LISPRO,
         maxBolus: 12,
         defaultAfterMealMinutes: 90,
       });
@@ -422,7 +421,7 @@ describe('Profile page', () => {
       roundStep: 0.5,
       carbUnit: 'g',
       gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
+      rapidInsulinType: ASPART,
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
       timezone: 'Europe/Moscow',
@@ -455,7 +454,7 @@ describe('Profile page', () => {
       roundStep: 0.5,
       carbUnit: 'g',
       gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
+      rapidInsulinType: ASPART,
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
       timezone: 'Europe/Moscow',
@@ -497,7 +496,7 @@ describe('Profile page', () => {
       roundStep: 0.5,
       carbUnit: 'g',
       gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
+      rapidInsulinType: ASPART,
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
       therapyType: 'insulin',
@@ -522,7 +521,7 @@ describe('Profile page', () => {
       roundStep: 0.5,
       carbUnit: 'g',
       gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
+      rapidInsulinType: ASPART,
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
       therapyType: 'insulin',
@@ -560,7 +559,7 @@ describe('Profile page', () => {
       roundStep: 0.5,
       carbUnit: 'g',
       gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
+      rapidInsulinType: ASPART,
       maxBolus: 10,
       defaultAfterMealMinutes: 120,
       therapyType: 'insulin',


### PR DESCRIPTION
## Summary
- strengthen rapid insulin typing in profile parsing tests
- use typed constants for rapid insulin in profile page tests

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter ./services/webapp/ui test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_68b6caac1258832a8f132e9826fb47e6