### PR TITLE
[build] Increase Node.js heap size for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "pnpm --filter ./services/webapp/ui dev",
-    "build": "pnpm --filter ./services/webapp/ui build",
+    "build": "NODE_OPTIONS=\"--max-old-space-size=4096\" pnpm --filter ./services/webapp/ui build",
     "preview": "pnpm --filter ./services/webapp/ui preview",
     "typecheck": "pnpm --filter ./services/webapp/ui typecheck",
     "generate:sdk": "bash scripts/gen_ts_sdk.sh"


### PR DESCRIPTION
## Summary
- prefix build script with NODE_OPTIONS to increase Node.js heap size to 4GB

## Testing
- `pnpm run build`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7d5a4d488832a826b2b4babe3c859