### PR TITLE
[legacy] Clarify DB error handling in profiles_get

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -55,9 +55,11 @@ async def profiles_get(
     except HTTPException:
         logger.exception("failed to fetch profile %s", tid)
         raise
-    except Exception as exc:  # pragma: no cover - unexpected DB error
+    except Exception as exc:
         logger.exception("failed to fetch profile %s", tid)
-        raise HTTPException(status_code=500, detail="db error") from exc
+        raise HTTPException(
+            status_code=500, detail="database connection failed"
+        ) from exc
 
     tz = profile.timezone if profile.timezone else "UTC"
     tz_auto = profile.timezone_auto if profile.timezone_auto is not None else True

--- a/tests/test_profiles_api.py
+++ b/tests/test_profiles_api.py
@@ -53,6 +53,25 @@ def test_profiles_get_missing_profile_returns_404(
     engine.dispose()
 
 
+def test_profiles_get_db_error_returns_500(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+
+    async def _get_profile(tid: int):  # noqa: ARG001
+        raise RuntimeError("boom")
+
+    from services.api.app import legacy as legacy_module
+
+    monkeypatch.setattr(legacy_module, "get_profile", _get_profile)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/profiles", params={"telegramId": 1})
+    assert resp.status_code == 500
+    assert resp.json() == {"detail": "database connection failed"}
+
+
 def test_profiles_post_creates_user_for_missing_telegram_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- return clearer message when profile lookup fails due to DB issues
- test profiles API for database failure handling

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b743bbd270832a984e50d6b60c1aec