### PR TITLE
[onboarding] Validate timezone from webapp

### DIFF
--- a/tests/billing/test_service.py
+++ b/tests/billing/test_service.py
@@ -10,14 +10,14 @@ from services.api.app.billing.providers.dummy import DummyBillingProvider
 
 @pytest.mark.asyncio
 async def test_create_payment_unknown_provider() -> None:
-    settings = BillingSettings(BILLING_PROVIDER="other")
+    settings = BillingSettings(BILLING_PROVIDER="other", BILLING_ADMIN_TOKEN="token")
     with pytest.raises(HTTPException):
         await service.create_payment(settings)
 
 
 @pytest.mark.asyncio
 async def test_create_subscription_unknown_provider() -> None:
-    settings = BillingSettings(BILLING_PROVIDER="other")
+    settings = BillingSettings(BILLING_PROVIDER="other", BILLING_ADMIN_TOKEN="token")
     with pytest.raises(HTTPException):
         await service.create_subscription(settings, "pro")
 
@@ -28,4 +28,4 @@ async def test_dummy_provider_methods() -> None:
     payment = await provider.create_payment()
     assert payment == {"status": "ok", "test_mode": False}
     checkout = await provider.create_subscription("pro")
-    assert checkout["url"].startswith("https://dummy/pro/")
+    assert checkout["url"].startswith("https://example.com/mock-checkout")

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -79,6 +79,10 @@ async def test_timezone_webapp_saves_tz_and_moves_to_reminders(
     monkeypatch.setattr(
         handlers.onboarding_state, "load_state", AsyncMock(return_value=None)
     )
+    monkeypatch.setattr(
+        handlers.onboarding_state, "save_state", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(handlers, "save_timezone", AsyncMock())
     prompt = AsyncMock(return_value=handlers.REMINDERS)
     monkeypatch.setattr(handlers, "_prompt_reminders", prompt)
     state = await handlers.timezone_webapp(update, context)


### PR DESCRIPTION
## Summary
- validate WebApp timezone and retry on invalid input
- persist detected timezone automatically during onboarding
- test timezone WebApp handler for valid and invalid data
- fix billing service tests for updated settings and dummy provider

## Testing
- `pytest -q --cov`
- `mypy --strict services/api/app/diabetes/handlers/onboarding_handlers.py tests/test_onboarding_timezone_webapp.py tests/test_timezone_button_webapp.py tests/billing/test_service.py`
- `ruff check services/api/app/diabetes/handlers/onboarding_handlers.py tests/test_onboarding_timezone_webapp.py tests/test_timezone_button_webapp.py tests/billing/test_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8958be4cc832a86f7d64e7c7b1bf3