### PR TITLE
[config] Default photos_dir to system path and fix JSON parsing

### DIFF
--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -3,7 +3,7 @@
 # General application settings
 APP_NAME=diabetes-bot
 DEBUG=False
-PHOTOS_DIR=photos
+PHOTOS_DIR=/var/lib/diabetes-bot/photos
 
 # Database configuration
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/diabetes

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -34,7 +34,9 @@ class Settings(BaseSettings):
     app_name: str = "diabetes-bot"
     debug: bool = False
 
-    photos_dir: str = Field(default="photos", alias="PHOTOS_DIR")
+    photos_dir: str = Field(
+        default="/var/lib/diabetes-bot/photos", alias="PHOTOS_DIR"
+    )
 
     # Database configuration
     database_url: str = Field(

--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -103,6 +103,9 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
         if ch not in "{[":
             i += 1
             continue
+        if i > 0 and text[i - 1] not in " \t\r\n,[":
+            i += 1
+            continue
 
         start = i
         stack: list[str] = [ch]
@@ -133,7 +136,8 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
             i += 1
 
         if stack:
-            return None
+            i = start + 1
+            continue
 
         candidate = text[start:i]
         try:


### PR DESCRIPTION
## Summary
- default `photos_dir` to `/var/lib/diabetes-bot/photos` and expose via `PHOTOS_DIR`
- document the new `PHOTOS_DIR` in `.env.example`
- harden `_extract_first_json` to skip malformed or nested JSON segments

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b7eb727f38832aa6d0694ca4d4aef8