### PR TITLE
[ui] Allow zero prebolus and after-meal delay

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -330,28 +330,29 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
         const timezoneAuto = data.timezoneAuto === true;
         const therapyType = data.therapyType ?? undefined;
 
-        const insulinRequiredComplete = [
-          icr,
-          cf,
-          target,
-          low,
-          high,
-          dia,
-          preBolus,
-          roundStep,
-          ...(carbUnit === "xe" ? [gramsPerXe] : []),
-          maxBolus,
-          afterMealMinutes,
-        ].every((v) => Number(v) > 0);
+        const insulinRequiredComplete =
+          [
+            icr,
+            cf,
+            target,
+            low,
+            high,
+            dia,
+            roundStep,
+            ...(carbUnit === "xe" ? [gramsPerXe] : []),
+            maxBolus,
+          ].every((v) => Number(v) > 0) &&
+          [preBolus, afterMealMinutes].every((v) => Number(v) >= 0);
 
-        const nonInsulinComplete = [
-          target,
-          low,
-          high,
-          roundStep,
-          ...(carbUnit === "xe" ? [gramsPerXe] : []),
-          afterMealMinutes,
-        ].every((v) => Number(v) > 0);
+        const nonInsulinComplete =
+          [
+            target,
+            low,
+            high,
+            roundStep,
+            ...(carbUnit === "xe" ? [gramsPerXe] : []),
+          ].every((v) => Number(v) > 0) &&
+          [afterMealMinutes].every((v) => Number(v) >= 0);
 
         const isComplete =
           therapyType === "tablets" || therapyType === "none"

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -343,6 +343,60 @@ describe('Profile page', () => {
     },
   );
 
+  it('allows zero pre-bolus and after-meal delay for insulin therapy', async () => {
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
+    (getProfile as vi.Mock).mockResolvedValueOnce({
+      telegramId: 123,
+      icr: 12,
+      cf: 2.5,
+      target: 6,
+      low: 4,
+      high: 10,
+      dia: 4,
+      preBolus: 0,
+      roundStep: 0.5,
+      carbUnit: 'g',
+      gramsPerXe: 12,
+      rapidInsulinType: 'aspart' as RapidInsulin,
+      maxBolus: 10,
+      defaultAfterMealMinutes: 0,
+      timezone: 'Europe/Moscow',
+      timezoneAuto: false,
+      therapyType: 'insulin',
+    });
+
+    render(<Profile />);
+    await waitFor(() => {
+      expect(getProfile).toHaveBeenCalled();
+    });
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it.each(nonInsulinTherapies)(
+    'allows zero after-meal delay for %s therapy',
+    async (therapy) => {
+      (resolveTelegramId as vi.Mock).mockReturnValue(123);
+      (getProfile as vi.Mock).mockResolvedValueOnce({
+        telegramId: 123,
+        target: 6,
+        low: 4,
+        high: 10,
+        roundStep: 1,
+        carbUnit: 'g',
+        gramsPerXe: 12,
+        defaultAfterMealMinutes: 0,
+        timezone: 'Europe/Moscow',
+        timezoneAuto: false,
+        therapyType: therapy,
+      });
+      render(<Profile therapyType={therapy} />);
+      await waitFor(() => {
+        expect(getProfile).toHaveBeenCalled();
+      });
+      expect(toast).not.toHaveBeenCalled();
+    },
+  );
+
   it('renders advanced bolus fields', async () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
     const { getByPlaceholderText } = render(<Profile />);


### PR DESCRIPTION
## Summary
- Allow zero `preBolus` and `afterMealMinutes` when determining profile completeness
- Add tests verifying profiles with zero pre-bolus and after-meal delay are valid

## Testing
- `pnpm --filter ./services/webapp/ui test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6cc5d14c0832a912ca14204848951