### PR TITLE
tests: cover timezone webapp flow

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -191,6 +191,30 @@ async def timezone_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     return await _prompt_reminders(message, user_id, user_data, variant)
 
 
+async def timezone_webapp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Handle timezone input coming from WebApp."""
+
+    message = update.effective_message
+    user = update.effective_user
+    if message is None or getattr(message, "web_app_data", None) is None or user is None:
+        return ConversationHandler.END
+    user_id = user.id
+    user_data = cast(dict[str, Any], context.user_data)
+    state = await onboarding_state.load_state(user_id)
+    variant = cast(str | None, user_data.get("variant"))
+    if state is not None:
+        user_data.update(state.data)
+        variant = variant or state.variant
+        user_data["variant"] = variant
+        if state.step != TIMEZONE:
+            if state.step == PROFILE:
+                return await _prompt_profile(message, user_id, user_data, variant)
+            if state.step == REMINDERS:
+                return await _prompt_reminders(message, user_id, user_data, variant)
+    user_data["timezone"] = message.web_app_data.data.strip() or "Europe/Moscow"
+    return await _prompt_reminders(message, user_id, user_data, variant)
+
+
 async def timezone_nav(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Handle navigation callbacks in timezone step."""
 
@@ -395,6 +419,7 @@ onboarding_conv = ConversationHandler(
                 timezone_nav,
                 pattern=f"^({CB_BACK}|{CB_SKIP}|{CB_CANCEL})$",
             ),
+            MessageHandler(filters.StatusUpdate.WEB_APP_DATA, timezone_webapp),
             MessageHandler(filters.TEXT & (~filters.COMMAND), timezone_text),
         ],
         REMINDERS: [CallbackQueryHandler(reminders_chosen)],
@@ -410,6 +435,7 @@ __all__ = [
     "start_command",
     "profile_chosen",
     "timezone_text",
+    "timezone_webapp",
     "timezone_nav",
     "reminders_chosen",
     "reset_onboarding",

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -135,6 +135,6 @@ def build_timezone_webapp_button() -> InlineKeyboardButton | None:
         return None
 
     return InlineKeyboardButton(
-        "Определить автоматически",
+        "Автоопределить (WebApp)",
         web_app=WebAppInfo(config.build_ui_url("/timezone.html")),
     )

--- a/services/webapp/ui/public/timezone.html
+++ b/services/webapp/ui/public/timezone.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/style.css">
+    <title>Часовой пояс</title>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <script type="module" src="%BASE_URL%telegram-init.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+            const status = document.getElementById('status');
+            const addButton = (text, handler) => {
+                const btn = document.createElement('button');
+                btn.textContent = text;
+                btn.className = 'medical-button';
+                btn.addEventListener('click', handler);
+                document.body.appendChild(btn);
+            };
+
+            if (window.Telegram && window.Telegram.WebApp) {
+                try {
+                    window.Telegram.WebApp.sendData(tz);
+                    status.textContent = 'Часовой пояс определён';
+                    addButton('Закрыть', () => window.Telegram.WebApp.close());
+                } catch (err) {
+                    status.textContent = 'Не удалось отправить данные. Проверьте подключение к сети и попробуйте ещё раз.';
+                    addButton('Повторить', () => location.reload());
+                }
+            } else {
+                status.textContent = 'Недоступно в этом окружении.';
+            }
+        });
+    </script>
+</head>
+<body>
+    <p id="status">Определение часового пояса…</p>
+</body>
+</html>

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -1,9 +1,19 @@
+import importlib
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
 import pytest
 from pathlib import Path
-from telegram import InlineKeyboardButton
+from telegram import InlineKeyboardButton, Update
+from telegram.ext import CallbackContext
 
 import services.api.app.config as config
 import services.api.app.diabetes.utils.ui as ui
+
+handlers = importlib.import_module(
+    "services.api.app.diabetes.handlers.onboarding_handlers"
+)
 
 
 def test_timezone_button_webapp_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -23,6 +33,7 @@ def test_timezone_button_webapp_enabled(monkeypatch: pytest.MonkeyPatch) -> None
 
     button = ui.build_timezone_webapp_button()
     assert isinstance(button, InlineKeyboardButton)
+    assert button.text == "Автоопределить (WebApp)"
     web_app = button.web_app
     assert web_app is not None
     assert web_app.url.endswith("/timezone.html")
@@ -30,6 +41,32 @@ def test_timezone_button_webapp_enabled(monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_timezone_page_loads_sdk_and_sends_timezone() -> None:
     """Timezone webapp should include Telegram SDK and send timezone."""
-    html = Path("services/webapp/ui/src/pages/timezone.html").read_text(encoding="utf-8")
+    html = Path("services/webapp/ui/public/timezone.html").read_text(encoding="utf-8")
     assert "https://telegram.org/js/telegram-web-app.js" in html
     assert "window.Telegram.WebApp.sendData" in html
+
+
+@pytest.mark.asyncio
+async def test_timezone_webapp_saves_tz_and_moves_to_reminders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    message = SimpleNamespace(web_app_data=SimpleNamespace(data="Asia/Tokyo"))
+    update = cast(
+        Update,
+        SimpleNamespace(
+            effective_message=message, effective_user=SimpleNamespace(id=1)
+        ),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
+    )
+    monkeypatch.setattr(
+        handlers.onboarding_state, "load_state", AsyncMock(return_value=None)
+    )
+    prompt = AsyncMock(return_value=handlers.REMINDERS)
+    monkeypatch.setattr(handlers, "_prompt_reminders", prompt)
+    state = await handlers.timezone_webapp(update, context)
+    assert state == handlers.REMINDERS
+    assert context.user_data["timezone"] == "Asia/Tokyo"
+    prompt.assert_awaited_once()


### PR DESCRIPTION
## Summary
- update timezone webapp button text and target
- add timezone_webapp handler and tests
- move timezone.html to ui/public

## Testing
- `ruff check services/api/app/diabetes/utils/ui.py services/api/app/diabetes/handlers/onboarding_handlers.py tests/test_timezone_button_webapp.py`
- `mypy --strict services/api/app/diabetes/utils/ui.py services/api/app/diabetes/handlers/onboarding_handlers.py` *(fails: Interrupted)*
- `pytest tests/test_timezone_button_webapp.py -q --cov=services.api.app.diabetes.utils.ui --cov=services.api.app.diabetes.handlers.onboarding_handlers --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68b84e5cf6a8832aba00a49a86b7ca68