### PR TITLE
[db] add onboarding state model

### DIFF
--- a/services/api/alembic.ini
+++ b/services/api/alembic.ini
@@ -8,7 +8,7 @@
 
 script_location = services/api/alembic
 
-version_locations = %(here)s/alembic/versions
+version_locations = %(here)s/alembic/versions:%(here)s/app/db/migrations/versions
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/services/api/app/db/migrations/versions/20250907_onboarding_state.py
+++ b/services/api/app/db/migrations/versions/20250907_onboarding_state.py
@@ -1,0 +1,31 @@
+"""create onboarding_states table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20250907_onboarding_state"
+down_revision = "20250906_move_user_settings_to_profile"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "onboarding_states",
+        sa.Column("user_id", sa.BigInteger(), sa.ForeignKey("users.telegram_id"), primary_key=True),
+        sa.Column("step", sa.String(), nullable=False),
+        sa.Column("data_json", sa.JSON(), nullable=True),
+        sa.Column(
+            "started_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), onupdate=sa.func.now()),
+        sa.Column("completed_at", sa.TIMESTAMP(timezone=True)),
+        sa.Column("variant", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("onboarding_states")

--- a/services/api/app/diabetes/models.py
+++ b/services/api/app/diabetes/models.py
@@ -1,7 +1,6 @@
-
+from services.api.app.models.onboarding_state import OnboardingState
 from .services.db import Base
-
 
 metadata = Base.metadata
 
-__all__ = ["metadata"]
+__all__ = ["metadata", "OnboardingState"]

--- a/services/api/app/models/__init__.py
+++ b/services/api/app/models/__init__.py
@@ -1,0 +1,1 @@
+"""ORM models for application-level data."""

--- a/services/api/app/models/onboarding_state.py
+++ b/services/api/app/models/onboarding_state.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import BigInteger, ForeignKey, JSON, String, TIMESTAMP, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.api.app.diabetes.services.db import Base
+
+
+class OnboardingState(Base):
+    __tablename__ = "onboarding_states"
+
+    user_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
+    )
+    step: Mapped[str] = mapped_column(String, nullable=False)
+    data_json: Mapped[dict[str, object] | None] = mapped_column(JSON, nullable=True)
+    started_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), onupdate=func.now()
+    )
+    completed_at: Mapped[Optional[datetime]] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    variant: Mapped[Optional[str]] = mapped_column(String)


### PR DESCRIPTION
## Summary
- add OnboardingState ORM model and expose through diabetes models
- create Alembic migration for onboarding_states table with FK to users
- include new migration location in Alembic config

## Testing
- `DATABASE_URL=sqlite:///./test.db alembic -c services/api/alembic.ini upgrade head` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*
- `pytest --cov` *(fails: 450 failed, 410 passed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b83df13e64832abac22ff4cb09327c