### PR TITLE
[billing] add subscription initiation endpoint

### DIFF
--- a/services/api/app/billing/__init__.py
+++ b/services/api/app/billing/__init__.py
@@ -1,12 +1,12 @@
 """Billing utilities and configuration."""
 
 from .config import BillingSettings, get_billing_settings, reload_billing_settings
-from .service import create_payment
+from .service import create_payment, create_subscription
 
 __all__ = [
     "BillingSettings",
     "get_billing_settings",
     "reload_billing_settings",
     "create_payment",
+    "create_subscription",
 ]
-

--- a/services/api/app/billing/config.py
+++ b/services/api/app/billing/config.py
@@ -32,4 +32,3 @@ def reload_billing_settings() -> BillingSettings:
     global billing_settings
     billing_settings = BillingSettings()
     return billing_settings
-

--- a/services/api/app/billing/providers/__init__.py
+++ b/services/api/app/billing/providers/__init__.py
@@ -3,4 +3,3 @@
 from .dummy import DummyBillingProvider
 
 __all__ = ["DummyBillingProvider"]
-

--- a/services/api/app/billing/providers/dummy.py
+++ b/services/api/app/billing/providers/dummy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from uuid import uuid4
 
 
 @dataclass
@@ -16,3 +17,11 @@ class DummyBillingProvider:
 
         return {"status": "ok", "test_mode": self.test_mode}
 
+    async def create_subscription(self, plan: str) -> dict[str, str]:
+        """Return dummy checkout details for subscription creation."""
+
+        checkout_id = f"chk_{uuid4().hex}"
+        return {
+            "id": checkout_id,
+            "url": f"https://dummy/{plan}/{checkout_id}",
+        }

--- a/services/api/app/billing/service.py
+++ b/services/api/app/billing/service.py
@@ -16,3 +16,11 @@ async def create_payment(settings: BillingSettings) -> dict[str, object]:
         return await provider.create_payment()
     raise HTTPException(status_code=501, detail="billing provider not supported")
 
+
+async def create_subscription(settings: BillingSettings, plan: str) -> dict[str, str]:
+    """Create a subscription checkout using the configured provider."""
+
+    if settings.billing_provider == "dummy":
+        provider = DummyBillingProvider(test_mode=settings.billing_test_mode)
+        return await provider.create_subscription(plan)
+    raise HTTPException(status_code=501, detail="billing provider not supported")

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -366,6 +366,7 @@ class SubscriptionPlan(str, Enum):
 
 class SubscriptionStatus(str, Enum):
     TRIAL = "trial"
+    PENDING = "pending"
     ACTIVE = "active"
     CANCELED = "canceled"
     EXPIRED = "expired"

--- a/services/api/app/schemas/billing.py
+++ b/services/api/app/schemas/billing.py
@@ -15,6 +15,13 @@ class FeatureFlags(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class CheckoutSchema(BaseModel):
+    """Checkout information returned by billing provider."""
+
+    id: str
+    url: str
+
+
 class SubscriptionSchema(BaseModel):
     """Information about a user subscription."""
 

--- a/tests/billing/test_billing_subscribe.py
+++ b/tests/billing/test_billing_subscribe.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+import pytest
+
+from services.api.app.billing import reload_billing_settings
+from services.api.app.diabetes.services.db import (
+    Base,
+    Subscription,
+    SubscriptionPlan,
+    SubscriptionStatus,
+)
+from services.api.app.routers import billing
+from services.api.app.billing.config import BillingSettings
+from services.api.app.main import app
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def setup_db() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[Subscription.__table__])
+    return sessionmaker(bind=engine)
+
+
+def make_client(
+    monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]
+) -> TestClient:
+    async def run_db(
+        fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs
+    ):
+        with sessionmaker() as session:
+            return fn(session, *args, **kwargs)
+
+    monkeypatch.setattr(billing, "run_db", run_db, raising=False)
+    monkeypatch.setattr(billing, "SessionLocal", session_local, raising=False)
+    settings = BillingSettings(
+        billing_enabled=True,
+        billing_test_mode=True,
+        billing_provider="dummy",
+        paywall_mode="soft",
+    )
+    client = TestClient(app)
+    client.app.dependency_overrides[billing._require_billing_enabled] = lambda: settings
+    return client
+
+
+# --- tests -----------------------------------------------------------------
+
+
+def test_subscribe_billing_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BILLING_ENABLED", "false")
+    reload_billing_settings()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/billing/subscribe", params={"user_id": 1, "plan": "pro"}
+        )
+    assert resp.status_code == 503
+
+
+def test_subscribe_dummy_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.post(
+            "/api/billing/subscribe", params={"user_id": 1, "plan": "pro"}
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data) == {"id", "url"}
+
+    with client:
+        webhook = client.post(f"/api/billing/mock-webhook/{data['id']}")
+    assert webhook.status_code == 200
+
+    with session_local() as session:
+        sub = session.scalar(
+            select(Subscription).where(Subscription.transaction_id == data["id"])
+        )
+        assert sub is not None
+        assert sub.status == SubscriptionStatus.ACTIVE
+        assert sub.plan == SubscriptionPlan.PRO


### PR DESCRIPTION
## Summary
- support draft subscriptions with new `PENDING` status
- add dummy billing provider checkout and subscription service
- expose `POST /billing/subscribe` and test-mode webhook

## Testing
- `ruff check services/api/app/billing services/api/app/routers/billing.py services/api/app/diabetes/services/db.py services/api/app/schemas/billing.py tests/billing/test_billing_subscribe.py`
- `mypy --strict .`
- `pytest tests/billing/test_billing_router.py tests/billing/test_billing_subscribe.py tests/test_billing_status.py tests/test_billing_trial.py -q --cov=services/api/app/routers/billing.py --cov=services/api/app/billing --cov=services/api/app/diabetes/services/db.py --cov=services/api/app/schemas/billing.py --cov-report=term-missing --cov-fail-under=85 -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68b87ddf9c7c832abc12441bd38b038b