### PR TITLE
[api] Return 503 on database downtime

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -58,7 +58,8 @@ async def profiles_get(
     except Exception as exc:
         logger.exception("failed to fetch profile %s", tid)
         raise HTTPException(
-            status_code=500, detail="database connection failed"
+            status_code=503,
+            detail="database temporarily unavailable",
         ) from exc
 
     tz = profile.timezone if profile.timezone else "UTC"

--- a/tests/test_profiles_api.py
+++ b/tests/test_profiles_api.py
@@ -53,7 +53,7 @@ def test_profiles_get_missing_profile_returns_404(
     engine.dispose()
 
 
-def test_profiles_get_db_error_returns_500(
+def test_profiles_get_db_error_returns_503(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     app = FastAPI()
@@ -68,8 +68,8 @@ def test_profiles_get_db_error_returns_500(
 
     with TestClient(app) as client:
         resp = client.get("/api/profiles", params={"telegramId": 1})
-    assert resp.status_code == 500
-    assert resp.json() == {"detail": "database connection failed"}
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "database temporarily unavailable"}
 
 
 def test_profiles_post_creates_user_for_missing_telegram_id(


### PR DESCRIPTION
## Summary
- return 503 with clear message when profile lookup fails to reach DB
- add test ensuring 503 is returned for DB connectivity errors

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b749084e24832a802512bcba6332b8