### PR TITLE
[routers] add onboarding metrics endpoint

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -36,6 +36,7 @@ from .diabetes.services.repository import CommitError, commit
 from .legacy import router as legacy_router
 from .routers.internal_reminders import router as internal_reminders_router
 from .routers.stats import router as stats_router
+from .routers import metrics
 from .schemas.history import ALLOWED_HISTORY_TYPES, HistoryRecordSchema, HistoryType
 from .schemas.role import RoleSchema
 from .services.profile import patch_user_settings
@@ -97,6 +98,7 @@ async def value_error_handler(_: Request, exc: ValueError) -> JSONResponse:
 api_router = APIRouter()
 api_router.include_router(stats_router)
 api_router.include_router(legacy_router)
+api_router.include_router(metrics.router)
 
 # ────────── статические файлы UI ──────────
 BASE_DIR = Path(__file__).resolve().parents[2] / "webapp"

--- a/services/api/app/routers/metrics.py
+++ b/services/api/app/routers/metrics.py
@@ -1,0 +1,54 @@
+import logging
+from datetime import datetime
+from typing import cast
+
+from fastapi import APIRouter, Query
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..diabetes.services.db import SessionLocal, run_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+STEP_MAP = {
+    "start": "onboarding_started",
+    "step1": "step_completed_1",
+    "step2": "step_completed_2",
+    "step3": "step_completed_3",
+    "finish": "onboarding_finished",
+    "cancel": "onboarding_cancelled",
+}
+
+
+@router.get("/metrics/onboarding")
+async def get_onboarding_metrics(
+    from_: datetime = Query(alias="from"),
+    to: datetime = Query(alias="to"),
+) -> dict[str, dict[str, int]]:
+    def _query(session: Session) -> dict[str, dict[str, int]]:
+        rows = session.execute(
+            text(
+                """
+                SELECT variant, step, count(*) AS cnt
+                FROM onboarding_events
+                WHERE event_time >= :from AND event_time <= :to
+                GROUP BY variant, step
+                """
+            ),
+            {"from": from_, "to": to},
+        ).all()
+        result: dict[str, dict[str, int]] = {}
+        for row in rows:
+            variant = cast(str, row[0])
+            step = cast(str, row[1])
+            cnt = cast(int, row[2])
+            key = STEP_MAP.get(step)
+            if key is None:
+                continue
+            counts = result.setdefault(variant, {k: 0 for k in STEP_MAP.values()})
+            counts[key] = cnt
+        return result
+
+    return await run_db(_query, sessionmaker=SessionLocal)

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Callable, TypeVar
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import Column, MetaData, String, Table, TIMESTAMP, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.routers import metrics
+
+
+def setup_db() -> tuple[sessionmaker[Session], datetime]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    metadata = MetaData()
+    events = Table(
+        "onboarding_events",
+        metadata,
+        Column("variant", String),
+        Column("step", String),
+        Column("event_time", TIMESTAMP(timezone=True)),
+    )
+    metadata.create_all(engine)
+    session_local = sessionmaker(bind=engine)
+    now = datetime.now()
+    with engine.begin() as conn:
+        conn.execute(
+            events.insert(),
+            [
+                {"variant": "A", "step": "start", "event_time": now},
+                {"variant": "A", "step": "step1", "event_time": now},
+                {"variant": "A", "step": "finish", "event_time": now},
+                {"variant": "B", "step": "start", "event_time": now},
+            ],
+        )
+    return session_local, now
+
+
+T = TypeVar("T")
+
+
+def test_onboarding_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local, now = setup_db()
+
+    async def run_db(
+        fn: Callable[[Session], T],
+        *args: object,
+        sessionmaker: sessionmaker[Session] = session_local,
+        **kwargs: object,
+    ) -> T:
+        with sessionmaker() as session:
+            return fn(session)
+
+    monkeypatch.setattr(metrics, "SessionLocal", session_local, raising=False)
+    monkeypatch.setattr(metrics, "run_db", run_db, raising=False)
+
+    from services.api.app.main import app
+
+    later = now + timedelta(days=1)
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/metrics/onboarding",
+            params={"from": now.isoformat(), "to": later.isoformat()},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "A": {
+            "onboarding_started": 1,
+            "step_completed_1": 1,
+            "step_completed_2": 0,
+            "step_completed_3": 0,
+            "onboarding_finished": 1,
+            "onboarding_cancelled": 0,
+        },
+        "B": {
+            "onboarding_started": 1,
+            "step_completed_1": 0,
+            "step_completed_2": 0,
+            "step_completed_3": 0,
+            "onboarding_finished": 0,
+            "onboarding_cancelled": 0,
+        },
+    }


### PR DESCRIPTION
## Summary
- add /metrics/onboarding endpoint that aggregates onboarding events by variant and step
- expose metrics router via main API router
- add tests for onboarding metrics

## Testing
- `pytest -q --cov` *(fails: DetachedInstanceError in tests/diabetes/test_onboarding_reminders.py::test_onboarding_creates_reminder)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b8628429ec832aa92716af3225ff11