### PR TITLE
[db] move timezone to profile

### DIFF
--- a/migrations/versions/20250902_drop_user_timezone.py
+++ b/migrations/versions/20250902_drop_user_timezone.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250902_drop_user_timezone"
+down_revision: Union[str, Sequence[str], None] = "20250901_profile_mvp"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_column("users", "timezone")
+    op.drop_column("users", "timezone_auto")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("timezone", sa.String(), nullable=False, server_default="UTC"),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "timezone_auto", sa.Boolean(), nullable=False, server_default=sa.true()
+        ),
+    )
+    op.alter_column("users", "timezone", server_default=None)
+    op.alter_column("users", "timezone_auto", server_default=None)

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -156,10 +156,11 @@ class User(Base):
     onboarding_complete: Mapped[bool] = mapped_column(Boolean, default=False)
     plan: Mapped[str] = mapped_column(String, default="free")
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
-    timezone: Mapped[str] = mapped_column(String, default="UTC")
-    timezone_auto: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now()
+    )
+    profile: Mapped["Profile"] = relationship(
+        "Profile", back_populates="user", uselist=False
     )
 
 
@@ -208,7 +209,7 @@ class Profile(Base):
     postmeal_check_min: Mapped[int] = mapped_column(Integer, default=0)
 
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
-    user: Mapped[User] = relationship("User")
+    user: Mapped[User] = relationship("User", back_populates="profile")
 
 
 class UserSettings(Base):

--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -36,7 +36,7 @@ async def _reminders_gc(_context: ContextTypes.DEFAULT_TYPE) -> None:
         with session_factory() as session:
             return (
                 session.query(Reminder)
-                .options(selectinload(Reminder.user))
+                .options(selectinload(Reminder.user).selectinload(User.profile))
                 .filter(Reminder.is_enabled == True)  # noqa: E712
                 .all()
             )

--- a/tests/test_legacy_reminders_auth.py
+++ b/tests/test_legacy_reminders_auth.py
@@ -50,7 +50,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]
 
     monkeypatch.setattr(reminders_router, "_post_job_queue_event", _noop)
     with TestSession() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
     try:
         with TestClient(server.app) as test_client:

--- a/tests/test_profile_optional_fields.py
+++ b/tests/test_profile_optional_fields.py
@@ -17,7 +17,7 @@ async def test_save_profile_saves_computed_target(
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
     data = ProfileSchema(
         telegramId=1,

--- a/tests/test_profile_quiet_fields.py
+++ b/tests/test_profile_quiet_fields.py
@@ -16,7 +16,7 @@ async def test_save_profile_stores_quiet_fields(monkeypatch: pytest.MonkeyPatch)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
     data = ProfileSchema(
         telegramId=1,
@@ -43,7 +43,7 @@ async def test_save_profile_defaults_quiet_fields(monkeypatch: pytest.MonkeyPatc
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
-        session.add(User(telegram_id=2, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=2, thread_id="t"))
         session.commit()
     data = ProfileSchema(
         telegramId=2,

--- a/tests/test_profile_sos_fields.py
+++ b/tests/test_profile_sos_fields.py
@@ -17,7 +17,7 @@ async def test_save_profile_stores_sos_fields(monkeypatch: pytest.MonkeyPatch) -
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
     data = ProfileSchema(
         telegramId=1,
@@ -46,7 +46,7 @@ async def test_save_profile_defaults_sos_fields(
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
-        session.add(User(telegram_id=2, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=2, thread_id="t"))
         session.commit()
     data = ProfileSchema(
         telegramId=2,
@@ -73,7 +73,7 @@ async def test_save_profile_persists_quiet_hours(
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
-        session.add(User(telegram_id=3, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=3, thread_id="t"))
         session.commit()
     data = ProfileSchema(
         telegramId=3,
@@ -102,7 +102,7 @@ async def test_save_profile_defaults_quiet_hours(
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     monkeypatch.setattr(db, "SessionLocal", TestSession)
     with TestSession() as session:
-        session.add(User(telegram_id=4, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=4, thread_id="t"))
         session.commit()
     data = ProfileSchema(
         telegramId=4,

--- a/tests/test_reminder_collector.py
+++ b/tests/test_reminder_collector.py
@@ -136,7 +136,7 @@ async def test_gc_replaces_outdated_job(
     monkeypatch.setattr(reminder_handlers, "SessionLocal", session_factory)
 
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(
             Reminder(
                 id=1,
@@ -175,8 +175,8 @@ async def test_gc_preloads_users(
     with session_factory() as session:
         session.add_all(
             [
-                User(telegram_id=1, thread_id="t1", timezone="UTC"),
-                User(telegram_id=2, thread_id="t2", timezone="UTC"),
+                User(telegram_id=1, thread_id="t1"),
+                User(telegram_id=2, thread_id="t2"),
             ]
         )
         session.add_all(
@@ -235,8 +235,8 @@ async def test_gc_continues_after_schedule_error(
     with session_factory() as session:
         session.add_all(
             [
-                User(telegram_id=1, thread_id="t1", timezone="UTC"),
-                User(telegram_id=2, thread_id="t2", timezone="UTC"),
+                User(telegram_id=1, thread_id="t1"),
+                User(telegram_id=2, thread_id="t2"),
             ]
         )
         session.add_all(

--- a/tests/test_reminder_reschedule.py
+++ b/tests/test_reminder_reschedule.py
@@ -130,7 +130,7 @@ def test_editing_reminder_replaces_job() -> None:
         is_enabled=True,
         days_mask=0,
     )
-    user = SimpleNamespace(timezone="UTC")
+    user = SimpleNamespace(profile=SimpleNamespace(timezone="UTC"))
 
     reminder_jobs.schedule_reminder(rem, job_queue, user)
     assert [j.run_time for j in job_queue.get_jobs_by_name("reminder_1")] == [dt_time(8, 0)]
@@ -156,7 +156,7 @@ def test_reschedule_job_helper_recreates_job() -> None:
         is_enabled=True,
         days_mask=0,
     )
-    user = SimpleNamespace(timezone="UTC")
+    user = SimpleNamespace(profile=SimpleNamespace(timezone="UTC"))
 
     reminder_jobs.schedule_reminder(rem, job_queue, user)
     assert [j.run_time for j in job_queue.get_jobs_by_name("reminder_1")] == [dt_time(8, 0)]
@@ -182,7 +182,7 @@ def test_reschedule_job_helper_handles_jobs_without_remove() -> None:
         is_enabled=True,
         days_mask=0,
     )
-    user = SimpleNamespace(timezone="UTC")
+    user = SimpleNamespace(profile=SimpleNamespace(timezone="UTC"))
 
     reminder_jobs.schedule_reminder(rem, job_queue, user)
     job = job_queue.get_jobs_by_name("reminder_1")[0]
@@ -209,7 +209,7 @@ def test_reschedule_job_updates_next_run_time() -> None:
         is_enabled=True,
         days_mask=0,
     )
-    user = SimpleNamespace(timezone="UTC")
+    user = SimpleNamespace(profile=SimpleNamespace(timezone="UTC"))
 
     reminder_jobs.schedule_reminder(rem, job_queue, user)
     rem.time = dt_time(10, 15)

--- a/tests/test_reminder_timezones.py
+++ b/tests/test_reminder_timezones.py
@@ -171,7 +171,7 @@ async def test_daily_reminder_respects_timezone(queue_cls: QueueType) -> None:
             kind="at_time",
             is_enabled=True,
         )
-        user = SimpleNamespace(timezone="Asia/Tokyo")
+        user = SimpleNamespace(profile=SimpleNamespace(timezone="Asia/Tokyo"))
         reminder_jobs.schedule_reminder(rem, job_queue, user)
         await asyncio.wait_for(event.wait(), timeout=5)
     finally:

--- a/tests/test_reminders_api.py
+++ b/tests/test_reminders_api.py
@@ -165,7 +165,7 @@ def test_empty_returns_200(
     client: TestClient, session_factory: sessionmaker[Session]
 ) -> None:
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
     resp = client.get("/api/reminders", params={"telegramId": 1})
     assert resp.status_code == 200
@@ -176,7 +176,7 @@ def test_nonempty_returns_list(
     client: TestClient, session_factory: sessionmaker[Session]
 ) -> None:
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(
             Reminder(
                 id=1,
@@ -216,7 +216,7 @@ def test_get_single_reminder(
     client: TestClient, session_factory: sessionmaker[Session]
 ) -> None:
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(
             Reminder(
                 id=1,
@@ -268,7 +268,7 @@ def test_get_single_reminder_not_found(
     client: TestClient, session_factory: sessionmaker[Session]
 ) -> None:
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
     resp = client.get("/api/reminders/1", params={"telegramId": 1})
     assert resp.status_code == 404
@@ -281,7 +281,7 @@ def test_patch_updates_reminder(
 ) -> None:
     client, _ = client_with_job_queue
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(
             Reminder(
                 id=1,
@@ -321,7 +321,7 @@ def test_delete_reminder(
 ) -> None:
     client, job_queue = client_with_job_queue
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar"))
         session.commit()
     job_queue.run_daily(lambda: None, time(8, 0), name="reminder_1")
@@ -340,7 +340,7 @@ def test_post_reminder_schedules_job(
 ) -> None:
     client, job_queue = client_with_job_queue
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
     resp = client.post(
         "/api/reminders",
@@ -357,7 +357,7 @@ def test_patch_reminder_schedules_job(
 ) -> None:
     client, job_queue = client_with_job_queue
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar"))
         session.commit()
     resp = client.patch(
@@ -387,7 +387,7 @@ def test_post_reminder_sends_event_without_job_queue(
 
     monkeypatch.setattr(reminders_router, "_post_job_queue_event", fake_post)
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
     resp = client.post(
         "/api/reminders",
@@ -411,7 +411,7 @@ def test_patch_reminder_sends_event_without_job_queue(
 
     monkeypatch.setattr(reminders_router, "_post_job_queue_event", fake_post)
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar"))
         session.commit()
     resp = client.patch(
@@ -441,7 +441,7 @@ def test_delete_reminder_sends_event_without_job_queue(
 
     monkeypatch.setattr(reminders_router, "_post_job_queue_event", fake_post)
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar"))
         session.commit()
     resp = client.delete("/api/reminders", params={"telegramId": 1, "id": 1})
@@ -506,7 +506,7 @@ def test_post_reminder_handles_notify_error(
     monkeypatch.setattr(reminder_events, "notify_reminder_saved", boom)
 
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
 
     resp = client.post(

--- a/tests/test_reminders_job_queue.py
+++ b/tests/test_reminders_job_queue.py
@@ -111,7 +111,7 @@ def test_post_reminder_uses_job_queue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
 
     fake_queue = DummyJobQueue()
@@ -137,7 +137,7 @@ def test_edit_reminder_replaces_job(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     with session_factory() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
 
     fake_queue = DummyJobQueue()

--- a/tests/test_schedule_all_queries.py
+++ b/tests/test_schedule_all_queries.py
@@ -91,7 +91,7 @@ def test_schedule_all_uses_constant_queries() -> None:
     TestSession, engine = _setup_session()
     handlers.SessionLocal = TestSession
     with TestSession() as session:
-        session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(DbUser(telegram_id=1, thread_id="t"))
         for _ in range(50):
             session.add(
                 Reminder(
@@ -127,7 +127,7 @@ def test_schedule_all_removes_existing_jobs() -> None:
     TestSession, _ = _setup_session()
     handlers.SessionLocal = TestSession
     with TestSession() as session:
-        session.add(DbUser(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(DbUser(telegram_id=1, thread_id="t"))
         rem = Reminder(
             telegram_id=1,
             type="sugar",

--- a/tests/test_services_reminders.py
+++ b/tests/test_services_reminders.py
@@ -38,7 +38,7 @@ async def test_save_reminder_sets_default_title(
 ) -> None:
     monkeypatch.setattr(reminders, "SessionLocal", session_factory)
     with cast(ContextManager[SASession], session_factory()) as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
 
     rem_id = await reminders.save_reminder(
@@ -60,7 +60,7 @@ async def test_save_reminder_preserves_title_on_update(
 ) -> None:
     monkeypatch.setattr(reminders, "SessionLocal", session_factory)
     with cast(ContextManager[SASession], session_factory()) as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
 
     rem_id = await reminders.save_reminder(
@@ -91,7 +91,7 @@ async def test_save_reminder_sets_default_title_on_update_if_missing(
 ) -> None:
     monkeypatch.setattr(reminders, "SessionLocal", session_factory)
     with cast(ContextManager[SASession], session_factory()) as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar", time=time(8, 0)))
         session.commit()
 
@@ -109,7 +109,7 @@ async def test_save_reminder_interval_minutes(
 ) -> None:
     monkeypatch.setattr(reminders, "SessionLocal", session_factory)
     with cast(ContextManager[SASession], session_factory()) as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
 
     rem_id = await reminders.save_reminder(
@@ -131,7 +131,7 @@ async def test_save_reminder_not_found_or_wrong_user(
 ) -> None:
     monkeypatch.setattr(reminders, "SessionLocal", session_factory)
     with cast(ContextManager[SASession], session_factory()) as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar"))
         session.commit()
 
@@ -170,7 +170,7 @@ async def test_list_reminders_stats(
     monkeypatch.setattr(reminders, "SessionLocal", session_factory)
     now = datetime.now(timezone.utc)
     with cast(ContextManager[SASession], session_factory()) as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar"))
         recent = now - timedelta(days=1)
         session.add(
@@ -197,7 +197,7 @@ async def test_save_reminder_kind_and_days(
 ) -> None:
     monkeypatch.setattr(reminders, "SessionLocal", session_factory)
     with cast(ContextManager[SASession], session_factory()) as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
 
     rem_id = await reminders.save_reminder(
@@ -227,7 +227,7 @@ async def test_list_reminders_next_at(
         lambda rem, tz: datetime(2023, 1, 1, tzinfo=timezone.utc),
     )
     with cast(ContextManager[SASession], session_factory()) as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar"))
         session.commit()
     rems = await reminders.list_reminders(1)
@@ -240,7 +240,7 @@ async def test_delete_reminder(
 ) -> None:
     monkeypatch.setattr(reminders, "SessionLocal", session_factory)
     with cast(ContextManager[SASession], session_factory()) as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar"))
         session.commit()
 
@@ -255,7 +255,7 @@ async def test_delete_reminder_with_logs(
 ) -> None:
     monkeypatch.setattr(reminders, "SessionLocal", session_factory)
     with cast(ContextManager[SASession], session_factory()) as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar"))
         session.add(ReminderLog(reminder_id=1, telegram_id=1))
         session.commit()
@@ -278,7 +278,7 @@ async def test_delete_reminder_not_found_or_wrong_user(
 ) -> None:
     monkeypatch.setattr(reminders, "SessionLocal", session_factory)
     with cast(ContextManager[SASession], session_factory()) as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.add(Reminder(id=1, telegram_id=1, type="sugar"))
         session.commit()
     with pytest.raises(HTTPException):

--- a/tests/test_webapp_reminders_auth.py
+++ b/tests/test_webapp_reminders_auth.py
@@ -45,7 +45,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     monkeypatch.setattr(reminders, "SessionLocal", TestSession)
     with TestSession() as session:
-        session.add(User(telegram_id=1, thread_id="t", timezone="UTC"))
+        session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
     try:
         with TestClient(server.app) as test_client:


### PR DESCRIPTION
## Summary
- drop `timezone` and `timezone_auto` from `users`, storing them only on `profiles`
- read reminder timezones from `user.profile` and preload profiles when scheduling
- add migration to remove user timezone columns and update tests

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b72dcf75bc832a935b7f3190ef6098