### PR TITLE
webapp: use typed stats api

### DIFF
--- a/services/webapp/ui/src/api/stats.test.ts
+++ b/services/webapp/ui/src/api/stats.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+const mockGetAnalytics = vi.fn();
+const mockGetStats = vi.fn();
+
+const configInstance = {};
+
+vi.mock('@sdk/runtime.ts', () => ({
+  Configuration: vi.fn(() => configInstance),
+}));
+
+vi.mock('@sdk/apis', () => ({
+  DefaultApi: vi.fn().mockImplementation(() => ({
+    getAnalyticsAnalyticsGet: mockGetAnalytics,
+    getStatsStatsGet: mockGetStats,
+  })),
+}));
+
+vi.mock('@/lib/telegram-auth', () => ({
+  getTelegramAuthHeaders: vi.fn(() => ({ 'x-telegram-init-data': 'test' })),
+}));
+
+import { fetchAnalytics, fetchDayStats } from './stats';
+import { Configuration } from '@sdk/runtime.ts';
+import { DefaultApi } from '@sdk/apis';
+
+describe('stats api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchAnalytics calls SDK method', async () => {
+    const points = [{ date: '2024-01-01', sugar: 5 }];
+    mockGetAnalytics.mockResolvedValue(points);
+
+    const res = await fetchAnalytics(1);
+
+    expect(Configuration).toHaveBeenCalledWith({
+      basePath: '/api',
+      headers: { 'x-telegram-init-data': 'test' },
+    });
+    expect(DefaultApi).toHaveBeenCalledWith(configInstance);
+    expect(mockGetAnalytics).toHaveBeenCalledWith({ telegramId: 1 });
+    expect(res).toEqual(points);
+  });
+
+  it('fetchDayStats calls SDK method', async () => {
+    const stats = { sugar: 6.2, breadUnits: 4, insulin: 12 };
+    mockGetStats.mockResolvedValue(stats);
+
+    const res = await fetchDayStats(2);
+
+    expect(Configuration).toHaveBeenCalledWith({
+      basePath: '/api',
+      headers: { 'x-telegram-init-data': 'test' },
+    });
+    expect(DefaultApi).toHaveBeenCalledWith(configInstance);
+    expect(mockGetStats).toHaveBeenCalledWith({ telegramId: 2 });
+    expect(res).toEqual(stats);
+  });
+});

--- a/services/webapp/ui/src/api/stats.ts
+++ b/services/webapp/ui/src/api/stats.ts
@@ -11,20 +11,6 @@ function makeApi(): DefaultApi {
   return new DefaultApi(cfg);
 }
 
-export const fallbackAnalytics: AnalyticsPoint[] = [
-  { date: '2024-01-01', sugar: 5.5 },
-  { date: '2024-01-02', sugar: 6.1 },
-  { date: '2024-01-03', sugar: 5.8 },
-  { date: '2024-01-04', sugar: 6.0 },
-  { date: '2024-01-05', sugar: 5.4 },
-];
-
-export const fallbackDayStats: DayStats = {
-  sugar: 6.2,
-  breadUnits: 4,
-  insulin: 12,
-};
-
 export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint[]> {
   const api = makeApi();
   return api.getAnalyticsAnalyticsGet({ telegramId });
@@ -32,8 +18,7 @@ export async function fetchAnalytics(telegramId: number): Promise<AnalyticsPoint
 
 export async function fetchDayStats(
   telegramId: number,
-): Promise<DayStats | null> {
+): Promise<DayStats | null | undefined> {
   const api = makeApi();
-  const data = await api.getStatsStatsGet({ telegramId });
-  return data ?? null;
+  return api.getStatsStatsGet({ telegramId });
 }

--- a/services/webapp/ui/src/pages/Analytics.tsx
+++ b/services/webapp/ui/src/pages/Analytics.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { MedicalHeader } from '@/components/MedicalHeader';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
 import { useTelegram } from '@/hooks/useTelegram';
-import { fetchAnalytics, fallbackAnalytics } from '@/api/stats';
+import { fetchAnalytics } from '@/api/stats';
 
 const Analytics = () => {
   const navigate = useNavigate();
@@ -14,10 +14,9 @@ const Analytics = () => {
     queryKey: ['analytics', user?.id],
     queryFn: () => fetchAnalytics(user?.id ?? 0),
     enabled: !!user?.id,
-    placeholderData: fallbackAnalytics,
   });
 
-  const chartData = data ?? fallbackAnalytics;
+  const chartData = data ?? [];
 
   return (
     <div className="min-h-screen bg-background">

--- a/services/webapp/ui/src/pages/Home.tsx
+++ b/services/webapp/ui/src/pages/Home.tsx
@@ -5,7 +5,7 @@ import { MedicalHeader } from '@/components/MedicalHeader';
 import { useTelegram } from '@/hooks/useTelegram';
 import MedicalButton from '@/components/MedicalButton';
 import { StatCard } from '@/components/StatCard';
-import { fetchDayStats, fallbackDayStats } from '@/api/stats';
+import { fetchDayStats } from '@/api/stats';
 
 const menuItems = [
   {
@@ -26,10 +26,7 @@ const Home = () => {
     queryKey: ['day-stats', user?.id],
     queryFn: () => fetchDayStats(user?.id ?? 0),
     enabled: !!user?.id,
-    placeholderData: fallbackDayStats,
   });
-
-  const dayStats = stats ?? fallbackDayStats;
 
   const handleTileClick = (route: string) => {
     navigate(route);
@@ -118,21 +115,21 @@ const Home = () => {
           </p>
         )}
         <div className="mt-6 grid grid-cols-3 gap-3">
-          <StatCard 
-            value={dayStats.sugar} 
-            unit="ммоль/л" 
+          <StatCard
+            value={stats?.sugar ?? 0}
+            unit="ммоль/л"
             label="Сахар"
             variant="sugar"
           />
-          <StatCard 
-            value={dayStats.breadUnits} 
-            unit="ХЕ" 
+          <StatCard
+            value={stats?.breadUnits ?? 0}
+            unit="ХЕ"
             label="Хлебные единицы"
             variant="bread"
           />
-          <StatCard 
-            value={dayStats.insulin} 
-            unit="ед." 
+          <StatCard
+            value={stats?.insulin ?? 0}
+            unit="ед."
             label="Инсулин"
             variant="insulin"
           />


### PR DESCRIPTION
## Summary
- use DefaultApi with telegram auth for stats and analytics requests
- remove local fallback data and rely on typed SDK responses
- add unit tests mocking SDK calls

## Testing
- `pnpm --filter ./services/webapp/ui test` *(fails: multiple existing tests)*
- `pytest -q` *(fails: KeyboardInterrupt while loading dependencies)*
- `mypy --strict .` *(fails: process terminated)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7b785778c832a93acf7557953aaa8