### PR TITLE
[webapp] extend preBolus limit

### DIFF
--- a/services/webapp/ui/src/locales/ru/profileHelp.ts
+++ b/services/webapp/ui/src/locales/ru/profileHelp.ts
@@ -48,7 +48,7 @@ const profileHelp = {
     title: 'Пре-болюс',
     definition: 'За сколько минут до еды вводить инсулин',
     unit: 'мин',
-    range: '0–60',
+    range: '0–120',
   },
   maxBolus: {
     title: 'Максимальный болюс',

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -163,7 +163,7 @@ export const parseProfile = (
     parsed.low < parsed.target &&
     parsed.target < parsed.high &&
     parsed.dia <= 12 &&
-    parsed.preBolus <= 60 &&
+    parsed.preBolus <= 120 &&
     parsed.roundStep <= 5 &&
     parsed.maxBolus <= 25 &&
     parsed.afterMealMinutes <= 180 &&

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -95,6 +95,11 @@ describe("parseProfile", () => {
     expect(parseProfile(makeProfile({ target: "12" }))).toBeNull();
   });
 
+  it("validates preBolus upper bound", () => {
+    expect(parseProfile(makeProfile({ preBolus: "121" }))).toBeNull();
+    expect(parseProfile(makeProfile({ preBolus: "120" }))?.preBolus).toBe(120);
+  });
+
   it("parses tablet therapy profile skipping insulin fields", () => {
     const result = parseProfile(
       makeProfile({


### PR DESCRIPTION
## Summary
- allow pre-bolus times up to 120 minutes
- update Russian help text to show 0–120 min range
- test parseProfile accepts 120 and rejects 121

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: async def functions are not natively supported, 434 failed)*
- `mypy --strict .` *(interrupted: no output)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6dd2aac64832a80beb3a3140bff42