### PR TITLE
[billing] add dummy checkout and webhook verification

### DIFF
--- a/services/api/app/billing/__init__.py
+++ b/services/api/app/billing/__init__.py
@@ -1,12 +1,19 @@
 """Billing utilities and configuration."""
 
 from .config import BillingSettings, get_billing_settings, reload_billing_settings
-from .service import create_payment, create_subscription
+from .service import (
+    create_checkout,
+    create_payment,
+    create_subscription,
+    verify_webhook,
+)
 
 __all__ = [
     "BillingSettings",
     "get_billing_settings",
     "reload_billing_settings",
     "create_payment",
+    "create_checkout",
     "create_subscription",
+    "verify_webhook",
 ]

--- a/services/api/app/billing/providers/dummy.py
+++ b/services/api/app/billing/providers/dummy.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from uuid import uuid4
+
+from ...schemas.billing import WebhookEvent
+
+
+MOCK_CHECKOUT_URL = "https://example.com/mock-checkout"
 
 
 @dataclass
@@ -17,11 +23,31 @@ class DummyBillingProvider:
 
         return {"status": "ok", "test_mode": self.test_mode}
 
-    async def create_subscription(self, plan: str) -> dict[str, str]:
+    async def create_checkout(self, plan: str) -> dict[str, str]:
         """Return dummy checkout details for subscription creation."""
 
         checkout_id = f"chk_{uuid4().hex}"
+        logger = logging.getLogger(__name__)
+        logger.info("create_checkout %s", checkout_id)
         return {
             "id": checkout_id,
-            "url": f"https://dummy/{plan}/{checkout_id}",
+            "url": f"{MOCK_CHECKOUT_URL}?plan={plan}&transaction={checkout_id}",
         }
+
+    async def verify_webhook(self, event: WebhookEvent) -> bool:
+        """Verify webhook signature and log the transaction."""
+
+        logger = logging.getLogger(__name__)
+        expected_sig = f"{event.event_id}:{event.transaction_id}"
+        if event.signature != expected_sig:
+            logger.info("webhook %s invalid_signature", event.transaction_id)
+            return False
+        logger.info("webhook %s verified", event.transaction_id)
+        return True
+
+    async def create_subscription(
+        self, plan: str
+    ) -> dict[str, str]:  # pragma: no cover - compat
+        """Backward compatible alias for :meth:`create_checkout`."""
+
+        return await self.create_checkout(plan)

--- a/services/api/app/billing/service.py
+++ b/services/api/app/billing/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastapi import HTTPException
 
+from ..schemas.billing import WebhookEvent
 from .config import BillingSettings
 from .providers import DummyBillingProvider
 
@@ -17,10 +18,23 @@ async def create_payment(settings: BillingSettings) -> dict[str, object]:
     raise HTTPException(status_code=501, detail="billing provider not supported")
 
 
-async def create_subscription(settings: BillingSettings, plan: str) -> dict[str, str]:
+async def create_checkout(settings: BillingSettings, plan: str) -> dict[str, str]:
     """Create a subscription checkout using the configured provider."""
 
     if settings.billing_provider == "dummy":
         provider = DummyBillingProvider(test_mode=settings.billing_test_mode)
-        return await provider.create_subscription(plan)
+        return await provider.create_checkout(plan)
+    raise HTTPException(status_code=501, detail="billing provider not supported")
+
+
+# Backward compatibility -----------------------------------------------------
+create_subscription = create_checkout
+
+
+async def verify_webhook(settings: BillingSettings, event: WebhookEvent) -> bool:
+    """Verify webhook payload using the configured provider."""
+
+    if settings.billing_provider == "dummy":
+        provider = DummyBillingProvider(test_mode=settings.billing_test_mode)
+        return await provider.verify_webhook(event)
     raise HTTPException(status_code=501, detail="billing provider not supported")

--- a/tests/billing/test_billing_subscribe.py
+++ b/tests/billing/test_billing_subscribe.py
@@ -76,6 +76,7 @@ def test_subscribe_dummy_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     assert resp.status_code == 200
     data = resp.json()
     assert set(data) == {"id", "url"}
+    assert "mock-checkout" in data["url"]
 
     with client:
         webhook = client.post(f"/api/billing/mock-webhook/{data['id']}")

--- a/tests/billing/test_billing_webhook.py
+++ b/tests/billing/test_billing_webhook.py
@@ -56,7 +56,9 @@ def create_subscription(client: TestClient) -> str:
     return resp.json()["id"]
 
 
-def test_webhook_activates_subscription(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+def test_webhook_activates_subscription(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     session_local = setup_db()
     client = make_client(monkeypatch, session_local)
     checkout_id = create_subscription(client)
@@ -79,7 +81,7 @@ def test_webhook_activates_subscription(monkeypatch: pytest.MonkeyPatch, caplog:
         assert sub.status == SubscriptionStatus.ACTIVE
         assert sub.plan == SubscriptionPlan.PRO
         assert sub.end_date is not None
-    assert any("evt1 processed" in r.getMessage() for r in caplog.records)
+    assert any(f"{checkout_id} processed" in r.getMessage() for r in caplog.records)
 
 
 def test_webhook_duplicate_ignored(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- implement dummy billing provider with checkout creation and webhook verification
- wire up billing service and router to new provider interface
- log transaction IDs and document test coverage for mock checkout

## Testing
- `pytest tests/billing/test_billing_subscribe.py tests/billing/test_billing_webhook.py tests/billing/test_admin_mock_webhook.py -q --cov=services/api/app/billing --cov-report=term-missing --cov-fail-under=0`
- `mypy --strict services/api/app/billing services/api/app/routers/billing.py tests/billing/test_billing_subscribe.py tests/billing/test_billing_webhook.py tests/billing/test_admin_mock_webhook.py`
- `ruff check services/api/app/billing/__init__.py services/api/app/billing/providers/dummy.py services/api/app/billing/service.py services/api/app/routers/billing.py tests/billing/test_billing_subscribe.py tests/billing/test_billing_webhook.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8897a3e90832abefbbd55aec444de