### PR TITLE
[handlers] Clear GPT wait timestamp on photo errors

### DIFF
--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -40,7 +40,9 @@ async def photo_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     message = update.message
     if message is None:
         return
-    await message.reply_text("📸 Пришлите фото блюда для анализа.", reply_markup=menu_keyboard())
+    await message.reply_text(
+        "📸 Пришлите фото блюда для анализа.", reply_markup=menu_keyboard()
+    )
 
 
 async def photo_handler(
@@ -89,6 +91,7 @@ async def photo_handler(
         except (AttributeError, IndexError, TypeError):
             await message.reply_text("❗ Файл не распознан как изображение.")
             user_data.pop(WAITING_GPT_FLAG, None)
+            user_data.pop(WAITING_GPT_TIMESTAMP, None)
             return END
 
         os.makedirs("photos", exist_ok=True)
@@ -100,6 +103,7 @@ async def photo_handler(
             logger.exception("[PHOTO] Failed to save photo: %s", exc)
             await message.reply_text("⚠️ Не удалось сохранить фото. Попробуйте ещё раз.")
             user_data.pop(WAITING_GPT_FLAG, None)
+            user_data.pop(WAITING_GPT_TIMESTAMP, None)
             return END
 
     logger.info("[PHOTO] Saved to %s", file_path)
@@ -117,7 +121,9 @@ async def photo_handler(
                     try:
                         commit(session)
                     except CommitError:
-                        await message.reply_text("⚠️ Не удалось сохранить данные пользователя.")
+                        await message.reply_text(
+                            "⚠️ Не удалось сохранить данные пользователя."
+                        )
                         return END
             user_data["thread_id"] = thread_id
 
@@ -140,14 +146,18 @@ async def photo_handler(
             )
             user_data.pop(WAITING_GPT_FLAG, None)
             return END
-        status_message = await message.reply_text("🔍 Анализирую фото (это займёт 5‑10 с)…")
+        status_message = await message.reply_text(
+            "🔍 Анализирую фото (это займёт 5‑10 с)…"
+        )
         chat_id = getattr(message, "chat_id", None)
 
         async def send_typing_action() -> None:
             if not chat_id:
                 return
             try:
-                await context.bot.send_chat_action(chat_id=chat_id, action=ChatAction.TYPING)
+                await context.bot.send_chat_action(
+                    chat_id=chat_id, action=ChatAction.TYPING
+                )
             except TelegramError as exc:
                 logger.warning(
                     "[PHOTO][TYPING_ACTION] Failed to send typing action: %s",
@@ -190,7 +200,9 @@ async def photo_handler(
                         exc,
                     )
                     raise
-            await message.reply_text("⚠️ Время ожидания Vision истекло. Попробуйте позже.")
+            await message.reply_text(
+                "⚠️ Время ожидания Vision истекло. Попробуйте позже."
+            )
             return END
 
         if run.status != "completed":
@@ -288,11 +300,15 @@ async def photo_handler(
 
     except OSError as exc:
         logger.exception("[PHOTO] File processing error: %s", exc)
-        await message.reply_text("⚠️ Ошибка при обработке файла изображения. Попробуйте ещё раз.")
+        await message.reply_text(
+            "⚠️ Ошибка при обработке файла изображения. Попробуйте ещё раз."
+        )
         return END
     except OpenAIError as exc:
         logger.exception("[PHOTO] Vision API error: %s", exc)
-        await message.reply_text("⚠️ Vision не смог обработать фото. Попробуйте ещё раз.")
+        await message.reply_text(
+            "⚠️ Vision не смог обработать фото. Попробуйте ещё раз."
+        )
         return END
     except ValueError as exc:
         logger.exception("[PHOTO] Parsing error: %s", exc)

--- a/tests/test_photo_handler_errors.py
+++ b/tests/test_photo_handler_errors.py
@@ -83,6 +83,8 @@ async def test_photo_handler_not_image() -> None:
     result = await photo_handlers.photo_handler(update, context)
     assert result == photo_handlers.END
     assert message.texts == ["❗ Файл не распознан как изображение."]
+    assert photo_handlers.WAITING_GPT_FLAG not in context.user_data
+    assert photo_handlers.WAITING_GPT_TIMESTAMP not in context.user_data
 
 
 @pytest.mark.asyncio
@@ -127,8 +129,6 @@ async def test_photo_handler_timeout(
     result = await photo_handlers.photo_handler(update, context)
 
     assert result == photo_handlers.END
-    assert message.texts == [
-        "⚠️ Превышено время ожидания ответа. Попробуйте ещё раз."
-    ]
+    assert message.texts == ["⚠️ Превышено время ожидания ответа. Попробуйте ещё раз."]
     assert context.user_data is not None
     assert photo_handlers.WAITING_GPT_FLAG not in context.user_data

--- a/tests/test_photo_handlers.py
+++ b/tests/test_photo_handlers.py
@@ -56,7 +56,11 @@ async def test_photo_handler_clears_stale_waiting_flag(
     update = cast(
         Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
     )
-    old_ts = datetime.datetime.now(datetime.timezone.utc) - photo_handlers.WAITING_GPT_TIMEOUT - datetime.timedelta(seconds=1)
+    old_ts = (
+        datetime.datetime.now(datetime.timezone.utc)
+        - photo_handlers.WAITING_GPT_TIMEOUT
+        - datetime.timedelta(seconds=1)
+    )
     user_data = {
         photo_handlers.WAITING_GPT_FLAG: True,
         photo_handlers.WAITING_GPT_TIMESTAMP: old_ts,
@@ -114,6 +118,7 @@ async def test_photo_handler_get_file_telegram_error(
     assert context.user_data is not None
     user_data = context.user_data
     assert photo_handlers.WAITING_GPT_FLAG not in user_data
+    assert photo_handlers.WAITING_GPT_TIMESTAMP not in user_data
     assert "[PHOTO] Failed to save photo" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- Clear WAITING_GPT_TIMESTAMP in early photo_handler failures
- Test removal of WAITING_GPT_FLAG and WAITING_GPT_TIMESTAMP on recognition and save errors

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf8d989c832a9464d73b1657b584