### PR TITLE
[docs] Use snake_case for quiet hour API fields

### DIFF
--- a/docs/feature_my_profile.md
+++ b/docs/feature_my_profile.md
@@ -229,8 +229,8 @@ low     low     low     > 0
 high    high    high    > 0
 timezone        timezone        timezone        IANA
 timezoneAuto    timezone_auto   timezone_auto   bool
-quietStart      quietStart      quiet_start     HH:mm
-quietEnd        quietEnd        quiet_end       HH:mm
+quietStart      quiet_start      quiet_start     HH:mm
+quietEnd        quiet_end        quiet_end       HH:mm
 sosContact      sos_contact     sos_contact     формат валидируется
 sosEnabled      sos_enabled     sos_enabled     bool
 carbUnits       carb_units      carb_units      g | xe


### PR DESCRIPTION
## Summary
- fix quietStart/quietEnd API column values to quiet_start/quiet_end in profile table
- ensure file ends with a newline

## Testing
- `pytest --maxfail=1` *(fails: TypeError: 'timezone' is an invalid keyword argument for User)*
- `mypy --strict .` *(interrupted: command exceeded time limits)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6fde5a0bc832a95ada4f549bb8766