### PR TITLE
[handlers] Guard against malformed reminder callback data

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -1129,7 +1129,14 @@ async def reminder_action_cb(
     user = update.effective_user
     if query is None or query.data is None or user is None:
         return
-    action_raw, rid_str = query.data.split(":", 1)
+    if ":" not in query.data:
+        await query.answer("Некорректное действие", show_alert=True)
+        return
+    try:
+        action_raw, rid_str = query.data.split(":", 1)
+    except ValueError:
+        await query.answer("Некорректное действие", show_alert=True)
+        return
     if not action_raw.startswith("rem_"):
         await query.answer("Некорректное действие", show_alert=True)
         return

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -1401,6 +1401,15 @@ async def test_toggle_reminder_missing_user(
 
 
 @pytest.mark.asyncio
+async def test_reminder_action_cb_invalid_data() -> None:
+    query = DummyCallbackQuery("rem_toggle1", DummyMessage())
+    update = make_update(callback_query=query, effective_user=make_user(1))
+    context = make_context(job_queue=None, user_data={})
+    await handlers.reminder_action_cb(update, context)
+    assert query.answers == ["Некорректное действие"]
+
+
+@pytest.mark.asyncio
 async def test_edit_reminder(monkeypatch: pytest.MonkeyPatch) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)


### PR DESCRIPTION
## Summary
- validate reminder callback data for required ':' and handle split errors
- test reminder action callback with malformed data

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7ccd81ff8832a93824afca63f7bee