### PR TITLE
[webapp] unify http utils and tests

### DIFF
--- a/services/webapp/ui/src/api/http.ts
+++ b/services/webapp/ui/src/api/http.ts
@@ -1,35 +1,10 @@
-import { getTelegramAuthHeaders } from '@/lib/telegram-auth';
+import { request as baseRequest } from '@/lib/http';
 
 const API_BASE = '/api';
 
 async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
-  const headers = new Headers(init.headers);
-
-  if (init.body !== undefined && !headers.has('Content-Type')) {
-    headers.set('Content-Type', 'application/json');
-  }
-
-  const authHeaders = getTelegramAuthHeaders();
-  Object.entries(authHeaders).forEach(([key, value]) => headers.set(key, value));
-
   try {
-    const res = await fetch(`${API_BASE}${path}`, {
-      ...init,
-      headers,
-    });
-
-    // Check if response is HTML (backend not available) - do this BEFORE parsing JSON
-    const contentType = res.headers.get('content-type');
-    if (contentType?.includes('text/html')) {
-      throw new Error('Backend returned HTML instead of JSON');
-    }
-
-    const data = (await res.json()) as Record<string, unknown>;
-    if (!res.ok) {
-      const msg = typeof data.detail === 'string' ? data.detail : 'Request failed';
-      throw new Error(msg);
-    }
-    return data as T;
+    return await baseRequest<T>(`${API_BASE}${path}`, init);
   } catch (error) {
     console.warn('[API] Backend request failed:', error);
     throw error;
@@ -39,17 +14,9 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
 export const http = {
   get: <T>(path: string) => request<T>(path),
   post: <T>(path: string, body: unknown) =>
-    request<T>(path, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    }),
+    request<T>(path, { method: 'POST', body }),
   patch: <T>(path: string, body: unknown) =>
-    request<T>(path, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    }),
+    request<T>(path, { method: 'PATCH', body }),
   delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
 };
 

--- a/services/webapp/ui/src/lib/http.ts
+++ b/services/webapp/ui/src/lib/http.ts
@@ -1,0 +1,81 @@
+import { getTelegramAuthHeaders } from './telegram-auth';
+
+interface BuildHeadersOptions {
+  telegram?: boolean;
+}
+
+export function buildHeaders(
+  init: RequestInit,
+  { telegram = false }: BuildHeadersOptions = {},
+): Headers {
+  const headers = new Headers(init.headers);
+
+  if (init.body !== undefined && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  if (telegram) {
+    const tgHeaders = getTelegramAuthHeaders();
+    Object.entries(tgHeaders).forEach(([key, value]) => {
+      if (!headers.has(key)) {
+        headers.set(key, value);
+      }
+    });
+  }
+
+  return headers;
+}
+
+export async function handleResponse<T>(res: Response): Promise<T> {
+  const contentType = res.headers.get('content-type');
+  if (contentType?.includes('text/html')) {
+    throw new Error('Backend returned HTML instead of JSON');
+  }
+
+  const isJson = contentType?.includes('application/json');
+  let data: unknown;
+
+  if (isJson) {
+    try {
+      data = await res.json();
+    } catch {
+      throw new Error('Некорректный ответ сервера');
+    }
+  } else {
+    data = await res.text();
+  }
+
+  if (!res.ok) {
+    const msg =
+      typeof (data as Record<string, unknown> | undefined)?.detail === 'string'
+        ? (data as Record<string, string>).detail
+        : typeof data === 'string'
+          ? data
+          : 'Request failed';
+    throw new Error(msg);
+  }
+
+  return data as T;
+}
+
+interface RequestOptions {
+  telegram?: boolean;
+}
+
+export async function request<T>(
+  url: string,
+  init: RequestInit = {},
+  opts: RequestOptions = {},
+): Promise<T> {
+  let body: BodyInit | null | undefined = init.body;
+
+  if (body !== undefined && body !== null) {
+    if (typeof body !== 'string' && !(body instanceof FormData)) {
+      body = JSON.stringify(body);
+    }
+  }
+
+  const headers = buildHeaders({ ...init, body }, opts);
+  const res = await fetch(url, { ...init, headers, body });
+  return handleResponse<T>(res);
+}

--- a/services/webapp/ui/src/lib/tgFetch.ts
+++ b/services/webapp/ui/src/lib/tgFetch.ts
@@ -1,73 +1,18 @@
+import { request } from './http';
+
 const API_BASE = (
   import.meta.env.VITE_API_BASE as string | undefined
 ) ?? '/api';
 
-function buildHeaders(init: RequestInit): Headers {
-  const headers = new Headers(init.headers);
-
-  if (init.body !== undefined && !headers.has('Content-Type')) {
-    headers.set('Content-Type', 'application/json');
-  }
-
-  const initData = (
-    window as unknown as { Telegram?: { WebApp?: { initData?: string } } }
-  )?.Telegram?.WebApp?.initData;
-
-  if (initData && !headers.has('X-Telegram-Init-Data')) {
-    headers.set('X-Telegram-Init-Data', initData);
-  }
-
-  return headers;
-}
-
-async function tgFetch<T>(
-  path: string,
-  init: RequestInit = {},
-): Promise<T> {
-  const headers = buildHeaders(init);
-  let body: BodyInit | null | undefined = init.body;
-
-  if (body !== undefined && body !== null) {
-    if (typeof body !== 'string' && !(body instanceof FormData)) {
-      body = JSON.stringify(body);
-    }
-  }
-
-  const res = await fetch(`${API_BASE}${path}`, { ...init, headers, body });
-  const isJson = res.headers.get('content-type')?.includes('application/json');
-  let data: unknown;
-
-  if (isJson) {
-    try {
-      data = await res.json();
-    } catch {
-      throw new Error('Некорректный ответ сервера');
-    }
-  } else {
-    data = await res.text();
-  }
-
-  if (!res.ok) {
-    const msg =
-      typeof (data as Record<string, unknown> | undefined)?.detail === 'string'
-        ? ((data as Record<string, string>).detail)
-        : typeof data === 'string'
-          ? data
-          : 'Request failed';
-    throw new Error(msg);
-  }
-
-  return data as T;
+function tgFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  return request<T>(`${API_BASE}${path}`, init, { telegram: true });
 }
 
 export const api = {
   get: <T>(path: string) => tgFetch<T>(path),
-  post: <T>(path: string, body: unknown) =>
-    tgFetch<T>(path, { method: 'POST', body }),
-  patch: <T>(path: string, body: unknown) =>
-    tgFetch<T>(path, { method: 'PATCH', body }),
-  put: <T>(path: string, body: unknown) =>
-    tgFetch<T>(path, { method: 'PUT', body }),
+  post: <T>(path: string, body: unknown) => tgFetch<T>(path, { method: 'POST', body }),
+  patch: <T>(path: string, body: unknown) => tgFetch<T>(path, { method: 'PATCH', body }),
+  put: <T>(path: string, body: unknown) => tgFetch<T>(path, { method: 'PUT', body }),
   delete: <T>(path: string) => tgFetch<T>(path, { method: 'DELETE' }),
 };
 

--- a/services/webapp/ui/tests/http.test.ts
+++ b/services/webapp/ui/tests/http.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const makeJsonResponse = () =>
+  new Response('{}', {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('http request', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it('serializes JSON bodies and sets content type', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeJsonResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { request } = await import('../src/lib/http');
+    await request('/api/test', { method: 'POST', body: { a: 1 } });
+    const init = fetchMock.mock.calls[0][1]!;
+    expect(init.body).toBe('{"a":1}');
+    const headers = init.headers as Headers;
+    expect(headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('adds telegram headers when option enabled', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeJsonResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const auth = await import('../src/lib/telegram-auth');
+    vi.spyOn(auth, 'getTelegramAuthHeaders').mockReturnValue({
+      'x-telegram-init-data': 'init',
+    });
+    const { request } = await import('../src/lib/http');
+    await request('/api/ping', {}, { telegram: true });
+    const headers = fetchMock.mock.calls[0][1]!.headers as Headers;
+    expect(headers.get('x-telegram-init-data')).toBe('init');
+  });
+
+  it('throws error on failed response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ detail: 'fail' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const { request } = await import('../src/lib/http');
+    await expect(request('/api/boom')).rejects.toThrow('fail');
+  });
+
+  it('throws error on HTML response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response('<html></html>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const { request } = await import('../src/lib/http');
+    await expect(request('/api/boom')).rejects.toThrow(
+      'Backend returned HTML instead of JSON',
+    );
+  });
+});

--- a/services/webapp/ui/tests/tgFetch.test.ts
+++ b/services/webapp/ui/tests/tgFetch.test.ts
@@ -38,32 +38,6 @@ describe('tgFetch', () => {
     expect(fetchMock).toHaveBeenCalledWith('http://example.com/test', expect.any(Object));
   });
 
-  it('serializes JSON bodies', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(makeJsonResponse());
-    vi.stubGlobal('fetch', fetchMock);
-    const { api } = await import('../src/lib/tgFetch');
-    await api.post('/item', { a: 1 });
-    const init = fetchMock.mock.calls[0][1]!;
-    expect(init.method).toBe('POST');
-    expect(init.body).toBe('{"a":1}');
-    const headers = init.headers as Headers;
-    expect(headers.get('Content-Type')).toBe('application/json');
-  });
-
-  it('throws error on failed response', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify({ detail: 'fail' }), {
-          status: 400,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-      );
-    vi.stubGlobal('fetch', fetchMock);
-    const { tgFetch } = await import('../src/lib/tgFetch');
-    await expect(tgFetch('/boom')).rejects.toThrow('fail');
-  });
-
   it('api.delete uses DELETE method', async () => {
     const fetchMock = vi.fn().mockResolvedValue(makeJsonResponse());
     vi.stubGlobal('fetch', fetchMock);


### PR DESCRIPTION
## Summary
- add shared http helper with optional telegram headers and response parsing
- refactor tgFetch and api/http to use shared helper
- expand tests for request helper and simplify tgFetch tests

## Testing
- `pnpm test tests/http.test.ts tests/tgFetch.test.ts`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b71d8f4f80832ab1a54e43d5c97995