### PR TITLE
[webapp] integrate billing subscription page

### DIFF
--- a/services/webapp/ui/src/api/billing.ts
+++ b/services/webapp/ui/src/api/billing.ts
@@ -1,0 +1,29 @@
+import { api } from './index';
+
+export interface BillingFeatureFlags {
+  billingEnabled: boolean;
+  paywallMode: string;
+  testMode?: boolean;
+}
+
+export interface SubscriptionInfo {
+  plan: string;
+  status: string;
+  provider: string;
+  startDate: string;
+  endDate: string | null;
+}
+
+export interface BillingStatus {
+  featureFlags: BillingFeatureFlags;
+  subscription: SubscriptionInfo | null;
+}
+
+export const getBillingStatus = () =>
+  api.get<BillingStatus>('/billing/status');
+
+export const startTrial = () =>
+  api.post<SubscriptionInfo>('/billing/trial', {});
+
+export const subscribePlan = (plan: string) =>
+  api.post<{ id: string; url: string }>(`/billing/subscribe?plan=${plan}`, {});

--- a/services/webapp/ui/src/pages/Subscription.test.tsx
+++ b/services/webapp/ui/src/pages/Subscription.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, vi, beforeEach } from 'vitest';
+import Subscription from './Subscription';
+import { getBillingStatus } from '@/api/billing';
+
+vi.mock('@/components/ThemeToggle', () => ({ default: () => <div /> }));
+vi.mock('@/api/billing', () => ({
+  getBillingStatus: vi.fn(),
+  startTrial: vi.fn(),
+  subscribePlan: vi.fn(),
+}));
+
+const mockedStatus = getBillingStatus as unknown as vi.Mock;
+
+describe('Subscription states', () => {
+  beforeEach(() => {
+    mockedStatus.mockReset();
+  });
+
+  const renderPage = async (status: unknown) => {
+    mockedStatus.mockResolvedValue(status);
+    render(
+      <MemoryRouter>
+        <Subscription />
+      </MemoryRouter>,
+    );
+    await screen.findByTestId('status-card');
+  };
+
+  it('renders no subscription', async () => {
+    await renderPage({
+      featureFlags: { billingEnabled: false, paywallMode: 'soft', testMode: true },
+      subscription: null,
+    });
+    expect(screen.getByTestId('no-sub')).toBeTruthy();
+    expect(screen.getByTestId('flag-test')).toBeTruthy();
+    expect(screen.getByTestId('flag-paywall')).toHaveTextContent('soft');
+  });
+
+  it('renders trial subscription', async () => {
+    await renderPage({
+      featureFlags: { billingEnabled: true, paywallMode: 'soft' },
+      subscription: {
+        plan: 'pro',
+        status: 'trial',
+        provider: 'dummy',
+        startDate: '2024-01-01',
+        endDate: '2024-01-15',
+      },
+    });
+    expect(screen.getByTestId('current-plan')).toHaveTextContent('pro');
+    expect(screen.getByTestId('current-status')).toHaveTextContent('trial');
+  });
+
+  it('renders active subscription', async () => {
+    await renderPage({
+      featureFlags: { billingEnabled: true, paywallMode: 'soft' },
+      subscription: {
+        plan: 'pro',
+        status: 'active',
+        provider: 'dummy',
+        startDate: '2024-01-01',
+        endDate: null,
+      },
+    });
+    expect(screen.getByTestId('current-status')).toHaveTextContent('active');
+  });
+
+  it('renders expired subscription', async () => {
+    await renderPage({
+      featureFlags: { billingEnabled: true, paywallMode: 'soft' },
+      subscription: {
+        plan: 'pro',
+        status: 'expired',
+        provider: 'dummy',
+        startDate: '2024-01-01',
+        endDate: '2024-02-01',
+      },
+    });
+    expect(screen.getByTestId('current-status')).toHaveTextContent('expired');
+  });
+});


### PR DESCRIPTION
## Summary
- integrate billing API with subscription page
- show plan status and feature flags
- add subscription state tests

## Testing
- `pnpm --dir services/webapp/ui lint` *(fails: Unexpected any)*
- `pnpm --dir services/webapp/ui test` *(fails: JavaScript heap out of memory)*
- `pnpm --dir services/webapp/ui test -- --max-workers=2` *(fails: JavaScript heap out of memory)*
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b888ff3480832a8d2ad214d54d7ba9