### PR TITLE
[profile] Support afterMealMinutes alias

### DIFF
--- a/services/webapp/ui/src/features/profile/hooks.ts
+++ b/services/webapp/ui/src/features/profile/hooks.ts
@@ -10,8 +10,9 @@ export function useDefaultAfterMealMinutes(telegramId: number | null | undefined
     getProfile(telegramId)
       .then((profile: Profile) => {
         const minutes =
-          profile.default_after_meal_minutes ??
-          profile.defaultAfterMealMinutes;
+          profile.afterMealMinutes ??
+          profile.defaultAfterMealMinutes ??
+          profile.default_after_meal_minutes;
         if (typeof minutes === "number") {
           setValue(minutes);
         }

--- a/services/webapp/ui/src/features/profile/types.ts
+++ b/services/webapp/ui/src/features/profile/types.ts
@@ -10,6 +10,7 @@ export interface Profile extends ProfileSchema {
   gramsPerXe?: number | null;
   rapidInsulinType?: RapidInsulin | null;
   maxBolus?: number | null;
+  afterMealMinutes?: number | null;
   defaultAfterMealMinutes?: number | null;
   /** Compatibility with snake_case responses */
   default_after_meal_minutes?: number | null;

--- a/services/webapp/ui/tests/useDefaultAfterMealMinutes.test.ts
+++ b/services/webapp/ui/tests/useDefaultAfterMealMinutes.test.ts
@@ -1,0 +1,40 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/features/profile/api', () => ({
+  getProfile: vi.fn(),
+}));
+
+import { useDefaultAfterMealMinutes } from '../src/features/profile/hooks';
+import { getProfile } from '../src/features/profile/api';
+
+describe('useDefaultAfterMealMinutes', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses afterMealMinutes when present', async () => {
+    (getProfile as vi.Mock).mockResolvedValue({ afterMealMinutes: 30 });
+    const { result } = renderHook(() => useDefaultAfterMealMinutes(1));
+    await waitFor(() => {
+      expect(result.current).toBe(30);
+    });
+  });
+
+  it('falls back to defaultAfterMealMinutes', async () => {
+    (getProfile as vi.Mock).mockResolvedValue({ defaultAfterMealMinutes: 45 });
+    const { result } = renderHook(() => useDefaultAfterMealMinutes(1));
+    await waitFor(() => {
+      expect(result.current).toBe(45);
+    });
+  });
+
+  it('falls back to default_after_meal_minutes', async () => {
+    (getProfile as vi.Mock).mockResolvedValue({ default_after_meal_minutes: 60 });
+    const { result } = renderHook(() => useDefaultAfterMealMinutes(1));
+    await waitFor(() => {
+      expect(result.current).toBe(60);
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- prefer `afterMealMinutes` when deriving default after-meal reminder delay
- type profile objects with new `afterMealMinutes` field
- test all accepted profile fields for after-meal minutes

## Testing
- `pnpm --filter ./services/webapp/ui exec eslint src/features/profile/hooks.ts src/features/profile/types.ts tests/useDefaultAfterMealMinutes.test.ts`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test tests/useDefaultAfterMealMinutes.test.ts`
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any in existing test files)*
- `pnpm --filter ./services/webapp/ui test` *(fails: JavaScript heap out of memory)*
- `pytest -q --cov --cov-fail-under=85` *(fails: pytest-cov not installed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b739bc388c832abf08baa5b5b803ac