### PR TITLE
[handlers] Track nutrition info

### DIFF
--- a/migrations/versions/20250903_entry_nutrition.py
+++ b/migrations/versions/20250903_entry_nutrition.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250903_entry_nutrition"
+down_revision: Union[str, Sequence[str], None] = "20250902_drop_user_timezone"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("entries", sa.Column("weight_g", sa.Float(), nullable=True))
+    op.add_column("entries", sa.Column("protein_g", sa.Float(), nullable=True))
+    op.add_column("entries", sa.Column("fat_g", sa.Float(), nullable=True))
+    op.add_column("entries", sa.Column("calories_kcal", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("entries", "calories_kcal")
+    op.drop_column("entries", "fat_g")
+    op.drop_column("entries", "protein_g")
+    op.drop_column("entries", "weight_g")

--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -13,6 +13,10 @@ class EntryData(TypedDict, total=False):
     event_time: datetime.datetime
     xe: float | None
     carbs_g: float | None
+    weight_g: float | None
+    protein_g: float | None
+    fat_g: float | None
+    calories_kcal: float | None
     dose: float | None
     sugar_before: float | None
     photo_path: str | None

--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -19,7 +19,10 @@ from services.api.app.diabetes.services.gpt_client import (
     send_message,
 )
 from services.api.app.diabetes.services.repository import CommitError, commit
-from services.api.app.diabetes.utils.functions import extract_nutrition_info
+from services.api.app.diabetes.utils.functions import (
+    extract_nutrition_info,
+    extract_macros_info,
+)
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
 from . import EntryData, UserData
@@ -256,6 +259,7 @@ async def photo_handler(
         )
 
         carbs_g, xe = extract_nutrition_info(vision_text)
+        weight_g, protein_g, fat_g, calories_kcal = extract_macros_info(vision_text)
         if carbs_g is None and xe is None:
             logger.debug(
                 "[VISION][NO_PARSE] Ответ ассистента: %r для пользователя: %s",
@@ -280,7 +284,17 @@ async def photo_handler(
                 "event_time": datetime.datetime.now(datetime.timezone.utc),
             },
         )
-        pending_entry.update({"carbs_g": carbs_g, "xe": xe, "photo_path": None})
+        pending_entry.update(
+            {
+                "carbs_g": carbs_g,
+                "xe": xe,
+                "photo_path": None,
+                "weight_g": weight_g,
+                "protein_g": protein_g,
+                "fat_g": fat_g,
+                "calories_kcal": calories_kcal,
+            }
+        )
         user_data["pending_entry"] = pending_entry
         if status_message and hasattr(status_message, "delete"):
             try:

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -58,6 +58,10 @@ class EntryLike(Protocol):
     carbs_g: float | None
     xe: float | None
     dose: float | str | None
+    weight_g: float | None
+    protein_g: float | None
+    fat_g: float | None
+    calories_kcal: float | None
 
 
 def render_entry(entry: EntryLike) -> str:
@@ -77,7 +81,29 @@ def render_entry(entry: EntryLike) -> str:
     else:
         carbs_text = "—"
 
-    return f"<b>{day_str}</b>\n🍭 Сахар: <b>{sugar}</b>\n🍞 Углеводы: <b>{carbs_text}</b>\n💉 Доза: <b>{dose}</b>"
+    weight = (
+        f"{html.escape(str(entry.weight_g))} г" if entry.weight_g is not None else "—"
+    )
+    protein = (
+        f"{html.escape(str(entry.protein_g))} г" if entry.protein_g is not None else "—"
+    )
+    fat = f"{html.escape(str(entry.fat_g))} г" if entry.fat_g is not None else "—"
+    calories = (
+        f"{html.escape(str(entry.calories_kcal))} ккал"
+        if entry.calories_kcal is not None
+        else "—"
+    )
+
+    return (
+        f"<b>{day_str}</b>\n"
+        f"🍭 Сахар: <b>{sugar}</b>\n"
+        f"🍞 Углеводы: <b>{carbs_text}</b>\n"
+        f"💉 Доза: <b>{dose}</b>\n"
+        f"⚖️ Вес: <b>{weight}</b>\n"
+        f"🥚 Белки: <b>{protein}</b>\n"
+        f"🥓 Жиры: <b>{fat}</b>\n"
+        f"🔥 Калории: <b>{calories}</b>"
+    )
 
 
 @dataclass
@@ -90,6 +116,10 @@ class HistoryEntry(EntryLike):
     carbs_g: float | None
     xe: float | None
     dose: float | str | None
+    weight_g: float | None = None
+    protein_g: float | None = None
+    fat_g: float | None = None
+    calories_kcal: float | None = None
 
 
 def _history_record_to_entry(record: HistoryRecord) -> HistoryEntry:

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -252,6 +252,10 @@ class Entry(Base):
 
     photo_path: Mapped[Optional[str]] = mapped_column(String)
     carbs_g: Mapped[Optional[float]] = mapped_column(Float)
+    weight_g: Mapped[Optional[float]] = mapped_column(Float)
+    protein_g: Mapped[Optional[float]] = mapped_column(Float)
+    fat_g: Mapped[Optional[float]] = mapped_column(Float)
+    calories_kcal: Mapped[Optional[float]] = mapped_column(Float)
     xe: Mapped[Optional[float]] = mapped_column(Float)
     sugar_before: Mapped[Optional[float]] = mapped_column(Float)
     dose: Mapped[Optional[float]] = mapped_column(Float)

--- a/services/api/app/diabetes/utils/functions.py
+++ b/services/api/app/diabetes/utils/functions.py
@@ -47,6 +47,13 @@ XE_RANGE_RE = re.compile(
 CARBS_PM_RE = re.compile(rf"({NUMBER_RE})\s*(?:г)?\s*±\s*({NUMBER_RE})\s*г", re.IGNORECASE)
 CARBS_RANGE_RE = re.compile(rf"{DASH_RANGE_RE.pattern}\s*г", re.IGNORECASE)
 
+WEIGHT_RE = re.compile(rf"(?:вес|масса)[^\d]*({NUMBER_RE})\s*г", re.IGNORECASE)
+PROTEIN_RE = re.compile(rf"белк[аи][^\d]*({NUMBER_RE})\s*г", re.IGNORECASE)
+FAT_RE = re.compile(rf"жир[ыа]?[^\d]*({NUMBER_RE})\s*г", re.IGNORECASE)
+CALORIES_RE = re.compile(
+    rf"(?:ккал|калор(?:ий|ия|и))[^0-9]*({NUMBER_RE})", re.IGNORECASE
+)
+
 # Patterns for ``smart_input``.
 BAD_SUGAR_UNIT_RE = re.compile(rf"\b{SUGAR_WORD_RE.pattern}\s*[:=]?\s*{NUMBER_RE}\s*(?:xe|хе|ед)\b(?!\s*[\d=:])")
 BAD_XE_UNIT_RE = re.compile(
@@ -201,6 +208,21 @@ def extract_nutrition_info(text: object) -> tuple[float | None, float | None]:
             if first is not None and second is not None:
                 carbs = (first + second) / 2
     return carbs, xe
+
+
+def extract_macros_info(
+    text: object,
+) -> tuple[float | None, float | None, float | None, float | None]:
+    """Извлекает массу, белки, жиры и калории из произвольной строки."""
+
+    if not isinstance(text, str):
+        return (None, None, None, None)
+
+    weight = _safe_float(m.group(1)) if (m := WEIGHT_RE.search(text)) else None
+    protein = _safe_float(m.group(1)) if (m := PROTEIN_RE.search(text)) else None
+    fat = _safe_float(m.group(1)) if (m := FAT_RE.search(text)) else None
+    calories = _safe_float(m.group(1)) if (m := CALORIES_RE.search(text)) else None
+    return weight, protein, fat, calories
 
 
 def smart_input(message: str) -> dict[str, float | None]:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -5,6 +5,7 @@ import pytest
 from services.api.app.diabetes.utils.functions import (
     _safe_float,
     extract_nutrition_info,
+    extract_macros_info,
     smart_input,
 )
 
@@ -101,6 +102,19 @@ def test_extract_nutrition_info_first_line_xe_only() -> None:
 
 def test_extract_nutrition_info_non_string() -> None:
     assert extract_nutrition_info(123) == (None, None)
+
+
+def test_extract_macros_info_simple() -> None:
+    text = "вес: 100 г белки: 20 г жиры: 10 г калории: 200"
+    weight, protein, fat, calories = extract_macros_info(text)
+    assert weight == 100
+    assert protein == 20
+    assert fat == 10
+    assert calories == 200
+
+
+def test_extract_macros_info_non_string() -> None:
+    assert extract_macros_info(123) == (None, None, None, None)
 
 
 def test_smart_input_basic() -> None:

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -132,7 +132,18 @@ async def test_history_view_buttons(monkeypatch: pytest.MonkeyPatch) -> None:
         datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
     ]:
         day_str = d.strftime("%d.%m %H:%M")
-        expected_texts.append(f"<b>{day_str}</b>\n🍭 Сахар: <b>—</b>\n🍞 Углеводы: <b>—</b>\n💉 Доза: <b>—</b>")
+        expected_texts.append(
+            (
+                f"<b>{day_str}</b>\n"
+                "🍭 Сахар: <b>—</b>\n"
+                "🍞 Углеводы: <b>—</b>\n"
+                "💉 Доза: <b>—</b>\n"
+                "⚖️ Вес: <b>—</b>\n"
+                "🥚 Белки: <b>—</b>\n"
+                "🥓 Жиры: <b>—</b>\n"
+                "🔥 Калории: <b>—</b>"
+            )
+        )
     for text, kwargs, expected in zip(message.replies[1:-1], message.kwargs[1:-1], expected_texts):
         markup = kwargs.get("reply_markup")
         assert kwargs.get("parse_mode") == "HTML"

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -159,6 +159,9 @@ async def test_photo_flow_saves_entry(
     monkeypatch.setattr(
         photo_handlers, "extract_nutrition_info", lambda text: (30.0, 2.0)
     )
+    monkeypatch.setattr(
+        photo_handlers, "extract_macros_info", lambda text: (100.0, 20.0, 10.0, 200.0)
+    )
     user_data["thread_id"] = "tid"
 
     msg_photo = DummyMessage(photo=cast(tuple[PhotoSize, ...], (DummyPhoto(),)))
@@ -175,6 +178,10 @@ async def test_photo_flow_saves_entry(
     assert entry["carbs_g"] == 30.0
     assert entry["xe"] == 2.0
     assert entry["photo_path"] is None
+    assert entry["weight_g"] == 100.0
+    assert entry["protein_g"] == 20.0
+    assert entry["fat_g"] == 10.0
+    assert entry["calories_kcal"] == 200.0
 
     msg_sugar = DummyMessage("5.5")
     update_sugar = cast(
@@ -209,6 +216,10 @@ async def test_photo_flow_saves_entry(
     saved = DummySession.added_entries[0]
     assert saved.carbs_g == 30.0
     assert saved.sugar_before == 5.5
+    assert saved.weight_g == 100.0
+    assert saved.protein_g == 20.0
+    assert saved.fat_g == 10.0
+    assert saved.calories_kcal == 200.0
     assert "pending_entry" not in user_data
     assert query.edited == ["✅ Запись сохранена в дневник!"]
 

--- a/tests/test_render_entry.py
+++ b/tests/test_render_entry.py
@@ -15,6 +15,10 @@ def make_entry(**kwargs: Any) -> EntryLike:
         "carbs_g": None,
         "xe": None,
         "dose": 1.0,
+        "weight_g": None,
+        "protein_g": None,
+        "fat_g": None,
+        "calories_kcal": None,
     }
     defaults.update(kwargs)
     return cast(EntryLike, SimpleNamespace(**defaults))
@@ -43,3 +47,17 @@ def test_render_entry_escapes_html() -> None:
     entry: EntryLike = make_entry(dose="<script>")
     text = render_entry(entry)
     assert "&lt;script&gt;" in text
+
+
+def test_render_entry_shows_macros() -> None:
+    entry: EntryLike = make_entry(
+        weight_g=100,
+        protein_g=20,
+        fat_g=10,
+        calories_kcal=200,
+    )
+    text = render_entry(entry)
+    assert "⚖️ Вес: <b>100 г</b>" in text
+    assert "🥚 Белки: <b>20 г</b>" in text
+    assert "🥓 Жиры: <b>10 г</b>" in text
+    assert "🔥 Калории: <b>200 ккал</b>" in text


### PR DESCRIPTION
## Summary
- Extend diary entry data with weight, protein, fat, and calorie fields
- Persist new nutrition metrics and render them in reports
- Support parsing macros from GPT output and test saving/retrieval

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b81807e250832abce213eea7ec3e1b