### PR TITLE
[services] add user timezone persistence

### DIFF
--- a/services/api/app/diabetes/models.py
+++ b/services/api/app/diabetes/models.py
@@ -1,6 +1,6 @@
-from services.api.app.services.onboarding_state import OnboardingState
+from services.api.app.services.onboarding_state import OnboardingState  # noqa: F401
 from .services.db import Base
 
 metadata = Base.metadata
 
-__all__ = ["metadata", "OnboardingState"]
+__all__ = ["metadata"]

--- a/services/api/app/diabetes/services/__init__.py
+++ b/services/api/app/diabetes/services/__init__.py
@@ -1,0 +1,3 @@
+from .user_profile import save_timezone
+
+__all__ = ["save_timezone"]

--- a/services/api/app/diabetes/services/user_profile.py
+++ b/services/api/app/diabetes/services/user_profile.py
@@ -1,0 +1,39 @@
+import logging
+from typing import cast
+
+from sqlalchemy.orm import Session
+
+from .db import Profile, SessionLocal, User, run_db
+from .repository import CommitError, commit
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["save_timezone"]
+
+
+async def save_timezone(telegram_id: int, tz: str, auto: bool) -> None:
+    """Persist user's timezone preferences.
+
+    Ensures that both :class:`~services.api.app.diabetes.services.db.User` and
+    :class:`~services.api.app.diabetes.services.db.Profile` exist for the given
+    ``telegram_id`` and updates the timezone fields.
+    """
+
+    def _save(session: Session) -> None:
+        user = cast(User | None, session.get(User, telegram_id))
+        if user is None:
+            user = User(telegram_id=telegram_id, thread_id="api")
+            session.add(user)
+        profile = cast(Profile | None, session.get(Profile, telegram_id))
+        if profile is None:
+            profile = Profile(telegram_id=telegram_id)
+            session.add(profile)
+        profile.timezone = tz
+        profile.timezone_auto = auto
+        try:
+            commit(session)
+        except CommitError:
+            logger.exception("Failed to commit timezone for %s", telegram_id)
+            raise
+
+    await run_db(_save, sessionmaker=SessionLocal)

--- a/tests/services/test_user_profile.py
+++ b/tests/services/test_user_profile.py
@@ -1,0 +1,34 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as SASession, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.services import db
+from services.api.app.diabetes.services import user_profile
+
+
+@pytest.fixture()
+def session_local(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[SASession]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, class_=SASession, autoflush=False, autocommit=False)
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(user_profile, "SessionLocal", SessionLocal, raising=False)
+    yield SessionLocal
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_save_timezone_persists(session_local: sessionmaker[SASession]) -> None:
+    await user_profile.save_timezone(1, "Europe/Moscow", False)
+    with session_local() as session:
+        profile = session.get(db.Profile, 1)
+        user = session.get(db.User, 1)
+        assert user is not None
+        assert profile is not None
+        assert profile.timezone == "Europe/Moscow"
+        assert profile.timezone_auto is False


### PR DESCRIPTION
## Summary
- add async `save_timezone` service and export
- ensure models export only metadata
- test timezone persistence in DB

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b84a4656fc832ab038e95a55657dce