### PR TITLE
[services] Allow NULL sos_contact

### DIFF
--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -57,7 +57,9 @@ async def patch_user_settings(
         try:
             ZoneInfo(device_tz)
         except ZoneInfoNotFoundError as exc:  # pragma: no cover - validation
-            raise HTTPException(status_code=400, detail="invalid device timezone") from exc
+            raise HTTPException(
+                status_code=400, detail="invalid device timezone"
+            ) from exc
 
     def _patch(session: SessionProtocol) -> ProfileSettingsOut:
         user = cast(User | None, session.get(User, telegram_id))
@@ -116,9 +118,7 @@ async def patch_user_settings(
             sosAlertsEnabled=profile.sos_alerts_enabled,
             therapyType=TherapyType(profile.therapy_type),
             rapidInsulinType=(
-                RapidInsulinType(profile.insulin_type)
-                if profile.insulin_type
-                else None
+                RapidInsulinType(profile.insulin_type) if profile.insulin_type else None
             ),
             maxBolus=profile.max_bolus,
             preBolus=profile.prebolus_min,
@@ -175,14 +175,20 @@ async def save_profile(data: ProfileSchema) -> None:
             "high_threshold": data.high,
             "quiet_start": data.quietStart,
             "quiet_end": data.quietEnd,
-            "sos_contact": data.sosContact or "",
-            "sos_alerts_enabled": (data.sosAlertsEnabled if data.sosAlertsEnabled is not None else True),
+            "sos_contact": data.sosContact,
+            "sos_alerts_enabled": (
+                data.sosAlertsEnabled if data.sosAlertsEnabled is not None else True
+            ),
             "timezone": data.timezone,
             "timezone_auto": data.timezoneAuto,
         }
 
         stmt = insert(Profile).values(**profile_data)
-        update_values = {key: getattr(stmt.excluded, key) for key in profile_data.keys() if key != "telegram_id"}
+        update_values = {
+            key: getattr(stmt.excluded, key)
+            for key in profile_data.keys()
+            if key != "telegram_id"
+        }
         session.execute(
             stmt.on_conflict_do_update(
                 index_elements=[Profile.telegram_id],

--- a/tests/test_profile_sos_fields.py
+++ b/tests/test_profile_sos_fields.py
@@ -59,7 +59,7 @@ async def test_save_profile_defaults_sos_fields(
     await profile_service.save_profile(data)
     prof = await profile_service.get_profile(2)
     assert prof is not None
-    assert prof.sos_contact == ""
+    assert prof.sos_contact is None
     assert prof.sos_alerts_enabled is True
     engine.dispose()
 


### PR DESCRIPTION
## Summary
- let profile.save_profile persist `sos_contact` as NULL when absent
- update tests for default `sos_contact`

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b739d03fd4832aa5de8c2a5fc752e4