### PR TITLE
[gpt_client] Make OpenAI client disposal async

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -51,7 +51,7 @@ def _get_async_client() -> AsyncOpenAI:
     return _async_client
 
 
-def dispose_openai_clients() -> None:
+async def dispose_openai_clients() -> None:
     """Close and reset cached OpenAI clients."""
     global _client, _async_client
     with _client_lock:
@@ -60,12 +60,7 @@ def dispose_openai_clients() -> None:
             _client = None
     with _async_client_lock:
         if _async_client is not None:
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                asyncio.run(_async_client.close())
-            else:
-                loop.create_task(_async_client.close())
+            await _async_client.close()
             _async_client = None
 
 

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -68,7 +68,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     finally:
         reminder_events.register_job_queue(None)
         dispose_http_client()
-        dispose_openai_clients()
+        await dispose_openai_clients()
 
 
 app = FastAPI(title="Diabetes Assistant API", version="1.0.0", lifespan=lifespan)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+import asyncio
 import sqlite3
 import subprocess
 from typing import Any, Callable, cast
@@ -238,5 +239,4 @@ def _dispose_openai_clients_after_test() -> Iterator[None]:
     """Dispose OpenAI clients after each test."""
     yield
     from services.api.app.diabetes.services.gpt_client import dispose_openai_clients
-
-    dispose_openai_clients()
+    asyncio.run(dispose_openai_clients())

--- a/tests/test_shutdown_openai_client.py
+++ b/tests/test_shutdown_openai_client.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -7,9 +7,10 @@ from services.api.app.main import app
 
 def test_shutdown_openai_client_disposes() -> None:
     with patch("services.api.app.main.dispose_http_client") as dispose_http, patch(
-        "services.api.app.main.dispose_openai_clients"
+        "services.api.app.main.dispose_openai_clients",
+        new_callable=AsyncMock,
     ) as dispose_clients:
         with TestClient(app):
             pass
         dispose_http.assert_called_once()
-        dispose_clients.assert_called_once()
+        dispose_clients.assert_awaited_once()


### PR DESCRIPTION
## Summary
- make `dispose_openai_clients` an async function
- await OpenAI client shutdown in app lifespan
- cover sync and async disposal paths in tests

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7c5db5660832aa27f9280e7ca01bd