### PR TITLE
[ui] Default therapy type to none before profile load

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -163,7 +163,9 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
   const sectionsByTherapy = sections.filter(
     (section) =>
       section.key !== 'insulin' ||
-      (therapyType !== 'tablets' && therapyType !== 'none'),
+      (therapyType !== undefined &&
+        therapyType !== 'tablets' &&
+        therapyType !== 'none'),
   );
 
   return (

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -232,8 +232,8 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
   });
   const [original, setOriginal] = useState<ProfileForm | null>(null);
   const [timezones, setTimezones] = useState<string[]>([]);
-  const [therapyType, setTherapyType] = useState<TherapyType | undefined>(
-    therapyTypeProp,
+  const [therapyType, setTherapyType] = useState<TherapyType>(
+    therapyTypeProp ?? 'none',
   );
 
   const isInsulinTherapy =
@@ -329,7 +329,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
             ? data.timezone
             : deviceTz;
         const timezoneAuto = data.timezoneAuto === true;
-        const therapyType = data.therapyType ?? undefined;
+        const therapyType = data.therapyType ?? 'none';
 
         const insulinRequiredComplete =
           [

--- a/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
+++ b/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
@@ -10,10 +10,14 @@ vi.mock('@/hooks/use-mobile', () => ({
 }));
 
 describe('ProfileHelpSheet', () => {
-  it.each(['none', 'tablets'] as const)(
+  it.each([undefined, 'none', 'tablets'] as const)(
     'hides insulin section for %s therapy',
     (therapy) => {
-      render(<ProfileHelpSheet therapyType={therapy} />);
+      if (therapy === undefined) {
+        render(<ProfileHelpSheet />);
+      } else {
+        render(<ProfileHelpSheet therapyType={therapy} />);
+      }
       fireEvent.click(screen.getAllByLabelText('Справка')[0]);
       expect(screen.queryByText('Инсулин')).toBeNull();
       expect(screen.queryByText('Тип быстрого инсулина')).toBeNull();


### PR DESCRIPTION
## Summary
- default Profile therapyType state to 'none' so help sheet renders correctly before profile data loads
- filter out insulin help section when therapy type is unknown
- cover undefined therapy type in ProfileHelpSheet tests

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any)*
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: async plugin missing, many tests fail)*
- `mypy --strict .` *(no output)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6dd1e8258832aa57b71355a04c9f4