### PR TITLE
[api] support gramsPerXe setting

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -733,6 +733,9 @@ components:
           - g
           - xe
           title: Carb Units
+        gramsPerXe:
+          type: number
+          title: Grams Per Xe
         sosContact:
           anyOf:
           - type: string
@@ -753,6 +756,7 @@ components:
       - dia
       - roundStep
       - carbUnits
+      - gramsPerXe
       - sosAlertsEnabled
       title: ProfileSettingsOut
     ProfileSchema:

--- a/libs/ts-sdk/models/ProfileSettingsIn.ts
+++ b/libs/ts-sdk/models/ProfileSettingsIn.ts
@@ -51,6 +51,12 @@ export interface ProfileSettingsIn {
     carbUnits?: ProfileSettingsInCarbUnitsEnum;
     /**
      * 
+     * @type {number}
+     * @memberof ProfileSettingsIn
+     */
+    gramsPerXe?: number;
+    /**
+     * 
      * @type {string}
      * @memberof ProfileSettingsIn
      */
@@ -96,6 +102,7 @@ export function ProfileSettingsInFromJSONTyped(json: any, ignoreDiscriminator: b
         'dia': json['dia'] == null ? undefined : json['dia'],
         'roundStep': json['roundStep'] == null ? undefined : json['roundStep'],
         'carbUnits': json['carbUnits'] == null ? undefined : json['carbUnits'],
+        'gramsPerXe': json['gramsPerXe'] == null ? undefined : json['gramsPerXe'],
         'sosContact': json['sosContact'] == null ? undefined : json['sosContact'],
         'sosAlertsEnabled': json['sosAlertsEnabled'] == null ? undefined : json['sosAlertsEnabled'],
     };
@@ -117,6 +124,7 @@ export function ProfileSettingsInToJSONTyped(value?: ProfileSettingsIn | null, i
         'dia': value['dia'],
         'roundStep': value['roundStep'],
         'carbUnits': value['carbUnits'],
+        'gramsPerXe': value['gramsPerXe'],
         'sosContact': value['sosContact'],
         'sosAlertsEnabled': value['sosAlertsEnabled'],
     };

--- a/libs/ts-sdk/models/ProfileSettingsOut.ts
+++ b/libs/ts-sdk/models/ProfileSettingsOut.ts
@@ -51,6 +51,12 @@ export interface ProfileSettingsOut {
     carbUnits: ProfileSettingsOutCarbUnitsEnum;
     /**
      * 
+     * @type {number}
+     * @memberof ProfileSettingsOut
+     */
+    gramsPerXe: number;
+    /**
+     * 
      * @type {string}
      * @memberof ProfileSettingsOut
      */
@@ -83,6 +89,7 @@ export function instanceOfProfileSettingsOut(value: object): value is ProfileSet
     if (!('dia' in value) || value['dia'] === undefined) return false;
     if (!('roundStep' in value) || value['roundStep'] === undefined) return false;
     if (!('carbUnits' in value) || value['carbUnits'] === undefined) return false;
+    if (!('gramsPerXe' in value) || value['gramsPerXe'] === undefined) return false;
     if (!('sosAlertsEnabled' in value) || value['sosAlertsEnabled'] === undefined) return false;
     return true;
 }
@@ -102,6 +109,7 @@ export function ProfileSettingsOutFromJSONTyped(json: any, ignoreDiscriminator: 
         'dia': json['dia'],
         'roundStep': json['roundStep'],
         'carbUnits': json['carbUnits'],
+        'gramsPerXe': json['gramsPerXe'],
         'sosContact': json['sosContact'] == null ? undefined : json['sosContact'],
         'sosAlertsEnabled': json['sosAlertsEnabled'],
     };
@@ -123,6 +131,7 @@ export function ProfileSettingsOutToJSONTyped(value?: ProfileSettingsOut | null,
         'dia': value['dia'],
         'roundStep': value['roundStep'],
         'carbUnits': value['carbUnits'],
+        'gramsPerXe': value['gramsPerXe'],
         'sosContact': value['sosContact'],
         'sosAlertsEnabled': value['sosAlertsEnabled'],
     };

--- a/services/api/app/diabetes/schemas/profile.py
+++ b/services/api/app/diabetes/schemas/profile.py
@@ -38,6 +38,11 @@ class ProfileSettingsIn(BaseModel):
         alias="carbUnits",
         validation_alias=AliasChoices("carbUnits", "carb_units"),
     )
+    gramsPerXe: float | None = Field(
+        default=None,
+        alias="gramsPerXe",
+        validation_alias=AliasChoices("gramsPerXe", "grams_per_xe"),
+    )
     sosContact: str | None = Field(
         default=None,
         alias="sosContact",
@@ -62,6 +67,8 @@ class ProfileSettingsIn(BaseModel):
             raise ValueError("dia must be between 1 and 24 hours")
         if self.roundStep is not None and self.roundStep <= 0:
             raise ValueError("roundStep must be positive")
+        if self.gramsPerXe is not None and self.gramsPerXe <= 0:
+            raise ValueError("gramsPerXe must be positive")
         return self
 
 
@@ -73,6 +80,7 @@ class ProfileSettingsOut(ProfileSettingsIn):
     dia: float
     roundStep: float = Field(alias="roundStep")
     carbUnits: CarbUnits = Field(alias="carbUnits")
+    gramsPerXe: float = Field(alias="gramsPerXe")
     sosContact: str | None = Field(default=None, alias="sosContact")
     sosAlertsEnabled: bool = Field(alias="sosAlertsEnabled")
     therapyType: TherapyType = Field(alias="therapyType")

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -76,6 +76,8 @@ async def patch_user_settings(
             profile.round_step = data.roundStep
         if data.carbUnits is not None:
             profile.carb_units = data.carbUnits.value
+        if data.gramsPerXe is not None:
+            profile.grams_per_xe = data.gramsPerXe
         if data.sosContact is not None:
             profile.sos_contact = data.sosContact
         if data.sosAlertsEnabled is not None:
@@ -97,6 +99,7 @@ async def patch_user_settings(
             dia=profile.dia,
             roundStep=profile.round_step,
             carbUnits=CarbUnits(profile.carb_units),
+            gramsPerXe=profile.grams_per_xe,
             sosContact=profile.sos_contact,
             sosAlertsEnabled=profile.sos_alerts_enabled,
             therapyType=TherapyType(profile.therapy_type),

--- a/tests/test_profile_patch_endpoint.py
+++ b/tests/test_profile_patch_endpoint.py
@@ -114,3 +114,21 @@ def test_profile_patch_partial_update(
         assert prof.carb_units == "g"
         assert prof.sos_alerts_enabled is True
         assert prof.sos_contact is None
+
+
+def test_profile_patch_sets_grams_per_xe(
+    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
+) -> None:
+    SessionLocal = setup_db(monkeypatch)
+    with TestClient(server.app) as client:
+        resp = client.patch(
+            "/api/profile", json={"gramsPerXe": 15}, headers=auth_headers
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["gramsPerXe"] == 15
+
+    with SessionLocal() as session:
+        prof = session.get(db.Profile, 1)
+        assert prof is not None
+        assert prof.grams_per_xe == 15


### PR DESCRIPTION
## Summary
- add gramsPerXe field to profile settings schemas and service handler
- expose gramsPerXe in OpenAPI and regenerate TypeScript SDK
- test saving gramsPerXe via profile patch endpoint

## Testing
- `pytest -q` (fails: TypeError: 'timezone' is an invalid keyword argument for User)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b70a9ecaf4832a9e5a49ff75885832