### PR TITLE
[contracts] Allow clearing timezone in profile settings

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -718,10 +718,14 @@ components:
     ProfileSettingsIn:
       properties:
         timezone:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Timezone
         timezoneAuto:
-          type: boolean
+          anyOf:
+          - type: boolean
+          - type: 'null'
           title: Timezone Auto
         dia:
           type: number

--- a/libs/ts-sdk/models/ProfileSettingsIn.ts
+++ b/libs/ts-sdk/models/ProfileSettingsIn.ts
@@ -24,13 +24,13 @@ export interface ProfileSettingsIn {
      * @type {string}
      * @memberof ProfileSettingsIn
      */
-    timezone?: string;
+    timezone?: string | null;
     /**
      * 
      * @type {boolean}
      * @memberof ProfileSettingsIn
      */
-    timezoneAuto?: boolean;
+    timezoneAuto?: boolean | null;
     /**
      * 
      * @type {number}

--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -63,12 +63,11 @@ export async function saveProfile({
 
 export async function patchProfile(payload: PatchProfileDto) {
   try {
-    const body: Record<string, unknown> = {};
-    Object.entries(payload).forEach(([key, value]) => {
-      if (value !== undefined) {
-        body[key] = value;
-      }
-    });
+    // Preserve explicit `null` values to clear fields, but drop `undefined`.
+    const body = Object.fromEntries(
+      Object.entries(payload).filter(([, value]) => value !== undefined),
+    ) as Record<string, unknown>;
+
     return await tgFetch<unknown>('/profile', { method: 'PATCH', body });
   } catch (error) {
     console.error('Failed to update profile:', error);

--- a/services/webapp/ui/src/features/profile/types.ts
+++ b/services/webapp/ui/src/features/profile/types.ts
@@ -1,4 +1,4 @@
-import type { ProfileSchema } from "@sdk";
+import type { ProfileSchema, ProfileSettingsIn } from "@sdk";
 
 export type RapidInsulin = "aspart" | "lispro" | "glulisine" | "regular";
 
@@ -14,17 +14,20 @@ export interface Profile extends ProfileSchema {
   therapyType?: "insulin" | "tablets" | "none" | "mixed" | null;
 }
 
-export type PatchProfileDto = {
-  timezone?: string | null;
-  timezoneAuto?: boolean | null;
-  dia?: number | null;
-  preBolus?: number | null;
-  roundStep?: number | null;
-  carbUnits?: "g" | "xe" | null;
-  gramsPerXe?: number | null;
-  rapidInsulinType?: RapidInsulin | null;
-  maxBolus?: number | null;
-  afterMealMinutes?: number | null;
-  therapyType?: "insulin" | "tablets" | "none" | "mixed" | null;
-};
+export type PatchProfileDto = Partial<
+  Pick<
+    ProfileSettingsIn,
+    | "timezone"
+    | "timezoneAuto"
+    | "dia"
+    | "preBolus"
+    | "roundStep"
+    | "carbUnits"
+    | "gramsPerXe"
+    | "rapidInsulinType"
+    | "maxBolus"
+    | "afterMealMinutes"
+    | "therapyType"
+  >
+>;
 


### PR DESCRIPTION
## Summary
- allow `null` for `timezone` and `timezoneAuto` in profile settings contracts
- regenerate TypeScript SDK and types
- send `null` in `patchProfile` only when fields are explicitly cleared

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b7c31a7558832ab0c20af69807dcd7