### PR TITLE
[billing] Secure webhook verification

### DIFF
--- a/services/api/app/billing/config.py
+++ b/services/api/app/billing/config.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import field_validator
 
 
 class BillingSettings(BaseSettings):
     """Runtime billing configuration."""
 
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_file=".env", extra="ignore", populate_by_name=True
+    )
 
     billing_enabled: bool = Field(default=False, alias="BILLING_ENABLED")
     billing_test_mode: bool = Field(default=True, alias="BILLING_TEST_MODE")
@@ -18,6 +21,24 @@ class BillingSettings(BaseSettings):
     billing_admin_token: str | None = Field(
         default=None, alias="BILLING_ADMIN_TOKEN"
     )
+    billing_webhook_secret: str | None = Field(
+        default=None, alias="BILLING_WEBHOOK_SECRET"
+    )
+    billing_webhook_ips: list[str] = Field(
+        default_factory=list, alias="BILLING_WEBHOOK_IPS"
+    )
+    billing_webhook_timeout: float = Field(
+        default=5.0, alias="BILLING_WEBHOOK_TIMEOUT"
+    )
+
+    @field_validator("billing_webhook_ips", mode="before")
+    @classmethod
+    def split_ips(cls, value: str | list[str] | None) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [ip.strip() for ip in value.split(",") if ip.strip()]
+        return value
 
 
 billing_settings = BillingSettings()


### PR DESCRIPTION
## Summary
- add configuration for billing webhook secrets, IP whitelist, and timeout
- validate webhook signatures and client IPs with HMAC
- cover billing webhook security with new tests

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: async plugin missing)*
- `pytest tests/billing/test_billing_webhook.py -q --no-cov`
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b889b89c2c832aaf298c9b75d84ff6