### PR TITLE
[migrations] Add pending subscription status

### DIFF
--- a/services/api/alembic/versions/20250909_add_subscriptions_table.py
+++ b/services/api/alembic/versions/20250909_add_subscriptions_table.py
@@ -15,7 +15,15 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 plan_enum = sa.Enum("free", "pro", "family", name="subscription_plan")
-status_enum = sa.Enum("trial", "active", "canceled", "expired", name="subscription_status")
+status_enum = sa.Enum(
+    "trial",
+    "pending",
+    "active",
+    "canceled",
+    "expired",
+    name="subscription_status",
+    create_type=False,
+)
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary
- allow `pending` in `subscription_status` enum

## Testing
- `DATABASE_URL=sqlite:///tmp.db alembic -c services/api/alembic.ini upgrade head` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*
- `pytest -q --cov` *(fails: No module named 'reportlab')*
- `mypy --strict services/api/alembic/versions/20250909_add_subscriptions_table.py --ignore-missing-imports`
- `ruff check services/api/alembic/versions/20250909_add_subscriptions_table.py`


------
https://chatgpt.com/codex/tasks/task_e_68b894431d50832abfe5e8bc300432fc