### PR TITLE
[tests] Refactor photo handler tests for in-memory downloads

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -15,7 +15,7 @@ class EntryData(TypedDict, total=False):
     carbs_g: float | None
     dose: float | None
     sugar_before: float | None
-    photo_path: str | None
+    photo_bytes: bytes | None
 
 
 class UserData(TypedDict, total=False):
@@ -34,7 +34,6 @@ class UserData(TypedDict, total=False):
     profile_cf: float
     profile_target: float
     profile_low: float
-    __file_path: str
     reminder_id: int
     chat_id: int
 

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -577,7 +577,7 @@ async def finalize_entry(
         "carbs_g": fields.get("carbs_g"),
         "dose": fields.get("dose"),
         "sugar_before": fields.get("sugar_before"),
-        "photo_path": None,
+        "photo_bytes": None,
     }
     pending_entry = user_data["pending_entry"]
     xe_val: float | None = pending_entry.get("xe")

--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -4,8 +4,6 @@ import asyncio
 import datetime
 import html
 import logging
-import os
-from pathlib import Path
 from typing import cast
 
 from openai import OpenAIError
@@ -23,8 +21,6 @@ from services.api.app.diabetes.services.gpt_client import (
 from services.api.app.diabetes.services.repository import CommitError, commit
 from services.api.app.diabetes.utils.functions import extract_nutrition_info
 from services.api.app.diabetes.utils.ui import menu_keyboard
-from services.api.app.config import settings
-
 from . import EntryData, UserData
 
 logger = logging.getLogger(__name__)
@@ -54,7 +50,7 @@ async def photo_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 async def photo_handler(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
-    file_path: str | None = None,
+    file_bytes: bytes | None = None,
 ) -> int:
     """Process food photos and trigger nutrition analysis."""
     user_data_raw = context.user_data
@@ -87,10 +83,7 @@ async def photo_handler(
     user_data[WAITING_GPT_FLAG] = True
     user_data[WAITING_GPT_TIMESTAMP] = now
 
-    if file_path is None:
-        file_path = user_data.pop("__file_path", None)
-
-    if not file_path:
+    if file_bytes is None:
         try:
             photo = message.photo[-1]
         except (AttributeError, IndexError, TypeError):
@@ -98,24 +91,21 @@ async def photo_handler(
             _clear_waiting_gpt(user_data)
             return END
 
-        photos_dir = settings.photos_dir
         try:
-            os.makedirs(photos_dir, exist_ok=True)
-            file_path = f"{photos_dir}/{user_id}_{photo.file_unique_id}.jpg"
             file = await context.bot.get_file(photo.file_id)
-            await file.download_to_drive(file_path)
+            file_bytes = bytes(await file.download_as_bytearray())
         except OSError as exc:
-            logger.exception("[PHOTO] Failed to save photo: %s", exc)
+            logger.exception("[PHOTO] Failed to load photo: %s", exc)
             await message.reply_text("⚠️ Не удалось сохранить фото. Попробуйте ещё раз.")
             _clear_waiting_gpt(user_data)
             return END
         except TelegramError as exc:
-            logger.exception("[PHOTO] Failed to save photo: %s", exc)
+            logger.exception("[PHOTO] Failed to load photo: %s", exc)
             await message.reply_text("⚠️ Не удалось сохранить фото. Попробуйте ещё раз.")
             _clear_waiting_gpt(user_data)
             return END
 
-    logger.info("[PHOTO] Saved to %s", file_path)
+    logger.info("[PHOTO] Loaded photo bytes (%d)", len(file_bytes))
 
     try:
         thread_id = user_data.get("thread_id")
@@ -145,7 +135,7 @@ async def photo_handler(
                     "Углеводы: <...>\n"
                     "ХЕ: <...>"
                 ),
-                image_path=file_path,
+                image_bytes=file_bytes,
                 keep_image=True,
             )
         except asyncio.TimeoutError:
@@ -255,18 +245,13 @@ async def photo_handler(
                 if text_block is not None:
                     vision_text = text_block.value
                     break
-        logger.debug(
-            "[VISION][RESPONSE] Ответ Vision для %s:\n%s",
-            file_path,
-            vision_text,
-        )
+        logger.debug("[VISION][RESPONSE] Ответ Vision:\n%s", vision_text)
 
         carbs_g, xe = extract_nutrition_info(vision_text)
         if carbs_g is None and xe is None:
             logger.debug(
-                "[VISION][NO_PARSE] Ответ ассистента: %r для файла: %s",
+                "[VISION][NO_PARSE] Ответ ассистента: %r",
                 vision_text,
-                file_path,
             )
             await message.reply_text(
                 "⚠️ Не смог разобрать углеводы на фото.\n\n"
@@ -286,7 +271,7 @@ async def photo_handler(
                 "event_time": datetime.datetime.now(datetime.timezone.utc),
             },
         )
-        pending_entry.update({"carbs_g": carbs_g, "xe": xe, "photo_path": file_path})
+        pending_entry.update({"carbs_g": carbs_g, "xe": xe, "photo_bytes": file_bytes})
         user_data["pending_entry"] = pending_entry
         if status_message and hasattr(status_message, "delete"):
             try:
@@ -330,15 +315,6 @@ async def photo_handler(
         return END
     finally:
         _clear_waiting_gpt(user_data)
-        if file_path:
-            try:
-                Path(file_path).unlink()
-            except OSError as exc:
-                logger.warning(
-                    "[PHOTO][CLEANUP] Failed to remove file %s: %s",
-                    file_path,
-                    exc,
-                )
 
 
 async def doc_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -362,26 +338,19 @@ async def doc_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     if mime_type is None or not mime_type.startswith("image/"):
         return END
 
-    user_id = effective_user.id
-    filename = document.file_name or ""
-    ext = Path(filename).suffix or ".jpg"
-    photos_dir = settings.photos_dir
-    path = f"{photos_dir}/{user_id}_{document.file_unique_id}{ext}"
     try:
-        os.makedirs(photos_dir, exist_ok=True)
         file = await context.bot.get_file(document.file_id)
-        await file.download_to_drive(path)
+        file_bytes = bytes(await file.download_as_bytearray())
     except OSError as exc:
-        logger.exception("[DOC] Failed to save document: %s", exc)
+        logger.exception("[DOC] Failed to load document: %s", exc)
         await message.reply_text("⚠️ Не удалось сохранить документ. Попробуйте ещё раз.")
         return END
     except TelegramError as exc:
-        logger.exception("[DOC] Failed to save document: %s", exc)
+        logger.exception("[DOC] Failed to load document: %s", exc)
         await message.reply_text("⚠️ Не удалось сохранить документ. Попробуйте ещё раз.")
         return END
 
-    user_data.pop("__file_path", None)
-    return await photo_handler(update, context, file_path=path)
+    return await photo_handler(update, context, file_bytes=file_bytes)
 
 
 prompt_photo = photo_prompt


### PR DESCRIPTION
## Summary
- adjust photo handler to accept in-memory bytes
- update gpt client to upload image bytes
- rewrite photo handler tests to mock download_as_bytearray

## Testing
- `pytest tests/test_handlers_doc.py::test_doc_handler_calls_photo_handler -q` *(fails: async plugin missing & coverage <85)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f9267ec4832aaccae6e01cad658d