### PR TITLE
[tests] patch run_db for onboarding tests

### DIFF
--- a/tests/test_onboarding_timezone_webapp.py
+++ b/tests/test_onboarding_timezone_webapp.py
@@ -46,6 +46,7 @@ def session_local(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[SASession]:
     monkeypatch.setattr(db, "run_db", run_db, raising=False)
     monkeypatch.setattr(onboarding_state, "run_db", run_db, raising=False)
     monkeypatch.setattr(profile_service.db, "run_db", run_db, raising=False)
+    monkeypatch.setattr(onboarding, "run_db", run_db, raising=False)
     yield SessionLocal
     engine.dispose()
 


### PR DESCRIPTION
## Summary
- patch run_db with session-backed stub for onboarding tests

## Testing
- `pytest tests/handlers/test_wizard_navigation.py tests/test_onboarding_timezone_webapp.py tests/test_timezone_button_webapp.py -q --no-cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b8705e48d4832a86386bd6bd6b5215