### PR TITLE
[profile] Add therapy type selection

### DIFF
--- a/services/api/app/diabetes/schemas/profile.py
+++ b/services/api/app/diabetes/schemas/profile.py
@@ -9,6 +9,15 @@ class CarbUnits(str, Enum):
     XE = "xe"
 
 
+class TherapyType(str, Enum):
+    """Available therapy types for a patient profile."""
+
+    INSULIN = "insulin"
+    TABLETS = "tablets"
+    NONE = "none"
+    MIXED = "mixed"
+
+
 class ProfileSettingsIn(BaseModel):
     """Incoming user settings for profile configuration."""
 
@@ -39,6 +48,11 @@ class ProfileSettingsIn(BaseModel):
         alias="sosAlertsEnabled",
         validation_alias=AliasChoices("sosAlertsEnabled", "sos_alerts_enabled"),
     )
+    therapyType: TherapyType | None = Field(
+        default=None,
+        alias="therapyType",
+        validation_alias=AliasChoices("therapyType", "therapy_type"),
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -61,3 +75,4 @@ class ProfileSettingsOut(ProfileSettingsIn):
     carbUnits: CarbUnits = Field(alias="carbUnits")
     sosContact: str | None = Field(default=None, alias="sosContact")
     sosAlertsEnabled: bool = Field(alias="sosAlertsEnabled")
+    therapyType: TherapyType = Field(alias="therapyType")

--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -29,6 +29,8 @@ async def profiles_post(data: ProfileSchema) -> ProfileSchema:
             session.add(profile)
         profile.timezone = data.timezone
         profile.timezone_auto = data.timezoneAuto
+        if data.therapyType is not None:
+            profile.therapy_type = data.therapyType
         try:
             commit(session)
         except CommitError:
@@ -77,4 +79,5 @@ async def profiles_get(
         ),
         timezone=tz,
         timezoneAuto=tz_auto,
+        therapyType=profile.therapy_type,
     )

--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -63,6 +63,11 @@ class ProfileSchema(BaseModel):
         alias="timezoneAuto",
         validation_alias=AliasChoices("timezoneAuto", "timezone_auto"),
     )
+    therapyType: str | None = Field(
+        default=None,
+        alias="therapyType",
+        validation_alias=AliasChoices("therapyType", "therapy_type"),
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -15,6 +15,7 @@ from ..diabetes.schemas.profile import (
     CarbUnits,
     ProfileSettingsIn,
     ProfileSettingsOut,
+    TherapyType,
 )
 from ..types import SessionProtocol
 
@@ -79,6 +80,8 @@ async def patch_user_settings(
             profile.sos_contact = data.sosContact
         if data.sosAlertsEnabled is not None:
             profile.sos_alerts_enabled = data.sosAlertsEnabled
+        if data.therapyType is not None:
+            profile.therapy_type = data.therapyType.value
 
         if profile.timezone_auto and device_tz and profile.timezone != device_tz:
             profile.timezone = device_tz
@@ -96,6 +99,7 @@ async def patch_user_settings(
             carbUnits=CarbUnits(profile.carb_units),
             sosContact=profile.sos_contact,
             sosAlertsEnabled=profile.sos_alerts_enabled,
+            therapyType=TherapyType(profile.therapy_type),
         )
 
     return await db.run_db(_patch, sessionmaker=db.SessionLocal)

--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -124,6 +124,13 @@ const sections: HelpSection[] = [
         rangeKey: 'profileHelp.roundStep.range',
       },
       {
+        key: 'therapyType',
+        titleKey: 'profileHelp.therapyType.title',
+        definitionKey: 'profileHelp.therapyType.definition',
+        unitKey: 'profileHelp.therapyType.unit',
+        rangeKey: 'profileHelp.therapyType.range',
+      },
+      {
         key: 'carbUnit',
         titleKey: 'profileHelp.carbUnit.title',
         definitionKey: 'profileHelp.carbUnit.definition',

--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -82,6 +82,7 @@ export type PatchProfileDto = {
   rapidInsulinType?: RapidInsulin | null;
   maxBolus?: number | null;
   defaultAfterMealMinutes?: number | null;
+  therapyType?: 'insulin' | 'tablets' | 'none' | 'mixed' | null;
 };
 
 export async function patchProfile(payload: PatchProfileDto) {

--- a/services/webapp/ui/src/locales/ru/profileHelp.ts
+++ b/services/webapp/ui/src/locales/ru/profileHelp.ts
@@ -103,6 +103,18 @@ const profileHelp = {
     range: 'UTC−12:00 — UTC+14:00',
     auto: 'Определять автоматически',
   },
+  therapyType: {
+    title: 'Тип терапии',
+    definition: 'Используемый режим лечения',
+    unit: '—',
+    range: '—',
+    options: {
+      insulin: 'Инсулин',
+      tablets: 'Таблетки',
+      none: 'Нет',
+      mixed: 'Смешанная',
+    },
+  },
 };
 
 export default profileHelp;

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -244,6 +244,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
   const [therapyType, setTherapyType] = useState<TherapyType>(
     therapyTypeProp ?? 'none',
   );
+  const [originalTherapyType, setOriginalTherapyType] = useState<TherapyType>(
+    therapyTypeProp ?? 'none',
+  );
 
   const isInsulinTherapy =
     therapyType === 'insulin' || therapyType === 'mixed';
@@ -390,6 +393,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
         setProfile(loaded);
         setOriginal(loaded);
         setTherapyType(therapyType);
+        setOriginalTherapyType(therapyType);
 
         if (timezoneAuto && timezone !== deviceTz) {
           patchProfile({
@@ -458,9 +462,14 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     }
   };
 
-  const buildPatch = (parsed: ParsedProfile): PatchProfileDto => {
+  const buildPatch = (
+    parsed: ParsedProfile,
+    therapyTypeValue: TherapyType,
+  ): PatchProfileDto => {
     if (!original) return {};
     const patch: PatchProfileDto = {};
+    if (therapyTypeValue !== originalTherapyType)
+      patch.therapyType = therapyTypeValue;
     if (profile.timezone !== original.timezone) patch.timezone = profile.timezone;
     if (profile.timezoneAuto !== original.timezoneAuto)
       patch.timezoneAuto = profile.timezoneAuto;
@@ -511,6 +520,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
 
       await saveProfile(payload);
       setOriginal(profile);
+      if (data.therapyType) {
+        setOriginalTherapyType(data.therapyType);
+      }
       toast({
         title: t('profile.saved'),
         description: t('profile.settingsUpdated'),
@@ -555,7 +567,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
       setPendingProfile({
         telegramId,
         ...parsed,
-        patch: buildPatch(parsed),
+        patch: buildPatch(parsed, therapyType),
         therapyType,
       });
       setWarningOpen(true);
@@ -569,7 +581,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     await saveParsedProfile({
       telegramId,
       ...parsed,
-      patch: buildPatch(parsed),
+      patch: buildPatch(parsed, therapyType),
       therapyType,
     });
   };
@@ -610,6 +622,37 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
         <main className="container mx-auto px-4 py-6">
         <div className="medical-card animate-slide-up bg-gradient-to-br from-primary/5 to-primary/10 border-primary/20">
         <div className="space-y-6">
+          <div>
+            <label
+              htmlFor="therapyType"
+              className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
+            >
+              {t('profileHelp.therapyType.title')}
+              <HelpHint label="profileHelp.therapyType.title">
+                {t('profileHelp.therapyType.definition')}
+              </HelpHint>
+            </label>
+            <select
+              id="therapyType"
+              className="medical-input"
+              value={therapyType}
+              onChange={(e) => setTherapyType(e.target.value as TherapyType)}
+            >
+              <option value="insulin">
+                {t('profileHelp.therapyType.options.insulin')}
+              </option>
+              <option value="tablets">
+                {t('profileHelp.therapyType.options.tablets')}
+              </option>
+              <option value="none">
+                {t('profileHelp.therapyType.options.none')}
+              </option>
+              <option value="mixed">
+                {t('profileHelp.therapyType.options.mixed')}
+              </option>
+            </select>
+          </div>
+
           {isInsulinTherapy && (
             <>
               {/* ICR */}

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -217,6 +217,25 @@ describe("parseProfile", () => {
       ),
     ).toBeNull();
   });
+
+  it("parses mixed therapy profile including insulin fields", () => {
+    const result = parseProfile(makeProfile(), "mixed");
+    expect(result).toEqual({
+      icr: 1,
+      cf: 2,
+      target: 5,
+      low: 4,
+      high: 10,
+      dia: 7,
+      preBolus: 10,
+      roundStep: 1,
+      carbUnit: "g",
+      gramsPerXe: 12,
+      rapidInsulinType: "lispro" as RapidInsulin,
+      maxBolus: 20,
+      afterMealMinutes: 60,
+    });
+  });
 });
 
 describe("shouldWarnProfile", () => {
@@ -337,6 +356,26 @@ describe("shouldWarnProfile", () => {
 
     expect(
       shouldWarnProfile({ ...original, carbUnit: "xe", icr: 0.8 }, original),
+    ).toBe(false);
+  });
+
+  it("does not warn for non-insulin therapy", () => {
+    expect(
+      shouldWarnProfile({
+        icr: 0,
+        cf: 0,
+        target: 5,
+        low: 4,
+        high: 10,
+        dia: 0,
+        preBolus: 0,
+        roundStep: 1,
+        carbUnit: "g",
+        gramsPerXe: 10,
+        rapidInsulinType: "aspart" as RapidInsulin,
+        maxBolus: 0,
+        afterMealMinutes: 0,
+      }),
     ).toBe(false);
   });
 });

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -549,6 +549,32 @@ describe('Profile page', () => {
     });
   });
 
+  it('sends therapyType change to server on save', async () => {
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
+    (saveProfile as vi.Mock).mockResolvedValue(undefined);
+    const { getByLabelText, getByText } = render(<Profile />);
+    const { t } = useTranslation();
+
+    await waitFor(() => {
+      expect(
+        (getByLabelText(
+          t('profileHelp.therapyType.title'),
+        ) as HTMLSelectElement).value,
+      ).toBe('insulin');
+    });
+
+    const select = getByLabelText(
+      t('profileHelp.therapyType.title'),
+    ) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'tablets' } });
+
+    fireEvent.click(getByText('Сохранить настройки'));
+
+    await waitFor(() => {
+      expect(patchProfile).toHaveBeenCalledWith({ therapyType: 'tablets' });
+    });
+  });
+
   it('loads profile on mount and updates form', async () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
     (getProfile as vi.Mock).mockResolvedValue({

--- a/tests/test_profile_patch_status.py
+++ b/tests/test_profile_patch_status.py
@@ -24,7 +24,8 @@ def test_patch_profile_returns_status_ok(monkeypatch: pytest.MonkeyPatch) -> Non
 
     with TestClient(server.app) as client:
         resp = client.patch(
-            "/api/profile", json={"timezone": "UTC", "timezoneAuto": False}
+            "/api/profile",
+            json={"timezone": "UTC", "timezoneAuto": False, "therapyType": "tablets"},
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -32,5 +33,6 @@ def test_patch_profile_returns_status_ok(monkeypatch: pytest.MonkeyPatch) -> Non
         assert data["timezoneAuto"] is False
         assert data["sosAlertsEnabled"] is True
         assert data["sosContact"] is None
+        assert data["therapyType"] == "tablets"
 
     server.app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add therapy type selector to profile page and handle onChange
- extend profile patch API and backend to store therapy type
- cover new therapy paths with tests and translations

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter ./services/webapp/ui test`
- `pytest tests/test_profile_patch_status.py -q` *(fails: Required test coverage of 85% not reached. Total coverage: 25.34%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b6ffb755bc832aa4da5befa70c4dc9