### PR TITLE
[build] disable minification and sourcemaps for UI build

### DIFF
--- a/services/webapp/ui/vite.config.ts
+++ b/services/webapp/ui/vite.config.ts
@@ -89,9 +89,10 @@ export default defineConfig(async ({ mode, command }) => {
 
     build: {
       outDir: 'dist',
-      minify: mode === 'development' ? false : 'esbuild',
+      minify: false, // or 'esbuild'
+      cssMinify: false,
       minifyInternalExports: false,
-      sourcemap: true,
+      sourcemap: false,
       rollupOptions: {
         ...(mode === 'development' ? { treeshake: false } : {}),
         input: {


### PR DESCRIPTION
## Summary
- turn off source maps, JS/CSS minification for Vite build to lower build-time memory usage

## Testing
- `pnpm build`
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7d5aa7348832aadd9fc36f65a5d2b