### PR TITLE
[handlers] Escape Vision HTML

### DIFF
--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import html
 import logging
 import os
 from pathlib import Path
@@ -219,7 +220,7 @@ async def photo_handler(
             )
             await message.reply_text(
                 "⚠️ Не смог разобрать углеводы на фото.\n\n"
-                f"Вот полный ответ Vision:\n<pre>{vision_text}</pre>\n"
+                f"Вот полный ответ Vision:\n<pre>{html.escape(vision_text)}</pre>\n"
                 "Введите /dose и укажите их вручную.",
                 parse_mode="HTML",
                 reply_markup=menu_keyboard(),


### PR DESCRIPTION
## Summary
- escape Vision text before sending to Telegram
- import `html` for escaping

## Testing
- `pytest -q --cov` *(fails: Required test coverage of 85% not reached. Total coverage: 83.66%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7c5d1dc7c832aaa796259dea1c54b