### PR TITLE
[gpt_client] handle asyncio timeouts

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -106,6 +106,10 @@ async def create_thread() -> str:
     except OpenAIError as exc:
         logger.exception("[OpenAI] Failed to create thread: %s", exc)
         raise
+    except asyncio.TimeoutError:
+        message = "Thread creation timed out"
+        logger.exception("[OpenAI] %s", message)
+        raise RuntimeError(message)
     return thread.id
 
 
@@ -167,6 +171,9 @@ async def send_message(
                     return client.files.create(file=f, purpose="vision")
 
             file = await asyncio.wait_for(asyncio.to_thread(_upload), timeout=FILE_UPLOAD_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.exception("[OpenAI] Timeout while uploading %s", image_path)
+            raise RuntimeError("Timed out while uploading image")
         except OSError as exc:
             logger.exception("[OpenAI] Failed to read %s: %s", image_path, exc)
             raise
@@ -203,6 +210,10 @@ async def send_message(
     except OpenAIError as exc:
         logger.exception("[OpenAI] Failed to create message: %s", exc)
         raise
+    except asyncio.TimeoutError:
+        message = "Message creation timed out"
+        logger.exception("[OpenAI] %s", message)
+        raise RuntimeError(message)
 
     # 3. Запускаем ассистента
     try:
@@ -217,6 +228,10 @@ async def send_message(
     except OpenAIError as exc:
         logger.exception("[OpenAI] Failed to create run: %s", exc)
         raise
+    except asyncio.TimeoutError:
+        message = "Run creation timed out"
+        logger.exception("[OpenAI] %s", message)
+        raise RuntimeError(message)
 
     if run is None:
         message = "Run creation returned None"


### PR DESCRIPTION
## Summary
- log and raise RuntimeError on asyncio timeouts in OpenAI thread and message operations
- cover timeout handling with tests

## Testing
- `pytest tests/test_gpt_client.py::test_create_thread_timeout tests/test_gpt_client.py::test_send_message_timeout tests/test_gpt_client.py::test_send_message_run_timeout -q --no-cov`
- `pytest tests/services/test_gpt_client_service.py -q --no-cov`
- `mypy --strict services/api/app/diabetes/services/gpt_client.py tests/test_gpt_client.py` *(fails: command interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_68b7dd0db640832ab36b07b0780b7081