### PR TITLE
[ui] Separate unit and range display in ProfileHelpSheet

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -211,9 +211,13 @@ const ProfileHelpSheet = ({ therapyType }: ProfileHelpSheetProps) => {
                         <p className="text-sm text-muted-foreground">
                           {t(item.definitionKey)}
                         </p>
-                        {unit !== '—' && range !== '—' && (
+                        {unit !== '—' && (
                           <p className="text-sm text-muted-foreground">
-                            {t('profileHelp.units')}: {unit};{' '}
+                            {t('profileHelp.units')}: {unit}
+                          </p>
+                        )}
+                        {range !== '—' && (
+                          <p className="text-sm text-muted-foreground">
                             {t('profileHelp.range')}: {range}
                           </p>
                         )}

--- a/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
+++ b/services/webapp/ui/tests/ProfileHelpSheet.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+import ru from '../src/locales/ru';
 
 import ProfileHelpSheet from '../src/components/ProfileHelpSheet';
 import * as mobileHook from '@/hooks/use-mobile';
@@ -57,5 +58,33 @@ describe('ProfileHelpSheet', () => {
 
     expect(screen.getByText('Целевой уровень сахара')).toBeTruthy();
     expect(screen.getByText('Шаг округления')).toBeTruthy();
+  });
+
+  it('renders unit without range when range translation is missing', () => {
+    const original = ru.profileHelp.target.range;
+    ru.profileHelp.target.range = '—';
+
+    render(<ProfileHelpSheet />);
+    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Цели сахара' }));
+
+    expect(screen.getByText(/Единицы:\s*ммоль\/л/)).toBeTruthy();
+    expect(screen.queryByText(/Диапазон:\s*4.0–7.0/)).toBeNull();
+
+    ru.profileHelp.target.range = original;
+  });
+
+  it('renders range without unit when unit translation is missing', () => {
+    const original = ru.profileHelp.target.unit;
+    ru.profileHelp.target.unit = '—';
+
+    render(<ProfileHelpSheet />);
+    fireEvent.click(screen.getAllByLabelText('Справка')[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Цели сахара' }));
+
+    expect(screen.getByText(/Диапазон:\s*4.0–7.0/)).toBeTruthy();
+    expect(screen.queryByText(/Единицы:\s*ммоль\/л/)).toBeNull();
+
+    ru.profileHelp.target.unit = original;
   });
 });


### PR DESCRIPTION
## Summary
- Render unit and range separately in ProfileHelpSheet
- Add tests for missing unit or range scenarios

## Testing
- `pnpm --filter ./services/webapp/ui test` *(fails: Unable to find an element with the text regex in ProfileHelpSheet tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b6dd38b0f0832a88ed408e442b3005