### PR TITLE
[telegram] validate user id type

### DIFF
--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -85,6 +85,6 @@ def require_tg_user(
     data: dict[str, object] = parse_and_verify_init_data(init_data, token)
     user_raw = data.get("user")
     user = user_raw if isinstance(user_raw, dict) else None
-    if user is None or "id" not in user:
+    if user is None or not isinstance(user.get("id"), int):
         raise HTTPException(status_code=401, detail="invalid user")
     return cast(UserContext, user)


### PR DESCRIPTION
## Summary
- ensure Telegram user id in auth header is an integer
- test Telegram auth with both valid and invalid user id types

## Testing
- `mypy --strict services/api/app/telegram_auth.py tests/test_telegram_auth.py`
- `ruff check services/api/app/telegram_auth.py tests/test_telegram_auth.py`
- `pytest tests/test_telegram_auth.py -q` *(fails: Coverage failure: total of 25 is less than fail-under=85)*


------
https://chatgpt.com/codex/tasks/task_e_68b7d3c77be4832a894e32c23484f937