### PR TITLE
[bot] add trial and upgrade commands

### DIFF
--- a/services/api/app/diabetes/handlers/billing_handlers.py
+++ b/services/api/app/diabetes/handlers/billing_handlers.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+import httpx
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from ... import config
+
+logger = logging.getLogger(__name__)
+
+
+async def trial_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Activate a 14-day trial subscription for the user."""
+
+    message = update.message
+    user = update.effective_user
+    if message is None or user is None:
+        return
+
+    base = config.get_settings().api_url
+    if not base:
+        await message.reply_text("❌ Не настроен API_URL")
+        return
+    url = f"{base.rstrip('/')}/billing/trial"
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, params={"user_id": user.id}, timeout=10.0)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPError:
+        logger.exception("failed to start trial")
+        await message.reply_text(
+            "❌ Не удалось активировать пробный период. Попробуйте позже."
+        )
+        return
+
+    end_raw = data.get("endDate")
+    try:
+        end_dt = datetime.fromisoformat(end_raw)
+    except Exception:  # pragma: no cover - defensive
+        await message.reply_text(
+            "❌ Ошибка сервера: неверный формат даты trial."
+        )
+        return
+    end_str = end_dt.strftime("%d.%m.%Y")
+    await message.reply_text(f"🎉 Пробный период активирован до {end_str}")
+
+
+async def upgrade_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send a link to the subscription page."""
+
+    message = update.message
+    if message is None:
+        return
+    try:
+        url = config.build_ui_url("/subscription")
+    except RuntimeError:
+        await message.reply_text("❌ Не настроена ссылка на оплату.")
+        return
+    await message.reply_text(f"💳 Оформить подписку: {url}")
+
+
+__all__ = ["trial_command", "upgrade_command"]

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -167,6 +167,7 @@ def register_handlers(
         photo_handlers,
         sugar_handlers,
         gpt_handlers,
+        billing_handlers,
     )
 
     app.add_handler(onboarding_conv)
@@ -194,6 +195,8 @@ def register_handlers(
     app.add_handler(
         CommandHandlerT("gpt", gpt_handlers.chat_with_gpt)
     )
+    app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
+    app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))
     register_reminder_handlers(app)
     app.add_handler(
         CommandHandlerT(

--- a/tests/test_billing_commands.py
+++ b/tests/test_billing_commands.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import httpx
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app import config
+from services.api.app.diabetes.handlers import billing_handlers
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+
+    async def reply_text(self, text: str, **_: Any) -> None:
+        self.texts.append(text)
+
+
+@pytest.mark.asyncio
+async def test_trial_command_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_URL", "http://api.test/api")
+    config.reload_settings()
+
+    end_date = "2025-01-15T00:00:00+00:00"
+
+    class DummyClient:
+        async def __aenter__(self) -> "DummyClient":
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            pass
+
+        async def post(
+            self, url: str, params: dict[str, int], timeout: float
+        ) -> httpx.Response:
+            assert url == "http://api.test/api/billing/trial"
+            assert params == {"user_id": 42}
+            req = httpx.Request("POST", url)
+            return httpx.Response(200, request=req, json={"endDate": end_date})
+
+    monkeypatch.setattr(billing_handlers.httpx, "AsyncClient", lambda: DummyClient())
+
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=42)))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+
+    await billing_handlers.trial_command(update, context)
+
+    assert message.texts == ["🎉 Пробный период активирован до 15.01.2025"]
+    monkeypatch.delenv("API_URL")
+    config.reload_settings()
+
+
+@pytest.mark.asyncio
+async def test_trial_command_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_URL", "http://api.test/api")
+    config.reload_settings()
+
+    class FailingClient:
+        async def __aenter__(self) -> "FailingClient":
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            pass
+
+        async def post(self, url: str, params: dict[str, int], timeout: float) -> httpx.Response:
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(billing_handlers.httpx, "AsyncClient", lambda: FailingClient())
+
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+
+    await billing_handlers.trial_command(update, context)
+
+    assert message.texts == [
+        "❌ Не удалось активировать пробный период. Попробуйте позже."
+    ]
+    monkeypatch.delenv("API_URL")
+    config.reload_settings()
+
+
+@pytest.mark.asyncio
+async def test_upgrade_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PUBLIC_ORIGIN", "http://example.org")
+    config.reload_settings()
+
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+
+    await billing_handlers.upgrade_command(update, context)
+
+    assert message.texts == ["💳 Оформить подписку: http://example.org/ui/subscription"]
+    monkeypatch.delenv("PUBLIC_ORIGIN")
+    config.reload_settings()

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -27,7 +27,11 @@ from services.api.app.diabetes.handlers.registration import (
 )
 from services.api.app.diabetes.handlers.router import callback_router
 from services.api.app.diabetes.handlers.onboarding_handlers import start_command
-from services.api.app.diabetes.handlers import security_handlers, reminder_handlers
+from services.api.app.diabetes.handlers import (
+    security_handlers,
+    reminder_handlers,
+    billing_handlers,
+)
 
 
 def test_register_handlers_attaches_expected_handlers(
@@ -71,6 +75,8 @@ def test_register_handlers_attaches_expected_handlers(
     )
     assert gpt_handlers.chat_with_gpt in callbacks
     assert security_handlers.hypo_alert_faq in callbacks
+    assert billing_handlers.trial_command in callbacks
+    assert billing_handlers.upgrade_command in callbacks
     # Reminder handlers should be registered
     assert any(
         isinstance(h, CallbackQueryHandler)


### PR DESCRIPTION
## Summary
- add billing handler for `/trial` command calling API and notifying trial end date
- add `/upgrade` command linking to subscription page
- register new commands and cover them with tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b8896ab3d0832a82aad8868df041a4