### PR TITLE
[webapp] Avoid JSON headers for FormData

### DIFF
--- a/services/webapp/ui/src/api/http.ts
+++ b/services/webapp/ui/src/api/http.ts
@@ -2,10 +2,17 @@ import { getTelegramAuthHeaders } from '@/lib/telegram-auth';
 
 const API_BASE = '/api';
 
-async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+export async function request<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
   const headers = new Headers(init.headers);
 
-  if (init.body !== undefined && !headers.has('Content-Type')) {
+  if (
+    init.body !== undefined &&
+    !(init.body instanceof FormData) &&
+    !headers.has('Content-Type')
+  ) {
     headers.set('Content-Type', 'application/json');
   }
 

--- a/services/webapp/ui/src/lib/tgFetch.ts
+++ b/services/webapp/ui/src/lib/tgFetch.ts
@@ -5,7 +5,11 @@ const API_BASE = (
 function buildHeaders(init: RequestInit): Headers {
   const headers = new Headers(init.headers);
 
-  if (init.body !== undefined && !headers.has('Content-Type')) {
+  if (
+    init.body !== undefined &&
+    !(init.body instanceof FormData) &&
+    !headers.has('Content-Type')
+  ) {
     headers.set('Content-Type', 'application/json');
   }
 

--- a/services/webapp/ui/tests/http.test.ts
+++ b/services/webapp/ui/tests/http.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/telegram-auth', () => ({
+  getTelegramAuthHeaders: () => ({}),
+}));
+
+const makeJsonResponse = () =>
+  new Response('{}', {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('http.request', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not set Content-Type for FormData bodies', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeJsonResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { request } = await import('../src/api/http');
+    const form = new FormData();
+    form.append('field', 'value');
+    await request('/upload', { method: 'POST', body: form });
+    const init = fetchMock.mock.calls[0][1]!;
+    const headers = init.headers as Headers;
+    expect(headers.has('Content-Type')).toBe(false);
+    expect(init.body).toBe(form);
+  });
+});
+

--- a/services/webapp/ui/tests/tgFetch.test.ts
+++ b/services/webapp/ui/tests/tgFetch.test.ts
@@ -50,6 +50,19 @@ describe('tgFetch', () => {
     expect(headers.get('Content-Type')).toBe('application/json');
   });
 
+  it('does not set Content-Type for FormData bodies', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeJsonResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { tgFetch } = await import('../src/lib/tgFetch');
+    const form = new FormData();
+    form.append('field', 'value');
+    await tgFetch('/upload', { method: 'POST', body: form });
+    const init = fetchMock.mock.calls[0][1]!;
+    const headers = init.headers as Headers;
+    expect(headers.has('Content-Type')).toBe(false);
+    expect(init.body).toBe(form);
+  });
+
   it('throws error on failed response', async () => {
     const fetchMock = vi
       .fn()


### PR DESCRIPTION
## Summary
- Avoid setting JSON content-type when body is FormData in tgFetch and http.request
- Export request helper for testing and ensure FormData bypasses JSON serialization
- Add vitest coverage for FormData requests

## Testing
- `pnpm --filter ./services/webapp/ui test` *(fails: JavaScript heap out of memory)*
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b71d6687dc832aa1ed6cb367a92352