### PR TITLE
[services] add timeouts for thread and message creation

### DIFF
--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -43,9 +43,7 @@ def test_get_client_thread_safe(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_message_openaierror(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_send_message_openaierror(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     def raise_error(**kwargs: Any) -> None:
         raise OpenAIError("boom")
 
@@ -68,15 +66,11 @@ async def test_send_message_openaierror(
 
 
 @pytest.mark.asyncio
-async def test_create_thread_openaierror(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_create_thread_openaierror(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     def raise_error() -> None:
         raise OpenAIError("boom")
 
-    fake_client = SimpleNamespace(
-        beta=SimpleNamespace(threads=SimpleNamespace(create=raise_error))
-    )
+    fake_client = SimpleNamespace(beta=SimpleNamespace(threads=SimpleNamespace(create=raise_error)))
 
     monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
 
@@ -123,9 +117,7 @@ async def test_dispose_openai_clients_resets_all_async(
 
 
 @pytest.mark.asyncio
-async def test_send_message_upload_error_removes_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_send_message_upload_error_removes_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     img = tmp_path / "img.jpg"
     img.write_bytes(b"data")
 
@@ -142,9 +134,7 @@ async def test_send_message_upload_error_removes_file(
 
 
 @pytest.mark.asyncio
-async def test_send_message_empty_string_preserved(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_send_message_empty_string_preserved(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     img = tmp_path / "img.jpg"
     img.write_bytes(b"data")
 
@@ -153,9 +143,7 @@ async def test_send_message_empty_string_preserved(
     def fake_files_create(file: Any, purpose: str) -> SimpleNamespace:
         return SimpleNamespace(id="f1")
 
-    def fake_messages_create(
-        *, thread_id: str, role: str, content: list[dict[str, Any]]
-    ) -> None:
+    def fake_messages_create(*, thread_id: str, role: str, content: list[dict[str, Any]]) -> None:
         captured["content"] = content
 
     fake_client = SimpleNamespace(
@@ -174,3 +162,42 @@ async def test_send_message_empty_string_preserved(
     await gpt_client.send_message(thread_id="t", content="", image_path=str(img))
     assert captured["content"][1]["text"] == ""
     assert not img.exists()
+
+
+@pytest.mark.asyncio
+async def test_create_thread_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def slow_create() -> None:
+        time.sleep(0.05)
+
+    fake_client = SimpleNamespace(beta=SimpleNamespace(threads=SimpleNamespace(create=slow_create)))
+
+    monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
+    monkeypatch.setattr(gpt_client, "THREAD_CREATION_TIMEOUT", 0.01)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await gpt_client.create_thread()
+
+
+@pytest.mark.asyncio
+async def test_send_message_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def slow_message_create(*, thread_id: str, role: str, content: list[dict[str, Any]]) -> None:
+        time.sleep(0.05)
+
+    run_create = Mock()
+    fake_client = SimpleNamespace(
+        beta=SimpleNamespace(
+            threads=SimpleNamespace(
+                messages=SimpleNamespace(create=slow_message_create),
+                runs=SimpleNamespace(create=run_create),
+            )
+        )
+    )
+
+    monkeypatch.setattr(gpt_client, "_get_client", lambda: fake_client)
+    monkeypatch.setattr(settings, "openai_assistant_id", "asst_test")
+    monkeypatch.setattr(gpt_client, "MESSAGE_CREATION_TIMEOUT", 0.01)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await gpt_client.send_message(thread_id="t", content="hi")
+
+    run_create.assert_not_called()


### PR DESCRIPTION
## Summary
- define constants for thread and message creation timeouts
- enforce timeouts when creating OpenAI threads and messages
- test timeout handling for thread and message operations

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7cb32378c832a923ab80bdc5a3b63