### PR TITLE
[handlers] export create_reminder_from_preset

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -1323,4 +1323,5 @@ __all__ = [
     "reminder_webapp_handler",
     "SessionLocal",
     "commit",
+    "create_reminder_from_preset",
 ]


### PR DESCRIPTION
## Summary
- expose `create_reminder_from_preset` through `reminder_handlers.__all__`

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: Name "timezone_webapp" already defined on line 173; Item "None" of "WebAppData | None" has no attribute "data")*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b85888c8b8832a8eaa57c45bba3f6e