### PR TITLE
[profile] extend profile view and fallback fields

### DIFF
--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import time as time_type
 from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Session
@@ -30,6 +31,18 @@ class LocalProfile:
     high: float | None = None
     sos_contact: str | None = None
     sos_alerts_enabled: bool = True
+    dia: float | None = None
+    round_step: float | None = None
+    carb_units: str | None = None
+    grams_per_xe: float | None = None
+    therapy_type: str | None = None
+    rapid_insulin_type: str | None = None
+    prebolus_min: int | None = None
+    max_bolus: float | None = None
+    postmeal_check_min: int | None = None
+    quiet_start: time_type | None = None
+    quiet_end: time_type | None = None
+    timezone: str | None = None
 
 
 @dataclass
@@ -68,8 +81,20 @@ class LocalProfileAPI:
                 profile.target or 0.0,
                 profile.low or 0.0,
                 profile.high or 0.0,
-                profile.sos_contact,
-                profile.sos_alerts_enabled,
+                sos_contact=profile.sos_contact,
+                sos_alerts_enabled=profile.sos_alerts_enabled,
+                dia=profile.dia,
+                round_step=profile.round_step,
+                carb_units=profile.carb_units,
+                grams_per_xe=profile.grams_per_xe,
+                therapy_type=profile.therapy_type,
+                rapid_insulin_type=profile.rapid_insulin_type,
+                prebolus_min=profile.prebolus_min,
+                max_bolus=profile.max_bolus,
+                postmeal_check_min=profile.postmeal_check_min,
+                quiet_start=profile.quiet_start,
+                quiet_end=profile.quiet_end,
+                timezone=profile.timezone,
             )
             if not ok:
                 raise ProfileSaveError("Failed to save profile")
@@ -90,6 +115,18 @@ class LocalProfileAPI:
                 high=prof.high_threshold,
                 sos_contact=prof.sos_contact,
                 sos_alerts_enabled=prof.sos_alerts_enabled,
+                dia=prof.dia,
+                round_step=prof.round_step,
+                carb_units=prof.carb_units,
+                grams_per_xe=prof.grams_per_xe,
+                therapy_type=prof.therapy_type,
+                rapid_insulin_type=prof.insulin_type,
+                prebolus_min=prof.prebolus_min,
+                max_bolus=prof.max_bolus,
+                postmeal_check_min=prof.postmeal_check_min,
+                quiet_start=prof.quiet_start,
+                quiet_end=prof.quiet_end,
+                timezone=prof.timezone,
             )
 
 
@@ -137,8 +174,21 @@ def save_profile(
     target: float,
     low: float,
     high: float,
+    *,
     sos_contact: str | None = None,
     sos_alerts_enabled: bool = True,
+    dia: float | None = None,
+    round_step: float | None = None,
+    carb_units: str | None = None,
+    grams_per_xe: float | None = None,
+    therapy_type: str | None = None,
+    rapid_insulin_type: str | None = None,
+    prebolus_min: int | None = None,
+    max_bolus: float | None = None,
+    postmeal_check_min: int | None = None,
+    quiet_start: time_type | None = None,
+    quiet_end: time_type | None = None,
+    timezone: str | None = None,
 ) -> bool:
     """Persist profile values into the local database."""
     user = session.get(User, user_id)
@@ -156,6 +206,30 @@ def save_profile(
     prof.high_threshold = high
     prof.sos_contact = sos_contact
     prof.sos_alerts_enabled = sos_alerts_enabled
+    if dia is not None:
+        prof.dia = dia
+    if round_step is not None:
+        prof.round_step = round_step
+    if carb_units is not None:
+        prof.carb_units = carb_units
+    if grams_per_xe is not None:
+        prof.grams_per_xe = grams_per_xe
+    if therapy_type is not None:
+        prof.therapy_type = therapy_type
+    if rapid_insulin_type is not None:
+        prof.insulin_type = rapid_insulin_type
+    if prebolus_min is not None:
+        prof.prebolus_min = prebolus_min
+    if max_bolus is not None:
+        prof.max_bolus = max_bolus
+    if postmeal_check_min is not None:
+        prof.postmeal_check_min = postmeal_check_min
+    if quiet_start is not None:
+        prof.quiet_start = quiet_start
+    if quiet_end is not None:
+        prof.quiet_end = quiet_end
+    if timezone is not None:
+        prof.timezone = timezone
     try:
         commit(session)
     except CommitError:

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -245,14 +245,90 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             await message.reply_text(text, parse_mode="Markdown")
         return
 
-    msg = (
-        "📄 Ваш профиль:\n"
-        f"• ИКХ: {profile.icr} г/ед.\n"
-        f"• КЧ: {profile.cf} ммоль/л\n"
-        f"• Целевой сахар: {profile.target} ммоль/л\n"
-        f"• Низкий порог: {profile.low} ммоль/л\n"
-        f"• Высокий порог: {profile.high} ммоль/л"
-    )
+    icr = getattr(profile, "icr", None)
+    cf = getattr(profile, "cf", None)
+    target = getattr(profile, "target", None)
+    low = getattr(profile, "low", None)
+    high = getattr(profile, "high", None)
+    dia = getattr(profile, "dia", None)
+    round_step = getattr(profile, "round_step", None)
+    carb_units = getattr(profile, "carb_units", None)
+    grams_per_xe = getattr(profile, "grams_per_xe", None)
+    therapy_type = getattr(profile, "therapy_type", None)
+    rapid_insulin_type = getattr(profile, "rapid_insulin_type", None)
+    if rapid_insulin_type is None:
+        rapid_insulin_type = getattr(profile, "insulin_type", None)
+    prebolus_min = getattr(profile, "prebolus_min", None)
+    max_bolus = getattr(profile, "max_bolus", None)
+    postmeal_check_min = getattr(profile, "postmeal_check_min", None)
+    quiet_start = getattr(profile, "quiet_start", None)
+    quiet_end = getattr(profile, "quiet_end", None)
+    timezone = getattr(profile, "timezone", None)
+    sos_contact = getattr(profile, "sos_contact", None)
+    sos_alerts_enabled = getattr(profile, "sos_alerts_enabled", None)
+
+    bolus_lines = []
+    if icr is not None:
+        bolus_lines.append(f"• ИКХ: {icr} г/ед.")
+    if cf is not None:
+        bolus_lines.append(f"• КЧ: {cf} ммоль/л")
+    if target is not None:
+        bolus_lines.append(f"• Целевой сахар: {target} ммоль/л")
+    if low is not None:
+        bolus_lines.append(f"• Низкий порог: {low} ммоль/л")
+    if high is not None:
+        bolus_lines.append(f"• Высокий порог: {high} ммоль/л")
+    if dia is not None:
+        bolus_lines.append(f"• ДиА: {dia} ч")
+    if round_step is not None:
+        bolus_lines.append(f"• Округление: {round_step} ед.")
+    if therapy_type is not None:
+        bolus_lines.append(f"• Терапия: {therapy_type}")
+    if rapid_insulin_type is not None:
+        bolus_lines.append(f"• Инсулин: {rapid_insulin_type}")
+    if prebolus_min is not None:
+        bolus_lines.append(f"• Преболюс: {prebolus_min} мин")
+    if max_bolus is not None:
+        bolus_lines.append(f"• Макс. болюс: {max_bolus}")
+    if postmeal_check_min is not None:
+        bolus_lines.append(f"• Проверка после еды: {postmeal_check_min} мин")
+
+    carb_lines: list[str] = []
+    if carb_units is not None:
+        carb_lines.append(f"• Ед. углеводов: {carb_units}")
+    if grams_per_xe is not None:
+        carb_lines.append(f"• Грамм/ХЕ: {grams_per_xe}")
+
+    safety_lines: list[str] = []
+    if quiet_start and quiet_end:
+        qs = (
+            quiet_start.strftime("%H:%M")
+            if hasattr(quiet_start, "strftime")
+            else str(quiet_start)
+        )
+        qe = (
+            quiet_end.strftime("%H:%M")
+            if hasattr(quiet_end, "strftime")
+            else str(quiet_end)
+        )
+        safety_lines.append(f"• Тихий режим: {qs}-{qe}")
+    if timezone is not None:
+        safety_lines.append(f"• Часовой пояс: {timezone}")
+    if sos_contact is not None:
+        safety_lines.append(f"• SOS контакт: {sos_contact}")
+    if sos_alerts_enabled is not None:
+        state = "вкл" if sos_alerts_enabled else "выкл"
+        safety_lines.append(f"• SOS оповещения: {state}")
+
+    sections: list[str] = []
+    if bolus_lines:
+        sections.append("💉 *Болус*\n" + "\n".join(bolus_lines))
+    if carb_lines:
+        sections.append("🍽 *Углеводы*\n" + "\n".join(carb_lines))
+    if safety_lines:
+        sections.append("🛡 *Безопасность*\n" + "\n".join(safety_lines))
+
+    msg = "📄 Ваш профиль:\n\n" + "\n\n".join(sections)
     rows = [
         [InlineKeyboardButton("✏️ Изменить", callback_data="profile_edit")],
         [InlineKeyboardButton("🔔 Безопасность", callback_data="profile_security")],
@@ -261,7 +337,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if webapp_button is not None:
         rows.insert(1, webapp_button)
     keyboard = InlineKeyboardMarkup(rows)
-    await message.reply_text(msg, reply_markup=keyboard)
+    await message.reply_text(msg, reply_markup=keyboard, parse_mode="Markdown")
 
 
 async def profile_webapp_save(

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -14,6 +14,7 @@ import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F40
 from services.api.app.diabetes.handlers import profile as profile_handlers
 import services.api.app.diabetes.services.db as db
 from services.api.app.diabetes.services.db import Base, Entry, User
+from tests.utils.profile_factory import make_profile
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -65,6 +66,7 @@ async def test_profile_input_not_logged_as_sugar(
 
     with TestSession() as session:
         session.add(User(telegram_id=1, thread_id="t"))
+        session.add(make_profile(telegram_id=1))
         session.commit()
 
     # Start sugar conversation
@@ -100,7 +102,10 @@ async def test_profile_input_not_logged_as_sugar(
     )
     result = await profile_handlers.profile_command(prof_update, prof_context)
     assert result == profile_handlers.END
-    assert "Ваш профиль" in prof_msg.replies[0]
+    reply = prof_msg.replies[0]
+    assert "💉 *Болус*" in reply
+    assert "🍽 *Углеводы*" in reply
+    assert "🛡 *Безопасность*" in reply
     assert "sugar_active" not in shared_chat_data
 
     # Attempt to send a value; sugar conversation should be inactive

--- a/tests/utils/profile_factory.py
+++ b/tests/utils/profile_factory.py
@@ -1,0 +1,37 @@
+"""Factories for test profiles."""
+
+from __future__ import annotations
+
+from datetime import time
+
+from services.api.app.diabetes.services.db import Profile
+
+
+def make_profile(telegram_id: int = 1, **overrides: object) -> Profile:
+    """Create a ``Profile`` instance with sensible defaults for tests."""
+
+    data: dict[str, object] = {
+        "telegram_id": telegram_id,
+        "icr": 8.0,
+        "cf": 3.0,
+        "target_bg": 6.0,
+        "low_threshold": 4.0,
+        "high_threshold": 9.0,
+        "sos_contact": "+123",
+        "sos_alerts_enabled": True,
+        "dia": 4.0,
+        "round_step": 0.5,
+        "carb_units": "g",
+        "grams_per_xe": 12.0,
+        "therapy_type": "insulin",
+        "insulin_type": "rapid",
+        "prebolus_min": 15,
+        "max_bolus": 10.0,
+        "postmeal_check_min": 120,
+        "quiet_start": time(23, 0),
+        "quiet_end": time(7, 0),
+        "timezone": "UTC",
+    }
+    data.update(overrides)
+    return Profile(**data)
+


### PR DESCRIPTION
## Summary
- extend local profile fallback with therapy, carb and safety settings
- display profile metrics grouped by Bolus, Carbs and Safety
- add factory and tests for extended profile fields

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b8232d23cc832abc809eeb9ced2457