### PR TITLE
[tests] add onboarding state tests

### DIFF
--- a/services/api/app/diabetes/onboarding_state.py
+++ b/services/api/app/diabetes/onboarding_state.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+logger = logging.getLogger(__name__)
+
+RESET_AFTER = timedelta(days=14)
+
+
+@dataclass
+class State:
+    step: int = 0
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+class OnboardingStateStore:
+    """In-memory store for onboarding progress."""
+
+    def __init__(self) -> None:
+        self._states: dict[int, State] = {}
+
+    def get(self, user_id: int) -> State:
+        state = self._states.get(user_id)
+        now = datetime.now(UTC)
+        if state is None or now - state.updated_at > RESET_AFTER:
+            state = State()
+            self._states[user_id] = state
+        return state
+
+    def set_step(self, user_id: int, step: int) -> None:
+        self._states[user_id] = State(step=step)
+
+    def reset(self, user_id: int) -> None:
+        self._states.pop(user_id, None)
+
+    def to_dict(self) -> dict[int, dict[str, float | int]]:
+        return {
+            uid: {"step": s.step, "updated_at": s.updated_at.timestamp()}
+            for uid, s in self._states.items()
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[int, dict[str, float | int]]) -> OnboardingStateStore:
+        store = cls()
+        for uid, info in data.items():
+            store._states[uid] = State(
+                step=int(info["step"]),
+                updated_at=datetime.fromtimestamp(
+                    float(info["updated_at"]), tz=UTC
+                ),
+            )
+        return store
+
+
+async def reset_onboarding(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Handle ``/reset_onboarding`` command."""
+
+    message = update.effective_message
+    user = update.effective_user
+    if message is None or user is None:
+        return None
+    store = cast(
+        OnboardingStateStore,
+        context.application.bot_data.setdefault("onb_state", OnboardingStateStore()),
+    )
+    store.reset(user.id)
+    await message.reply_text("Onboarding reset.")
+    return None
+
+
+__all__ = ["OnboardingStateStore", "reset_onboarding"]

--- a/tests/test_onboarding_state.py
+++ b/tests/test_onboarding_state.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.diabetes.onboarding_state import (
+    OnboardingStateStore,
+    reset_onboarding,
+)
+from tests.utils.warn_ctx import warn_or_not
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_reset_command() -> None:
+    store = OnboardingStateStore()
+    store.set_step(1, 2)
+    message = DummyMessage()
+    update = cast(
+        Update,
+        SimpleNamespace(
+            message=message,
+            effective_user=SimpleNamespace(id=1),
+            effective_message=message,
+        ),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(application=SimpleNamespace(bot_data={"onb_state": store})),
+    )
+    with warn_or_not(None):
+        await reset_onboarding(update, context)
+    assert store.get(1).step == 0
+    assert message.replies and "reset" in message.replies[-1].lower()
+
+
+def test_continue_after_restart() -> None:
+    store = OnboardingStateStore()
+    store.set_step(1, 2)
+    data = store.to_dict()
+    with warn_or_not(None):
+        restored = OnboardingStateStore.from_dict(data)
+    assert restored.get(1).step == 2
+
+
+def test_auto_reset_after_inactivity() -> None:
+    store = OnboardingStateStore()
+    state = store.get(1)
+    state.step = 2
+    state.updated_at = datetime.now(UTC) - timedelta(days=15)
+    with warn_or_not(None):
+        new_state = store.get(1)
+    assert new_state.step == 0

--- a/tests/utils/warn_ctx.py
+++ b/tests/utils/warn_ctx.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import warnings
+from contextlib import contextmanager
+from typing import Iterator, TypeVar
+from warnings import WarningMessage
+
+T = TypeVar("T", bound=Warning)
+
+@contextmanager
+def warn_or_not(category: type[T] | None) -> Iterator[list[WarningMessage]]:
+    """Assert that a warning of ``category`` is emitted or not.
+
+    When ``category`` is ``None`` the context ensures that no warnings were
+    produced.
+    """
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        yield records
+        if category is None:
+            assert not records, records
+        else:
+            assert any(issubclass(r.category, category) for r in records), records


### PR DESCRIPTION
## Summary
- add in-memory onboarding state store with reset command
- cover onboarding state persistence and reset cases
- provide warn_or_not test helper

## Testing
- `ruff check services/api/app/diabetes/onboarding_state.py tests/test_onboarding_state.py tests/utils/warn_ctx.py`
- `mypy --strict services/api/app/diabetes/onboarding_state.py tests/test_onboarding_state.py tests/utils/warn_ctx.py`
- `pytest tests/test_onboarding_state.py -q --cov=services.api.app.diabetes.onboarding_state --cov-report=term-missing --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68b83dfe4d6c832a8c13c3e4892fc40c