### PR TITLE
[profile] Support rapid insulin and bolus settings

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -742,6 +742,25 @@ components:
           type: boolean
           title: Sos Alerts Enabled
           default: true
+        rapidInsulinType:
+          anyOf:
+          - type: string
+            enum:
+            - aspart
+            - lispro
+            - glulisine
+            - regular
+          - type: 'null'
+          title: Rapid Insulin Type
+        maxBolus:
+          type: number
+          title: Max Bolus
+        preBolus:
+          type: integer
+          title: Pre Bolus
+        afterMealMinutes:
+          type: integer
+          title: After Meal Minutes
       type: object
       title: ProfileSettingsIn
     ProfileSettingsOut:
@@ -754,6 +773,9 @@ components:
       - roundStep
       - carbUnits
       - sosAlertsEnabled
+      - maxBolus
+      - preBolus
+      - afterMealMinutes
       title: ProfileSettingsOut
     ProfileSchema:
       properties:

--- a/libs/ts-sdk/models/ProfileSettingsIn.ts
+++ b/libs/ts-sdk/models/ProfileSettingsIn.ts
@@ -61,6 +61,30 @@ export interface ProfileSettingsIn {
      * @memberof ProfileSettingsIn
      */
     sosAlertsEnabled?: boolean;
+    /**
+     * 
+     * @type {string}
+     * @memberof ProfileSettingsIn
+     */
+    rapidInsulinType?: ProfileSettingsInRapidInsulinTypeEnum | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof ProfileSettingsIn
+     */
+    maxBolus?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ProfileSettingsIn
+     */
+    preBolus?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ProfileSettingsIn
+     */
+    afterMealMinutes?: number;
 }
 
 
@@ -72,6 +96,17 @@ export const ProfileSettingsInCarbUnitsEnum = {
     Xe: 'xe'
 } as const;
 export type ProfileSettingsInCarbUnitsEnum = typeof ProfileSettingsInCarbUnitsEnum[keyof typeof ProfileSettingsInCarbUnitsEnum];
+
+/**
+ * @export
+ */
+export const ProfileSettingsInRapidInsulinTypeEnum = {
+    Aspart: 'aspart',
+    Lispro: 'lispro',
+    Glulisine: 'glulisine',
+    Regular: 'regular'
+} as const;
+export type ProfileSettingsInRapidInsulinTypeEnum = typeof ProfileSettingsInRapidInsulinTypeEnum[keyof typeof ProfileSettingsInRapidInsulinTypeEnum];
 
 
 /**
@@ -98,6 +133,10 @@ export function ProfileSettingsInFromJSONTyped(json: any, ignoreDiscriminator: b
         'carbUnits': json['carbUnits'] == null ? undefined : json['carbUnits'],
         'sosContact': json['sosContact'] == null ? undefined : json['sosContact'],
         'sosAlertsEnabled': json['sosAlertsEnabled'] == null ? undefined : json['sosAlertsEnabled'],
+        'rapidInsulinType': json['rapidInsulinType'] == null ? undefined : json['rapidInsulinType'],
+        'maxBolus': json['maxBolus'] == null ? undefined : json['maxBolus'],
+        'preBolus': json['preBolus'] == null ? undefined : json['preBolus'],
+        'afterMealMinutes': json['afterMealMinutes'] == null ? undefined : json['afterMealMinutes'],
     };
 }
 
@@ -119,6 +158,10 @@ export function ProfileSettingsInToJSONTyped(value?: ProfileSettingsIn | null, i
         'carbUnits': value['carbUnits'],
         'sosContact': value['sosContact'],
         'sosAlertsEnabled': value['sosAlertsEnabled'],
+        'rapidInsulinType': value['rapidInsulinType'],
+        'maxBolus': value['maxBolus'],
+        'preBolus': value['preBolus'],
+        'afterMealMinutes': value['afterMealMinutes'],
     };
 }
 

--- a/libs/ts-sdk/models/ProfileSettingsOut.ts
+++ b/libs/ts-sdk/models/ProfileSettingsOut.ts
@@ -61,6 +61,30 @@ export interface ProfileSettingsOut {
      * @memberof ProfileSettingsOut
      */
     sosAlertsEnabled: boolean;
+    /**
+     * 
+     * @type {string}
+     * @memberof ProfileSettingsOut
+     */
+    rapidInsulinType?: ProfileSettingsOutRapidInsulinTypeEnum;
+    /**
+     * 
+     * @type {number}
+     * @memberof ProfileSettingsOut
+     */
+    maxBolus: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ProfileSettingsOut
+     */
+    preBolus: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ProfileSettingsOut
+     */
+    afterMealMinutes: number;
 }
 
 
@@ -73,6 +97,17 @@ export const ProfileSettingsOutCarbUnitsEnum = {
 } as const;
 export type ProfileSettingsOutCarbUnitsEnum = typeof ProfileSettingsOutCarbUnitsEnum[keyof typeof ProfileSettingsOutCarbUnitsEnum];
 
+/**
+ * @export
+ */
+export const ProfileSettingsOutRapidInsulinTypeEnum = {
+    Aspart: 'aspart',
+    Lispro: 'lispro',
+    Glulisine: 'glulisine',
+    Regular: 'regular'
+} as const;
+export type ProfileSettingsOutRapidInsulinTypeEnum = typeof ProfileSettingsOutRapidInsulinTypeEnum[keyof typeof ProfileSettingsOutRapidInsulinTypeEnum];
+
 
 /**
  * Check if a given object implements the ProfileSettingsOut interface.
@@ -84,6 +119,9 @@ export function instanceOfProfileSettingsOut(value: object): value is ProfileSet
     if (!('roundStep' in value) || value['roundStep'] === undefined) return false;
     if (!('carbUnits' in value) || value['carbUnits'] === undefined) return false;
     if (!('sosAlertsEnabled' in value) || value['sosAlertsEnabled'] === undefined) return false;
+    if (!('maxBolus' in value) || value['maxBolus'] === undefined) return false;
+    if (!('preBolus' in value) || value['preBolus'] === undefined) return false;
+    if (!('afterMealMinutes' in value) || value['afterMealMinutes'] === undefined) return false;
     return true;
 }
 
@@ -104,6 +142,10 @@ export function ProfileSettingsOutFromJSONTyped(json: any, ignoreDiscriminator: 
         'carbUnits': json['carbUnits'],
         'sosContact': json['sosContact'] == null ? undefined : json['sosContact'],
         'sosAlertsEnabled': json['sosAlertsEnabled'],
+        'rapidInsulinType': json['rapidInsulinType'] == null ? undefined : json['rapidInsulinType'],
+        'maxBolus': json['maxBolus'],
+        'preBolus': json['preBolus'],
+        'afterMealMinutes': json['afterMealMinutes'],
     };
 }
 
@@ -125,6 +167,10 @@ export function ProfileSettingsOutToJSONTyped(value?: ProfileSettingsOut | null,
         'carbUnits': value['carbUnits'],
         'sosContact': value['sosContact'],
         'sosAlertsEnabled': value['sosAlertsEnabled'],
+        'rapidInsulinType': value['rapidInsulinType'],
+        'maxBolus': value['maxBolus'],
+        'preBolus': value['preBolus'],
+        'afterMealMinutes': value['afterMealMinutes'],
     };
 }
 

--- a/services/api/app/diabetes/schemas/profile.py
+++ b/services/api/app/diabetes/schemas/profile.py
@@ -18,6 +18,15 @@ class TherapyType(str, Enum):
     MIXED = "mixed"
 
 
+class RapidInsulinType(str, Enum):
+    """Types of rapid-acting insulin."""
+
+    ASPART = "aspart"
+    LISPRO = "lispro"
+    GLULISINE = "glulisine"
+    REGULAR = "regular"
+
+
 class ProfileSettingsIn(BaseModel):
     """Incoming user settings for profile configuration."""
 
@@ -53,6 +62,31 @@ class ProfileSettingsIn(BaseModel):
         alias="therapyType",
         validation_alias=AliasChoices("therapyType", "therapy_type"),
     )
+    rapidInsulinType: RapidInsulinType | None = Field(
+        default=None,
+        alias="rapidInsulinType",
+        validation_alias=AliasChoices("rapidInsulinType", "insulin_type"),
+    )
+    maxBolus: float | None = Field(
+        default=None,
+        alias="maxBolus",
+        validation_alias=AliasChoices("maxBolus", "max_bolus"),
+    )
+    preBolus: int | None = Field(
+        default=None,
+        alias="preBolus",
+        validation_alias=AliasChoices("preBolus", "prebolus_min"),
+    )
+    afterMealMinutes: int | None = Field(
+        default=None,
+        alias="afterMealMinutes",
+        validation_alias=AliasChoices(
+            "afterMealMinutes",
+            "postmeal_check_min",
+            "postMealCheckMin",
+            "defaultAfterMealMinutes",
+        ),
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -62,6 +96,12 @@ class ProfileSettingsIn(BaseModel):
             raise ValueError("dia must be between 1 and 24 hours")
         if self.roundStep is not None and self.roundStep <= 0:
             raise ValueError("roundStep must be positive")
+        if self.maxBolus is not None and self.maxBolus <= 0:
+            raise ValueError("maxBolus must be positive")
+        if self.preBolus is not None and not (0 <= self.preBolus <= 60):
+            raise ValueError("preBolus must be between 0 and 60 minutes")
+        if self.afterMealMinutes is not None and not (0 <= self.afterMealMinutes <= 240):
+            raise ValueError("afterMealMinutes must be between 0 and 240 minutes")
         return self
 
 
@@ -76,3 +116,7 @@ class ProfileSettingsOut(ProfileSettingsIn):
     sosContact: str | None = Field(default=None, alias="sosContact")
     sosAlertsEnabled: bool = Field(alias="sosAlertsEnabled")
     therapyType: TherapyType = Field(alias="therapyType")
+    rapidInsulinType: RapidInsulinType | None = Field(default=None, alias="rapidInsulinType")
+    maxBolus: float = Field(alias="maxBolus")
+    preBolus: int = Field(alias="preBolus")
+    afterMealMinutes: int = Field(alias="afterMealMinutes")

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -13,6 +13,7 @@ from ..diabetes.services.repository import CommitError, commit
 from ..schemas.profile import ProfileSchema
 from ..diabetes.schemas.profile import (
     CarbUnits,
+    RapidInsulinType,
     ProfileSettingsIn,
     ProfileSettingsOut,
     TherapyType,
@@ -82,6 +83,14 @@ async def patch_user_settings(
             profile.sos_alerts_enabled = data.sosAlertsEnabled
         if data.therapyType is not None:
             profile.therapy_type = data.therapyType.value
+        if data.rapidInsulinType is not None:
+            profile.insulin_type = data.rapidInsulinType.value
+        if data.maxBolus is not None:
+            profile.max_bolus = data.maxBolus
+        if data.preBolus is not None:
+            profile.prebolus_min = data.preBolus
+        if data.afterMealMinutes is not None:
+            profile.postmeal_check_min = data.afterMealMinutes
 
         if profile.timezone_auto and device_tz and profile.timezone != device_tz:
             profile.timezone = device_tz
@@ -100,6 +109,10 @@ async def patch_user_settings(
             sosContact=profile.sos_contact,
             sosAlertsEnabled=profile.sos_alerts_enabled,
             therapyType=TherapyType(profile.therapy_type),
+            rapidInsulinType=(RapidInsulinType(profile.insulin_type) if profile.insulin_type is not None else None),
+            maxBolus=profile.max_bolus,
+            preBolus=profile.prebolus_min,
+            afterMealMinutes=profile.postmeal_check_min,
         )
 
     return await db.run_db(_patch, sessionmaker=db.SessionLocal)


### PR DESCRIPTION
## Summary
- add rapidInsulinType, maxBolus, preBolus and afterMealMinutes settings
- persist new profile settings and expose in responses
- update OpenAPI spec, TypeScript SDK and tests

## Testing
- `pytest -q --cov` *(fails: 'timezone' is an invalid keyword argument for User)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b70aa884b0832ab3ba338e2d07c831