### PR TITLE
[profile] Relax icr/cf for non-insulin profiles

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -798,10 +798,14 @@ components:
           type: integer
           title: Telegram Id
         icr:
-          type: number
+          anyOf:
+          - type: number
+          - type: 'null'
           title: Icr
         cf:
-          type: number
+          anyOf:
+          - type: number
+          - type: 'null'
           title: Cf
           description: Alias `cf` for compatibility.
         target:
@@ -848,7 +852,6 @@ components:
       type: object
       required:
       - telegramId
-      - icr
       - target
       - low
       - high

--- a/libs/ts-sdk/models/ProfileSchema.ts
+++ b/libs/ts-sdk/models/ProfileSchema.ts
@@ -30,13 +30,13 @@ export interface ProfileSchema {
      * @type {number}
      * @memberof ProfileSchema
      */
-    icr: number;
+    icr?: number | null;
     /**
-     * Alias `cf` for compatibility.
+     * 
      * @type {number}
      * @memberof ProfileSchema
      */
-    cf?: number;
+    cf?: number | null;
     /**
      * 
      * @type {number}
@@ -104,7 +104,6 @@ export interface ProfileSchema {
  */
 export function instanceOfProfileSchema(value: object): value is ProfileSchema {
     if (!('telegramId' in value) || value['telegramId'] === undefined) return false;
-    if (!('icr' in value) || value['icr'] === undefined) return false;
     if (!('target' in value) || value['target'] === undefined) return false;
     if (!('low' in value) || value['low'] === undefined) return false;
     if (!('high' in value) || value['high'] === undefined) return false;
@@ -122,7 +121,7 @@ export function ProfileSchemaFromJSONTyped(json: any, ignoreDiscriminator: boole
     return {
         
         'telegramId': json['telegramId'],
-        'icr': json['icr'],
+        'icr': json['icr'] == null ? undefined : json['icr'],
         'cf': json['cf'] == null ? undefined : json['cf'],
         'target': json['target'],
         'low': json['low'],

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -131,12 +131,13 @@ async def patch_user_settings(
 def _validate_profile(data: ProfileSchema) -> None:
     """Validate business rules for a patient profile."""
     required = {
-        "icr": data.icr,
-        "cf": data.cf,
         "target": data.target,
         "low": data.low,
         "high": data.high,
     }
+    if data.therapyType in {"insulin", "mixed"}:
+        required["icr"] = data.icr
+        required["cf"] = data.cf
     for name, value in required.items():
         if value is None:
             raise ValueError(f"{name} is required")  # pragma: no cover

--- a/tests/test_profile_non_insulin.py
+++ b/tests/test_profile_non_insulin.py
@@ -1,0 +1,36 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import services.api.app.diabetes.services.db as db
+from services.api.app.diabetes.services.db import Base, User
+from services.api.app.schemas.profile import ProfileSchema
+from services.api.app.services import profile as profile_service
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("therapy_type", ["tablets", "none"])
+async def test_save_profile_allows_non_insulin(
+    therapy_type: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    monkeypatch.setattr(db, "SessionLocal", TestSession)
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.commit()
+
+    data = ProfileSchema(
+        telegramId=1,
+        target=5.0,
+        low=4.0,
+        high=6.0,
+        therapyType=therapy_type,
+    )
+
+    await profile_service.save_profile(data)
+    prof = await profile_service.get_profile(1)
+    assert prof.icr is None
+    assert prof.cf is None
+    engine.dispose()

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -14,6 +14,7 @@ def test_validate_profile_allows_computed_target() -> None:
         cf=1.0,
         low=4.0,
         high=6.0,
+        therapyType="insulin",
     )
     _validate_profile(data)
     assert data.target == 5.0
@@ -28,6 +29,7 @@ def test_validate_profile_rejects_target_outside_limits(target: Any) -> None:
         target=target,
         low=4.0,
         high=7.0,
+        therapyType="insulin",
     )
     with pytest.raises(ValueError) as exc:
         _validate_profile(data)
@@ -55,6 +57,7 @@ def test_validate_profile_rejects_invalid_values(
         "target": 5.0,
         "low": 4.0,
         "high": 7.0,
+        "therapyType": "insulin",
     }
     if field == "low_high":
         kwargs["low"], kwargs["high"] = value
@@ -82,6 +85,7 @@ def test_validate_profile_rejects_missing_fields(field: str, message: str) -> No
         "cf": 1.0,
         "low": 4.0,
         "high": 7.0,
+        "therapyType": "insulin",
     }
     kwargs.pop(field)
     data = ProfileSchema(**kwargs)
@@ -102,7 +106,20 @@ def test_profile_rejects_malformed_quiet_times(field: str, value: str) -> None:
         "target": 5.0,
         "low": 4.0,
         "high": 7.0,
+        "therapyType": "insulin",
     }
     kwargs[field] = value
     with pytest.raises(ValidationError):
         ProfileSchema(**kwargs)
+
+
+@pytest.mark.parametrize("therapy_type", ["tablets", "none"])
+def test_validate_profile_skips_icr_cf_for_non_insulin(therapy_type: str) -> None:
+    data = ProfileSchema(
+        telegramId=1,
+        target=5.0,
+        low=4.0,
+        high=6.0,
+        therapyType=therapy_type,
+    )
+    _validate_profile(data)

--- a/tests/test_profiles_api.py
+++ b/tests/test_profiles_api.py
@@ -193,6 +193,7 @@ def test_profiles_post_invalid_icr_returns_422(
         "target": 5.0,
         "low": 4.0,
         "high": 6.0,
+        "therapyType": "insulin",
     }
     with TestClient(app) as client:
         resp = client.post("/api/profiles", json=payload)
@@ -228,6 +229,7 @@ def test_profiles_post_invalid_cf_returns_422(
         "target": 5.0,
         "low": 4.0,
         "high": 6.0,
+        "therapyType": "insulin",
     }
     with TestClient(app) as client:
         resp = client.post("/api/profiles", json=payload)


### PR DESCRIPTION
## Summary
- skip icr/cf validation unless therapy type is insulin or mixed
- make icr and cf optional in OpenAPI and regenerate TS SDK
- add tests for non-insulin therapy profile saving

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter "./services/webapp/ui" test` *(fails: tgFetch and profile api tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b771df34832aadab01af5fb8af30