### PR TITLE
[commands] Add help and onboarding reset handlers

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import logging
+from typing import cast
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from .onboarding_state import OnboardingStateStore
+
+logger = logging.getLogger(__name__)
+
+HELP_TEXT = (
+    "\n".join(
+        [
+            "Доступные команды:",
+            "/start - начать работу с ботом",
+            "/help - краткая справка",
+            "/reset_onboarding - сбросить мастер настройки",
+            "",
+            "Для работы с WebApp откройте меню и выберите нужную кнопку.",
+        ]
+    )
+)
+
+
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send a brief help message about bot commands and WebApp."""
+
+    message = update.message
+    if message:
+        await message.reply_text(HELP_TEXT)
+
+
+async def reset_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Warn user and reset onboarding state on confirmation."""
+
+    message = update.effective_message
+    user = update.effective_user
+    if message is None or user is None:
+        return
+
+    user_data = cast(dict[str, object], context.user_data)
+    if user_data.pop("_onb_reset_confirm", False):
+        store = cast(
+            OnboardingStateStore,
+            context.application.bot_data.setdefault(
+                "onb_state", OnboardingStateStore()
+            ),
+        )
+        store.reset(user.id)
+        await message.reply_text(
+            "Онбординг сброшен. Отправьте /start, чтобы начать заново."
+        )
+        return
+
+    user_data["_onb_reset_confirm"] = True
+    await message.reply_text(
+        "⚠️ Это сбросит прогресс онбординга. Профиль и напоминания не затронутся.\n"
+        "Отправьте /reset_onboarding ещё раз для подтверждения."
+    )
+
+
+__all__ = ["help_command", "reset_onboarding"]

--- a/tests/diabetes/test_commands.py
+++ b/tests/diabetes/test_commands.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.diabetes import commands
+from services.api.app.diabetes.onboarding_state import OnboardingStateStore
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+
+class DummyApp:
+    def __init__(self) -> None:
+        self.bot_data: dict[str, object] = {}
+
+
+@pytest.mark.asyncio
+async def test_help_mentions_webapp() -> None:
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+
+    await commands.help_command(update, context)
+
+    text = message.replies[0]
+    assert "/start" in text
+    assert "WebApp" in text
+
+
+@pytest.mark.asyncio
+async def test_reset_onboarding_warns_and_resets() -> None:
+    message = DummyMessage()
+    user = SimpleNamespace(id=1)
+    update = cast(
+        Update,
+        SimpleNamespace(effective_message=message, message=message, effective_user=user),
+    )
+    app = DummyApp()
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(application=app, user_data={}),
+    )
+    store = OnboardingStateStore()
+    store.set_step(1, 2)
+    app.bot_data["onb_state"] = store
+
+    await commands.reset_onboarding(update, context)
+    assert "подтверж" in message.replies[0].lower()
+    assert store.get(1).step == 2
+
+    message.replies.clear()
+    await commands.reset_onboarding(update, context)
+    assert store.get(1).step == 0
+    assert "сброшен" in message.replies[0].lower()


### PR DESCRIPTION
## Summary
- add /help command describing bot features and WebApp
- add /reset_onboarding command with confirmation step and state reset
- test command handlers

## Testing
- `mypy --strict services/api/app/diabetes/commands.py tests/diabetes/test_commands.py`
- `PYTEST_ADDOPTS="--cov=services.api.app.diabetes --cov-report=term-missing --cov-fail-under=0" pytest tests/diabetes/test_commands.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87fc25e74832a83d93ec3e1ef7063