### PR TITLE
[webapp] handle localStorage errors

### DIFF
--- a/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
@@ -59,7 +59,13 @@ export default function RemindersList({
   const [items, setItems] = useState<ReminderDto[]>([]);
   const [loading, setLoading] = useState(false);
   const [filter, setFilter] = useState<"all" | "on" | "off">(() => {
-    return (localStorage.getItem('reminderFilter') as "all" | "on" | "off") || "all";
+    try {
+      return (
+        localStorage.getItem('reminderFilter') as "all" | "on" | "off"
+      ) || "all";
+    } catch {
+      return "all";
+    }
   });
 
   async function load() {

--- a/services/webapp/ui/tests/RemindersList.localStorage.test.tsx
+++ b/services/webapp/ui/tests/RemindersList.localStorage.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import RemindersList from '../src/features/reminders/pages/RemindersList';
+
+vi.mock('../src/features/reminders/api/reminders', () => ({
+  useRemindersApi: () => ({
+    remindersGetRaw: vi.fn().mockResolvedValue({
+      value: async () => [
+        {
+          id: 1,
+          telegramId: 1,
+          type: 'sugar',
+          kind: 'at_time',
+          isEnabled: true,
+        },
+      ],
+      raw: { headers: new Headers() },
+    }),
+  }),
+}));
+
+vi.mock('@/hooks/useTelegram', () => ({
+  useTelegram: () => ({ user: { id: 1 } }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+describe('RemindersList localStorage fallback', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: () => {
+          throw new Error('blocked');
+        },
+        setItem: vi.fn(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    delete (window as any).localStorage;
+    cleanup();
+  });
+
+  it('uses default filter when localStorage is unavailable', async () => {
+    render(<RemindersList />);
+    const allButton = await screen.findByText(/^Все/);
+    expect(allButton.className).toContain('bg-primary');
+  });
+});


### PR DESCRIPTION
## Summary
- guard reminder filter reading with try/catch and default to "all"
- add test covering localStorage failure fallback

## Testing
- `pnpm --filter ./services/webapp/ui test tests/RemindersList.localStorage.test.tsx`
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b71d87044c832a8d76ed066da3c96b