### PR TITLE
[bot] add telegram payments provider

### DIFF
--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -37,6 +37,7 @@ FONT_DIR=infra/fonts
 
 # Telegram
 TELEGRAM_TOKEN=your-telegram-bot-token
+TELEGRAM_PAYMENTS_PROVIDER_TOKEN=your-telegram-payments-token
 
 # Billing configuration
 BILLING_ENABLED=false

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -11,9 +11,7 @@ from pydantic import Field, field_validator
 try:  # pragma: no cover - import guard
     from pydantic_settings import BaseSettings, SettingsConfigDict
 except ModuleNotFoundError as exc:  # pragma: no cover - executed at import time
-    raise ImportError(
-        "`pydantic-settings` is required. Install it with `pip install pydantic-settings`."
-    ) from exc
+    raise ImportError("`pydantic-settings` is required. Install it with `pip install pydantic-settings`.") from exc
 
 
 logger = logging.getLogger(__name__)
@@ -34,9 +32,7 @@ class Settings(BaseSettings):
     app_name: str = "diabetes-bot"
     debug: bool = False
 
-    photos_dir: str = Field(
-        default="/var/lib/diabetes-bot/photos", alias="PHOTOS_DIR"
-    )
+    photos_dir: str = Field(default="/var/lib/diabetes-bot/photos", alias="PHOTOS_DIR")
 
     # Database configuration
     database_url: str = Field(
@@ -58,22 +54,17 @@ class Settings(BaseSettings):
     ui_base_url: str = Field(default="/ui", alias="UI_BASE_URL")
     api_url: Optional[str] = Field(default=None, alias="API_URL")
     openai_api_key: Optional[str] = Field(default=None, alias="OPENAI_API_KEY")
-    openai_assistant_id: Optional[str] = Field(
-        default=None, alias="OPENAI_ASSISTANT_ID"
-    )
-    openai_command_model: str = Field(
-        default="gpt-4o-mini", alias="OPENAI_COMMAND_MODEL"
-    )
+    openai_assistant_id: Optional[str] = Field(default=None, alias="OPENAI_ASSISTANT_ID")
+    openai_command_model: str = Field(default="gpt-4o-mini", alias="OPENAI_COMMAND_MODEL")
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
     font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
     telegram_token: Optional[str] = Field(default=None, alias="TELEGRAM_TOKEN")
+    telegram_payments_provider_token: Optional[str] = Field(default=None, alias="TELEGRAM_PAYMENTS_PROVIDER_TOKEN")
     admin_id: Optional[int] = Field(default=None, alias="ADMIN_ID")
 
     @field_validator("log_level", mode="before")
     @classmethod
-    def parse_log_level(
-        cls, v: int | str | None
-    ) -> int:  # pragma: no cover - simple parsing
+    def parse_log_level(cls, v: int | str | None) -> int:  # pragma: no cover - simple parsing
         if isinstance(v, str):
             v_lower = v.lower()
             level_map: dict[str, int] = {

--- a/services/bot/telegram_payments.py
+++ b/services/bot/telegram_payments.py
@@ -1,0 +1,79 @@
+"""Telegram Payments adapter for subscription billing."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from telegram import LabeledPrice, Update
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    PreCheckoutQueryHandler,
+    filters,
+)
+
+from services.api.app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TelegramPaymentsAdapter:
+    """Adapter to handle Telegram Payments flow."""
+
+    provider_token: str = settings.telegram_payments_provider_token or ""
+
+    async def create_invoice(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Send an invoice to the user."""
+
+        chat = update.effective_chat
+        assert chat is not None
+        chat_id = chat.id
+        prices = [LabeledPrice(label="Subscription", amount=100)]
+        await context.bot.send_invoice(
+            chat_id=chat_id,
+            title="Subscription",
+            description="Monthly subscription",
+            payload="subscription",
+            provider_token=self.provider_token,
+            currency="RUB",
+            prices=prices,
+        )
+
+    async def handle_pre_checkout_query(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Confirm pre checkout query."""
+
+        query = update.pre_checkout_query
+        assert query is not None
+        await query.answer(ok=True)
+
+    async def handle_successful_payment(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Notify backend about successful payment."""
+
+        msg = update.message
+        assert msg is not None
+        payment = msg.successful_payment
+        assert payment is not None
+        api_url = settings.api_url or "http://localhost:8000"
+        payload = payment.invoice_payload
+        async with httpx.AsyncClient() as client:
+            await client.post(f"{api_url}/billing/webhook", json={"payload": payload})
+        await msg.reply_text("✅ Платёж успешно получен")
+
+
+def register_billing_handlers(
+    app: Application[Any, Any, Any, Any, Any, Any],
+    adapter: TelegramPaymentsAdapter | None = None,
+) -> None:
+    """Register Telegram Payments handlers with the application."""
+
+    if adapter is None:
+        adapter = TelegramPaymentsAdapter()
+    app.add_handler(CommandHandler("subscribe", adapter.create_invoice))
+    app.add_handler(PreCheckoutQueryHandler(adapter.handle_pre_checkout_query))
+    app.add_handler(MessageHandler(filters.SUCCESSFUL_PAYMENT, adapter.handle_successful_payment))

--- a/tests/test_telegram_payments.py
+++ b/tests/test_telegram_payments.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from services.bot.telegram_payments import TelegramPaymentsAdapter
+
+
+@pytest.mark.asyncio
+async def test_create_invoice(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = TelegramPaymentsAdapter(provider_token="token")
+    bot = AsyncMock()
+    context = SimpleNamespace(bot=bot)
+    chat = SimpleNamespace(id=1)
+    update = SimpleNamespace(effective_chat=chat)
+
+    await adapter.create_invoice(update, context)
+
+    bot.send_invoice.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_pre_checkout_query() -> None:
+    adapter = TelegramPaymentsAdapter()
+    pre_checkout = AsyncMock()
+    update = SimpleNamespace(pre_checkout_query=pre_checkout)
+    context = SimpleNamespace()
+
+    await adapter.handle_pre_checkout_query(update, context)
+
+    pre_checkout.answer.assert_called_once_with(ok=True)
+
+
+@pytest.mark.asyncio
+async def test_handle_successful_payment(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = TelegramPaymentsAdapter()
+    message = SimpleNamespace(
+        successful_payment=SimpleNamespace(invoice_payload="payload"),
+        reply_text=AsyncMock(),
+    )
+    update = SimpleNamespace(message=message)
+    context = SimpleNamespace()
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self.post = AsyncMock()
+
+        async def __aenter__(self) -> DummyClient:  # type: ignore[override]
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:  # type: ignore[override]
+            return None
+
+    dummy_client = DummyClient()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: dummy_client)
+
+    await adapter.handle_successful_payment(update, context)
+
+    dummy_client.post.assert_called_once()
+    message.reply_text.assert_called_once()


### PR DESCRIPTION
## Summary
- add Telegram Payments adapter with invoice and webhook calls
- expose TELEGRAM_PAYMENTS_PROVIDER_TOKEN setting
- wire billing handlers into bot

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8898fb4a0832ab4b6ef1c15c2d53d