### PR TITLE
[handlers] ensure user exists when saving profile

### DIFF
--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -140,8 +140,12 @@ def save_profile(
     sos_alerts_enabled: bool = True,
 ) -> bool:
     """Persist profile values into the local database."""
+    user = session.get(User, user_id)
+    if user is None:
+        session.add(User(telegram_id=user_id, thread_id="api"))
+
     prof = session.get(Profile, user_id)
-    if not prof:
+    if prof is None:
         prof = Profile(telegram_id=user_id)
         session.add(prof)
     prof.icr = icr
@@ -179,7 +183,10 @@ def get_user_settings(session: Session, user_id: int) -> LocalUserSettings | Non
 
 
 def patch_user_settings(
-    session: Session, user_id: int, data: ProfileSettingsIn, device_tz: str | None = None
+    session: Session,
+    user_id: int,
+    data: ProfileSettingsIn,
+    device_tz: str | None = None,
 ) -> tuple[bool, bool]:
     """Persist user settings updating only provided values."""
     user = session.get(User, user_id)

--- a/tests/handlers/profile/test_api.py
+++ b/tests/handlers/profile/test_api.py
@@ -23,7 +23,9 @@ def session_factory() -> Generator[sessionmaker[Session], None, None]:
         poolclass=StaticPool,
     )
     Base.metadata.create_all(engine)
-    TestSession: sessionmaker[Session] = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    TestSession: sessionmaker[Session] = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False
+    )
     try:
         yield TestSession
     finally:
@@ -157,6 +159,19 @@ def test_save_profile_commit_failure(
     with session_factory() as session:
         prof = session.get(Profile, 1)
         assert prof is None
+
+
+def test_save_profile_creates_missing_user(
+    session_factory: sessionmaker[Session],
+) -> None:
+    with session_factory() as session:
+        ok = profile_api.save_profile(session, 1, 1.0, 2.0, 3.0, 4.0, 5.0)
+        assert ok is True
+
+    with session_factory() as session:
+        user = session.get(User, 1)
+        profile = session.get(Profile, 1)
+        assert user is not None and profile is not None
 
 
 def test_local_profiles_post_failure(


### PR DESCRIPTION
## Summary
- create missing users before saving a profile
- regression test for saving profile of a new user

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `pytest tests/handlers/profile/test_api.py::test_save_profile_creates_missing_user -q --no-cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b715265ba4832aa56e2c1d79de7910