### PR TITLE
[billing] add service and job tests

### DIFF
--- a/tests/billing/test_expire_job.py
+++ b/tests/billing/test_expire_job.py
@@ -82,3 +82,20 @@ def test_schedule_subscription_expiration_sets_job_kwargs() -> None:
     jq = DummyJobQueue()
     jobs.schedule_subscription_expiration(cast(Any, jq))
     assert jq.kwargs == {"id": "subscriptions_expire", "replace_existing": True}
+
+
+def test_schedule_subscription_expiration_skips_without_run_daily(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class Dummy:
+        pass
+
+    jq = Dummy()
+    caplog.set_level(logging.INFO)
+    jobs.schedule_subscription_expiration(cast(Any, jq))
+    assert not any("subscriptions_expire" in r.getMessage() for r in caplog.records)
+
+
+def test_utcnow_returns_aware_datetime() -> None:
+    now = jobs._utcnow()
+    assert now.tzinfo is timezone.utc

--- a/tests/billing/test_service.py
+++ b/tests/billing/test_service.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from services.api.app.billing import service
+from services.api.app.billing.config import BillingSettings
+from services.api.app.billing.providers.dummy import DummyBillingProvider
+
+
+@pytest.mark.asyncio
+async def test_create_payment_unknown_provider() -> None:
+    settings = BillingSettings(BILLING_PROVIDER="other")
+    with pytest.raises(HTTPException):
+        await service.create_payment(settings)
+
+
+@pytest.mark.asyncio
+async def test_create_subscription_unknown_provider() -> None:
+    settings = BillingSettings(BILLING_PROVIDER="other")
+    with pytest.raises(HTTPException):
+        await service.create_subscription(settings, "pro")
+
+
+@pytest.mark.asyncio
+async def test_dummy_provider_methods() -> None:
+    provider = DummyBillingProvider(test_mode=False)
+    payment = await provider.create_payment()
+    assert payment == {"status": "ok", "test_mode": False}
+    checkout = await provider.create_subscription("pro")
+    assert checkout["url"].startswith("https://dummy/pro/")


### PR DESCRIPTION
## Summary
- test unsupported providers and dummy provider flows
- ensure scheduler handles missing run_daily and utc helper

## Testing
- `pytest tests/billing tests/test_billing_status.py tests/test_billing_trial.py --cov=services/api/app/billing --cov-report=term-missing --cov-fail-under=85 -q -c /dev/null`
- `mypy --strict tests/billing/test_service.py tests/billing/test_expire_job.py`
- `mypy --strict services/api/app/billing`
- `ruff check tests/billing services/api/app/billing`


------
https://chatgpt.com/codex/tasks/task_e_68b889c6b7b0832a8fc75e68e865e3dc