### PR TITLE
[handlers] Handle missing debug reminder module

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -128,8 +128,11 @@ def register_reminder_handlers(
             register_debug_reminder_handlers,
         )
         register_debug_reminder_handlers(app)
-    except Exception as e:
+    except ImportError as e:
         logger.warning("⚠️ Could not load debug reminder handlers: %s", e)
+    except Exception:
+        logger.exception("Failed to load debug reminder handlers")
+        raise
 
     # --- Schedule reminders ---
     job_queue = app.job_queue


### PR DESCRIPTION
## Summary
- catch ImportError separately when loading debug reminder handlers and log other exceptions
- test reminder handler registration with missing debug module

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7d658dbac832aaf4652d14b4734cb