### PR TITLE
tests: add profile handlers unit tests

### DIFF
--- a/tests/test_profile_args_parsing.py
+++ b/tests/test_profile_args_parsing.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from services.api.app.diabetes.handlers.profile.validation import (
+    MSG_CF_GT0,
+    MSG_HIGH_GT_LOW,
+    MSG_ICR_GT0,
+    MSG_LOW_GT0,
+    MSG_TARGET_GT0,
+    MSG_TARGET_RANGE,
+    parse_profile_args,
+    validate_profile_numbers,
+)
+
+
+def test_parse_profile_args_positional() -> None:
+    res = parse_profile_args(["1", "2", "3", "4", "5"])
+    assert res == {
+        "icr": "1",
+        "cf": "2",
+        "target": "3",
+        "low": "4",
+        "high": "5",
+    }
+
+
+def test_parse_profile_args_key_value() -> None:
+    res = parse_profile_args(["ICR=1", "c=2", "tar=3", "L=4", "H=5"])
+    assert res == {
+        "icr": "1",
+        "cf": "2",
+        "target": "3",
+        "low": "4",
+        "high": "5",
+    }
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["icr=1", "cf=2"],
+        ["foo=1", "cf=2", "target=3", "low=4", "high=5"],
+        ["icr=1", "cf=2", "target=3", "low=4", "bad"],
+    ],
+)
+def test_parse_profile_args_invalid(args: list[str]) -> None:
+    assert parse_profile_args(args) is None
+
+
+@pytest.mark.parametrize(
+    "nums, msg",
+    [
+        ((0, 1, 2, 3, 4), MSG_ICR_GT0),
+        ((1, 0, 2, 3, 4), MSG_CF_GT0),
+        ((1, 2, 0, 3, 4), MSG_TARGET_GT0),
+        ((1, 2, 3, 0, 4), MSG_LOW_GT0),
+        ((1, 2, 3, 4, 3), MSG_HIGH_GT_LOW),
+        ((1, 2, 5, 1, 4), MSG_TARGET_RANGE),
+    ],
+)
+def test_validate_profile_numbers_errors(
+    nums: tuple[float, float, float, float, float], msg: str
+) -> None:
+    assert validate_profile_numbers(*nums) == msg
+
+
+def test_validate_profile_numbers_success() -> None:
+    assert validate_profile_numbers(1, 2, 5, 3, 7) is None

--- a/tests/test_profile_timezone_save_flow.py
+++ b/tests/test_profile_timezone_save_flow.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+handlers = importlib.import_module(
+    "services.api.app.diabetes.handlers.profile.conversation"
+)
+
+
+class DummyMessage:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_profile_timezone_save_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(handlers, "build_timezone_webapp_button", lambda: None)
+    run_db = AsyncMock()
+    monkeypatch.setattr(handlers, "run_db", run_db)
+    message = DummyMessage("Bad/Zone")
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    state = await handlers.profile_timezone_save(update, context)
+    assert state == handlers.PROFILE_TZ
+    assert any("Некорректный часовой пояс" in r for r in message.replies)
+    assert run_db.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_profile_timezone_save_db_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_db = AsyncMock(return_value=(True, False))
+    monkeypatch.setattr(handlers, "run_db", run_db)
+    message = DummyMessage("Europe/Moscow")
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    state = await handlers.profile_timezone_save(update, context)
+    assert state == handlers.END
+    assert any("Не удалось обновить" in r for r in message.replies)
+    run_db.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_profile_timezone_save_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reminder_user = SimpleNamespace(id=1)
+    reminder = SimpleNamespace(id=5, user=reminder_user)
+
+    async def run_db(fn, *, sessionmaker):
+        run_db.calls += 1
+        if run_db.calls == 1:
+            return True, True
+        return [reminder]
+
+    run_db.calls = 0
+    monkeypatch.setattr(handlers, "run_db", run_db)
+
+    calls: list[tuple[Any, Any, Any]] = []
+
+    def reschedule(job_queue: Any, rem: Any, user: Any) -> None:
+        calls.append((job_queue, rem, user))
+
+    monkeypatch.setattr(handlers.reminder_handlers, "_reschedule_job", reschedule)
+
+    job_queue = object()
+    message = DummyMessage("Europe/Moscow")
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(job_queue=job_queue),
+    )
+    state = await handlers.profile_timezone_save(update, context)
+    assert state == handlers.END
+    assert any("Часовой пояс обновлён" in r for r in message.replies)
+    assert calls == [(job_queue, reminder, reminder_user)]
+    assert run_db.calls == 2

--- a/tests/test_profile_webapp_save_flow.py
+++ b/tests/test_profile_webapp_save_flow.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import importlib
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+handlers = importlib.import_module(
+    "services.api.app.diabetes.handlers.profile.conversation"
+)
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+        self.web_app_data: Any | None = None
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.texts.append(text)
+
+
+ERROR_MSG = "⚠️ Некорректные данные из WebApp."
+
+
+@pytest.mark.asyncio
+async def test_webapp_save_payload_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    post_mock = MagicMock()
+    monkeypatch.setattr(handlers, "get_api", lambda: (None, None, None))
+    monkeypatch.setattr(handlers, "post_profile", post_mock)
+    msg = DummyMessage()
+    msg.web_app_data = SimpleNamespace(data=json.dumps({"icr": 1}))
+    update = cast(
+        Update,
+        SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    await handlers.profile_webapp_save(update, context)
+    assert post_mock.call_count == 0
+    assert msg.texts == [ERROR_MSG]
+
+
+@pytest.mark.asyncio
+async def test_webapp_save_negative_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    post_mock = MagicMock()
+    monkeypatch.setattr(handlers, "get_api", lambda: (None, None, None))
+    monkeypatch.setattr(handlers, "post_profile", post_mock)
+    msg = DummyMessage()
+    msg.web_app_data = SimpleNamespace(
+        data=json.dumps({"icr": -1, "cf": 3, "target": 6, "low": 4, "high": 9})
+    )
+    update = cast(
+        Update,
+        SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    await handlers.profile_webapp_save(update, context)
+    assert post_mock.call_count == 0
+    assert msg.texts == [handlers.MSG_ICR_GT0]
+
+
+@pytest.mark.asyncio
+async def test_webapp_save_comma_decimal(monkeypatch: pytest.MonkeyPatch) -> None:
+    post_mock = MagicMock(return_value=(True, None))
+    save_mock = MagicMock(return_value=True)
+
+    async def run_db(func, sessionmaker):
+        session = MagicMock()
+        return func(session)
+
+    monkeypatch.setattr(handlers, "get_api", lambda: (None, None, None))
+    monkeypatch.setattr(handlers, "post_profile", post_mock)
+    monkeypatch.setattr(handlers, "save_profile", save_mock)
+    monkeypatch.setattr(handlers, "run_db", run_db)
+
+    msg = DummyMessage()
+    msg.web_app_data = SimpleNamespace(
+        data=json.dumps(
+            {"icr": "8,5", "cf": "3", "target": "6", "low": "4,2", "high": "9"}
+        )
+    )
+    update = cast(
+        Update,
+        SimpleNamespace(effective_message=msg, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    await handlers.profile_webapp_save(update, context)
+    assert post_mock.call_count == 1
+    assert post_mock.call_args[0][3:] == (1, 8.5, 3.0, 6.0, 4.2, 9.0)
+    save_mock.assert_called_once()
+    text = msg.texts[0]
+    assert "ИКХ: 8.5" in text
+    assert "Низкий порог: 4.2" in text


### PR DESCRIPTION
## Summary
- add argument parsing and numeric validation tests for /profile command
- cover webapp profile save flow including edge payloads
- test timezone update flow success and failure cases

## Testing
- `pytest -q` *(fails: TypeError: 'timezone' is an invalid keyword argument for User)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b715294638832a9fc4dbfe4d3be2e9