### PR TITLE
[services] Persist onboarding state

### DIFF
--- a/services/api/app/services/onboarding_state.py
+++ b/services/api/app/services/onboarding_state.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import cast
+
+from sqlalchemy import BigInteger, Integer, String, JSON, TIMESTAMP, func
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from ..diabetes.services.db import Base, SessionLocal, run_db
+from ..diabetes.services.repository import commit
+from ..types import SessionProtocol
+
+logger = logging.getLogger(__name__)
+
+
+class OnboardingState(Base):
+    __tablename__ = "onboarding_states"
+
+    user_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    step: Mapped[int] = mapped_column(Integer, nullable=False)
+    data: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False)
+    variant: Mapped[str | None] = mapped_column(String)
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+
+async def save_state(user_id: int, step: int, data: dict[str, object], variant: str | None = None) -> None:
+    """Persist onboarding state for a user."""
+
+    def _save(session: SessionProtocol) -> None:
+        state = cast(OnboardingState | None, session.get(OnboardingState, user_id))
+        if state is None:
+            state = OnboardingState(user_id=user_id)
+            cast(Session, session).add(state)
+        state.step = step
+        state.data = dict(data)
+        state.variant = variant
+        state.updated_at = datetime.now(timezone.utc)
+        commit(cast(Session, session))
+
+    await run_db(_save, sessionmaker=SessionLocal)
+
+
+async def load_state(user_id: int) -> OnboardingState | None:
+    """Load onboarding state for a user.
+
+    Records older than 14 days are removed and ``None`` is returned.
+    """
+
+    def _load(session: SessionProtocol) -> OnboardingState | None:
+        state = cast(OnboardingState | None, session.get(OnboardingState, user_id))
+        if state is None:
+            return None
+        updated = (
+            state.updated_at if state.updated_at.tzinfo is not None else state.updated_at.replace(tzinfo=timezone.utc)
+        )
+        if datetime.now(timezone.utc) - updated >= timedelta(days=14):
+            session.delete(state)
+            commit(cast(Session, session))
+            return None
+        return state
+
+    return await run_db(_load, sessionmaker=SessionLocal)

--- a/tests/services/test_onboarding_state.py
+++ b/tests/services/test_onboarding_state.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as SASession, sessionmaker
+
+from services.api.app.diabetes.services import db
+from services.api.app.services import onboarding_state
+
+
+@pytest.fixture()
+def session_local(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[SASession]:
+    engine = create_engine("sqlite:///:memory:")
+    SessionLocal = sessionmaker(bind=engine, class_=SASession)
+    db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(onboarding_state, "SessionLocal", SessionLocal, raising=False)
+    yield SessionLocal
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_save_and_load(session_local: sessionmaker[SASession]) -> None:
+    await onboarding_state.save_state(1, 2, {"foo": "bar"}, "v1")
+    state = await onboarding_state.load_state(1)
+    assert state is not None
+    assert state.step == 2
+    assert state.data == {"foo": "bar"}
+    assert state.variant == "v1"
+
+
+@pytest.mark.asyncio
+async def test_load_state_expired(session_local: sessionmaker[SASession]) -> None:
+    await onboarding_state.save_state(1, 1, {})
+    with session_local() as session:
+        st = session.get(onboarding_state.OnboardingState, 1)
+        assert st is not None
+        st.updated_at = datetime.now(timezone.utc) - timedelta(days=15)
+        session.commit()
+    state = await onboarding_state.load_state(1)
+    assert state is None
+    with session_local() as session:
+        assert session.get(onboarding_state.OnboardingState, 1) is None


### PR DESCRIPTION
## Summary
- add service to save and load onboarding state with 14-day TTL
- extend onboarding handlers with compatibility constants and endpoints
- cover onboarding state persistence with tests

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b83df5cdd0832a9bfaefb4a41a180c