### PR TITLE
[config] make GPT command model configurable

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -57,6 +57,9 @@ class Settings(BaseSettings):
     openai_assistant_id: Optional[str] = Field(
         default=None, alias="OPENAI_ASSISTANT_ID"
     )
+    openai_command_model: str = Field(
+        default="gpt-4o-mini", alias="OPENAI_COMMAND_MODEL"
+    )
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
     font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
     telegram_token: Optional[str] = Field(default=None, alias="TELEGRAM_TOKEN")

--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -10,6 +10,7 @@ from openai.types.chat import ChatCompletion
 
 from pydantic import ValidationError
 
+from services.api.app import config
 from services.api.app.diabetes.services.gpt_client import create_chat_completion
 from services.api.app.schemas import CommandSchema
 
@@ -175,7 +176,7 @@ async def parse_command(text: str, timeout: float = 10) -> dict[str, object] | N
 
     try:
         resp: ChatCompletion | Awaitable[ChatCompletion] = create_chat_completion(
-            model="gpt-4o-mini",
+            model=config.get_settings().openai_command_model,
             messages=[
                 {"role": "system", "content": SYSTEM_PROMPT},
                 {"role": "user", "content": text},


### PR DESCRIPTION
## Summary
- add `openai_command_model` setting with default `gpt-4o-mini`
- use configurable model in GPT command parser
- adjust parser tests to read model from configuration

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check tests/test_gpt_command_parser.py services/api/app/config.py services/api/app/diabetes/gpt_command_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7cb411778832ab1d4d985dfcf6dd6