### PR TITLE
[handlers] Validate report period callback data

### DIFF
--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -206,12 +206,16 @@ async def report_period_callback(
     query = update.callback_query
     if query is None or query.data is None or query.message is None:
         return
-    await query.answer()
     message = cast(Message, query.message)
     if query.data == "report_back":
+        await query.answer()
         await message.delete()
         await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
         return
+    if ":" not in query.data:
+        await query.answer("Некорректный формат данных", show_alert=True)
+        return
+    await query.answer()
     period = query.data.split(":", 1)[1]
     now = datetime.datetime.now(datetime.timezone.utc)
     if period == "today":


### PR DESCRIPTION
## Summary
- avoid crashing on malformed report period callbacks
- test report period callback without delimiter

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7ccd1f6d0832a86d25b6cd9ce8a27