### PR TITLE
[deploy] refine bot run script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,9 @@ const profile = await api.profilesGet({ telegramId: 123 });
 
 ### Переменные окружения
 
-- `TELEGRAM_TOKEN` — токен Telegram‑бота.
+- `TELEGRAM_TOKEN` — токен Telegram‑бота (**обязательно**).
 - `PUBLIC_ORIGIN` — публичный URL API, например `https://example.com`.
-  Используется для формирования ссылок и кнопок.
+  Используется для формирования ссылок, кнопок и health‑check.
 - `UI_BASE_URL` — базовый путь UI (по умолчанию `/ui`).
 
 ### Ручной запуск
@@ -298,8 +298,8 @@ const profile = await api.profilesGet({ telegramId: 123 });
 scripts/run_bot.sh
 ```
 
-Скрипт читает `.env`, устанавливает `PYTHONPATH` и выполняет
-`services.api.app.bot`.
+Скрипт подгружает `.env`, проверяет обязательные переменные и
+запускает `services.api.app.bot`.
 
 ### systemd
 
@@ -313,8 +313,12 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now diabetes-bot
 ```
 
-Файл запускает `scripts/run_bot.sh`, логирует в journald и перед стартом
-пингует `${PUBLIC_ORIGIN}/health`.
+Служба пингует `${PUBLIC_ORIGIN}/health` перед стартом, запускает
+`scripts/run_bot.sh`, а логи доступны через journald:
+
+```bash
+journalctl -u diabetes-bot
+```
 
 ## Сервисный запуск
 

--- a/scripts/run_bot.sh
+++ b/scripts/run_bot.sh
@@ -15,4 +15,12 @@ if [[ -f .env ]]; then
 fi
 
 export PYTHONPATH="${REPO_ROOT}:${PYTHONPATH:-}"
+
+# basic sanity checks for required configuration
+: "${TELEGRAM_TOKEN:?TELEGRAM_TOKEN is not set}"
+: "${PUBLIC_ORIGIN:?PUBLIC_ORIGIN is not set}"
+
+# UI_BASE_URL defaults to /ui but can be overridden in the environment
+export UI_BASE_URL="${UI_BASE_URL:-/ui}"
+
 exec python -m services.api.app.bot "$@"

--- a/services/deploy/systemd/diabetes-bot.service.example
+++ b/services/deploy/systemd/diabetes-bot.service.example
@@ -1,3 +1,6 @@
+## Example unit file for running the Diabetes bot
+## Copy to /etc/systemd/system/diabetes-bot.service and adjust paths and user
+
 [Unit]
 Description=Diabetes Telegram bot
 After=network.target
@@ -6,10 +9,11 @@ After=network.target
 Type=simple
 WorkingDirectory=/srv/diabetes-bot
 EnvironmentFile=/srv/diabetes-bot/.env
-ExecStartPre=/bin/sh -c '/usr/bin/curl -fsS "$PUBLIC_ORIGIN/health" || exit 1'
+ExecStartPre=/usr/bin/curl -fsS "$PUBLIC_ORIGIN/health"
 ExecStart=/srv/diabetes-bot/scripts/run_bot.sh
 Restart=on-failure
 RestartSec=5
+# log to journald
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## Summary
- tighten bot launch script with env variable checks
- document deployment steps and systemd unit
- include journald logging and health check

## Testing
- `PYTHONPATH=. pytest -q --import-mode=importlib --maxfail=1` (fails: async def functions are not natively supported)
- `mypy --strict services/api/app/diabetes/__init__.py`
- `mypy --strict .` *(fails: interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b87adfc9b4832a96f6aa36db192a59