### PR TITLE
[billing] add billing config and dummy provider

### DIFF
--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -37,3 +37,9 @@ FONT_DIR=infra/fonts
 
 # Telegram
 TELEGRAM_TOKEN=your-telegram-bot-token
+
+# Billing configuration
+BILLING_ENABLED=false
+BILLING_TEST_MODE=true
+BILLING_PROVIDER=dummy
+PAYWALL_MODE=soft

--- a/services/api/app/billing/__init__.py
+++ b/services/api/app/billing/__init__.py
@@ -1,0 +1,12 @@
+"""Billing utilities and configuration."""
+
+from .config import BillingSettings, get_billing_settings, reload_billing_settings
+from .service import create_payment
+
+__all__ = [
+    "BillingSettings",
+    "get_billing_settings",
+    "reload_billing_settings",
+    "create_payment",
+]
+

--- a/services/api/app/billing/config.py
+++ b/services/api/app/billing/config.py
@@ -1,0 +1,35 @@
+"""Billing configuration via Pydantic settings."""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class BillingSettings(BaseSettings):
+    """Runtime billing configuration."""
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    billing_enabled: bool = Field(default=False, alias="BILLING_ENABLED")
+    billing_test_mode: bool = Field(default=True, alias="BILLING_TEST_MODE")
+    billing_provider: str = Field(default="dummy", alias="BILLING_PROVIDER")
+    paywall_mode: str = Field(default="soft", alias="PAYWALL_MODE")
+
+
+billing_settings = BillingSettings()
+
+
+def get_billing_settings() -> BillingSettings:
+    """Return current billing settings."""
+
+    return billing_settings
+
+
+def reload_billing_settings() -> BillingSettings:
+    """Reload billing settings from the environment."""
+
+    global billing_settings
+    billing_settings = BillingSettings()
+    return billing_settings
+

--- a/services/api/app/billing/providers/__init__.py
+++ b/services/api/app/billing/providers/__init__.py
@@ -1,0 +1,6 @@
+"""Billing providers."""
+
+from .dummy import DummyBillingProvider
+
+__all__ = ["DummyBillingProvider"]
+

--- a/services/api/app/billing/providers/dummy.py
+++ b/services/api/app/billing/providers/dummy.py
@@ -1,0 +1,18 @@
+"""Dummy billing provider used for tests and development."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class DummyBillingProvider:
+    """A simple provider that simulates successful payments."""
+
+    test_mode: bool = True
+
+    async def create_payment(self) -> dict[str, object]:
+        """Return a dummy successful payment response."""
+
+        return {"status": "ok", "test_mode": self.test_mode}
+

--- a/services/api/app/billing/service.py
+++ b/services/api/app/billing/service.py
@@ -1,0 +1,18 @@
+"""Billing service layer."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+
+from .config import BillingSettings
+from .providers import DummyBillingProvider
+
+
+async def create_payment(settings: BillingSettings) -> dict[str, object]:
+    """Create a payment using the configured provider."""
+
+    if settings.billing_provider == "dummy":
+        provider = DummyBillingProvider(test_mode=settings.billing_test_mode)
+        return await provider.create_payment()
+    raise HTTPException(status_code=501, detail="billing provider not supported")
+

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -37,6 +37,7 @@ from .legacy import router as legacy_router
 from .routers.internal_reminders import router as internal_reminders_router
 from .routers.stats import router as stats_router
 from .routers import metrics
+from .routers.billing import router as billing_router
 from .schemas.history import ALLOWED_HISTORY_TYPES, HistoryRecordSchema, HistoryType
 from .schemas.role import RoleSchema
 from .services.profile import patch_user_settings
@@ -99,6 +100,7 @@ api_router = APIRouter()
 api_router.include_router(stats_router)
 api_router.include_router(legacy_router)
 api_router.include_router(metrics.router)
+api_router.include_router(billing_router)
 
 # ────────── статические файлы UI ──────────
 BASE_DIR = Path(__file__).resolve().parents[2] / "webapp"

--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -1,0 +1,29 @@
+"""API routes for billing operations."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from services.api.app.billing import (
+    BillingSettings,
+    create_payment,
+    get_billing_settings,
+)
+
+router = APIRouter(prefix="/billing", tags=["Billing"])
+
+
+def _require_billing_enabled(
+    settings: BillingSettings = Depends(get_billing_settings),
+) -> BillingSettings:
+    if not settings.billing_enabled:
+        raise HTTPException(status_code=503, detail="billing disabled")
+    return settings
+
+
+@router.post("/pay")
+async def pay(settings: BillingSettings = Depends(_require_billing_enabled)) -> dict[str, object]:
+    """Create a payment using the configured provider."""
+
+    return await create_payment(settings)
+

--- a/tests/billing/test_billing_router.py
+++ b/tests/billing/test_billing_router.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from services.api.app.billing import reload_billing_settings
+from services.api.app.main import app
+
+
+def test_billing_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("BILLING_ENABLED", "false")
+    reload_billing_settings()
+    with TestClient(app) as client:
+        response = client.post("/api/billing/pay")
+    assert response.status_code == 503
+
+
+def test_dummy_provider(monkeypatch) -> None:
+    monkeypatch.setenv("BILLING_ENABLED", "true")
+    monkeypatch.setenv("BILLING_PROVIDER", "dummy")
+    monkeypatch.setenv("BILLING_TEST_MODE", "true")
+    reload_billing_settings()
+    with TestClient(app) as client:
+        response = client.post("/api/billing/pay")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "test_mode": True}
+


### PR DESCRIPTION
## Summary
- add billing settings with feature flags
- implement dummy billing provider and router
- document billing env vars

## Testing
- `pytest -q` *(fails: Table 'onboarding_events' is already defined)*
- `mypy --strict .` *(interrupt)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b87050ac38832a8ab91e60b6795b15