### PR TITLE
[alembic] prevent enum duplicate type creation

### DIFF
--- a/services/api/alembic/versions/20250909_add_subscriptions_table.py
+++ b/services/api/alembic/versions/20250909_add_subscriptions_table.py
@@ -14,8 +14,12 @@ down_revision: Union[str, Sequence[str], None] = (
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-plan_enum = sa.Enum("free", "pro", "family", name="subscription_plan")
-status_enum = sa.Enum("trial", "active", "canceled", "expired", name="subscription_status")
+plan_enum = sa.Enum(
+    "free", "pro", "family", name="subscription_plan", create_type=False
+)
+status_enum = sa.Enum(
+    "trial", "active", "canceled", "expired", name="subscription_status", create_type=False
+)
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary
- prevent `subscription_plan` and `subscription_status` enum types from being re-created

## Testing
- `python - <<'PY' ... migration script ...` *(upgrade done)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b89439789c832aa43730eb105a9a29