### PR TITLE
[handlers] Handle plus-prefixed SOS contacts

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -137,9 +137,11 @@ async def _send_alert_message(
                 chat_id = contact
             elif contact.isdigit():
                 chat_id = int(contact)
+            elif contact.startswith("+") and contact.lstrip("+").isdigit():
+                chat_id = int(contact.lstrip("+"))
             else:
                 logger.info(
-                    "SOS contact '%s' is not a Telegram username or chat id; skipping",
+                    "SOS contact '%s' is not a Telegram username, chat id, or phone number; skipping",
                     contact,
                 )
                 chat_id = None

--- a/tests/test_alert_handlers.py
+++ b/tests/test_alert_handlers.py
@@ -89,7 +89,7 @@ async def test_send_alert_message_invalid_contact(
 
     assert expected in caplog.text
     assert (
-        "SOS contact 'bad_contact' is not a Telegram username or chat id; skipping"
+        "SOS contact 'bad_contact' is not a Telegram username, chat id, or phone number; skipping"
         in caplog.text
     )
     assert bot.send_message.await_count == 1

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -117,9 +117,11 @@ async def test_alert_notifies_user_and_contact(
 
 
 @pytest.mark.asyncio
-async def test_alert_skips_phone_contact(
+async def test_alert_notifies_plus_contact(
     test_session: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Alerts are sent to SOS contacts starting with '+'."""
+
     with test_session() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.add(
@@ -127,7 +129,7 @@ async def test_alert_skips_phone_contact(
                 telegram_id=1,
                 low_threshold=4,
                 high_threshold=8,
-                sos_contact="+123",
+                sos_contact="+12345678",
                 sos_alerts_enabled=True,
             )
         )
@@ -152,7 +154,10 @@ async def test_alert_skips_phone_contact(
         )
 
     msg = "⚠️ У Ivan критический сахар 3 ммоль/л. 0,0 link"
-    assert send_mock.await_args_list == [call(chat_id=1, text=msg)]
+    assert send_mock.await_args_list == [
+        call(chat_id=1, text=msg),
+        call(chat_id=12345678, text=msg),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow '+'-prefixed SOS contact numbers in alert handlers
- clarify log message for invalid SOS contacts
- test SOS alerts with '+' numbers

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7d3bd0514832ab5e68b7122583b3a