### PR TITLE
[webapp] localize carb unit options

### DIFF
--- a/services/webapp/ui/src/locales/ru/profileHelp.ts
+++ b/services/webapp/ui/src/locales/ru/profileHelp.ts
@@ -67,6 +67,10 @@ const profileHelp = {
     definition: 'Единица измерения углеводов в расчётах',
     unit: 'г или ХЕ',
     range: 'г, ХЕ',
+    options: {
+      g: 'г',
+      xe: 'ХЕ',
+    },
   },
   gramsPerXe: {
     title: 'Граммов на 1 ХЕ',

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -808,8 +808,8 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                   value={profile.carbUnit}
                   onChange={(e) => handleInputChange('carbUnit', e.target.value)}
                 >
-                  <option value="g">г</option>
-                  <option value="xe">ХЕ</option>
+                  <option value="g">{t('profileHelp.carbUnit.options.g')}</option>
+                  <option value="xe">{t('profileHelp.carbUnit.options.xe')}</option>
                 </select>
               </div>
               {profile.carbUnit === 'xe' && (

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -39,6 +39,7 @@ import {
 } from '../src/features/profile/api';
 import { resolveTelegramId } from '../src/pages/resolveTelegramId';
 import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
+import { useTranslation } from '../src/i18n';
 
 const originalSupportedValuesOf = (Intl as any).supportedValuesOf;
 describe('Profile page', () => {
@@ -83,6 +84,21 @@ describe('Profile page', () => {
     cleanup();
     (Intl as any).supportedValuesOf = originalSupportedValuesOf;
     vi.restoreAllMocks();
+  });
+
+  it('displays carb unit options using localized text', () => {
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
+    const { getByLabelText } = render(<Profile />);
+    const { t } = useTranslation();
+    const select = getByLabelText(
+      t('profileHelp.carbUnit.title'),
+    ) as HTMLSelectElement;
+    expect(select.options[0].text).toBe(
+      t('profileHelp.carbUnit.options.g'),
+    );
+    expect(select.options[1].text).toBe(
+      t('profileHelp.carbUnit.options.xe'),
+    );
   });
 
   it('blocks save without telegramId and shows toast', () => {


### PR DESCRIPTION
## Summary
- add Russian translations for carb unit options
- use localized carb unit option labels in profile page
- test carb unit options localization

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `pnpm --prefix services/webapp/ui test` *(fails: default after meal minutes preselect test expected '150' got '120')*

------
https://chatgpt.com/codex/tasks/task_e_68b6cc60957c832a991a8b4b084a1ac0