### PR TITLE
[services] support user timezone

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -156,6 +156,8 @@ class User(Base):
     onboarding_complete: Mapped[bool] = mapped_column(Boolean, default=False)
     plan: Mapped[str] = mapped_column(String, default="free")
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
+    timezone: Mapped[str] = mapped_column(String, default="UTC")
+    timezone_auto: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now()
     )


### PR DESCRIPTION
## Summary
- add timezone fields to users
- handle reminders without profile using UTC

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b716eabd6c832a9b881d0abb07a67c