### PR TITLE
[handlers] Clear pending entry on recognition failure

### DIFF
--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -275,6 +275,7 @@ async def photo_handler(
                 parse_mode="HTML",
                 reply_markup=menu_keyboard(),
             )
+            user_data.pop("pending_entry", None)
             return END
 
         pending_entry = cast(


### PR DESCRIPTION
## Summary
- Clear `pending_entry` when photo recognition fails, preventing stale data from persisting
- Test that failed vision parsing removes existing `pending_entry`

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68b7eed452bc832a872216cb7d1cd197