### PR TITLE
[ui] warn on high DIA and carb unit change

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -173,8 +173,20 @@ export const parseProfile = (
   return numbersValid && positiveValid && rangeValid ? parsed : null;
 };
 
-export const shouldWarnProfile = (profile: ParsedProfile): boolean =>
-  profile.icr > 8 && profile.cf < 3;
+export const shouldWarnProfile = (
+  profile: ParsedProfile,
+  original?: ParsedProfile,
+): boolean => {
+  const icrCfWarn = profile.icr > 8 && profile.cf < 3;
+  const diaWarn = profile.dia > 12;
+  const carbUnitWarn =
+    !!original &&
+    original.carbUnit !== profile.carbUnit &&
+    original.icr === profile.icr &&
+    profile.icr > 0;
+
+  return icrCfWarn || diaWarn || carbUnitWarn;
+};
 
 interface ProfileFormHeaderProps {
   onBack: () => void;
@@ -538,7 +550,11 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
       return;
     }
 
-    if (shouldWarnProfile(parsed)) {
+    const originalParsed = original
+      ? parseProfile(original, therapyType) || undefined
+      : undefined;
+
+    if (shouldWarnProfile(parsed, originalParsed)) {
       setPendingProfile({
         telegramId,
         ...parsed,

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -191,7 +191,7 @@ describe("parseProfile", () => {
 });
 
 describe("shouldWarnProfile", () => {
-  it("detects suspicious profile values", () => {
+  it("warns when ICR is high and CF is low", () => {
     expect(
       shouldWarnProfile({
         icr: 9,
@@ -209,6 +209,7 @@ describe("shouldWarnProfile", () => {
         afterMealMinutes: 0,
       }),
     ).toBe(true);
+
     expect(
       shouldWarnProfile({
         icr: 8,
@@ -226,6 +227,7 @@ describe("shouldWarnProfile", () => {
         afterMealMinutes: 0,
       }),
     ).toBe(false);
+
     expect(
       shouldWarnProfile({
         icr: 9,
@@ -242,6 +244,70 @@ describe("shouldWarnProfile", () => {
         maxBolus: 1,
         afterMealMinutes: 0,
       }),
+    ).toBe(false);
+  });
+
+  it("warns when DIA exceeds 12", () => {
+    expect(
+      shouldWarnProfile({
+        icr: 1,
+        cf: 2,
+        target: 5,
+        low: 4,
+        high: 10,
+        dia: 13,
+        preBolus: 0,
+        roundStep: 1,
+        carbUnit: "g",
+        gramsPerXe: 10,
+        rapidInsulinType: "aspart" as RapidInsulin,
+        maxBolus: 1,
+        afterMealMinutes: 0,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldWarnProfile({
+        icr: 1,
+        cf: 2,
+        target: 5,
+        low: 4,
+        high: 10,
+        dia: 12,
+        preBolus: 0,
+        roundStep: 1,
+        carbUnit: "g",
+        gramsPerXe: 10,
+        rapidInsulinType: "aspart" as RapidInsulin,
+        maxBolus: 1,
+        afterMealMinutes: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("warns when carb unit changes without ICR recalculation", () => {
+    const original = {
+      icr: 10,
+      cf: 2,
+      target: 5,
+      low: 4,
+      high: 10,
+      dia: 1,
+      preBolus: 0,
+      roundStep: 1,
+      carbUnit: "g" as const,
+      gramsPerXe: 12,
+      rapidInsulinType: "aspart" as RapidInsulin,
+      maxBolus: 1,
+      afterMealMinutes: 0,
+    };
+
+    expect(
+      shouldWarnProfile({ ...original, carbUnit: "xe" }, original),
+    ).toBe(true);
+
+    expect(
+      shouldWarnProfile({ ...original, carbUnit: "xe", icr: 0.8 }, original),
     ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- warn when DIA exceeds 12 hours
- warn if carb unit changes without recalculating ICR
- expand profile warning tests for DIA and carb unit change

## Testing
- `pnpm --filter ./services/webapp/ui lint` (fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-explicit-any, etc.)
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test` (fails: FATAL ERROR JavaScript heap out of memory)
- `pnpm --filter ./services/webapp/ui test tests/parseProfile.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b6f260d144832a983239ec4ba8a628