### PR TITLE
[ui] handle API base for timezones

### DIFF
--- a/services/webapp/ui/src/api/timezones.ts
+++ b/services/webapp/ui/src/api/timezones.ts
@@ -1,13 +1,19 @@
+import { tgFetch } from '@/lib/tgFetch';
+
 export async function getTimezones(): Promise<string[]> {
-  const res = await fetch('/api/timezones');
-  if (!res.ok) {
-    const errorText = await res.text().catch(() => '');
-    const msg = errorText || 'Request failed';
-    throw new Error(msg);
+  try {
+    const data = await tgFetch<unknown>('/timezones');
+    if (Array.isArray(data)) {
+      return data as string[];
+    }
+    throw new Error('Некорректный ответ сервера');
+  } catch (error) {
+    console.error('Failed to load timezones:', error);
+    if (error instanceof Error) {
+      throw new Error(
+        `Не удалось получить список часовых поясов: ${error.message}`,
+      );
+    }
+    throw error;
   }
-  const data = await res.json();
-  if (Array.isArray(data)) {
-    return data as string[];
-  }
-  throw new Error('Invalid response');
 }

--- a/services/webapp/ui/tests/timezones.api.test.ts
+++ b/services/webapp/ui/tests/timezones.api.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const makeResponse = () =>
+  new Response(JSON.stringify(['UTC']), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('getTimezones', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('respects VITE_API_BASE', async () => {
+    vi.stubEnv('VITE_API_BASE', 'http://example.com');
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse());
+    vi.stubGlobal('fetch', fetchMock);
+    const { getTimezones } = await import('../src/api/timezones');
+    await getTimezones();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://example.com/timezones',
+      expect.any(Object),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- use tgFetch for timezone list requests
- cover timezone loader respects VITE_API_BASE

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter ./services/webapp/ui test tests/timezones.api.test.ts`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7b77f8318832a8059d75e64e9dfe7