### PR TITLE
[ui] Validate chart color values

### DIFF
--- a/services/webapp/ui/src/components/ui/chart.test.tsx
+++ b/services/webapp/ui/src/components/ui/chart.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { ChartStyle, ChartConfig } from "./chart"
+
+describe("ChartStyle color validation", () => {
+  const id = "test"
+
+  it("ignores invalid color values", () => {
+    const config: ChartConfig = {
+      series: { color: "javascript:alert(1)" },
+    }
+    const { container } = render(<ChartStyle id={id} config={config} />)
+    const style = container.querySelector("style")
+    expect(style?.innerHTML).not.toContain("--color-series")
+  })
+
+  it("applies valid color values", () => {
+    const config: ChartConfig = {
+      series: { color: "#abc" },
+    }
+    const { container } = render(<ChartStyle id={id} config={config} />)
+    const style = container.querySelector("style")
+    expect(style?.innerHTML).toContain("--color-series: #abc")
+  })
+})

--- a/services/webapp/ui/src/components/ui/chart.tsx
+++ b/services/webapp/ui/src/components/ui/chart.tsx
@@ -65,6 +65,13 @@ const ChartContainer = React.forwardRef<
 })
 ChartContainer.displayName = "Chart"
 
+const COLOR_REGEX =
+  /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6,8})$|^(?:rgb|hsl)a?\([0-9.,%\s]+\)$/i
+
+function isValidColor(color: string): boolean {
+  return COLOR_REGEX.test(color.trim())
+}
+
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(
     ([_, config]) => config.theme || config.color
@@ -86,7 +93,9 @@ ${colorConfig
     const color =
       itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
       itemConfig.color
-    return color ? `  --color-${key}: ${color};` : null
+    return color && isValidColor(color)
+      ? `  --color-${key}: ${color};`
+      : null
   })
   .join("\n")}
 }


### PR DESCRIPTION
## Summary
- guard chart CSS variables with a regex-based color validator
- test valid and invalid color handling in `ChartStyle`

## Testing
- `pnpm --filter ./services/webapp/ui test src/components/ui/chart.test.tsx`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`

Full UI test suite (`pnpm --filter ./services/webapp/ui test`) failed due to JavaScript heap out of memory.


------
https://chatgpt.com/codex/tasks/task_e_68b71d717d98832a9eab8087a0391980