### PR TITLE
[deploy] Configure Matplotlib cache path

### DIFF
--- a/docs/deploy/diabetes-assistant.service
+++ b/docs/deploy/diabetes-assistant.service
@@ -5,8 +5,12 @@ After=network.target
 [Service]
 Type=simple
 User=www-data
+PermissionsStartOnly=true
 WorkingDirectory=/opt/saharlight-ux
 EnvironmentFile=/opt/saharlight-ux/.env
+Environment=MPLCONFIGDIR=/var/cache/diabetes-bot/mpl
+ExecStartPre=/usr/bin/mkdir -p /var/cache/diabetes-bot/mpl
+ExecStartPre=/usr/bin/chown www-data:www-data /var/cache/diabetes-bot/mpl
 ExecStart=/usr/bin/env uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000 --workers 4
 Restart=on-failure
 RestartSec=5

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -8,7 +8,8 @@ source ./.env
 set +a
 
 # Конфигурация для Matplotlib
-export MPLCONFIGDIR="${MPLCONFIGDIR:-/var/cache/matplotlib}"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-/var/cache/diabetes-bot/mpl}"
+mkdir -p "$MPLCONFIGDIR"
 
 # Запускаем API с авто-reload (1 процесс)
 uvicorn services.api.app.main:app \


### PR DESCRIPTION
## Summary
- set MPLCONFIGDIR to /var/cache/diabetes-bot/mpl for dev and systemd
- ensure cache directory exists and is owned by bot user in service unit

## Testing
- `pytest -q --cov` *(fails: async plugin missing, coverage < 85)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7e28df000832a972bdaa85a12f567