### PR TITLE
[webapp] omit insulin fields for non-insulin therapy

### DIFF
--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -37,16 +37,31 @@ export async function saveProfile({
   target,
   low,
   high,
-}: Pick<ProfileSchema, 'telegramId' | 'icr' | 'cf' | 'target' | 'low' | 'high'>) {
+}: {
+  telegramId: number;
+  target: number;
+  low: number;
+  high: number;
+  icr?: number;
+  cf?: number;
+}) {
   try {
-    return await api.post<ProfileSchema>('/profiles', {
+    const body: Record<string, unknown> = {
       telegramId,
-      icr,
-      cf,
       target,
       low,
       high,
-    });
+    };
+
+    if (icr !== undefined) {
+      body.icr = icr;
+    }
+
+    if (cf !== undefined) {
+      body.cf = cf;
+    }
+
+    return await api.post<ProfileSchema>('/profiles', body);
   } catch (error) {
     console.error('Failed to save profile:', error);
     if (error instanceof Error) {

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -69,6 +69,31 @@ describe('profile api', () => {
     );
   });
 
+  it('does not send insulin fields for non-insulin profiles', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ telegramId: 1, target: 5, low: 4, high: 10 }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      );
+    vi.stubGlobal('fetch', mockFetch);
+
+    await saveProfile({ telegramId: 1, target: 5, low: 4, high: 10 });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/profiles',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ telegramId: 1, target: 5, low: 4, high: 10 }),
+      }),
+    );
+  });
+
   it('throws error when patchProfile request fails', async () => {
     const mockFetch = vi
       .fn()


### PR DESCRIPTION
## Summary
- avoid sending insulin ratios when therapy type is tablets or none
- allow optional icr/cf in saveProfile API
- cover non-insulin saveProfile behavior with tests

## Testing
- `NODE_OPTIONS="--max-old-space-size=4096" pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: unrecognized arguments --cov)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6cc5fec3c832aaece05b8077f410a