### PR TITLE
[handlers] Persist onboarding state and resume

### DIFF
--- a/services/api/app/diabetes/models.py
+++ b/services/api/app/diabetes/models.py
@@ -1,4 +1,4 @@
-from services.api.app.models.onboarding_state import OnboardingState
+from services.api.app.services.onboarding_state import OnboardingState
 from .services.db import Base
 
 metadata = Base.metadata

--- a/tests/services/test_onboarding_state.py
+++ b/tests/services/test_onboarding_state.py
@@ -43,3 +43,12 @@ async def test_load_state_expired(session_local: sessionmaker[SASession]) -> Non
     assert state is None
     with session_local() as session:
         assert session.get(onboarding_state.OnboardingState, 1) is None
+
+
+@pytest.mark.asyncio
+async def test_complete_state(session_local: sessionmaker[SASession]) -> None:
+    await onboarding_state.save_state(1, 1, {})
+    await onboarding_state.complete_state(1)
+    state = await onboarding_state.load_state(1)
+    assert state is not None
+    assert state.completed_at is not None


### PR DESCRIPTION
## Summary
- persist onboarding progress and variant in database
- resume onboarding from last saved step
- mark onboarding completion in user record
- add tests for onboarding state and resume

## Testing
- `pytest tests/test_onboarding_conversation.py tests/services/test_onboarding_state.py tests/handlers/test_wizard_navigation.py -q` *(fails: Coverage failure: total of 33 is less than fail-under=85)*
- `mypy --strict services/api/app/diabetes/handlers/onboarding_handlers.py services/api/app/services/onboarding_state.py tests/test_onboarding_conversation.py tests/services/test_onboarding_state.py tests/handlers/test_wizard_navigation.py` *(fails: command interrupted)*
- `ruff check services/api/app/diabetes/handlers/onboarding_handlers.py services/api/app/services/onboarding_state.py tests/test_onboarding_conversation.py tests/services/test_onboarding_state.py tests/handlers/test_wizard_navigation.py`

------
https://chatgpt.com/codex/tasks/task_e_68b83df9254c832aa756c9bbfdd70296