### PR TITLE
[docs] Correct quiet hours API field names

### DIFF
--- a/docs/feature_my_profile.md
+++ b/docs/feature_my_profile.md
@@ -221,8 +221,8 @@ low	low	low	> 0
 high	high	high	> 0
 timezone	timezone	timezone	IANA
 autoTimezone	auto_timezone	auto_timezone	bool
-quietStart	quietStart	quiet_start	HH:mm
-quietEnd	quietEnd	quiet_end	HH:mm
+quietStart	quiet_start	quiet_start	HH:mm
+quietEnd	quiet_end	quiet_end	HH:mm
 sosContact	sos_contact	sos_contact	формат валидируется
 sosEnabled	sos_enabled	sos_enabled	bool
 carbUnits	carb_units	carb_units	grams | xe


### PR DESCRIPTION
## Summary
- fix quiet hours names in profile fields matrix
- add missing trailing newline

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported; requires plugin)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6f2920a08832ab6bcf12bcf40a57a