### PR TITLE
ui: rename carbUnit to carbUnits

### DIFF
--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -131,11 +131,11 @@ const sections: HelpSection[] = [
         rangeKey: 'profileHelp.therapyType.range',
       },
       {
-        key: 'carbUnit',
-        titleKey: 'profileHelp.carbUnit.title',
-        definitionKey: 'profileHelp.carbUnit.definition',
-        unitKey: 'profileHelp.carbUnit.unit',
-        rangeKey: 'profileHelp.carbUnit.range',
+        key: 'carbUnits',
+        titleKey: 'profileHelp.carbUnits.title',
+        definitionKey: 'profileHelp.carbUnits.definition',
+        unitKey: 'profileHelp.carbUnits.unit',
+        rangeKey: 'profileHelp.carbUnits.range',
       },
       {
         key: 'gramsPerXe',

--- a/services/webapp/ui/src/features/profile/types.ts
+++ b/services/webapp/ui/src/features/profile/types.ts
@@ -6,7 +6,7 @@ export interface Profile extends ProfileSchema {
   dia?: number | null;
   preBolus?: number | null;
   roundStep?: number | null;
-  carbUnit?: "g" | "xe" | null;
+  carbUnits?: "g" | "xe" | null;
   gramsPerXe?: number | null;
   rapidInsulinType?: RapidInsulin | null;
   maxBolus?: number | null;
@@ -23,7 +23,7 @@ export type PatchProfileDto = {
   dia?: number | null;
   preBolus?: number | null;
   roundStep?: number | null;
-  carbUnit?: "g" | "xe" | null;
+  carbUnits?: "g" | "xe" | null;
   gramsPerXe?: number | null;
   rapidInsulinType?: RapidInsulin | null;
   maxBolus?: number | null;

--- a/services/webapp/ui/src/locales/ru/profileHelp.ts
+++ b/services/webapp/ui/src/locales/ru/profileHelp.ts
@@ -62,9 +62,9 @@ const profileHelp = {
     unit: 'Ед',
     range: '0.1–5',
   },
-  carbUnit: {
-    title: 'Единица углеводов',
-    definition: 'Единица измерения углеводов в расчётах',
+  carbUnits: {
+    title: 'Единицы углеводов',
+    definition: 'Единицы измерения углеводов в расчётах',
     unit: 'г или ХЕ',
     range: 'г, ХЕ',
     options: {

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -38,7 +38,7 @@ type ProfileForm = {
   dia: string;
   preBolus: string;
   roundStep: string;
-  carbUnit: 'g' | 'xe';
+  carbUnits: 'g' | 'xe';
   gramsPerXe: string;
   rapidInsulinType: RapidInsulin;
   maxBolus: string;
@@ -54,7 +54,7 @@ type ParsedProfile = {
   dia: number;
   preBolus: number;
   roundStep: number;
-  carbUnit: 'g' | 'xe';
+  carbUnits: 'g' | 'xe';
   gramsPerXe: number;
   rapidInsulinType: RapidInsulin;
   maxBolus: number;
@@ -76,13 +76,13 @@ export const parseProfile = (
       dia: 0,
       preBolus: 0,
       roundStep: Number(profile.roundStep.replace(/,/g, '.')),
-      carbUnit: profile.carbUnit,
+      carbUnits: profile.carbUnits,
       gramsPerXe: Number.isFinite(gramsPerXe) ? gramsPerXe : 0,
       rapidInsulinType: profile.rapidInsulinType,
       maxBolus: 0,
       afterMealMinutes: Number(profile.afterMealMinutes.replace(/,/g, '.')),
     } satisfies ParsedProfile;
-    const validateGrams = parsed.carbUnit === 'xe';
+    const validateGrams = parsed.carbUnits === 'xe';
     const numbersValid =
       [
         parsed.target,
@@ -104,7 +104,7 @@ export const parseProfile = (
       parsed.low < parsed.target &&
       parsed.target < parsed.high &&
       parsed.afterMealMinutes <= 240 &&
-      (parsed.carbUnit === 'g' || parsed.carbUnit === 'xe') &&
+      (parsed.carbUnits === 'g' || parsed.carbUnits === 'xe') &&
       (!validateGrams || parsed.gramsPerXe > 0);
     return numbersValid && positiveValid && rangeValid ? parsed : null;
   }
@@ -119,13 +119,13 @@ export const parseProfile = (
     dia: Number(profile.dia.replace(/,/g, '.')),
     preBolus: Number(profile.preBolus.replace(/,/g, '.')),
     roundStep: Number(profile.roundStep.replace(/,/g, '.')),
-    carbUnit: profile.carbUnit,
+    carbUnits: profile.carbUnits,
     gramsPerXe: Number.isFinite(gramsPerXe) ? gramsPerXe : 0,
     rapidInsulinType: profile.rapidInsulinType,
     maxBolus: Number(profile.maxBolus.replace(/,/g, '.')),
     afterMealMinutes: Number(profile.afterMealMinutes.replace(/,/g, '.')),
   } satisfies ParsedProfile;
-  const validateGrams = parsed.carbUnit === 'xe';
+  const validateGrams = parsed.carbUnits === 'xe';
   const numbersValid =
     [
       parsed.icr,
@@ -159,7 +159,7 @@ export const parseProfile = (
     parsed.dia <= 24 &&
     parsed.preBolus <= 60 &&
     parsed.afterMealMinutes <= 240 &&
-    (parsed.carbUnit === 'g' || parsed.carbUnit === 'xe') &&
+    (parsed.carbUnits === 'g' || parsed.carbUnits === 'xe') &&
     parsed.rapidInsulinType.length > 0 &&
     (!validateGrams || parsed.gramsPerXe > 0);
   return numbersValid && positiveValid && rangeValid ? parsed : null;
@@ -171,13 +171,13 @@ export const shouldWarnProfile = (
 ): boolean => {
   const icrCfWarn = profile.icr > 8 && profile.cf < 3;
   const diaWarn = profile.dia > 12;
-  const carbUnitWarn =
+  const carbUnitsWarn =
     !!original &&
-    original.carbUnit !== profile.carbUnit &&
+    original.carbUnits !== profile.carbUnits &&
     original.icr === profile.icr &&
     profile.icr > 0;
 
-  return icrCfWarn || diaWarn || carbUnitWarn;
+  return icrCfWarn || diaWarn || carbUnitsWarn;
 };
 
 interface ProfileFormHeaderProps {
@@ -228,7 +228,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     dia: "",
     preBolus: "",
     roundStep: "",
-    carbUnit: 'g',
+    carbUnits: 'g',
     gramsPerXe: "",
     rapidInsulinType: 'aspart',
     maxBolus: "",
@@ -310,7 +310,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
           typeof data.roundStep === "number" && data.roundStep > 0
             ? data.roundStep.toString()
             : "";
-        const carbUnit = data.carbUnit === "xe" ? "xe" : "g";
+        const carbUnits = data.carbUnits === "xe" ? "xe" : "g";
         const gramsPerXe =
           typeof data.gramsPerXe === "number" && data.gramsPerXe > 0
             ? data.gramsPerXe.toString()
@@ -349,7 +349,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
           dia,
           preBolus,
           roundStep,
-          carbUnit,
+          carbUnits,
           gramsPerXe,
           rapidInsulinType,
           maxBolus,
@@ -405,8 +405,8 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
       setProfile((prev) => ({ ...prev, timezone: value }));
       return;
     }
-    if (field === "carbUnit") {
-      setProfile((prev) => ({ ...prev, carbUnit: value as 'g' | 'xe' }));
+    if (field === "carbUnits") {
+      setProfile((prev) => ({ ...prev, carbUnits: value as 'g' | 'xe' }));
       return;
     }
     if (field === "rapidInsulinType") {
@@ -435,7 +435,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     if (profile.dia !== original.dia) patch.dia = parsed.dia;
     if (profile.preBolus !== original.preBolus) patch.preBolus = parsed.preBolus;
     if (profile.roundStep !== original.roundStep) patch.roundStep = parsed.roundStep;
-    if (profile.carbUnit !== original.carbUnit) patch.carbUnit = parsed.carbUnit;
+    if (profile.carbUnits !== original.carbUnits) patch.carbUnits = parsed.carbUnits;
     if (profile.gramsPerXe !== original.gramsPerXe)
       patch.gramsPerXe = parsed.gramsPerXe;
     if (profile.rapidInsulinType !== original.rapidInsulinType)
@@ -835,25 +835,25 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               {/* Carb unit and grams per XE */}
               <div>
                 <label
-                  htmlFor="carbUnit"
+                  htmlFor="carbUnits"
                   className="flex items-center gap-2 text-sm font-medium text-foreground mb-2"
                 >
-                  {t('profileHelp.carbUnit.title')}
-                  <HelpHint label="profileHelp.carbUnit.title">
-                    {t('profileHelp.carbUnit.definition')}
+                  {t('profileHelp.carbUnits.title')}
+                  <HelpHint label="profileHelp.carbUnits.title">
+                    {t('profileHelp.carbUnits.definition')}
                   </HelpHint>
                 </label>
                 <select
-                  id="carbUnit"
+                  id="carbUnits"
                   className="medical-input"
-                  value={profile.carbUnit}
-                  onChange={(e) => handleInputChange('carbUnit', e.target.value)}
+                  value={profile.carbUnits}
+                  onChange={(e) => handleInputChange('carbUnits', e.target.value)}
                 >
-                  <option value="g">{t('profileHelp.carbUnit.options.g')}</option>
-                  <option value="xe">{t('profileHelp.carbUnit.options.xe')}</option>
+                  <option value="g">{t('profileHelp.carbUnits.options.g')}</option>
+                  <option value="xe">{t('profileHelp.carbUnits.options.xe')}</option>
                 </select>
               </div>
-              {profile.carbUnit === 'xe' && (
+              {profile.carbUnits === 'xe' && (
                 <div>
                   <label
                     htmlFor="gramsPerXe"

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -15,7 +15,7 @@ const makeProfile = (
   dia: "7",
   preBolus: "10",
   roundStep: "1",
-  carbUnit: "g",
+  carbUnits: "g",
   gramsPerXe: "12",
   rapidInsulinType: "lispro" as RapidInsulin,
   maxBolus: "20",
@@ -35,7 +35,7 @@ describe("parseProfile", () => {
       dia: 7,
       preBolus: 10,
       roundStep: 1,
-      carbUnit: "g",
+      carbUnits: "g",
       gramsPerXe: 12,
       rapidInsulinType: "lispro" as RapidInsulin,
       maxBolus: 20,
@@ -63,8 +63,8 @@ describe("parseProfile", () => {
     expect(result).toBeNull();
   });
 
-  it("skips gramsPerXe validation when carb unit is grams", () => {
-    const result = parseProfile(makeProfile({ gramsPerXe: "", carbUnit: "g" }));
+  it("skips gramsPerXe validation when carbUnits is grams", () => {
+    const result = parseProfile(makeProfile({ gramsPerXe: "", carbUnits: "g" }));
     expect(result).toEqual({
       icr: 1,
       cf: 2,
@@ -74,7 +74,7 @@ describe("parseProfile", () => {
       dia: 7,
       preBolus: 10,
       roundStep: 1,
-      carbUnit: "g",
+      carbUnits: "g",
       gramsPerXe: 0,
       rapidInsulinType: "lispro" as RapidInsulin,
       maxBolus: 20,
@@ -82,9 +82,9 @@ describe("parseProfile", () => {
     });
   });
 
-  it("validates gramsPerXe when carb unit is XE", () => {
+  it("validates gramsPerXe when carbUnits is XE", () => {
     const result = parseProfile(
-      makeProfile({ gramsPerXe: "", carbUnit: "xe" }),
+      makeProfile({ gramsPerXe: "", carbUnits: "xe" }),
     );
     expect(result).toBeNull();
   });
@@ -124,7 +124,7 @@ describe("parseProfile", () => {
 
   it("allows gramsPerXe above 20", () => {
     const result = parseProfile(
-      makeProfile({ gramsPerXe: "25", carbUnit: "xe" }),
+      makeProfile({ gramsPerXe: "25", carbUnits: "xe" }),
     );
     expect(result?.gramsPerXe).toBe(25);
   });
@@ -149,7 +149,7 @@ describe("parseProfile", () => {
       dia: 0,
       preBolus: 0,
       roundStep: 1,
-      carbUnit: "g",
+      carbUnits: "g",
       gramsPerXe: 12,
       rapidInsulinType: "lispro" as RapidInsulin,
       maxBolus: 0,
@@ -177,7 +177,7 @@ describe("parseProfile", () => {
       dia: 0,
       preBolus: 0,
       roundStep: 1,
-      carbUnit: "g",
+      carbUnits: "g",
       gramsPerXe: 12,
       rapidInsulinType: "lispro" as RapidInsulin,
       maxBolus: 0,
@@ -229,7 +229,7 @@ describe("parseProfile", () => {
       dia: 7,
       preBolus: 10,
       roundStep: 1,
-      carbUnit: "g",
+      carbUnits: "g",
       gramsPerXe: 12,
       rapidInsulinType: "lispro" as RapidInsulin,
       maxBolus: 20,
@@ -250,7 +250,7 @@ describe("shouldWarnProfile", () => {
         dia: 1,
         preBolus: 0,
         roundStep: 1,
-        carbUnit: "g",
+        carbUnits: "g",
         gramsPerXe: 10,
         rapidInsulinType: "aspart" as RapidInsulin,
         maxBolus: 1,
@@ -268,7 +268,7 @@ describe("shouldWarnProfile", () => {
         dia: 1,
         preBolus: 0,
         roundStep: 1,
-        carbUnit: "g",
+        carbUnits: "g",
         gramsPerXe: 10,
         rapidInsulinType: "aspart" as RapidInsulin,
         maxBolus: 1,
@@ -286,7 +286,7 @@ describe("shouldWarnProfile", () => {
         dia: 1,
         preBolus: 0,
         roundStep: 1,
-        carbUnit: "g",
+        carbUnits: "g",
         gramsPerXe: 10,
         rapidInsulinType: "aspart" as RapidInsulin,
         maxBolus: 1,
@@ -306,7 +306,7 @@ describe("shouldWarnProfile", () => {
         dia: 13,
         preBolus: 0,
         roundStep: 1,
-        carbUnit: "g",
+        carbUnits: "g",
         gramsPerXe: 10,
         rapidInsulinType: "aspart" as RapidInsulin,
         maxBolus: 1,
@@ -324,7 +324,7 @@ describe("shouldWarnProfile", () => {
         dia: 12,
         preBolus: 0,
         roundStep: 1,
-        carbUnit: "g",
+        carbUnits: "g",
         gramsPerXe: 10,
         rapidInsulinType: "aspart" as RapidInsulin,
         maxBolus: 1,
@@ -333,7 +333,7 @@ describe("shouldWarnProfile", () => {
     ).toBe(false);
   });
 
-  it("warns when carb unit changes without ICR recalculation", () => {
+  it("warns when carbUnits change without ICR recalculation", () => {
     const original = {
       icr: 10,
       cf: 2,
@@ -343,7 +343,7 @@ describe("shouldWarnProfile", () => {
       dia: 1,
       preBolus: 0,
       roundStep: 1,
-      carbUnit: "g" as const,
+      carbUnits: "g" as const,
       gramsPerXe: 12,
       rapidInsulinType: "aspart" as RapidInsulin,
       maxBolus: 1,
@@ -351,11 +351,11 @@ describe("shouldWarnProfile", () => {
     };
 
     expect(
-      shouldWarnProfile({ ...original, carbUnit: "xe" }, original),
+      shouldWarnProfile({ ...original, carbUnits: "xe" }, original),
     ).toBe(true);
 
     expect(
-      shouldWarnProfile({ ...original, carbUnit: "xe", icr: 0.8 }, original),
+      shouldWarnProfile({ ...original, carbUnits: "xe", icr: 0.8 }, original),
     ).toBe(false);
   });
 
@@ -370,7 +370,7 @@ describe("shouldWarnProfile", () => {
         dia: 0,
         preBolus: 0,
         roundStep: 1,
-        carbUnit: "g",
+        carbUnits: "g",
         gramsPerXe: 10,
         rapidInsulinType: "aspart" as RapidInsulin,
         maxBolus: 0,

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -51,7 +51,7 @@ describe('Profile page', () => {
       dia: 4,
       preBolus: 15,
       roundStep: 0.5,
-      carbUnit: 'g',
+      carbUnits: 'g',
       gramsPerXe: 12,
       rapidInsulinType: 'aspart' as RapidInsulin,
       maxBolus: 10,
@@ -82,18 +82,18 @@ describe('Profile page', () => {
     vi.restoreAllMocks();
   });
 
-  it('displays carb unit options using localized text', () => {
+  it('displays carbUnits options using localized text', () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
     const { getByLabelText } = render(<Profile />);
     const { t } = useTranslation();
     const select = getByLabelText(
-      t('profileHelp.carbUnit.title'),
+      t('profileHelp.carbUnits.title'),
     ) as HTMLSelectElement;
     expect(select.options[0].text).toBe(
-      t('profileHelp.carbUnit.options.g'),
+      t('profileHelp.carbUnits.options.g'),
     );
     expect(select.options[1].text).toBe(
-      t('profileHelp.carbUnit.options.xe'),
+      t('profileHelp.carbUnits.options.xe'),
     );
   });
 
@@ -278,7 +278,7 @@ describe('Profile page', () => {
         dia: 4,
         preBolus: 15,
         roundStep: 0.5,
-        carbUnit: 'g',
+        carbUnits: 'g',
         gramsPerXe: 12,
         rapidInsulinType: 'aspart' as RapidInsulin,
         maxBolus: 10,
@@ -310,7 +310,7 @@ describe('Profile page', () => {
         low: 4,
         high: 10,
         roundStep: 1,
-        carbUnit: 'g',
+        carbUnits: 'g',
         gramsPerXe: 12,
         defaultAfterMealMinutes: 120,
         timezone: 'Europe/Moscow',
@@ -334,7 +334,7 @@ describe('Profile page', () => {
         low: 4,
         high: 10,
         roundStep: 1,
-        carbUnit: 'g',
+        carbUnits: 'g',
         gramsPerXe: 12,
         defaultAfterMealMinutes: 120,
         timezone: 'Europe/Moscow',
@@ -367,7 +367,7 @@ describe('Profile page', () => {
       dia: 4,
       preBolus: 0,
       roundStep: 0.5,
-      carbUnit: 'g',
+      carbUnits: 'g',
       gramsPerXe: 12,
       rapidInsulinType: 'aspart' as RapidInsulin,
       maxBolus: 10,
@@ -394,7 +394,7 @@ describe('Profile page', () => {
         low: 4,
         high: 10,
         roundStep: 1,
-        carbUnit: 'g',
+        carbUnits: 'g',
         gramsPerXe: 12,
         defaultAfterMealMinutes: 0,
         timezone: 'Europe/Moscow',
@@ -464,7 +464,7 @@ describe('Profile page', () => {
         dia: 5,
         preBolus: 20,
         roundStep: 1,
-        carbUnit: 'xe',
+        carbUnits: 'xe',
         gramsPerXe: 15,
         rapidInsulinType: 'lispro' as RapidInsulin,
         maxBolus: 12,
@@ -486,7 +486,7 @@ describe('Profile page', () => {
       dia: 4,
       preBolus: 15,
       roundStep: 0.5,
-      carbUnit: 'g',
+      carbUnits: 'g',
       gramsPerXe: 12,
       rapidInsulinType: 'aspart' as RapidInsulin,
       maxBolus: 10,
@@ -519,7 +519,7 @@ describe('Profile page', () => {
       dia: 4,
       preBolus: 15,
       roundStep: 0.5,
-      carbUnit: 'g',
+      carbUnits: 'g',
       gramsPerXe: 12,
       rapidInsulinType: 'aspart' as RapidInsulin,
       maxBolus: 10,
@@ -587,7 +587,7 @@ describe('Profile page', () => {
       dia: 4,
       preBolus: 15,
       roundStep: 0.5,
-      carbUnit: 'g',
+      carbUnits: 'g',
       gramsPerXe: 12,
       rapidInsulinType: 'aspart' as RapidInsulin,
       maxBolus: 10,
@@ -612,7 +612,7 @@ describe('Profile page', () => {
       dia: 4,
       preBolus: 15,
       roundStep: 0.5,
-      carbUnit: 'g',
+      carbUnits: 'g',
       gramsPerXe: 12,
       rapidInsulinType: 'aspart' as RapidInsulin,
       maxBolus: 10,
@@ -644,7 +644,7 @@ describe('Profile page', () => {
       dia: 4,
       preBolus: 15,
       roundStep: 0.5,
-      carbUnit: 'g',
+      carbUnits: 'g',
       gramsPerXe: 12,
       rapidInsulinType: 'aspart' as RapidInsulin,
       maxBolus: 10,
@@ -679,7 +679,7 @@ describe('Profile page', () => {
     ['tablets', 'g', false],
     ['tablets', 'xe', true],
   ])(
-    'handles gramsPerXe requirement for therapyType %s and carbUnit %s',
+    'handles gramsPerXe requirement for therapyType %s and carbUnits %s',
     async (
       therapyType: 'insulin' | 'tablets',
       unit: 'g' | 'xe',
@@ -696,7 +696,7 @@ describe('Profile page', () => {
         dia: 4,
         preBolus: 15,
         roundStep: 0.5,
-        carbUnit: unit,
+        carbUnits: unit,
         gramsPerXe: 0,
         rapidInsulinType: 'aspart' as RapidInsulin,
         maxBolus: 10,


### PR DESCRIPTION
## Summary
- rename carbUnit to carbUnits in profile types and forms
- update locale and help sheet to new carbUnits field
- adjust profile tests to expect carbUnits

## Testing
- `pnpm --filter ./services/webapp/ui test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b11aec68832aa0cab6cd31b3e7e9