### PR TITLE
[webapp] Align profile validation ranges

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -108,10 +108,9 @@ export const parseProfile = (
       parsed.low < parsed.high &&
       parsed.low < parsed.target &&
       parsed.target < parsed.high &&
-      parsed.roundStep <= 5 &&
-      parsed.afterMealMinutes <= 180 &&
+      parsed.afterMealMinutes <= 240 &&
       (parsed.carbUnit === 'g' || parsed.carbUnit === 'xe') &&
-      (!validateGrams || (parsed.gramsPerXe >= 5 && parsed.gramsPerXe <= 20));
+      (!validateGrams || parsed.gramsPerXe > 0);
     return numbersValid && positiveValid && rangeValid ? parsed : null;
   }
 
@@ -162,14 +161,12 @@ export const parseProfile = (
     parsed.low < parsed.high &&
     parsed.low < parsed.target &&
     parsed.target < parsed.high &&
-    parsed.dia <= 12 &&
-    parsed.preBolus <= 120 &&
-    parsed.roundStep <= 5 &&
-    parsed.maxBolus <= 25 &&
-    parsed.afterMealMinutes <= 180 &&
+    parsed.dia <= 24 &&
+    parsed.preBolus <= 60 &&
+    parsed.afterMealMinutes <= 240 &&
     (parsed.carbUnit === 'g' || parsed.carbUnit === 'xe') &&
     parsed.rapidInsulinType.length > 0 &&
-    (!validateGrams || (parsed.gramsPerXe >= 5 && parsed.gramsPerXe <= 20));
+    (!validateGrams || parsed.gramsPerXe > 0);
   return numbersValid && positiveValid && rangeValid ? parsed : null;
 };
 

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -96,8 +96,37 @@ describe("parseProfile", () => {
   });
 
   it("validates preBolus upper bound", () => {
-    expect(parseProfile(makeProfile({ preBolus: "121" }))).toBeNull();
-    expect(parseProfile(makeProfile({ preBolus: "120" }))?.preBolus).toBe(120);
+    expect(parseProfile(makeProfile({ preBolus: "61" }))).toBeNull();
+    expect(parseProfile(makeProfile({ preBolus: "60" }))?.preBolus).toBe(60);
+  });
+
+  it("validates DIA upper bound", () => {
+    expect(parseProfile(makeProfile({ dia: "25" }))).toBeNull();
+    expect(parseProfile(makeProfile({ dia: "24" }))?.dia).toBe(24);
+  });
+
+  it("validates afterMealMinutes upper bound", () => {
+    expect(
+      parseProfile(makeProfile({ afterMealMinutes: "241" })),
+    ).toBeNull();
+    expect(
+      parseProfile(makeProfile({ afterMealMinutes: "240" }))?.afterMealMinutes,
+    ).toBe(240);
+  });
+
+  it("allows large roundStep and maxBolus", () => {
+    const result = parseProfile(
+      makeProfile({ roundStep: "10", maxBolus: "50" }),
+    );
+    expect(result?.roundStep).toBe(10);
+    expect(result?.maxBolus).toBe(50);
+  });
+
+  it("allows gramsPerXe above 20", () => {
+    const result = parseProfile(
+      makeProfile({ gramsPerXe: "25", carbUnit: "xe" }),
+    );
+    expect(result?.gramsPerXe).toBe(25);
   });
 
   it("parses tablet therapy profile skipping insulin fields", () => {


### PR DESCRIPTION
## Summary
- unify profile boundaries with spec
- cover new limits for parseProfile

## Testing
- `pnpm --filter ./services/webapp/ui test tests/parseProfile.test.ts`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test` *(failed: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f24a264c832aa1b587ef5160c4e4