### PR TITLE
[onboarding] support WebApp timezone detection

### DIFF
--- a/services/api/app/services/__init__.py
+++ b/services/api/app/services/__init__.py
@@ -1,6 +1,6 @@
 from ..diabetes.services.db import init_db
 
-from .profile import save_profile, set_timezone, patch_user_settings
+from .profile import save_profile, save_timezone, set_timezone, patch_user_settings
 from .reminders import delete_reminder, list_reminders, save_reminder
 from .stats import get_day_stats
 
@@ -8,6 +8,7 @@ __all__ = [
     "init_db",
     "set_timezone",
     "patch_user_settings",
+    "save_timezone",
     "save_profile",
     "list_reminders",
     "save_reminder",

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "set_timezone",
     "patch_user_settings",
+    "save_timezone",
     "save_profile",
     "get_profile",
 ]
@@ -126,6 +127,19 @@ async def patch_user_settings(
         )
 
     return await db.run_db(_patch, sessionmaker=db.SessionLocal)
+
+
+async def save_timezone(telegram_id: int, tz: str, *, auto: bool) -> bool:
+    """Persist only timezone and its auto-detection flag."""
+
+    try:
+        await patch_user_settings(
+            telegram_id,
+            ProfileSettingsIn(timezone=tz, timezoneAuto=auto),
+        )
+    except HTTPException:
+        return False
+    return True
 
 
 def _validate_profile(data: ProfileSchema) -> None:

--- a/tests/test_onboarding_conversation.py
+++ b/tests/test_onboarding_conversation.py
@@ -45,6 +45,10 @@ def fake_onboarding_state(monkeypatch: pytest.MonkeyPatch) -> None:
         pass
 
     monkeypatch.setattr(onboarding, "_mark_user_complete", noop_mark)
+    async def noop_save_timezone(telegram_id: int, tz: str, *, auto: bool) -> bool:
+        return True
+
+    monkeypatch.setattr(onboarding, "save_timezone", noop_save_timezone)
 
 
 class DummyMessage:

--- a/tests/test_onboarding_timezone_webapp.py
+++ b/tests/test_onboarding_timezone_webapp.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as SASession, sessionmaker
+from telegram import Update
+from telegram.ext import CallbackContext
+
+import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
+from services.api.app.diabetes.services import db
+from services.api.app.services import onboarding_state
+import services.api.app.services.profile as profile_service
+
+
+class DummyMessage:
+    def __init__(self, data: str) -> None:
+        self.web_app_data = SimpleNamespace(data=data)
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.replies.append(text)
+
+
+@pytest.fixture()
+def session_local(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[SASession]:
+    engine = create_engine("sqlite:///:memory:")
+    SessionLocal = sessionmaker(bind=engine, class_=SASession)
+    db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(onboarding, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(onboarding_state, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(profile_service.db, "SessionLocal", SessionLocal, raising=False)
+    yield SessionLocal
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_timezone_webapp_saves(session_local: sessionmaker[SASession]) -> None:
+    user_id = 1
+    await onboarding_state.save_state(user_id, onboarding.TIMEZONE, {}, None)
+    message = DummyMessage("Europe/Moscow")
+    update = cast(
+        Update,
+        SimpleNamespace(
+            message=message,
+            effective_user=SimpleNamespace(id=user_id),
+        ),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
+    )
+    state = await onboarding.timezone_webapp(update, context)
+    assert state == onboarding.REMINDERS
+    assert context.user_data["timezone"] == "Europe/Moscow"
+    with session_local() as session:
+        prof = session.get(db.Profile, user_id)
+        assert prof is not None
+        assert prof.timezone == "Europe/Moscow"
+        assert prof.timezone_auto is True
+        st = session.get(onboarding_state.OnboardingState, user_id)
+        assert st is not None
+        assert st.step == onboarding.REMINDERS
+        assert st.data.get("timezone") == "Europe/Moscow"


### PR DESCRIPTION
## Summary
- allow onboarding timezone auto-detection via WebApp
- validate and persist timezone through profile service
- cover onboarding timezone WebApp flow with tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b84d52bb84832aa769f4ec09db961c