### PR TITLE
[services] handle non-sqlalchemy errors in transactional

### DIFF
--- a/services/api/app/diabetes/services/repository.py
+++ b/services/api/app/diabetes/services/repository.py
@@ -41,7 +41,7 @@ def transactional(session: Session) -> Iterator[Session]:
     try:
         yield session
         session.commit()
-    except SQLAlchemyError:  # pragma: no cover - logging only
+    except Exception as exc:  # pragma: no cover - logging only
         session.rollback()
-        logger.exception("DB commit failed")
+        logger.exception("DB transaction failed: %s", exc.__class__.__name__)
         raise

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -42,3 +42,12 @@ def test_transactional_failure() -> None:
             raise DummyError("boom")
     session.rollback.assert_called_once()
     session.commit.assert_not_called()
+
+
+def test_transactional_value_error() -> None:
+    session = MagicMock()
+    with pytest.raises(ValueError):
+        with repository.transactional(session):
+            raise ValueError("boom")
+    session.rollback.assert_called_once()
+    session.commit.assert_not_called()


### PR DESCRIPTION
## Summary
- catch any exception in transactional and log its type
- test ValueError scenario in transactional ensures rollback

## Testing
- `pytest -q` *(fails: tests/test_gpt_command_parser.py::test_extract_first_json_braces_in_string_before_object)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7dd05c1f0832aa2e87313d92c1216