### PR TITLE
[handlers] handle sugar after photo

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -50,9 +50,7 @@ run_db: Callable[..., Awaitable[object]] | None
 try:
     from services.api.app.diabetes.services.db import run_db as _run_db
 except ImportError:  # pragma: no cover - optional db runner
-    logging.getLogger(__name__).info(
-        "run_db is unavailable; proceeding without async DB runner"
-    )
+    logging.getLogger(__name__).info("run_db is unavailable; proceeding without async DB runner")
     run_db = None
 else:
     run_db = cast(Callable[..., Awaitable[object]], _run_db)
@@ -226,12 +224,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
             sessionmaker=SessionLocal,
         )
 
-    if (
-        profile is None
-        or profile.icr is None
-        or profile.cf is None
-        or profile.target_bg is None
-    ):
+    if profile is None or profile.icr is None or profile.cf is None or profile.target_bg is None:
         await message.reply_text(
             "Профиль не настроен. Установите коэффициенты через /profile.",
             reply_markup=menu_keyboard(),
@@ -282,9 +275,7 @@ async def dose_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
 
 
 def _cancel_then(
-    handler: Callable[
-        [Update, ContextTypes.DEFAULT_TYPE], Coroutine[object, object, T]
-    ],
+    handler: Callable[[Update, ContextTypes.DEFAULT_TYPE], Coroutine[object, object, T]],
 ) -> Callable[[Update, ContextTypes.DEFAULT_TYPE], Coroutine[object, object, T]]:
     """Return a wrapper calling ``dose_cancel`` before ``handler``."""
 
@@ -337,12 +328,16 @@ dose_conv = ConversationHandler(
         MessageHandler(filters.Regex(f"^{DOSE_BUTTON_TEXT}$"), dose_start),
     ],
     states={
-        DOSE_METHOD: [
-            MessageHandler(filters.TEXT & ~filters.COMMAND, dose_method_choice)
-        ],
+        DOSE_METHOD: [MessageHandler(filters.TEXT & ~filters.COMMAND, dose_method_choice)],
         DOSE_XE: [MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), dose_xe)],
         DOSE_CARBS: [MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), dose_carbs)],
         DOSE_SUGAR: [MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), dose_sugar)],
+        PHOTO_SUGAR: [
+            MessageHandler(
+                filters.Regex(r"^-?\d+(?:[.,]\d+)?$"),
+                dose_sugar,
+            )
+        ],
     },
     fallbacks=[
         MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), dose_cancel),

--- a/tests/test_dose_conv_photo_sugar_state.py
+++ b/tests/test_dose_conv_photo_sugar_state.py
@@ -1,0 +1,10 @@
+from services.api.app.diabetes.handlers import dose_calc, photo_handlers, sugar_handlers
+
+
+def test_photo_sugar_state_uses_sugar_handler() -> None:
+    handlers = dose_calc.dose_conv.states.get(photo_handlers.PHOTO_SUGAR)
+    assert handlers, "PHOTO_SUGAR state is missing"
+    callbacks = {h.callback for h in handlers}
+    assert dose_calc.dose_sugar in callbacks or sugar_handlers.sugar_val in callbacks, (
+        "PHOTO_SUGAR state not linked to a sugar handler"
+    )


### PR DESCRIPTION
## Summary
- link PHOTO_SUGAR conversation state to sugar handler
- test PHOTO_SUGAR state mapping

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7eecd1dd0832a84a599b919e8f642