### PR TITLE
[onboarding] Support timezone WebApp

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any, cast
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
 from telegram.ext import (
@@ -24,7 +25,7 @@ from telegram.ext import (
 
 from services.api.app.diabetes.services.db import SessionLocal, User, run_db
 from services.api.app.diabetes.services.repository import commit
-from services.api.app.services import onboarding_state
+from services.api.app.services import onboarding_state, save_timezone
 from services.api.app.types import SessionProtocol
 from sqlalchemy.orm import Session
 from services.api.app.diabetes.utils.ui import (
@@ -79,6 +80,9 @@ def _timezone_keyboard() -> InlineKeyboardMarkup:
     rows: list[list[InlineKeyboardButton]] = []
     auto_btn = build_timezone_webapp_button()
     if auto_btn:
+        auto_btn = InlineKeyboardButton(
+            "Автоопределить (WebApp)", web_app=auto_btn.web_app
+        )
         rows.append([auto_btn])
     rows.append(_nav_buttons(back=True))
     return InlineKeyboardMarkup(rows)
@@ -167,6 +171,42 @@ async def _prompt_timezone(
     return TIMEZONE
 
 
+async def timezone_webapp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Handle timezone input sent via WebApp."""
+
+    message = update.message
+    user = update.effective_user
+    if message is None or user is None or message.web_app_data is None:
+        return ConversationHandler.END
+    raw = message.web_app_data.data
+    user_id = user.id
+    user_data = cast(dict[str, Any], context.user_data)
+    state = await onboarding_state.load_state(user_id)
+    variant = cast(str | None, user_data.get("variant"))
+    if state is not None:
+        user_data.update(state.data)
+        variant = variant or state.variant
+        user_data["variant"] = variant
+        if state.step != TIMEZONE:
+            if state.step == PROFILE:
+                return await _prompt_profile(message, user_id, user_data, variant)
+            if state.step == REMINDERS:
+                return await _prompt_reminders(message, user_id, user_data, variant)
+    try:
+        ZoneInfo(raw)
+    except ZoneInfoNotFoundError:
+        logger.warning("Invalid timezone provided: %s", raw)
+        await message.reply_text(
+            "Некорректный часовой пояс. Пример: Europe/Moscow",
+            reply_markup=_timezone_keyboard(),
+        )
+        return TIMEZONE
+    user_data["timezone"] = raw
+    await onboarding_state.save_state(user_id, TIMEZONE, user_data, variant)
+    await save_timezone(user_id, raw, auto=True)
+    return await _prompt_reminders(message, user_id, user_data, variant)
+
+
 async def timezone_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle timezone text input."""
 
@@ -187,7 +227,19 @@ async def timezone_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
                 return await _prompt_profile(message, user_id, user_data, variant)
             if state.step == REMINDERS:
                 return await _prompt_reminders(message, user_id, user_data, variant)
-    user_data["timezone"] = message.text.strip() or "Europe/Moscow"
+    raw = message.text.strip() or "Europe/Moscow"
+    try:
+        ZoneInfo(raw)
+    except ZoneInfoNotFoundError:
+        logger.warning("Invalid timezone provided: %s", raw)
+        await message.reply_text(
+            "Некорректный часовой пояс. Пример: Europe/Moscow",
+            reply_markup=_timezone_keyboard(),
+        )
+        return TIMEZONE
+    user_data["timezone"] = raw
+    await onboarding_state.save_state(user_id, TIMEZONE, user_data, variant)
+    await save_timezone(user_id, raw, auto=False)
     return await _prompt_reminders(message, user_id, user_data, variant)
 
 
@@ -366,6 +418,7 @@ onboarding_conv = ConversationHandler(
                 timezone_nav,
                 pattern=f"^({CB_BACK}|{CB_SKIP}|{CB_CANCEL})$",
             ),
+            MessageHandler(filters.StatusUpdate.WEB_APP_DATA, timezone_webapp),
             MessageHandler(filters.TEXT & (~filters.COMMAND), timezone_text),
         ],
         REMINDERS: [CallbackQueryHandler(reminders_chosen)],
@@ -380,6 +433,7 @@ __all__ = [
     "ONB_PROFILE_ICR",
     "start_command",
     "profile_chosen",
+    "timezone_webapp",
     "timezone_text",
     "timezone_nav",
     "reminders_chosen",

--- a/services/api/app/diabetes/models.py
+++ b/services/api/app/diabetes/models.py
@@ -1,6 +1,8 @@
-from services.api.app.services.onboarding_state import OnboardingState
+from services.api.app.services.onboarding_state import (  # noqa: F401
+    OnboardingState,
+)
 from .services.db import Base
 
 metadata = Base.metadata
 
-__all__ = ["metadata", "OnboardingState"]
+__all__ = ["metadata"]

--- a/services/api/app/services/__init__.py
+++ b/services/api/app/services/__init__.py
@@ -1,12 +1,13 @@
 from ..diabetes.services.db import init_db
 
-from .profile import save_profile, set_timezone, patch_user_settings
+from .profile import save_profile, save_timezone, set_timezone, patch_user_settings
 from .reminders import delete_reminder, list_reminders, save_reminder
 from .stats import get_day_stats
 
 __all__ = [
     "init_db",
     "set_timezone",
+    "save_timezone",
     "patch_user_settings",
     "save_profile",
     "list_reminders",

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "set_timezone",
+    "save_timezone",
     "patch_user_settings",
     "save_profile",
     "get_profile",
@@ -38,6 +39,15 @@ async def set_timezone(telegram_id: int, tz: str) -> None:  # pragma: no cover
     await patch_user_settings(
         telegram_id,
         ProfileSettingsIn(timezone=tz),
+    )
+
+
+async def save_timezone(telegram_id: int, tz: str, *, auto: bool) -> None:
+    """Save timezone and ``timezoneAuto`` flag for a user."""
+
+    await patch_user_settings(
+        telegram_id,
+        ProfileSettingsIn(timezone=tz, timezoneAuto=auto),
     )
 
 


### PR DESCRIPTION
## Summary
- add timezone_webapp handler with ZoneInfo validation and DB persistence
- persist timezone on text input via shared service
- expose save_timezone service and adjust keyboard label

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b84a44abb4832a9bce3fb9ff30b575