### PR TITLE
[api] add billing status endpoint

### DIFF
--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from services.api.app.billing import (
     BillingSettings,
     create_payment,
     get_billing_settings,
 )
+
+from ..diabetes.services.db import SessionLocal, Subscription, run_db
+from ..schemas.billing import BillingStatusResponse, FeatureFlags, SubscriptionSchema
 
 router = APIRouter(prefix="/billing", tags=["Billing"])
 
@@ -22,8 +27,38 @@ def _require_billing_enabled(
 
 
 @router.post("/pay")
-async def pay(settings: BillingSettings = Depends(_require_billing_enabled)) -> dict[str, object]:
+async def pay(
+    settings: BillingSettings = Depends(_require_billing_enabled),
+) -> dict[str, object]:
     """Create a payment using the configured provider."""
 
     return await create_payment(settings)
 
+
+@router.get("/status", response_model=BillingStatusResponse)
+async def status(
+    user_id: int, settings: BillingSettings = Depends(get_billing_settings)
+) -> BillingStatusResponse:
+    """Return billing feature flags and the latest subscription for a user."""
+
+    def _get_subscription(session: Session) -> Subscription | None:
+        stmt = (
+            select(Subscription)
+            .where(Subscription.user_id == user_id)
+            .order_by(Subscription.start_date.desc())
+            .limit(1)
+        )
+        return session.scalars(stmt).first()
+
+    subscription = await run_db(_get_subscription, sessionmaker=SessionLocal)
+    flags = FeatureFlags(
+        billingEnabled=settings.billing_enabled, paywallMode=settings.paywall_mode
+    )
+    if subscription is None:
+        return BillingStatusResponse(featureFlags=flags, subscription=None)
+    return BillingStatusResponse(
+        featureFlags=flags,
+        subscription=SubscriptionSchema.model_validate(
+            subscription, from_attributes=True
+        ),
+    )

--- a/services/api/app/schemas/billing.py
+++ b/services/api/app/schemas/billing.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+
+from services.api.app.diabetes.services.db import SubscriptionPlan, SubscriptionStatus
+
+
+class FeatureFlags(BaseModel):
+    """Flags describing billing-related features."""
+
+    billingEnabled: bool = Field(alias="billingEnabled")
+    paywallMode: str = Field(alias="paywallMode")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SubscriptionSchema(BaseModel):
+    """Information about a user subscription."""
+
+    plan: SubscriptionPlan
+    status: SubscriptionStatus
+    provider: str
+    startDate: datetime = Field(
+        alias="startDate", validation_alias=AliasChoices("startDate", "start_date")
+    )
+    endDate: datetime | None = Field(
+        default=None,
+        alias="endDate",
+        validation_alias=AliasChoices("endDate", "end_date"),
+    )
+
+    model_config = ConfigDict(
+        populate_by_name=True, from_attributes=True, use_enum_values=True
+    )
+
+
+class BillingStatusResponse(BaseModel):
+    """Response schema for billing status requests."""
+
+    featureFlags: FeatureFlags = Field(alias="featureFlags")
+    subscription: SubscriptionSchema | None
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/tests/test_billing_status.py
+++ b/tests/test_billing_status.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.routers import billing
+from services.api.app.diabetes.services.db import (
+    Base,
+    Subscription,
+    SubscriptionPlan,
+    SubscriptionStatus,
+)
+
+
+def setup_db() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[Subscription.__table__])
+    return sessionmaker(bind=engine)
+
+
+def make_client(
+    monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]
+) -> TestClient:
+    from services.api.app.billing.config import BillingSettings
+
+    async def run_db(
+        fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs
+    ):
+        with sessionmaker() as session:
+            return fn(session, *args, **kwargs)
+
+    monkeypatch.setattr(billing, "run_db", run_db, raising=False)
+    monkeypatch.setattr(billing, "SessionLocal", session_local, raising=False)
+    monkeypatch.setattr(
+        billing,
+        "get_billing_settings",
+        lambda: BillingSettings(
+            billing_enabled=False,
+            billing_test_mode=True,
+            billing_provider="dummy",
+            paywall_mode="soft",
+        ),
+        raising=False,
+    )
+
+    from services.api.app.main import app
+
+    return TestClient(app)
+
+
+def test_status_without_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.get("/api/billing/status", params={"user_id": 1})
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "featureFlags": {"billingEnabled": False, "paywallMode": "soft"},
+        "subscription": None,
+    }
+
+
+def test_status_with_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    with session_local() as session:
+        session.add(
+            Subscription(
+                user_id=1,
+                plan=SubscriptionPlan.PRO,
+                status=SubscriptionStatus.ACTIVE,
+                provider="dummy",
+                transaction_id="t1",
+                start_date=datetime(2024, 1, 1),
+                end_date=None,
+            )
+        )
+        session.commit()
+
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.get("/api/billing/status", params={"user_id": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["featureFlags"] == {"billingEnabled": False, "paywallMode": "soft"}
+    assert data["subscription"]["plan"] == "pro"
+    assert data["subscription"]["status"] == "active"
+    assert data["subscription"]["provider"] == "dummy"
+    assert data["subscription"]["startDate"].startswith("2024-01-01")
+    assert data["subscription"]["endDate"] is None
+
+
+def test_status_with_multiple_subscriptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_local = setup_db()
+    with session_local() as session:
+        session.add_all(
+            [
+                Subscription(
+                    user_id=1,
+                    plan=SubscriptionPlan.PRO,
+                    status=SubscriptionStatus.CANCELED,
+                    provider="dummy",
+                    transaction_id="t1",
+                    start_date=datetime(2024, 1, 1),
+                    end_date=datetime(2024, 2, 1),
+                ),
+                Subscription(
+                    user_id=1,
+                    plan=SubscriptionPlan.FAMILY,
+                    status=SubscriptionStatus.ACTIVE,
+                    provider="dummy",
+                    transaction_id="t2",
+                    start_date=datetime(2024, 3, 1),
+                    end_date=None,
+                ),
+            ]
+        )
+        session.commit()
+
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.get("/api/billing/status", params={"user_id": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["subscription"]["plan"] == "family"
+    assert data["subscription"]["status"] == "active"
+    assert data["subscription"]["startDate"].startswith("2024-03-01")


### PR DESCRIPTION
## Summary
- add schema for billing status with feature flags and subscription info
- implement GET /billing/status endpoint
- cover billing status endpoint with unit tests

## Testing
- `pytest tests/test_billing_status.py -q` *(fails: Required test coverage of 85% not reached)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b87728c560832aa06b6196b38e31e3