### PR TITLE
[gpt_command_parser] use debug level for raw GPT response logging

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -199,7 +199,7 @@ async def parse_command(text: str, timeout: float = 10) -> dict[str, object] | N
         return None
 
     safe_content = _sanitize_sensitive_data(content)
-    logger.info("GPT raw response: %s", safe_content[:200])
+    logger.debug("GPT raw response: %s", safe_content[:200])
     parsed = _extract_first_json(content)
     if parsed is None:
         logger.error("No JSON object found in response")

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -56,7 +56,7 @@ async def test_parse_command_timeout_non_blocking(
 
 @pytest.mark.asyncio
 async def test_parse_command_with_explanatory_text(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     class FakeResponse:
         choices = [
@@ -87,10 +87,12 @@ async def test_parse_command_with_explanatory_text(
 
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)
 
-    result = await gpt_command_parser.parse_command("test")
+    with caplog.at_level(logging.DEBUG):
+        result = await gpt_command_parser.parse_command("test")
 
     assert result == {"action": "add_entry", "time": "09:00", "fields": {}}
     assert captured.get("model") == config.get_settings().openai_command_model
+    assert "GPT raw response:" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- log raw GPT response at debug instead of info and sanitize tokens
- ensure parser tests capture debug log output

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7e88de9a0832ab4d8080b77439e12