### PR TITLE
[utils] Make OpenAI HTTP client disposal async

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -83,6 +83,22 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
     are ignored to avoid ambiguity.
     """
 
+    def _inside_quotes(src: str, index: int) -> bool:
+        in_single = False
+        in_double = False
+        i = 0
+        while i < index:
+            ch = src[i]
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == "'" and not in_double:
+                in_single = not in_single
+            elif ch == '"' and not in_single:
+                in_double = not in_double
+            i += 1
+        return in_single or in_double
+
     decoder = json.JSONDecoder()
     pos = 0
     while True:
@@ -90,7 +106,9 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
         if not match:
             return None
         start = pos + match.start()
-        if start > 0 and text[start - 1] not in " \t\n\r":
+        if _inside_quotes(text, start) or (
+            start > 0 and text[start - 1] not in " \t\n\r"
+        ):
             pos = start + 1
             continue
         try:

--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import threading
 from typing import Literal, overload
@@ -90,7 +89,7 @@ def get_async_openai_client() -> AsyncOpenAI:
     return client
 
 
-def dispose_http_client() -> None:
+async def dispose_http_client() -> None:
     """Close and reset the HTTP client used by OpenAI."""
     global _http_client, _async_http_client
     with _http_client_lock:
@@ -99,10 +98,5 @@ def dispose_http_client() -> None:
             _http_client = None
     with _async_http_client_lock:
         if _async_http_client is not None:
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                asyncio.run(_async_http_client.aclose())
-            else:
-                loop.create_task(_async_http_client.aclose())
+            await _async_http_client.aclose()
             _async_http_client = None

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -67,7 +67,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         yield
     finally:
         reminder_events.register_job_queue(None)
-        dispose_http_client()
+        await dispose_http_client()
         await dispose_openai_clients()
 
 

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -19,7 +19,10 @@ def test_get_openai_client_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> 
         openai_utils.get_openai_client()
 
 
-def test_get_openai_client_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_get_openai_client_uses_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     fake_http_client = Mock()
     http_client_mock = Mock(return_value=fake_http_client)
     openai_mock = Mock()
@@ -39,7 +42,7 @@ def test_get_openai_client_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     openai_mock.assert_called_once_with(api_key="key", http_client=fake_http_client)
     assert client is openai_mock.return_value
 
-    openai_utils.dispose_http_client()
+    await openai_utils.dispose_http_client()
     fake_http_client.close.assert_called_once()
 
 
@@ -79,7 +82,8 @@ def test_get_openai_client_without_proxy(monkeypatch: pytest.MonkeyPatch) -> Non
     assert client is openai_mock.return_value
 
 
-def test_http_client_lock_used(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_http_client_lock_used(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummyLock:
         def __init__(self) -> None:
             self.entered = False
@@ -109,9 +113,8 @@ def test_http_client_lock_used(monkeypatch: pytest.MonkeyPatch) -> None:
     dummy_lock.entered = False
     dummy_lock.exited = False
 
-    openai_utils.dispose_http_client()
+    await openai_utils.dispose_http_client()
     assert dummy_lock.entered and dummy_lock.exited
-
 
 
 def test_get_async_openai_client_requires_api_key(
@@ -126,7 +129,10 @@ def test_get_async_openai_client_requires_api_key(
         openai_utils.get_async_openai_client()
 
 
-def test_get_async_openai_client_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_get_async_openai_client_uses_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     fake_async_client = Mock()
     fake_async_client.aclose = AsyncMock()
     async_client_mock = Mock(return_value=fake_async_client)
@@ -149,12 +155,15 @@ def test_get_async_openai_client_uses_proxy(monkeypatch: pytest.MonkeyPatch) -> 
     openai_mock.assert_called_once_with(api_key="key", http_client=fake_async_client)
     assert client is openai_mock.return_value
 
-    openai_utils.dispose_http_client()
+    await openai_utils.dispose_http_client()
     fake_async_client.aclose.assert_awaited_once()
     assert openai_utils._async_http_client is None
 
 
-def test_dispose_http_client_resets_all(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_dispose_http_client_resets_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     fake_http_client = Mock()
     fake_async_client = Mock()
     fake_async_client.aclose = AsyncMock()
@@ -162,10 +171,9 @@ def test_dispose_http_client_resets_all(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(openai_utils, "_http_client", fake_http_client)
     monkeypatch.setattr(openai_utils, "_async_http_client", fake_async_client)
 
-    openai_utils.dispose_http_client()
+    await openai_utils.dispose_http_client()
 
     fake_http_client.close.assert_called_once()
     fake_async_client.aclose.assert_awaited_once()
     assert openai_utils._http_client is None
     assert openai_utils._async_http_client is None
-

--- a/tests/test_shutdown_openai_client.py
+++ b/tests/test_shutdown_openai_client.py
@@ -6,11 +6,14 @@ from services.api.app.main import app
 
 
 def test_shutdown_openai_client_disposes() -> None:
-    with patch("services.api.app.main.dispose_http_client") as dispose_http, patch(
+    with patch(
+        "services.api.app.main.dispose_http_client",
+        new_callable=AsyncMock,
+    ) as dispose_http, patch(
         "services.api.app.main.dispose_openai_clients",
         new_callable=AsyncMock,
     ) as dispose_clients:
         with TestClient(app):
             pass
-        dispose_http.assert_called_once()
+        dispose_http.assert_awaited_once()
         dispose_clients.assert_awaited_once()


### PR DESCRIPTION
## Summary
- make `dispose_http_client` asynchronous and await closing of HTTP clients
- await disposal during FastAPI lifespan shutdown
- fix JSON extraction helper to skip braces inside quoted strings

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7dd094398832a911be5874f953408