### PR TITLE
[ui] Handle non-JSON profile responses

### DIFF
--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -1,15 +1,16 @@
 import type { ProfileSchema } from '@sdk';
-import { api } from '@/api';
+import { api } from '@/lib/tgFetch';
 import type { Profile, PatchProfileDto, RapidInsulin } from './types';
 
 export async function getProfile(telegramId: number): Promise<Profile> {
   try {
-    return await api.get<Profile>(`/profiles?telegramId=${telegramId}`);
+    const data = await api.get<unknown>(`/profiles?telegramId=${telegramId}`);
+    if (typeof data === 'string') {
+      throw new Error('Некорректный ответ сервера');
+    }
+    return data as Profile;
   } catch (error) {
     console.error('Failed to load profile:', error);
-    if (error instanceof SyntaxError) {
-      throw new Error('Не удалось получить профиль: некорректный ответ сервера');
-    }
     if (error instanceof Error) {
       throw new Error(`Не удалось получить профиль: ${error.message}`);
     }

--- a/services/webapp/ui/src/lib/tgFetch.ts
+++ b/services/webapp/ui/src/lib/tgFetch.ts
@@ -38,6 +38,20 @@ async function tgFetch<T>(
   }
 
   const res = await fetch(`${API_BASE}${path}`, { ...init, headers, body });
+
+  if (!res.ok) {
+    let msg = '';
+    try {
+      msg = await res.text();
+    } catch {
+      // ignore
+    }
+    if (!msg) {
+      msg = res.statusText || `Request failed with status ${res.status}`;
+    }
+    throw new Error(msg);
+  }
+
   const isJson = res.headers.get('content-type')?.includes('application/json');
   let data: unknown;
 
@@ -49,16 +63,6 @@ async function tgFetch<T>(
     }
   } else {
     data = await res.text();
-  }
-
-  if (!res.ok) {
-    const msg =
-      typeof (data as Record<string, unknown> | undefined)?.detail === 'string'
-        ? ((data as Record<string, string>).detail)
-        : typeof data === 'string'
-          ? data
-          : 'Request failed';
-    throw new Error(msg);
   }
 
   return data as T;

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -11,13 +11,13 @@ describe('profile api', () => {
     vi.unstubAllGlobals();
   });
 
-  it('throws error when getProfile request fails', async () => {
+  it('throws error when getProfile request fails with 500', async () => {
     const mockFetch = vi
       .fn()
       .mockResolvedValue(
-        new Response(JSON.stringify({ detail: 'boom' }), {
-          status: 400,
-          headers: { 'Content-Type': 'application/json' },
+        new Response('boom', {
+          status: 500,
+          headers: { 'Content-Type': 'text/plain' },
         }),
       );
     vi.stubGlobal('fetch', mockFetch);
@@ -41,7 +41,7 @@ describe('profile api', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     await expect(getProfile(1)).rejects.toThrow(
-      'Не удалось получить профиль: некорректный ответ сервера',
+      'Не удалось получить профиль: Некорректный ответ сервера',
     );
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/profiles?telegramId=1',
@@ -53,9 +53,9 @@ describe('profile api', () => {
     const mockFetch = vi
       .fn()
       .mockResolvedValue(
-        new Response(JSON.stringify({ detail: 'fail' }), {
+        new Response('fail', {
           status: 500,
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'text/plain' },
         }),
       );
     vi.stubGlobal('fetch', mockFetch);
@@ -98,9 +98,9 @@ describe('profile api', () => {
     const mockFetch = vi
       .fn()
       .mockResolvedValue(
-        new Response(JSON.stringify({ detail: 'fail' }), {
+        new Response('fail', {
           status: 500,
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'text/plain' },
         }),
       );
     vi.stubGlobal('fetch', mockFetch);


### PR DESCRIPTION
## Summary
- avoid JSON parsing for failed fetch responses and fall back to status text
- use tgFetch in profile API and guard against non-JSON replies
- cover profile API with tests for 500 errors and invalid JSON

## Testing
- `npx vitest run tests/profile.api.test.ts`
- `ruff check .`
- `mypy --strict services/webapp/ui` *(no Python files)*
- `npm run lint` *(fails: Unexpected any)
- `pytest -q` *(import error: pypdf / KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b7367ccb44832abf368f7d46530225