### PR TITLE
[utils] Enforce HTTPS in get_coords_and_link

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -3,6 +3,7 @@ import os
 import re
 from datetime import datetime, time, timedelta
 from json import JSONDecodeError
+from urllib.parse import urlparse
 
 import httpx
 
@@ -68,6 +69,9 @@ async def get_coords_and_link(
     """Return approximate coordinates and Google Maps link based on IP."""
 
     url = source_url or GEO_DATA_URL
+    if urlparse(url).scheme.lower() != "https":
+        logger.warning("Insecure URL scheme: %s", url)
+        return None, None
 
     try:
         async with httpx.AsyncClient() as client:


### PR DESCRIPTION
## Summary
- ensure `get_coords_and_link` only uses HTTPS URLs, logging a warning for others
- test that insecure `http://` source URLs are rejected safely
- adjust custom source test to require HTTPS

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7d3c451c8832a99e7c9894f00ac24