### PR TITLE
[ci] add billing env matrix

### DIFF
--- a/.github/workflows/billing.yml
+++ b/.github/workflows/billing.yml
@@ -1,0 +1,50 @@
+name: Billing CI
+
+on:
+  push:
+    paths:
+      - '.github/workflows/billing.yml'
+      - 'services/api/app/billing/**'
+      - 'services/api/alembic/**'
+      - 'migrations/**'
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - env: dev
+            provider: dummy
+            test_mode: true
+          - env: staging
+            provider: stripe
+            test_mode: true
+          - env: prod
+            provider: stripe
+            test_mode: false
+    env:
+      BILLING_ENABLED: "true"
+      BILLING_PROVIDER: ${{ matrix.provider }}
+      BILLING_TEST_MODE: ${{ matrix.test_mode }}
+      BILLING_ADMIN_TOKEN: ${{ secrets.BILLING_ADMIN_TOKEN }}
+      DATABASE_URL: sqlite:///./${{ matrix.env }}.db
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r services/api/app/requirements-dev.txt
+      - name: Validate billing secrets
+        if: matrix.provider != 'dummy'
+        run: |
+          if [ -z "$BILLING_ADMIN_TOKEN" ]; then
+            echo 'BILLING_ADMIN_TOKEN is required for ${{ matrix.env }}'
+            exit 1
+          fi
+      - name: Run migrations
+        run: make migrate

--- a/services/api/app/billing/config.py
+++ b/services/api/app/billing/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,6 +18,13 @@ class BillingSettings(BaseSettings):
     billing_admin_token: str | None = Field(
         default=None, alias="BILLING_ADMIN_TOKEN"
     )
+
+    @model_validator(mode="after")
+    def _require_admin_token(self) -> "BillingSettings":
+        """Ensure real providers have an admin token configured."""
+        if self.billing_provider != "dummy" and not self.billing_admin_token:
+            raise ValueError("BILLING_ADMIN_TOKEN is required for non-dummy providers")
+        return self
 
 
 billing_settings = BillingSettings()

--- a/tests/billing/test_billing_config.py
+++ b/tests/billing/test_billing_config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from services.api.app.billing.config import BillingSettings
+
+
+def test_dummy_provider_allows_missing_admin_token(monkeypatch) -> None:
+    monkeypatch.setenv("BILLING_PROVIDER", "dummy")
+    monkeypatch.delenv("BILLING_ADMIN_TOKEN", raising=False)
+    settings = BillingSettings()
+    assert settings.billing_admin_token is None
+
+
+def test_real_provider_requires_admin_token(monkeypatch) -> None:
+    monkeypatch.setenv("BILLING_PROVIDER", "stripe")
+    monkeypatch.delenv("BILLING_ADMIN_TOKEN", raising=False)
+    with pytest.raises(ValidationError):
+        BillingSettings()


### PR DESCRIPTION
## Summary
- enforce billing admin token for real providers
- cover billing settings with tests
- run migrations across dev/staging/prod environments

## Testing
- `pytest --cov=services.api.app.diabetes --cov-report=term-missing --cov-report=xml`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b88a451c00832ab54050763b20c1d6