### PR TITLE
[webapp] add paywall guard

### DIFF
--- a/services/webapp/ui/src/App.tsx
+++ b/services/webapp/ui/src/App.tsx
@@ -19,6 +19,7 @@ import NewMeal from "./pages/NewMeal"
 import Analytics from "./pages/Analytics"
 import Subscription from "./pages/Subscription"
 import NotFound from "./pages/NotFound"
+import PaywallGuard from "./features/paywall/PaywallGuard"
 
 const queryClient = new QueryClient()
 
@@ -40,13 +41,13 @@ const AppContent = () => {
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/profile" element={<Profile />} />
-      <Route path="/reminders" element={<Reminders />} />
-      <Route path="/reminders/new" element={<RemindersCreate />} />
-      <Route path="/reminders/:id/edit" element={<RemindersEdit />} />
+      <Route path="/reminders" element={<PaywallGuard><Reminders /></PaywallGuard>} />
+      <Route path="/reminders/new" element={<PaywallGuard><RemindersCreate /></PaywallGuard>} />
+      <Route path="/reminders/:id/edit" element={<PaywallGuard><RemindersEdit /></PaywallGuard>} />
       <Route path="/history" element={<History />} />
       <Route path="/history/new-measurement" element={<NewMeasurement />} />
       <Route path="/history/new-meal" element={<NewMeal />} />
-      <Route path="/analytics" element={<Analytics />} />
+      <Route path="/analytics" element={<PaywallGuard><Analytics /></PaywallGuard>} />
       <Route path="/subscription" element={<Subscription />} />
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/services/webapp/ui/src/features/paywall/PaywallGuard.tsx
+++ b/services/webapp/ui/src/features/paywall/PaywallGuard.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { Navigate } from 'react-router-dom'
+import MedicalButton from '@/components/MedicalButton'
+
+export type PaywallMode = 'off' | 'soft' | 'hard'
+export type UserStatus = 'free' | 'pro'
+
+interface PaywallGuardProps {
+  children: React.ReactNode
+  status?: UserStatus
+  mode?: PaywallMode
+}
+
+const PaywallGuard: React.FC<PaywallGuardProps> = ({
+  children,
+  status,
+  mode,
+}) => {
+  const paywallMode =
+    mode ?? ((import.meta.env.VITE_PAYWALL_MODE as PaywallMode) || 'off')
+  const userStatus =
+    status ?? ((import.meta.env.VITE_USER_STATUS as UserStatus) || 'free')
+
+  if (userStatus === 'pro' || paywallMode === 'off') {
+    return <>{children}</>
+  }
+
+  console.log('[metrics] encountered paywall')
+
+  if (paywallMode === 'soft') {
+    return (
+      <div className="p-4 text-center" data-testid="paywall-teaser">
+        <p className="mb-2">Функция доступна в PRO-версии</p>
+        <MedicalButton onClick={() => (window.location.href = '/subscription')}>
+          Включить trial
+        </MedicalButton>
+      </div>
+    )
+  }
+
+  return <Navigate to="/subscription" replace />
+}
+
+export default PaywallGuard
+
+export const withPaywall = <P extends object>(
+  Component: React.ComponentType<P>,
+  mode?: PaywallMode,
+  status?: UserStatus,
+) => {
+  return (props: P) => (
+    <PaywallGuard mode={mode} status={status}>
+      <Component {...props} />
+    </PaywallGuard>
+  )
+}

--- a/services/webapp/ui/tests/PaywallGuard.test.tsx
+++ b/services/webapp/ui/tests/PaywallGuard.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import PaywallGuard from '@/features/paywall/PaywallGuard'
+import '@testing-library/jest-dom/vitest'
+
+describe('PaywallGuard', () => {
+  test('renders children for pro user', () => {
+    render(
+      <MemoryRouter>
+        <PaywallGuard status="pro" mode="soft">
+          <div>content</div>
+        </PaywallGuard>
+      </MemoryRouter>
+    )
+    expect(screen.getByText('content')).toBeInTheDocument()
+  })
+
+  test('shows teaser in soft mode for free user', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    render(
+      <MemoryRouter>
+        <PaywallGuard status="free" mode="soft">
+          <div>content</div>
+        </PaywallGuard>
+      </MemoryRouter>
+    )
+    expect(screen.getByTestId('paywall-teaser')).toBeInTheDocument()
+    expect(log).toHaveBeenCalledWith('[metrics] encountered paywall')
+    log.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- add PaywallGuard component to control access to PRO features based on PAYWALL_MODE and user status
- wrap Reminders and Analytics routes with paywall guard
- add PaywallGuard tests for pro and soft modes

## Testing
- `./node_modules/.bin/vitest run tests/PaywallGuard.test.tsx`
- `pnpm test` *(fails: mockApi not used in production, etc.)*
- `pytest -q tests` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b8894b4874832a87d4cacee5e8b777