### PR TITLE
ui: dynamically load mock server in dev

### DIFF
--- a/services/webapp/ui/src/features/reminders/components/Templates.tsx
+++ b/services/webapp/ui/src/features/reminders/components/Templates.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
 import { useRemindersApi } from "../api/reminders";
 import { buildReminderPayload } from "../api/buildPayload";
-import { mockApi } from "../../../api/mock-server";
 import { useToast } from "../../../shared/toast";
 import { useDefaultAfterMealMinutes } from "../../profile/hooks";
 import type { ReminderDto } from "../types";
@@ -61,8 +60,10 @@ export function Templates({
       try {
         await api.remindersPost({ reminder });
       } catch (apiError) {
-        console.warn("Backend API failed, using mock API:", apiError);
-        await mockApi.createReminder(reminder);
+        if (import.meta.env.DEV) {
+          console.warn("Backend API failed:", apiError);
+        }
+        throw apiError;
       }
       
       toast.success("Напоминание создано из шаблона");

--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -10,7 +10,6 @@ import { validate, hasErrors } from "../logic/validate";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 import { useTelegram } from "../../../hooks/useTelegram";
 import { getTelegramUserId } from "../../../shared/telegram";
-import { mockApi } from "../../../api/mock-server";
 import { useToast } from "../../../shared/toast";
 import TimeInput from "@/components/TimeInput";
 
@@ -42,7 +41,6 @@ export default function RemindersCreate() {
   );
   const nav = useNavigate();
   const toast = useToast();
-  const isDev = process.env.NODE_ENV === "development";
 
   const [form, setForm] = useState<ReminderDto>({
     telegramId,
@@ -81,16 +79,10 @@ export default function RemindersCreate() {
         const res = await api.remindersPost({ reminder });
         rid = res?.id;
       } catch (apiError) {
-        if (isDev) {
-          if (import.meta.env.DEV) {
-            console.warn("Backend API failed, using mock API:", apiError);
-          }
-          // Fallback на mock API
-          const res = await mockApi.createReminder(reminder);
-          rid = (res as { id?: number })?.id;
-        } else {
-          throw apiError;
+        if (import.meta.env.DEV) {
+          console.warn("Backend API failed:", apiError);
         }
+        throw apiError;
       }
 
       if (rid) {

--- a/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
@@ -10,7 +10,6 @@ import type { ReminderDto, ScheduleKind, ReminderType } from "../types";
 import { validate, hasErrors } from "../logic/validate";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
 import { getTelegramUserId } from "../../../shared/telegram";
-import { mockApi } from "../../../api/mock-server";
 import { useToast } from "../../../shared/toast";
 import { useTelegram } from "@/hooks/useTelegram";
 import TimeInput from "@/components/TimeInput";
@@ -82,8 +81,10 @@ export default function RemindersEdit() {
         try {
           reminder = await api.remindersIdGet({ id: Number(id), telegramId });
         } catch (apiError) {
-          console.warn("Backend API failed, using mock API:", apiError);
-          reminder = await mockApi.getReminder(telegramId, Number(id));
+          if (import.meta.env.DEV) {
+            console.warn("Backend API failed:", apiError);
+          }
+          throw apiError;
         }
         setForm(mapToForm(reminder));
       } catch (err) {
@@ -124,8 +125,10 @@ export default function RemindersEdit() {
       try {
         await api.remindersPatch({ reminder });
       } catch (apiError) {
-        console.warn("Backend API failed, using mock API:", apiError);
-        await mockApi.updateReminder(reminder);
+        if (import.meta.env.DEV) {
+          console.warn("Backend API failed:", apiError);
+        }
+        throw apiError;
       }
 
       const value = form.time

--- a/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersList.tsx
@@ -141,12 +141,9 @@ export default function RemindersList({
         await api.remindersPatch({ reminder });
       } catch (apiError) {
         if (isDev) {
-          console.warn("Backend API failed, using mock API:", apiError);
-          const { mockApi } = await import("../../../api/mock-server");
-          await mockApi.updateReminder({ ...r, isEnabled: !r.isEnabled });
-        } else {
-          throw apiError;
+          console.warn("Backend API failed:", apiError);
         }
+        throw apiError;
       }
       load();
     } catch {
@@ -207,12 +204,9 @@ export default function RemindersList({
         await api.remindersDelete({ telegramId: r.telegramId, id: r.id });
       } catch (apiError) {
         if (isDev) {
-          console.warn("Backend API failed, using mock API:", apiError);
-          const { mockApi } = await import("../../../api/mock-server");
-          await mockApi.deleteReminder(r.telegramId, r.id);
-        } else {
-          throw apiError;
+          console.warn("Backend API failed:", apiError);
         }
+        throw apiError;
       }
     } catch {
       toast({ title: "Ошибка", description: "Не удалось удалить", variant: "destructive" });

--- a/services/webapp/ui/src/main.tsx
+++ b/services/webapp/ui/src/main.tsx
@@ -3,6 +3,10 @@ import { createRoot } from 'react-dom/client'
 import App from './App'
 import './index.css'
 
+if (import.meta.env.DEV) {
+  import('./api/mock-server')
+}
+
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />

--- a/services/webapp/ui/tests/mockApi.test.tsx
+++ b/services/webapp/ui/tests/mockApi.test.tsx
@@ -67,7 +67,7 @@ describe('mockApi not used in production', () => {
 
   it('RemindersCreate uses toast and not mockApi in production', async () => {
     remindersPost.mockRejectedValue(new Error('fail'));
-    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('DEV', 'false');
     const { default: RemindersCreate } = await import('../src/features/reminders/pages/RemindersCreate');
     const { container } = render(<RemindersCreate />);
     const form = container.querySelector('form')!;


### PR DESCRIPTION
## Summary
- load mock server only during development
- drop direct mockApi fallbacks from reminders pages and templates

## Testing
- `pnpm --filter ./services/webapp/ui test` *(fails: tgFetch.test.ts 2 failed, ProfileHelpSheet.test.tsx 2 failed)*
- `pytest -q` *(fails: pytest-cov not installed)*
- `mypy --strict .` *(timed out)*
- `ruff check .`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b7d5b11e34832a947baebc98715591