### PR TITLE
utils: enrich nutrition parser

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -13,6 +13,10 @@ class EntryData(TypedDict, total=False):
     event_time: datetime.datetime
     xe: float | None
     carbs_g: float | None
+    portion_g: float | None
+    proteins_g: float | None
+    fats_g: float | None
+    calories_kcal: float | None
     dose: float | None
     sugar_before: float | None
     photo_path: str | None

--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -255,8 +255,8 @@ async def photo_handler(
             vision_text,
         )
 
-        carbs_g, xe = extract_nutrition_info(vision_text)
-        if carbs_g is None and xe is None:
+        nutrition = extract_nutrition_info(vision_text)
+        if nutrition.carbs_g is None and nutrition.xe is None:
             logger.debug(
                 "[VISION][NO_PARSE] Ответ ассистента: %r для пользователя: %s",
                 vision_text,
@@ -280,7 +280,17 @@ async def photo_handler(
                 "event_time": datetime.datetime.now(datetime.timezone.utc),
             },
         )
-        pending_entry.update({"carbs_g": carbs_g, "xe": xe, "photo_path": None})
+        pending_entry.update(
+            {
+                "carbs_g": nutrition.carbs_g,
+                "xe": nutrition.xe,
+                "portion_g": nutrition.portion_g,
+                "proteins_g": nutrition.proteins_g,
+                "fats_g": nutrition.fats_g,
+                "calories_kcal": nutrition.calories_kcal,
+                "photo_path": None,
+            }
+        )
         user_data["pending_entry"] = pending_entry
         if status_message and hasattr(status_message, "delete"):
             try:

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -40,7 +40,10 @@ async def handle_confirm_entry(
         return
     entry_data: EntryData = entry_data_raw
     with SessionLocal() as session:
-        entry = Entry(**entry_data)
+        # Filter out fields not defined in the ORM model to avoid TypeError
+        allowed_keys = set(Entry.__table__.columns.keys())
+        clean_data = {k: v for k, v in entry_data.items() if k in allowed_keys}
+        entry = Entry(**clean_data)
         session.add(entry)
         try:
             commit(session)

--- a/services/api/app/diabetes/utils/functions.py
+++ b/services/api/app/diabetes/utils/functions.py
@@ -1,5 +1,6 @@
 """Утилиты для расчёта болюса и разбора пищевой информации."""
 
+from dataclasses import dataclass
 import math
 import re
 
@@ -26,6 +27,10 @@ CARBS_LABELED_PM_RE = re.compile(
     rf"углевод[^\d]*:\s*({NUMBER_RE})\s*(?:г)?\s*±\s*({NUMBER_RE})\s*г",
     re.IGNORECASE,
 )
+CARBS_LABELED_RANGE_RE = re.compile(
+    rf"углевод[^\d]*:\s*{DASH_RANGE_RE.pattern}\s*г",
+    re.IGNORECASE,
+)
 CARBS_LABEL_RE = re.compile(r"углевод[^\d]*:\s*([\d.,]+)\s*г", re.IGNORECASE)
 XE_COLON_PM_RE = re.compile(
     rf"\b{XE_WORD_RE.pattern}\s*:\s*{PLUS_MINUS_RANGE_RE.pattern}",
@@ -46,6 +51,66 @@ XE_RANGE_RE = re.compile(
 )
 CARBS_PM_RE = re.compile(rf"({NUMBER_RE})\s*(?:г)?\s*±\s*({NUMBER_RE})\s*г", re.IGNORECASE)
 CARBS_RANGE_RE = re.compile(rf"{DASH_RANGE_RE.pattern}\s*г", re.IGNORECASE)
+
+# ---------------------------------------------------------------------------
+# Additional nutrition patterns (portion, proteins, fats, calories)
+# ---------------------------------------------------------------------------
+PORTION_LABEL_RE = r"(?:вес|масса|порц(?:ия|ии|ий)?|portion|weight)"
+PROTEIN_LABEL_RE = r"(?:белк(?:и)?|proteins?)"
+FAT_LABEL_RE = r"(?:жир(?:ы)?|fats?)"
+CALORIES_LABEL_RE = r"(?:калори(?:и)?|ккал|calories?)"
+
+PORTION_PM_RE = re.compile(
+    rf"{PORTION_LABEL_RE}[^\d]*:\s*({NUMBER_RE})\s*±\s*({NUMBER_RE})\s*г",
+    re.IGNORECASE,
+)
+PORTION_RANGE_RE = re.compile(
+    rf"{PORTION_LABEL_RE}[^\d]*:\s*{DASH_RANGE_RE.pattern}\s*г",
+    re.IGNORECASE,
+)
+PORTION_SINGLE_RE = re.compile(
+    rf"{PORTION_LABEL_RE}[^\d]*:\s*({NUMBER_RE})\s*г",
+    re.IGNORECASE,
+)
+
+PROTEIN_PM_RE = re.compile(
+    rf"{PROTEIN_LABEL_RE}[^\d]*:\s*({NUMBER_RE})\s*±\s*({NUMBER_RE})\s*г",
+    re.IGNORECASE,
+)
+PROTEIN_RANGE_RE = re.compile(
+    rf"{PROTEIN_LABEL_RE}[^\d]*:\s*{DASH_RANGE_RE.pattern}\s*г",
+    re.IGNORECASE,
+)
+PROTEIN_SINGLE_RE = re.compile(
+    rf"{PROTEIN_LABEL_RE}[^\d]*:\s*({NUMBER_RE})\s*г",
+    re.IGNORECASE,
+)
+
+FAT_PM_RE = re.compile(
+    rf"{FAT_LABEL_RE}[^\d]*:\s*({NUMBER_RE})\s*±\s*({NUMBER_RE})\s*г",
+    re.IGNORECASE,
+)
+FAT_RANGE_RE = re.compile(
+    rf"{FAT_LABEL_RE}[^\d]*:\s*{DASH_RANGE_RE.pattern}\s*г",
+    re.IGNORECASE,
+)
+FAT_SINGLE_RE = re.compile(
+    rf"{FAT_LABEL_RE}[^\d]*:\s*({NUMBER_RE})\s*г",
+    re.IGNORECASE,
+)
+
+CAL_PM_RE = re.compile(
+    rf"{CALORIES_LABEL_RE}[^\d]*:\s*({NUMBER_RE})\s*±\s*({NUMBER_RE})\s*(?:ккал|cal)",
+    re.IGNORECASE,
+)
+CAL_RANGE_RE = re.compile(
+    rf"{CALORIES_LABEL_RE}[^\d]*:\s*{DASH_RANGE_RE.pattern}\s*(?:ккал|cal)",
+    re.IGNORECASE,
+)
+CAL_SINGLE_RE = re.compile(
+    rf"{CALORIES_LABEL_RE}[^\d]*:\s*({NUMBER_RE})\s*(?:ккал|cal)",
+    re.IGNORECASE,
+)
 
 # Patterns for ``smart_input``.
 BAD_SUGAR_UNIT_RE = re.compile(rf"\b{SUGAR_WORD_RE.pattern}\s*[:=]?\s*{NUMBER_RE}\s*(?:xe|хе|ед)\b(?!\s*[\d=:])")
@@ -102,11 +167,53 @@ def _safe_float(value: object) -> float | None:
     return result if math.isfinite(result) else None
 
 
-def extract_nutrition_info(text: object) -> tuple[float | None, float | None]:
-    """Извлекает углеводы и ХЕ из произвольной строки.
+@dataclass
+class NutritionInfo:
+    """Parsed nutrition values."""
 
-    Поддерживаются варианты: ``"углеводы: 30 г"``, ``"XE: 2-3"``,
-    ``"2–3 ХЕ"`` и записи с погрешностью ``"a ± b"``.
+    portion_g: float | None = None
+    proteins_g: float | None = None
+    fats_g: float | None = None
+    carbs_g: float | None = None
+    calories_kcal: float | None = None
+    xe: float | None = None
+
+
+def _extract_labeled_value(
+    text: str,
+    pm_re: re.Pattern[str],
+    range_re: re.Pattern[str],
+    single_re: re.Pattern[str],
+) -> float | None:
+    """Generic helper to parse labeled numeric values.
+
+    Supports ``a ± b`` and ``a–b`` formats, returning the central value ``a``
+    for ``±`` and the average for ranges.
+    """
+
+    rng = pm_re.search(text)
+    if rng:
+        first = _safe_float(rng.group(1))
+        second = _safe_float(rng.group(2))
+        if first is not None and second is not None:
+            return first
+    rng = range_re.search(text)
+    if rng:
+        first = _safe_float(rng.group(1))
+        second = _safe_float(rng.group(2))
+        if first is not None and second is not None:
+            return (first + second) / 2
+    m = single_re.search(text)
+    if m:
+        return _safe_float(m.group(1))
+    return None
+
+
+def extract_nutrition_info(text: object) -> NutritionInfo:
+    """Извлекает пищевую информацию из произвольной строки.
+
+    Поддерживаются варианты ``"углеводы: 30 г"``, ``"XE: 2-3"``,
+    ``"2–3 ХЕ"`` и записи с погрешностью ``"a ± b"`` для всех полей.
     Десятичная часть может быть отделена запятой. При указании
     ``"a ± b"`` возвращается центральное значение ``a``, а ``b``
     игнорируется.
@@ -115,18 +222,12 @@ def extract_nutrition_info(text: object) -> tuple[float | None, float | None]:
         text: Строка с описанием продукта или блюда.
 
     Returns:
-        Кортеж ``(carbs, xe)``, где значения могут быть ``None``.
-
-    Examples:
-        >>> extract_nutrition_info("углеводы: 30 г, XE: 2")
-        (30.0, 2.0)
-        >>> extract_nutrition_info("2–3 ХЕ")
-        (None, 2.5)
-        >>> extract_nutrition_info("углеводы: 45 ± 5 г")
-        (45.0, None)
+        :class:`NutritionInfo` с распознанными значениями.
     """
+
     if not isinstance(text, str):
-        return (None, None)
+        return NutritionInfo()
+
     # На этом этапе ``text`` гарантированно строка.
     # Если первая строка не содержит цифр или ключевых слов,
     # считаем её названием блюда и игнорируем
@@ -134,73 +235,89 @@ def extract_nutrition_info(text: object) -> tuple[float | None, float | None]:
     if len(lines) > 1 and not FIRST_LINE_INFO_RE.search(lines[0]):
         text = "\n".join(lines[1:])
 
-    carbs = xe = None
+    result = NutritionInfo()
+
     # Парсим углеводы (carbs)
     m = CARBS_LABELED_PM_RE.search(text)
     if m:
         first = _safe_float(m.group(1))
         second = _safe_float(m.group(2))
         if first is not None and second is not None:
-            # В формате "a ± b" возвращаем центральное значение "a"
-            # Погрешность "b" пока игнорируется
-            carbs = first
+            result.carbs_g = first
     else:
-        m = CARBS_LABEL_RE.search(text)
+        m = CARBS_LABELED_RANGE_RE.search(text)
         if m:
-            carbs = _safe_float(m.group(1))
+            first = _safe_float(m.group(1))
+            second = _safe_float(m.group(2))
+            if first is not None and second is not None:
+                result.carbs_g = (first + second) / 2
+        else:
+            m = CARBS_LABEL_RE.search(text)
+            if m:
+                result.carbs_g = _safe_float(m.group(1))
+
     # Диапазон XE c двоеточием (например XE: 2±1 или XE: 2–3)
     rng = XE_COLON_PM_RE.search(text)
     if rng:
         first = _safe_float(rng.group(1))
         second = _safe_float(rng.group(2))
         if first is not None and second is not None:
-            # Возвращаем центральное значение "a" из записи "a ± b"
-            xe = first
+            result.xe = first
     else:
         rng = XE_COLON_RANGE_RE.search(text)
         if rng:
             first = _safe_float(rng.group(1))
             second = _safe_float(rng.group(2))
             if first is not None and second is not None:
-                xe = (first + second) / 2
+                result.xe = (first + second) / 2
         else:
-            # Одинарное значение XE: 3.1
             m = XE_COLON_SINGLE_RE.search(text)
             if m:
-                xe = _safe_float(m.group(1))
-            # Диапазон XE без двоеточия (например 2±1 ХЕ или 2–3 ХЕ)
-            if xe is None:
+                result.xe = _safe_float(m.group(1))
+            if result.xe is None:
                 rng = XE_PM_RE.search(text)
                 if rng:
                     first = _safe_float(rng.group(1))
                     second = _safe_float(rng.group(2))
                     if first is not None and second is not None:
-                        # Погрешность игнорируется, берём только значение "a"
-                        xe = first
-            if xe is None:
+                        result.xe = first
+            if result.xe is None:
                 rng = XE_RANGE_RE.search(text)
                 if rng:
                     first = _safe_float(rng.group(1))
                     second = _safe_float(rng.group(2))
                     if first is not None and second is not None:
-                        xe = (first + second) / 2
+                        result.xe = (first + second) / 2
+
     # Диапазон углеводов (carbs) если не найдено
-    if carbs is None:
+    if result.carbs_g is None:
         rng = CARBS_PM_RE.search(text)
         if rng:
             first = _safe_float(rng.group(1))
             second = _safe_float(rng.group(2))
             if first is not None and second is not None:
-                # Центральное значение при указании "a ± b"
-                carbs = first
-    if carbs is None:
+                result.carbs_g = first
+    if result.carbs_g is None:
         rng = CARBS_RANGE_RE.search(text)
         if rng:
             first = _safe_float(rng.group(1))
             second = _safe_float(rng.group(2))
             if first is not None and second is not None:
-                carbs = (first + second) / 2
-    return carbs, xe
+                result.carbs_g = (first + second) / 2
+
+    # Дополнительные поля
+    result.portion_g = _extract_labeled_value(
+        text, PORTION_PM_RE, PORTION_RANGE_RE, PORTION_SINGLE_RE
+    )
+    result.proteins_g = _extract_labeled_value(
+        text, PROTEIN_PM_RE, PROTEIN_RANGE_RE, PROTEIN_SINGLE_RE
+    )
+    result.fats_g = _extract_labeled_value(text, FAT_PM_RE, FAT_RANGE_RE, FAT_SINGLE_RE)
+    result.calories_kcal = _extract_labeled_value(
+        text, CAL_PM_RE, CAL_RANGE_RE, CAL_SINGLE_RE
+    )
+
+    return result
 
 
 def smart_input(message: str) -> dict[str, float | None]:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -6,6 +6,7 @@ from services.api.app.diabetes.utils.functions import (
     _safe_float,
     extract_nutrition_info,
     smart_input,
+    NutritionInfo,
 )
 
 
@@ -23,84 +24,104 @@ def test_safe_float_non_finite(value: str) -> None:
 
 
 def test_extract_nutrition_info_simple() -> None:
-    text = "углеводы: 45 г, ХЕ: 3.5"
-    carbs, xe = extract_nutrition_info(text)
-    assert carbs == 45
-    assert xe == 3.5
+    text = (
+        "Вес: 100 г, Белки: 5 г, Жиры: 10 г, углеводы: 45 г, Калории: 200 ккал, "
+        "ХЕ: 3.5"
+    )
+    info = extract_nutrition_info(text)
+    assert info.portion_g == 100
+    assert info.proteins_g == 5
+    assert info.fats_g == 10
+    assert info.carbs_g == 45
+    assert info.calories_kcal == 200
+    assert info.xe == 3.5
 
 
 def test_extract_nutrition_info_ranges() -> None:
-    text = "Углеводы: 30–50 г, XE: 2–3"
-    carbs, xe = extract_nutrition_info(text)
-    assert carbs == 40  # (30+50)/2
-    assert xe == 2.5  # (2+3)/2
+    text = (
+        "Вес: 90-110 г, Белки: 5-7 г, Жиры: 8-12 г, Углеводы: 30–50 г, "
+        "Калории: 180-220 ккал, XE: 2–3"
+    )
+    info = extract_nutrition_info(text)
+    assert info.portion_g == 100  # (90+110)/2
+    assert info.proteins_g == 6  # (5+7)/2
+    assert info.fats_g == 10  # (8+12)/2
+    assert info.carbs_g == 40  # (30+50)/2
+    assert info.calories_kcal == 200  # (180+220)/2
+    assert info.xe == 2.5  # (2+3)/2
 
 
 def test_extract_nutrition_info_plus_minus() -> None:
-    text = "углеводы: 45 г ± 5 г, XE: 3 ± 0.5"
-    carbs, xe = extract_nutrition_info(text)
-    assert carbs == 45
-    assert xe == 3
+    text = (
+        "Вес: 100 ± 10 г, Белки: 6 ± 1 г, Жиры: 10 ± 2 г, "
+        "углеводы: 45 г ± 5 г, Калории: 200 ± 20 ккал, XE: 3 ± 0.5"
+    )
+    info = extract_nutrition_info(text)
+    assert info.portion_g == 100
+    assert info.proteins_g == 6
+    assert info.fats_g == 10
+    assert info.carbs_g == 45
+    assert info.calories_kcal == 200
+    assert info.xe == 3
 
 
 def test_extract_nutrition_info_plus_minus_no_colon() -> None:
     text = "В блюде 30 г ± 10 г углеводов и 2 ± 1 ХЕ"
-    carbs, xe = extract_nutrition_info(text)
-    assert carbs == 30
-    assert xe == 2
+    info = extract_nutrition_info(text)
+    assert info.carbs_g == 30
+    assert info.xe == 2
 
 
 def test_extract_nutrition_info_plus_minus_with_comma() -> None:
     text = "углеводы: 10,5 г ± 0,5 г, ХЕ: 2,5 ± 0,5"
-    carbs, xe = extract_nutrition_info(text)
-    assert carbs == pytest.approx(10.5)
-    assert xe == pytest.approx(2.5)
+    info = extract_nutrition_info(text)
+    assert info.carbs_g == pytest.approx(10.5)
+    assert info.xe == pytest.approx(2.5)
 
 
 def test_extract_nutrition_info_missing() -> None:
     text = "Нет данных"
-    carbs, xe = extract_nutrition_info(text)
-    assert carbs is None
-    assert xe is None
+    info = extract_nutrition_info(text)
+    assert info == NutritionInfo()
 
 
 def test_extract_nutrition_info_invalid_carbs() -> None:
     text = "углеводы: 5..2 г, ХЕ: 3"
-    carbs, xe = extract_nutrition_info(text)
-    assert carbs is None
-    assert xe == 3
+    info = extract_nutrition_info(text)
+    assert info.carbs_g is None
+    assert info.xe == 3
 
 
 def test_extract_nutrition_info_invalid_xe() -> None:
     text = "углеводы: 45 г, ХЕ: 1..2"
-    carbs, xe = extract_nutrition_info(text)
-    assert carbs == 45
-    assert xe is None
+    info = extract_nutrition_info(text)
+    assert info.carbs_g == 45
+    assert info.xe is None
 
 
 def test_extract_nutrition_info_ignores_title_line() -> None:
     text = "Борщ\nУглеводы: 25 г\nХЕ: 2"
-    carbs, xe = extract_nutrition_info(text)
-    assert carbs == 25
-    assert xe == 2
+    info = extract_nutrition_info(text)
+    assert info.carbs_g == 25
+    assert info.xe == 2
 
 
 def test_extract_nutrition_info_first_line_with_data() -> None:
     text = "Углеводы: 25 г\nХЕ: 2"
-    carbs, xe = extract_nutrition_info(text)
-    assert carbs == 25
-    assert xe == 2
+    info = extract_nutrition_info(text)
+    assert info.carbs_g == 25
+    assert info.xe == 2
 
 
 def test_extract_nutrition_info_first_line_xe_only() -> None:
     text = "ХЕ: 3\nПрочее"
-    carbs, xe = extract_nutrition_info(text)
-    assert carbs is None
-    assert xe == 3
+    info = extract_nutrition_info(text)
+    assert info.carbs_g is None
+    assert info.xe == 3
 
 
 def test_extract_nutrition_info_non_string() -> None:
-    assert extract_nutrition_info(123) == (None, None)
+    assert extract_nutrition_info(123) == NutritionInfo()
 
 
 def test_smart_input_basic() -> None:

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
 import services.api.app.diabetes.handlers.gpt_handlers as gpt_handlers
+import services.api.app.diabetes.utils.functions as functions
 from services.api.app.config import settings
 
 pytestmark = pytest.mark.skip("photo handler refactor; tests need update")
@@ -331,7 +332,9 @@ async def test_photo_handler_sends_bytes(
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
     monkeypatch.setattr(
-        photo_handlers, "extract_nutrition_info", lambda text: (10.0, 1.0)
+        photo_handlers,
+        "extract_nutrition_info",
+        lambda text: functions.NutritionInfo(carbs_g=10.0, xe=1.0),
     )
     monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
 
@@ -383,7 +386,9 @@ async def test_photo_then_freeform_calculates_dose(
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
     monkeypatch.setattr(
-        photo_handlers, "extract_nutrition_info", lambda text: (10.0, 1.0)
+        photo_handlers,
+        "extract_nutrition_info",
+        lambda text: functions.NutritionInfo(carbs_g=10.0, xe=1.0),
     )
     monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
     monkeypatch.setattr(gpt_handlers, "confirm_keyboard", lambda: None)

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session, sessionmaker
 import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
 import services.api.app.diabetes.handlers.gpt_handlers as gpt_handlers
 import services.api.app.diabetes.handlers.router as router
+import services.api.app.diabetes.utils.functions as functions
 from services.api.app.config import settings
 
 
@@ -157,7 +158,9 @@ async def test_photo_flow_saves_entry(
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
     monkeypatch.setattr(
-        photo_handlers, "extract_nutrition_info", lambda text: (30.0, 2.0)
+        photo_handlers,
+        "extract_nutrition_info",
+        lambda text: functions.NutritionInfo(carbs_g=30.0, xe=2.0),
     )
     user_data["thread_id"] = "tid"
 

--- a/tests/test_photo_handler_run_filter.py
+++ b/tests/test_photo_handler_run_filter.py
@@ -10,6 +10,7 @@ from telegram import Update
 from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
+import services.api.app.diabetes.utils.functions as functions
 
 
 # ensure OpenAI env vars for tests
@@ -84,9 +85,9 @@ async def test_photo_handler_ignores_previous_runs(
 
     extracted: list[str] = []
 
-    def fake_extract(text: str) -> tuple[float | None, float | None]:
+    def fake_extract(text: str) -> functions.NutritionInfo:
         extracted.append(text)
-        return (30.0, 2.0)
+        return functions.NutritionInfo(carbs_g=30.0, xe=2.0)
 
     user_data: dict[str, Any] = {"thread_id": "tid"}
     context = cast(

--- a/tests/test_photo_handlers_additional.py
+++ b/tests/test_photo_handlers_additional.py
@@ -15,6 +15,7 @@ os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
 import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
+import services.api.app.diabetes.utils.functions as functions
 
 
 class DummyPhoto:
@@ -201,7 +202,9 @@ async def test_photo_handler_unparsed_response(
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
     monkeypatch.setattr(
-        photo_handlers, "extract_nutrition_info", lambda t: (None, None)
+        photo_handlers,
+        "extract_nutrition_info",
+        lambda t: functions.NutritionInfo(),
     )
 
     message = DummyMessage()
@@ -275,7 +278,9 @@ async def test_photo_handler_unparsed_response_clears_pending_entry(
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
     monkeypatch.setattr(
-        photo_handlers, "extract_nutrition_info", lambda t: (None, None)
+        photo_handlers,
+        "extract_nutrition_info",
+        lambda t: functions.NutritionInfo(),
     )
 
     message = DummyMessage()


### PR DESCRIPTION
## Summary
- Parse portion weight, proteins, fats, calories along with carbs/XE
- Return structured `NutritionInfo` and track extra metrics in pending entries
- Extend tests for full nutrition parsing and edge cases

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b818017eac832aa48e7f111f5b3c93