### PR TITLE
[ui] Add explicit reminder and profile types

### DIFF
--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -1,23 +1,10 @@
 import type { ProfileSchema } from '@sdk';
 import { api } from '@/api';
+import type { Profile, PatchProfileDto, RapidInsulin } from './types';
 
-export type RapidInsulin = 'aspart' | 'lispro' | 'glulisine' | 'regular';
-
-export interface ExtendedProfileSchema extends ProfileSchema {
-  dia?: number | null;
-  preBolus?: number | null;
-  roundStep?: number | null;
-  carbUnit?: 'g' | 'xe' | null;
-  gramsPerXe?: number | null;
-  rapidInsulinType?: RapidInsulin | null;
-  maxBolus?: number | null;
-  defaultAfterMealMinutes?: number | null;
-  therapyType?: 'insulin' | 'tablets' | 'none' | 'mixed' | null;
-}
-
-export async function getProfile(telegramId: number) {
+export async function getProfile(telegramId: number): Promise<Profile> {
   try {
-    return await api.get<ExtendedProfileSchema>(`/profiles?telegramId=${telegramId}`);
+    return await api.get<Profile>(`/profiles?telegramId=${telegramId}`);
   } catch (error) {
     console.error('Failed to load profile:', error);
     if (error instanceof SyntaxError) {
@@ -71,20 +58,6 @@ export async function saveProfile({
   }
 }
 
-export type PatchProfileDto = {
-  timezone?: string | null;
-  timezoneAuto?: boolean | null;
-  dia?: number | null;
-  preBolus?: number | null;
-  roundStep?: number | null;
-  carbUnit?: 'g' | 'xe' | null;
-  gramsPerXe?: number | null;
-  rapidInsulinType?: RapidInsulin | null;
-  maxBolus?: number | null;
-  defaultAfterMealMinutes?: number | null;
-  therapyType?: 'insulin' | 'tablets' | 'none' | 'mixed' | null;
-};
-
 export async function patchProfile(payload: PatchProfileDto) {
   try {
     const body: Record<string, unknown> = {};
@@ -102,3 +75,5 @@ export async function patchProfile(payload: PatchProfileDto) {
     throw error;
   }
 }
+
+export type { RapidInsulin, PatchProfileDto, Profile };

--- a/services/webapp/ui/src/features/profile/hooks.ts
+++ b/services/webapp/ui/src/features/profile/hooks.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { getProfile } from "./api";
+import type { Profile } from "./types";
 
 export function useDefaultAfterMealMinutes(telegramId: number | null | undefined) {
   const [value, setValue] = useState<number | null>(null);
@@ -7,10 +8,10 @@ export function useDefaultAfterMealMinutes(telegramId: number | null | undefined
   useEffect(() => {
     if (!telegramId) return;
     getProfile(telegramId)
-      .then((profile) => {
+      .then((profile: Profile) => {
         const minutes =
-          (profile as any).default_after_meal_minutes ??
-          (profile as any).defaultAfterMealMinutes;
+          profile.default_after_meal_minutes ??
+          profile.defaultAfterMealMinutes;
         if (typeof minutes === "number") {
           setValue(minutes);
         }

--- a/services/webapp/ui/src/features/profile/types.ts
+++ b/services/webapp/ui/src/features/profile/types.ts
@@ -1,0 +1,32 @@
+import type { ProfileSchema } from "@sdk";
+
+export type RapidInsulin = "aspart" | "lispro" | "glulisine" | "regular";
+
+export interface Profile extends ProfileSchema {
+  dia?: number | null;
+  preBolus?: number | null;
+  roundStep?: number | null;
+  carbUnit?: "g" | "xe" | null;
+  gramsPerXe?: number | null;
+  rapidInsulinType?: RapidInsulin | null;
+  maxBolus?: number | null;
+  defaultAfterMealMinutes?: number | null;
+  /** Compatibility with snake_case responses */
+  default_after_meal_minutes?: number | null;
+  therapyType?: "insulin" | "tablets" | "none" | "mixed" | null;
+}
+
+export type PatchProfileDto = {
+  timezone?: string | null;
+  timezoneAuto?: boolean | null;
+  dia?: number | null;
+  preBolus?: number | null;
+  roundStep?: number | null;
+  carbUnit?: "g" | "xe" | null;
+  gramsPerXe?: number | null;
+  rapidInsulinType?: RapidInsulin | null;
+  maxBolus?: number | null;
+  defaultAfterMealMinutes?: number | null;
+  therapyType?: "insulin" | "tablets" | "none" | "mixed" | null;
+};
+

--- a/services/webapp/ui/src/features/reminders/api/buildPayload.test.ts
+++ b/services/webapp/ui/src/features/reminders/api/buildPayload.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { buildReminderPayload } from "./buildPayload";
-
-import type { ReminderFormValues } from "./buildPayload";
+import type { ReminderDto } from "../types";
 
 describe("buildReminderPayload", () => {
   it("omits daysOfWeek for after_event reminders", () => {
-    const input: ReminderFormValues = {
+    const input: ReminderDto = {
       telegramId: 1,
       type: "after_meal",
       kind: "after_event",

--- a/services/webapp/ui/src/features/reminders/api/buildPayload.ts
+++ b/services/webapp/ui/src/features/reminders/api/buildPayload.ts
@@ -1,21 +1,5 @@
 import type { ReminderSchema } from "@sdk";
-
-export type ReminderType =
-  | "sugar" | "insulin_short" | "insulin_long" | "after_meal"
-  | "meal" | "sensor_change" | "injection_site" | "custom";
-export type ScheduleKind = "at_time" | "every" | "after_event";
-
-export interface ReminderFormValues {
-  telegramId: number;
-  type: ReminderType;
-  kind: ScheduleKind;
-  time?: string;
-  intervalMinutes?: number;
-  minutesAfter?: number;
-  daysOfWeek?: number[];
-  title?: string;
-  isEnabled?: boolean;
-}
+import type { ReminderDto, ReminderType } from "../types";
 
 const TYPE_LABEL: Record<ReminderType, string> = {
   sugar: "Измерение сахара",
@@ -28,7 +12,7 @@ const TYPE_LABEL: Record<ReminderType, string> = {
   custom: "Напоминание",
 };
 
-function generateTitle(v: ReminderFormValues): string {
+function generateTitle(v: ReminderDto): string {
   if (v.title?.trim()) return v.title.trim();
   if (v.kind === "at_time" && v.time) return `${TYPE_LABEL[v.type]} · ${v.time}`;
   if (v.kind === "every" && v.intervalMinutes) return `${TYPE_LABEL[v.type]} · каждые ${v.intervalMinutes} мин`;
@@ -36,7 +20,7 @@ function generateTitle(v: ReminderFormValues): string {
   return TYPE_LABEL[v.type];
 }
 
-export function buildReminderPayload(v: ReminderFormValues): ReminderSchema {
+export function buildReminderPayload(v: ReminderDto): ReminderSchema {
   // Guard: force after_event to use after_meal type
   const values = { ...v };
   if (values.kind === "after_event" && values.type !== "after_meal") {

--- a/services/webapp/ui/src/features/reminders/components/Templates.tsx
+++ b/services/webapp/ui/src/features/reminders/components/Templates.tsx
@@ -4,6 +4,7 @@ import { buildReminderPayload } from "../api/buildPayload";
 import { mockApi } from "../../../api/mock-server";
 import { useToast } from "../../../shared/toast";
 import { useDefaultAfterMealMinutes } from "../../profile/hooks";
+import type { ReminderDto } from "../types";
 
 export function Templates({
   telegramId,
@@ -53,7 +54,7 @@ export function Templates({
     [telegramId, defaultAfterMeal],
   );
   
-  const create = async (dto: any) => {
+  const create = async (dto: ReminderDto) => {
     try {
       const reminder = buildReminderPayload(dto);
 

--- a/services/webapp/ui/src/features/reminders/logic/validate.test.ts
+++ b/services/webapp/ui/src/features/reminders/logic/validate.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { validate } from "./validate";
-import type { ReminderFormValues } from "../api/buildPayload";
+import type { ReminderDto } from "../types";
 
 describe("validate", () => {
-  const base: ReminderFormValues = {
+  const base: ReminderDto = {
     telegramId: 1,
     type: "sugar",
     kind: "at_time",
@@ -21,7 +21,7 @@ describe("validate", () => {
     expect(errors.time).toBe("Формат HH:MM");
   });
 
-  const afterBase: ReminderFormValues = {
+  const afterBase: ReminderDto = {
     telegramId: 1,
     type: "after_meal",
     kind: "after_event",

--- a/services/webapp/ui/src/features/reminders/logic/validate.ts
+++ b/services/webapp/ui/src/features/reminders/logic/validate.ts
@@ -1,8 +1,8 @@
-import type { ReminderFormValues } from "../api/buildPayload";
+import type { ReminderDto } from "../types";
 
-export type FormErrors = Partial<Record<keyof ReminderFormValues, string>>;
+export type FormErrors = Partial<Record<keyof ReminderDto, string>>;
 
-export function validate(v: ReminderFormValues): FormErrors {
+export function validate(v: ReminderDto): FormErrors {
   const e: FormErrors = {};
   
   if (v.kind === "at_time" && !/^([01]\d|2[0-3]):[0-5]\d$/.test(v.time || "")) {

--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -4,12 +4,8 @@ import { useRemindersApi } from "../api/reminders"; // ваш хук, возвр
 import { DayOfWeekPicker } from "../components/DayOfWeekPicker";
 import { DaysPresets } from "../components/DaysPresets";
 import AfterEventDelay from "../components/AfterEventDelay";
-import {
-  buildReminderPayload,
-  ReminderFormValues,
-  ScheduleKind,
-  ReminderType,
-} from "../api/buildPayload";
+import { buildReminderPayload } from "../api/buildPayload";
+import type { ReminderDto, ScheduleKind, ReminderType } from "../types";
 import { validate, hasErrors } from "../logic/validate";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 import { useTelegram } from "../../../hooks/useTelegram";
@@ -48,7 +44,7 @@ export default function RemindersCreate() {
   const toast = useToast();
   const isDev = process.env.NODE_ENV === "development";
 
-  const [form, setForm] = useState<ReminderFormValues>({
+  const [form, setForm] = useState<ReminderDto>({
     telegramId,
     type: "sugar",
     kind: "at_time",
@@ -60,9 +56,9 @@ export default function RemindersCreate() {
   const errors = validate(form);
   const formHasErrors = hasErrors(errors);
 
-  const onChange = <K extends keyof ReminderFormValues>(
+  const onChange = <K extends keyof ReminderDto>(
     k: K,
-    v: ReminderFormValues[K],
+    v: ReminderDto[K],
   ) => setForm((s) => ({ ...s, [k]: v }));
 
   const presetsTime = ["07:30", "12:30", "22:00"];

--- a/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
@@ -5,12 +5,8 @@ import { useRemindersApi } from "../api/reminders";
 import { DayOfWeekPicker } from "../components/DayOfWeekPicker";
 import { DaysPresets } from "../components/DaysPresets";
 import AfterEventDelay from "../components/AfterEventDelay";
-import {
-  buildReminderPayload,
-  ReminderFormValues,
-  ScheduleKind,
-  ReminderType,
-} from "../api/buildPayload";
+import { buildReminderPayload } from "../api/buildPayload";
+import type { ReminderDto, ScheduleKind, ReminderType } from "../types";
 import { validate, hasErrors } from "../logic/validate";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 import { getTelegramUserId } from "../../../shared/telegram";
@@ -36,7 +32,7 @@ const KIND_OPTIONS: { value: ScheduleKind; label: string }[] = [
   { value: "after_event", label: "После события" },
 ];
 
-function mapToForm(reminder: ReminderSchema): ReminderFormValues {
+function mapToForm(reminder: ReminderSchema): ReminderDto {
   const kind: ScheduleKind =
     (reminder.kind as ScheduleKind | undefined) ||
     (reminder.time
@@ -72,7 +68,7 @@ export default function RemindersEdit() {
   const { id } = useParams<{ id: string }>();
   const nav = useNavigate();
   const toast = useToast();
-  const [form, setForm] = useState<ReminderFormValues | null>(null);
+  const [form, setForm] = useState<ReminderDto | null>(null);
   const [saving, setSaving] = useState(false);
 
   const presetsTime = ["07:30", "12:30", "22:00"];
@@ -109,9 +105,9 @@ export default function RemindersEdit() {
   const errors = validate(form);
   const formHasErrors = hasErrors(errors);
 
-  const onChange = <K extends keyof ReminderFormValues>(
+  const onChange = <K extends keyof ReminderDto>(
     k: K,
-    v: ReminderFormValues[K],
+    v: ReminderDto[K],
   ) => setForm((s) => (s ? { ...s, [k]: v } : s));
 
   async function onSubmit(e: React.FormEvent) {

--- a/services/webapp/ui/src/features/reminders/pages/RemindersList.bulk.ts
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersList.bulk.ts
@@ -1,6 +1,8 @@
 import type { ReminderSchema } from "@sdk";
+import type { RemindersApi } from "@sdk/apis";
+import type { Reminder } from "../types";
 
-export async function bulkToggle(api: any, items: any[], enable: boolean) {
+export async function bulkToggle(api: RemindersApi, items: Reminder[], enable: boolean) {
   let successCount = 0;
   let errorCount = 0;
 
@@ -10,12 +12,12 @@ export async function bulkToggle(api: any, items: any[], enable: boolean) {
         const reminder: ReminderSchema = {
           telegramId: r.telegramId,
           id: r.id,
-          type: r.type,
+          type: r.type as ReminderSchema["type"],
           kind: r.kind,
           time: r.time ?? undefined,
           intervalMinutes: r.intervalMinutes ?? undefined,
           minutesAfter: r.minutesAfter ?? undefined,
-          daysOfWeek: r.daysOfWeek ?? undefined,
+          daysOfWeek: r.daysOfWeek ? new Set(r.daysOfWeek) : undefined,
           isEnabled: enable,
         };
         await api.remindersPatch({ reminder });

--- a/services/webapp/ui/src/features/reminders/types.ts
+++ b/services/webapp/ui/src/features/reminders/types.ts
@@ -1,0 +1,30 @@
+export type ReminderType =
+  | "sugar"
+  | "insulin_short"
+  | "insulin_long"
+  | "after_meal"
+  | "meal"
+  | "sensor_change"
+  | "injection_site"
+  | "custom";
+
+export type ScheduleKind = "at_time" | "every" | "after_event";
+
+export interface ReminderDto {
+  telegramId: number;
+  type: ReminderType;
+  kind: ScheduleKind;
+  time?: string;
+  intervalMinutes?: number;
+  minutesAfter?: number;
+  daysOfWeek?: number[];
+  title?: string;
+  isEnabled?: boolean;
+}
+
+export interface Reminder extends ReminderDto {
+  id: number;
+  isEnabled: boolean;
+  nextAt?: string | null;
+}
+

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -11,13 +11,8 @@ import HelpHint from "@/components/HelpHint";
 import ProfileHelpSheet from "@/components/ProfileHelpSheet";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useTranslation } from "@/i18n";
-import {
-  saveProfile,
-  getProfile,
-  patchProfile,
-  type PatchProfileDto,
-  type RapidInsulin,
-} from "@/features/profile/api";
+import { saveProfile, getProfile, patchProfile } from "@/features/profile/api";
+import type { PatchProfileDto, RapidInsulin } from "@/features/profile/types";
 import { getTimezones } from "@/api/timezones";
 import { useTelegram } from "@/hooks/useTelegram";
 import { useTelegramInitData } from "@/hooks/useTelegramInitData";

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseProfile, shouldWarnProfile } from "../src/pages/Profile";
-import type { RapidInsulin } from "../src/features/profile/api";
+import type { RapidInsulin } from "../src/features/profile/types";
 
 const makeProfile = (
   overrides: Record<string, string | boolean | RapidInsulin> = {},

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -35,7 +35,7 @@ import { saveProfile, getProfile, patchProfile } from '../src/features/profile/a
 import { resolveTelegramId } from '../src/pages/resolveTelegramId';
 import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
 import { useTranslation } from '../src/i18n';
-import type { RapidInsulin } from '../src/features/profile/api';
+import type { RapidInsulin } from '../src/features/profile/types';
 
 const originalSupportedValuesOf = (Intl as any).supportedValuesOf;
 describe('Profile page', () => {


### PR DESCRIPTION
## Summary
- Define ReminderDto/Reminder interfaces and Profile types in dedicated modules
- Remove `any` usages in reminders templates, list, bulk toggle, and profile hooks
- Update tests to reference new typed modules

## Testing
- `pnpm --filter ./services/webapp/ui test` *(fails: ProfileHelpSheet.test.tsx, profile.test.tsx, reminders.default.test.tsx)*
- `pytest -q` *(fails: async def functions not supported)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b71d7b6f0c832a93f24682885ee6e1