### PR TITLE
[management] add onboarding metrics aggregation

### DIFF
--- a/services/api/alembic/versions/20250908_add_onboarding_metrics_daily.py
+++ b/services/api/alembic/versions/20250908_add_onboarding_metrics_daily.py
@@ -1,0 +1,26 @@
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250908_add_onboarding_metrics_daily"
+down_revision: Union[str, Sequence[str], None] = (
+    "20250906_move_user_settings_to_profile"
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "onboarding_metrics_daily",
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("variant", sa.String(), nullable=False),
+        sa.Column("step", sa.String(), nullable=False),
+        sa.Column("count", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("date", "variant", "step"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("onboarding_metrics_daily")

--- a/services/api/app/diabetes/models.py
+++ b/services/api/app/diabetes/models.py
@@ -1,4 +1,8 @@
 from services.api.app.services.onboarding_state import OnboardingState  # noqa: F401
+from services.api.app.models.onboarding_metrics import (  # noqa: F401
+    OnboardingEvent,
+    OnboardingMetricDaily,
+)
 from .services.db import Base
 
 metadata = Base.metadata

--- a/services/api/app/management/__init__.py
+++ b/services/api/app/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for maintenance tasks."""

--- a/services/api/app/management/aggregate_onboarding.py
+++ b/services/api/app/management/aggregate_onboarding.py
@@ -1,0 +1,100 @@
+"""Aggregate onboarding events into daily metrics.
+
+This script can be scheduled via cron. Example (run nightly for previous day):
+
+    5 0 * * * python -m services.api.app.management.aggregate_onboarding --date "$(date -I -d 'yesterday')"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import date, datetime, timedelta
+from typing import Iterable, Sequence, cast
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from services.api.app.diabetes.services.db import SessionLocal, SessionMaker
+from services.api.app.diabetes.services.repository import commit
+from services.api.app.models.onboarding_metrics import (
+    OnboardingEvent,
+    OnboardingMetricDaily,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _aggregate(
+    session: Session, start: datetime, end: datetime
+) -> Sequence[tuple[str, str, int]]:
+    """Return counts of onboarding events grouped by variant and step."""
+
+    rows = cast(
+        list[tuple[str, str, int]],
+        session.query(OnboardingEvent.variant, OnboardingEvent.step, func.count())
+        .filter(OnboardingEvent.created_at >= start, OnboardingEvent.created_at < end)
+        .group_by(OnboardingEvent.variant, OnboardingEvent.step)
+        .all(),
+    )
+    return rows
+
+
+def aggregate_for_date(
+    target_date: date, *, sessionmaker: SessionMaker[Session] = SessionLocal
+) -> list[dict[str, object]]:
+    """Aggregate ``OnboardingEvent`` rows for ``target_date``.
+
+    Parameters
+    ----------
+    target_date:
+        Date for which to aggregate metrics.
+    sessionmaker:
+        Factory creating :class:`~sqlalchemy.orm.Session` objects. Defaults to
+        ``SessionLocal`` but can be injected in tests.
+    """
+
+    start = datetime.combine(target_date, datetime.min.time())
+    end = start + timedelta(days=1)
+
+    with sessionmaker() as session:
+        rows = _aggregate(session, start, end)
+
+        session.query(OnboardingMetricDaily).filter(
+            OnboardingMetricDaily.date == target_date
+        ).delete()
+        for variant, step, count in rows:
+            session.add(
+                OnboardingMetricDaily(
+                    date=target_date, variant=variant, step=step, count=count
+                )
+            )
+        commit(session)
+
+    return [
+        {"variant": variant, "step": step, "count": count}
+        for variant, step, count in rows
+    ]
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Aggregate onboarding events into daily metrics"
+    )
+    parser.add_argument(
+        "--date",
+        type=date.fromisoformat,
+        default=date.today(),
+        help="Target date in YYYY-MM-DD (defaults to today)",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    metrics = aggregate_for_date(args.date)
+    print(json.dumps(metrics, ensure_ascii=False))
+    logger.info("Aggregated %d rows for %s", len(metrics), args.date)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/services/api/app/models/onboarding_metrics.py
+++ b/services/api/app/models/onboarding_metrics.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from sqlalchemy import Date, Integer, String, TIMESTAMP, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.api.app.diabetes.services.db import Base
+
+
+class OnboardingEvent(Base):
+    """Raw onboarding step event."""
+
+    __tablename__ = "onboarding_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    variant: Mapped[str] = mapped_column(String, nullable=False)
+    step: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class OnboardingMetricDaily(Base):
+    """Aggregated onboarding metrics per day."""
+
+    __tablename__ = "onboarding_metrics_daily"
+
+    date: Mapped[date] = mapped_column(Date, primary_key=True)
+    variant: Mapped[str] = mapped_column(String, primary_key=True)
+    step: Mapped[str] = mapped_column(String, primary_key=True)
+    count: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/tests/management/test_aggregate_onboarding.py
+++ b/tests/management/test_aggregate_onboarding.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as SASession, sessionmaker
+
+from services.api.app.diabetes.services import db
+from services.api.app.management import aggregate_onboarding
+from services.api.app.models.onboarding_metrics import (
+    OnboardingEvent,
+    OnboardingMetricDaily,
+)
+
+
+@pytest.fixture()
+def session_local(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[SASession]:
+    engine = create_engine("sqlite:///:memory:")
+    SessionLocal = sessionmaker(bind=engine, class_=SASession)
+    db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(
+        aggregate_onboarding, "SessionLocal", SessionLocal, raising=False
+    )
+    yield SessionLocal
+    engine.dispose()
+
+
+def test_aggregate_onboarding(session_local: sessionmaker[SASession]) -> None:
+    target = date(2024, 1, 2)
+    with session_local() as session:
+        session.add_all(
+            [
+                OnboardingEvent(
+                    variant="A", step="start", created_at=datetime(2024, 1, 2, 1)
+                ),
+                OnboardingEvent(
+                    variant="A", step="start", created_at=datetime(2024, 1, 2, 2)
+                ),
+                OnboardingEvent(
+                    variant="A", step="finish", created_at=datetime(2024, 1, 2, 3)
+                ),
+                OnboardingEvent(
+                    variant="B", step="start", created_at=datetime(2024, 1, 3, 1)
+                ),
+            ]
+        )
+        session.commit()
+
+    metrics = aggregate_onboarding.aggregate_for_date(
+        target, sessionmaker=session_local
+    )
+    assert {"variant": "A", "step": "start", "count": 2} in metrics
+    assert {"variant": "A", "step": "finish", "count": 1} in metrics
+    assert all(m["variant"] != "B" for m in metrics)
+
+    with session_local() as session:
+        rows = session.query(OnboardingMetricDaily).all()
+        assert len(rows) == 2
+        counts = {(r.variant, r.step): r.count for r in rows}
+        assert counts[("A", "start")] == 2
+        assert counts[("A", "finish")] == 1


### PR DESCRIPTION
## Summary
- add management command to aggregate onboarding events into daily metrics
- define onboarding event and metric models with migration
- test daily aggregation logic

## Testing
- `mypy --strict services/api/app/management/aggregate_onboarding.py services/api/app/models/onboarding_metrics.py tests/management/test_aggregate_onboarding.py`
- `ruff check services/api/app/management/aggregate_onboarding.py services/api/app/models/onboarding_metrics.py tests/management/test_aggregate_onboarding.py services/api/alembic/versions/20250908_add_onboarding_metrics_daily.py services/api/app/diabetes/models.py`
- `pytest tests/management/test_aggregate_onboarding.py -q -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68b862880130832abacba1a6df1085e7