### PR TITLE
[parser] Handle braces in string fields

### DIFF
--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -609,6 +609,27 @@ def test_extract_first_json_with_escaped_chars() -> None:
     }
 
 
+def test_extract_first_json_braces_inside_string_field() -> None:
+    text = (
+        'prefix {"action":"add_entry","fields":{"note":"use {curly} braces"}} '
+        "suffix"
+    )
+    assert gpt_command_parser._extract_first_json(text) == {
+        "action": "add_entry",
+        "fields": {"note": "use {curly} braces"},
+    }
+
+
+def test_extract_first_json_braces_and_quotes_inside_string_field() -> None:
+    text = (
+        '{"action":"add_entry","fields":{"note":"{\\"inner\\":1} end"}}'
+    )
+    assert gpt_command_parser._extract_first_json(text) == {
+        "action": "add_entry",
+        "fields": {"note": '{"inner":1} end'},
+    }
+
+
 @pytest.mark.asyncio
 async def test_parse_command_with_multiple_jsons(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- rewrite JSON extraction to track quotes and escapes, ensuring braces inside strings are ignored
- add tests covering JSON strings with curly braces

## Testing
- `pytest -q` *(fails: async def functions not supported)*
- `mypy --strict services/api/app/diabetes/gpt_command_parser.py tests/test_gpt_command_parser.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7e2fab314832a9fa0b54a81826fdc