### PR TITLE
[handlers] Remove os from photo_handlers __all__

### DIFF
--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -366,5 +366,4 @@ __all__ = [
     "photo_handler",
     "doc_handler",
     "prompt_photo",
-    "os",
 ]


### PR DESCRIPTION
## Summary
- remove stray `os` from `photo_handlers.__all__`

## Testing
- `pytest -q --maxfail=1` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf90442c832ab69077adef737b6c