### PR TITLE
[handlers] clear GPT timestamp on photo upload errors

### DIFF
--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -89,6 +89,7 @@ async def photo_handler(
         except (AttributeError, IndexError, TypeError):
             await message.reply_text("❗ Файл не распознан как изображение.")
             user_data.pop(WAITING_GPT_FLAG, None)
+            user_data.pop(WAITING_GPT_TIMESTAMP, None)
             return END
 
         os.makedirs("photos", exist_ok=True)
@@ -100,6 +101,7 @@ async def photo_handler(
             logger.exception("[PHOTO] Failed to save photo: %s", exc)
             await message.reply_text("⚠️ Не удалось сохранить фото. Попробуйте ещё раз.")
             user_data.pop(WAITING_GPT_FLAG, None)
+            user_data.pop(WAITING_GPT_TIMESTAMP, None)
             return END
 
     logger.info("[PHOTO] Saved to %s", file_path)

--- a/tests/test_photo_handler_errors.py
+++ b/tests/test_photo_handler_errors.py
@@ -83,6 +83,8 @@ async def test_photo_handler_not_image() -> None:
     result = await photo_handlers.photo_handler(update, context)
     assert result == photo_handlers.END
     assert message.texts == ["❗ Файл не распознан как изображение."]
+    assert photo_handlers.WAITING_GPT_FLAG not in context.user_data
+    assert photo_handlers.WAITING_GPT_TIMESTAMP not in context.user_data
 
 
 @pytest.mark.asyncio

--- a/tests/test_photo_handlers.py
+++ b/tests/test_photo_handlers.py
@@ -114,6 +114,7 @@ async def test_photo_handler_get_file_telegram_error(
     assert context.user_data is not None
     user_data = context.user_data
     assert photo_handlers.WAITING_GPT_FLAG not in user_data
+    assert photo_handlers.WAITING_GPT_TIMESTAMP not in user_data
     assert "[PHOTO] Failed to save photo" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- clear WAITING_GPT timestamp on early photo-handler exits
- ensure photo-handler tests cover timestamp cleanup

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7d3cc519c832a8641ba3abd256107