### PR TITLE
[billing] add trial subscription endpoint

### DIFF
--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -12,7 +15,13 @@ from services.api.app.billing import (
     get_billing_settings,
 )
 
-from ..diabetes.services.db import SessionLocal, Subscription, run_db
+from ..diabetes.services.db import (
+    SessionLocal,
+    Subscription,
+    SubscriptionPlan,
+    SubscriptionStatus,
+    run_db,
+)
 from ..schemas.billing import BillingStatusResponse, FeatureFlags, SubscriptionSchema
 
 router = APIRouter(prefix="/billing", tags=["Billing"])
@@ -33,6 +42,50 @@ async def pay(
     """Create a payment using the configured provider."""
 
     return await create_payment(settings)
+
+
+@router.post("/trial", response_model=SubscriptionSchema)
+async def start_trial(user_id: int) -> SubscriptionSchema:
+    """Start a trial subscription for the user."""
+
+    now = datetime.now(timezone.utc)
+
+    def _get_active_trial(session: Session) -> Subscription | None:
+        stmt = (
+            select(Subscription)
+            .where(
+                Subscription.user_id == user_id,
+                Subscription.status == SubscriptionStatus.TRIAL,
+                Subscription.end_date.is_not(None),
+                Subscription.end_date > now,
+            )
+            .order_by(Subscription.start_date.desc())
+            .limit(1)
+        )
+        return session.scalars(stmt).first()
+
+    trial = await run_db(_get_active_trial, sessionmaker=SessionLocal)
+    if trial is not None:
+        return SubscriptionSchema.model_validate(trial, from_attributes=True)
+
+    def _create_trial(session: Session) -> Subscription:
+        start = now
+        trial = Subscription(
+            user_id=user_id,
+            plan=SubscriptionPlan.PRO,
+            status=SubscriptionStatus.TRIAL,
+            provider="trial",
+            transaction_id=str(uuid4()),
+            start_date=start,
+            end_date=start + timedelta(days=14),
+        )
+        session.add(trial)
+        session.commit()
+        session.refresh(trial)
+        return trial
+
+    trial = await run_db(_create_trial, sessionmaker=SessionLocal)
+    return SubscriptionSchema.model_validate(trial, from_attributes=True)
 
 
 @router.get("/status", response_model=BillingStatusResponse)

--- a/tests/test_billing_trial.py
+++ b/tests/test_billing_trial.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.routers import billing
+from services.api.app.diabetes.services.db import (
+    Base,
+    Subscription,
+    SubscriptionStatus,
+)
+
+
+# --- helpers -----------------------------------------------------------------
+
+def setup_db() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[Subscription.__table__])
+    return sessionmaker(bind=engine)
+
+
+def make_client(
+    monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]
+) -> TestClient:
+    from services.api.app.billing.config import BillingSettings
+
+    async def run_db(
+        fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs
+    ):
+        with sessionmaker() as session:
+            return fn(session, *args, **kwargs)
+
+    monkeypatch.setattr(billing, "run_db", run_db, raising=False)
+    monkeypatch.setattr(billing, "SessionLocal", session_local, raising=False)
+    monkeypatch.setattr(
+        billing,
+        "get_billing_settings",
+        lambda: BillingSettings(
+            billing_enabled=False,
+            billing_test_mode=True,
+            billing_provider="dummy",
+            paywall_mode="soft",
+        ),
+        raising=False,
+    )
+
+    from services.api.app.main import app
+
+    return TestClient(app)
+
+
+# --- tests --------------------------------------------------------------------
+
+def test_trial_creation(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.post("/api/billing/trial", params={"user_id": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["plan"] == "pro"
+    assert data["status"] == SubscriptionStatus.TRIAL.value
+    start = datetime.fromisoformat(data["startDate"])
+    end = datetime.fromisoformat(data["endDate"])
+    assert end - start == timedelta(days=14)
+    count_stmt = select(func.count()).select_from(Subscription)
+    with session_local() as session:
+        count = session.scalar(count_stmt)
+    assert count == 1
+
+
+def test_trial_repeat_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp1 = client.post("/api/billing/trial", params={"user_id": 1})
+        resp2 = client.post("/api/billing/trial", params={"user_id": 1})
+    assert resp1.status_code == 200
+    assert resp1.json() == resp2.json()
+    count_stmt = select(func.count()).select_from(Subscription)
+    with session_local() as session:
+        count = session.scalar(count_stmt)
+    assert count == 1


### PR DESCRIPTION
## Summary
- add `/billing/trial` endpoint to create or reuse a trial subscription
- test trial creation and idempotent repeated calls

## Testing
- `PYTEST_ADDOPTS="--no-cov" pytest tests/test_billing_trial.py tests/test_billing_status.py tests/billing/test_billing_router.py -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b87aeb90ec832aa2e17bdb12ff726e