### PR TITLE
[contracts] add reminder stats fields

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -956,6 +956,17 @@ components:
           readOnly: true
           description: Next fire in user timezone
           title: Next At
+        lastFiredAt:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          readOnly: true
+          title: Last Fired At
+        fires7d:
+          type: integer
+          readOnly: true
+          title: Fires7d
       type: object
       required:
       - telegramId

--- a/libs/ts-sdk/apis/RemindersApi.ts
+++ b/libs/ts-sdk/apis/RemindersApi.ts
@@ -40,11 +40,11 @@ export interface RemindersIdGetRequest {
 }
 
 export interface RemindersPatchRequest {
-    reminder: ReminderSchema | null;
+    reminder: Omit<ReminderSchema, 'fires7d'> | null;
 }
 
 export interface RemindersPostRequest {
-    reminder: ReminderSchema | null;
+    reminder: Omit<ReminderSchema, 'fires7d'> | null;
 }
 
 /**

--- a/libs/ts-sdk/models/ReminderSchema.ts
+++ b/libs/ts-sdk/models/ReminderSchema.ts
@@ -112,6 +112,18 @@ export interface ReminderSchema {
      * @memberof ReminderSchema
      */
     nextAt?: Date | null;
+    /**
+     * 
+     * @type {Date}
+     * @memberof ReminderSchema
+     */
+    lastFiredAt?: Date | null;
+    /**
+     * 
+     * @type {number}
+     * @memberof ReminderSchema
+     */
+    readonly fires7d?: number;
 }
 
 /**
@@ -146,6 +158,8 @@ export function ReminderSchemaFromJSONTyped(json: any, ignoreDiscriminator: bool
         'isEnabled': json['isEnabled'] == null ? undefined : json['isEnabled'],
         'orgId': json['orgId'] == null ? undefined : json['orgId'],
         'nextAt': json['nextAt'] == null ? undefined : (new Date(json['nextAt'])),
+        'lastFiredAt': json['lastFiredAt'] == null ? undefined : (new Date(json['lastFiredAt'])),
+        'fires7d': json['fires7d'] == null ? undefined : json['fires7d'],
     };
 }
 
@@ -173,6 +187,7 @@ export function ReminderSchemaToJSONTyped(value?: ReminderSchema | null, ignoreD
         'isEnabled': value['isEnabled'],
         'orgId': value['orgId'],
         'nextAt': value['nextAt'] === null ? null : ((value['nextAt'] as any)?.toISOString()),
+        'lastFiredAt': value['lastFiredAt'] === null ? null : ((value['lastFiredAt'] as any)?.toISOString()),
     };
 }
 

--- a/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
@@ -73,6 +73,8 @@ export default function RemindersList({
         daysOfWeek: r.daysOfWeek ? Array.from(r.daysOfWeek) : undefined,
         isEnabled: r.isEnabled ?? false,
         nextAt: r.nextAt ? r.nextAt.toISOString() : undefined,
+        lastFiredAt: r.lastFiredAt ? r.lastFiredAt.toISOString() : undefined,
+        fires7d: r.fires7d,
       }));
       setItems(reminders);
 
@@ -292,6 +294,16 @@ export default function RemindersList({
                     <div className="text-xs text-muted-foreground/70">
                       Следующее: {formatNextAt(r.nextAt)}
                     </div>
+                    {r.lastFiredAt && (
+                      <div className="text-xs text-muted-foreground/70">
+                        Прошлое: {formatNextAt(r.lastFiredAt)}
+                      </div>
+                    )}
+                    {typeof r.fires7d === 'number' && (
+                      <div className="text-xs text-muted-foreground/70">
+                        За 7 дней: {r.fires7d}
+                      </div>
+                    )}
                   </div>
                   <div className="flex items-center gap-2 ml-4">
                     <button 

--- a/services/webapp/ui/src/features/reminders/types.ts
+++ b/services/webapp/ui/src/features/reminders/types.ts
@@ -26,5 +26,7 @@ export interface Reminder extends ReminderDto {
   id: number;
   isEnabled: boolean;
   nextAt?: string | null;
+  lastFiredAt?: string | null;
+  fires7d?: number;
 }
 


### PR DESCRIPTION
## Summary
- add lastFiredAt & fires7d fields to Reminder schema
- regenerate TS SDK and display reminder stats in UI

## Testing
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7b76f7064832a9b6e4dab359357ea