### PR TITLE
[handlers] Filter Vision messages by run

### DIFF
--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -192,12 +192,21 @@ async def photo_handler(
                 await message.reply_text("⚠️ Vision не смог обработать фото.")
             return END
 
-        messages = await asyncio.to_thread(
-            _get_client().beta.threads.messages.list,
-            thread_id=run.thread_id,
-        )
+        try:
+            messages = await asyncio.to_thread(
+                _get_client().beta.threads.messages.list,
+                thread_id=run.thread_id,
+                run_id=run.id,
+            )
+        except TypeError:
+            messages = await asyncio.to_thread(
+                _get_client().beta.threads.messages.list,
+                thread_id=run.thread_id,
+            )
         vision_text = ""
         for m in messages.data:
+            if getattr(m, "run_id", run.id) != run.id:
+                continue
             if m.role == "assistant" and m.content:
                 first_block: object = m.content[0]
                 text_block = getattr(first_block, "text", None)

--- a/tests/test_photo_handler_run_filter.py
+++ b/tests/test_photo_handler_run_filter.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
+
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+
+
+class DummyPhoto:
+    file_id = "fid"
+    file_unique_id = "uid"
+
+
+class DummyMessage:
+    def __init__(self, photo: tuple[Any, ...]) -> None:
+        self.photo = photo
+        self.texts: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.texts.append(text)
+
+
+@pytest.mark.asyncio
+async def test_photo_handler_ignores_previous_runs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    async def fake_get_file(file_id: str) -> Any:
+        class File:
+            async def download_to_drive(self, path: str) -> None:
+                Path(path).write_bytes(b"img")
+
+        return File()
+
+    class Run:
+        status = "completed"
+        thread_id = "tid"
+        id = "new"
+
+    async def fake_send_message(**kwargs: Any) -> Run:
+        return Run()
+
+    captured_run_ids: list[str | None] = []
+
+    def list_messages(thread_id: str, run_id: str | None = None) -> Any:
+        captured_run_ids.append(run_id)
+        return SimpleNamespace(
+            data=[
+                SimpleNamespace(
+                    run_id="old",
+                    role="assistant",
+                    content=[
+                        SimpleNamespace(text=SimpleNamespace(value="old info"))
+                    ],
+                ),
+                SimpleNamespace(
+                    run_id="new",
+                    role="assistant",
+                    content=[
+                        SimpleNamespace(text=SimpleNamespace(value="new info"))
+                    ],
+                ),
+            ]
+        )
+
+    dummy_client = SimpleNamespace(
+        beta=SimpleNamespace(
+            threads=SimpleNamespace(
+                runs=SimpleNamespace(retrieve=lambda thread_id, run_id: Run()),
+                messages=SimpleNamespace(list=list_messages),
+            )
+        )
+    )
+
+    extracted: list[str] = []
+
+    def fake_extract(text: str) -> tuple[float | None, float | None]:
+        extracted.append(text)
+        return (30.0, 2.0)
+
+    user_data: dict[str, Any] = {"thread_id": "tid"}
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(bot=SimpleNamespace(get_file=fake_get_file), user_data=user_data),
+    )
+    update = cast(
+        Update,
+        SimpleNamespace(
+            message=DummyMessage(photo=(DummyPhoto(),)),
+            effective_user=SimpleNamespace(id=1),
+        ),
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
+    monkeypatch.setattr(photo_handlers, "_get_client", lambda: dummy_client)
+    monkeypatch.setattr(photo_handlers, "extract_nutrition_info", fake_extract)
+    monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
+
+    await photo_handlers.photo_handler(update, context)
+
+    assert captured_run_ids == ["new"]
+    assert extracted == ["new info"]
+    entry = user_data["pending_entry"]
+    assert entry["carbs_g"] == 30.0
+    assert entry["xe"] == 2.0
+    assert photo_handlers.WAITING_GPT_FLAG not in user_data


### PR DESCRIPTION
## Summary
- filter Vision API messages by run ID to avoid cross-run contamination
- add regression test ensuring previous runs don't affect Vision response

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7c5d79688832aa7dde0cdab6416b1