### PR TITLE
[models] Add onboarding events table

### DIFF
--- a/services/api/alembic/versions/20250907_onboarding_events.py
+++ b/services/api/alembic/versions/20250907_onboarding_events.py
@@ -1,0 +1,31 @@
+
+"""create onboarding_events table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20250907_onboarding_events"
+down_revision = "20250906_move_user_settings_to_profile"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "onboarding_events",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.BigInteger(), sa.ForeignKey("users.telegram_id"), nullable=False),
+        sa.Column("event_name", sa.String(), nullable=False),
+        sa.Column("step", sa.Integer(), nullable=False),
+        sa.Column("variant", sa.String(), nullable=True),
+        sa.Column(
+            "ts",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("onboarding_events")

--- a/services/api/app/models/onboarding_event.py
+++ b/services/api/app/models/onboarding_event.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import BigInteger, ForeignKey, Integer, String, TIMESTAMP, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.api.app.diabetes.services.db import Base
+
+
+class OnboardingEvent(Base):
+    __tablename__ = "onboarding_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id"), nullable=False
+    )
+    event_name: Mapped[str] = mapped_column(String, nullable=False)
+    step: Mapped[int] = mapped_column(Integer, nullable=False)
+    variant: Mapped[Optional[str]] = mapped_column(String)
+    ts: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )


### PR DESCRIPTION
## Summary
- add `OnboardingEvent` ORM model
- add alembic migration for `onboarding_events`

## Testing
- `PYTHONPATH=/workspace/saharlight-ux DATABASE_URL=sqlite:///tmp_alembic.db alembic -c services/api/alembic.ini upgrade head` *(fails: Multiple head revisions are present)*
- `PYTHONPATH=/workspace/saharlight-ux DATABASE_URL=sqlite:///tmp_alembic.db alembic -c services/api/alembic.ini upgrade heads` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*
- `PYTHONPATH=/workspace/saharlight-ux DATABASE_URL=sqlite:///test.db pytest -q` *(fails: async def functions are not natively supported)*
- `PYTHONPATH=/workspace/saharlight-ux mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b8627dc5b8832ab835d62e51689e6f