### PR TITLE
[onboarding] add AB variant routing

### DIFF
--- a/services/api/app/models/onboarding_metrics.py
+++ b/services/api/app/models/onboarding_metrics.py
@@ -9,9 +9,9 @@ from services.api.app.diabetes.services.db import Base
 
 
 class OnboardingEvent(Base):
-    """Raw onboarding step event."""
+    """Raw onboarding step event for metrics."""
 
-    __tablename__ = "onboarding_events"
+    __tablename__ = "onboarding_events_metrics"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     variant: Mapped[str] = mapped_column(String, nullable=False)
@@ -30,3 +30,6 @@ class OnboardingMetricDaily(Base):
     variant: Mapped[str] = mapped_column(String, primary_key=True)
     step: Mapped[str] = mapped_column(String, primary_key=True)
     count: Mapped[int] = mapped_column(Integer, nullable=False)
+
+
+__all__ = ["OnboardingEvent", "OnboardingMetricDaily"]

--- a/services/api/app/utils/__init__.py
+++ b/services/api/app/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for application-wide helpers."""
+
+from .ab import choose_variant
+
+__all__ = ["choose_variant"]

--- a/services/api/app/utils/ab.py
+++ b/services/api/app/utils/ab.py
@@ -1,0 +1,28 @@
+"""A/B testing utilities."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Sequence
+
+
+def choose_variant(user_id: int, variants: Sequence[str] = ("A", "B")) -> str:
+    """Deterministically choose a variant for ``user_id``.
+
+    Parameters
+    ----------
+    user_id: int
+        Telegram user identifier used for hashing.
+    variants: Sequence[str]
+        Available variants to choose from. Defaults to ("A", "B").
+
+    Returns
+    -------
+    str
+        Selected variant name.
+    """
+    if not variants:
+        raise ValueError("variants must be non-empty")
+    digest = hashlib.sha256(str(user_id).encode("utf-8")).digest()
+    idx = int.from_bytes(digest[:4], "big") % len(variants)
+    return variants[idx]

--- a/tests/test_ab_utils.py
+++ b/tests/test_ab_utils.py
@@ -1,0 +1,14 @@
+from services.api.app.utils.ab import choose_variant
+
+
+def test_choose_variant_is_deterministic() -> None:
+    assert choose_variant(123) == choose_variant(123)
+    assert choose_variant(123) in {"A", "B"}
+
+
+def test_choose_variant_distribution() -> None:
+    a = choose_variant(1)
+    b = choose_variant(2)
+    assert a in {"A", "B"}
+    assert b in {"A", "B"}
+    assert a != b

--- a/tests/test_onboarding_conversation.py
+++ b/tests/test_onboarding_conversation.py
@@ -70,6 +70,7 @@ def fake_onboarding_state(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         onboarding.reminder_handlers, "_describe", fake_describe, raising=False
     )
+    monkeypatch.setattr(onboarding, "choose_variant", lambda uid: "A")
 
 
 class DummyMessage:


### PR DESCRIPTION
## Summary
- add deterministic A/B variant selector
- route onboarding steps based on sampled variant and record it in events
- support onboarding metrics table without clashing with event logging

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b86e0d9ee4832a974eb3ac5aa32551