### PR TITLE
[onboarding] Replace reminders set with list

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -10,7 +10,7 @@ Implements three steps with navigation and progress hints:
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any, Iterable, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from datetime import time as time_cls
 
@@ -412,7 +412,12 @@ async def reminders_chosen(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             return await _prompt_profile(message, user_id, user_data, variant)
         return await _prompt_timezone(message, user_id, user_data, variant)
     if data in {CB_SKIP, CB_DONE}:
-        await onboarding_state.save_state(user_id, REMINDERS, user_data, variant)
+        save_data = dict(user_data)
+        if "reminders" in save_data:
+            save_data["reminders"] = list(
+                cast(Iterable[str], save_data["reminders"])
+            )
+        await onboarding_state.save_state(user_id, REMINDERS, save_data, variant)
         return await _finish(
             message,
             user_id,
@@ -424,15 +429,25 @@ async def reminders_chosen(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         await message.reply_text("Отменено.")
         return ConversationHandler.END
     if data.startswith(CB_REMINDER_PREFIX):
-        reminders = cast(set[str], user_data.setdefault("reminders", set()))
+        reminders = cast(list[str], user_data.setdefault("reminders", []))
         code = data[len(CB_REMINDER_PREFIX) :]
         if code in reminders:
             reminders.remove(code)
         else:
-            reminders.add(code)
-        await onboarding_state.save_state(user_id, REMINDERS, user_data, variant)
+            reminders.append(code)
+        await onboarding_state.save_state(
+            user_id,
+            REMINDERS,
+            {**user_data, "reminders": list(reminders)},
+            variant,
+        )
         return REMINDERS
-    await onboarding_state.save_state(user_id, REMINDERS, user_data, variant)
+    save_data = dict(user_data)
+    if "reminders" in save_data:
+        save_data["reminders"] = list(
+            cast(Iterable[str], save_data["reminders"])
+        )
+    await onboarding_state.save_state(user_id, REMINDERS, save_data, variant)
     return REMINDERS
 
 
@@ -468,7 +483,12 @@ async def onboarding_reminders(
     message = cast(Message, query.message)
     user_data = cast(dict[str, Any], getattr(context, "user_data", {}))
     variant = cast(str | None, user_data.get("variant"))
-    await onboarding_state.save_state(user.id, REMINDERS, user_data, variant)
+    save_data = dict(user_data)
+    if "reminders" in save_data:
+        save_data["reminders"] = list(
+            cast(Iterable[str], save_data["reminders"])
+        )
+    await onboarding_state.save_state(user.id, REMINDERS, save_data, variant)
     return await _finish(
         message,
         user.id,
@@ -487,7 +507,7 @@ async def _finish(
     await onboarding_state.complete_state(user_id)
     await _mark_user_complete(user_id)
     reminders = []
-    for code in cast(set[str], user_data.get("reminders", set())):
+    for code in cast(list[str], user_data.get("reminders", [])):
         rem = await reminder_handlers.create_reminder_from_preset(
             user_id, code, job_queue
         )

--- a/tests/diabetes/test_onboarding_flow.py
+++ b/tests/diabetes/test_onboarding_flow.py
@@ -21,7 +21,10 @@ def fake_state(monkeypatch: pytest.MonkeyPatch) -> None:
         user_id: int, step: int, data: dict[str, object], variant: str | None = None
     ) -> None:
         steps[user_id] = step
-        store[user_id] = dict(data)
+        save_data = dict(data)
+        if isinstance(save_data.get("reminders"), set):
+            save_data["reminders"] = list(save_data["reminders"])
+        store[user_id] = save_data
         variants[user_id] = variant
 
     class DummyState:

--- a/tests/diabetes/test_onboarding_reminders.py
+++ b/tests/diabetes/test_onboarding_reminders.py
@@ -90,9 +90,14 @@ async def test_onboarding_creates_reminder(monkeypatch: pytest.MonkeyPatch) -> N
     steps: dict[int, int] = {}
     variants: dict[int, str | None] = {}
 
-    async def save_state(user_id: int, step: int, data: dict[str, Any], variant: str | None = None) -> None:
+    async def save_state(
+        user_id: int, step: int, data: dict[str, Any], variant: str | None = None
+    ) -> None:
         steps[user_id] = step
-        store[user_id] = dict(data)
+        save_data = dict(data)
+        if isinstance(save_data.get("reminders"), set):
+            save_data["reminders"] = list(save_data["reminders"])
+        store[user_id] = save_data
         variants[user_id] = variant
 
     class DummyState:

--- a/tests/test_onboarding_conversation.py
+++ b/tests/test_onboarding_conversation.py
@@ -21,7 +21,10 @@ def fake_onboarding_state(monkeypatch: pytest.MonkeyPatch) -> None:
         user_id: int, step: int, data: dict[str, object], variant: str | None = None
     ) -> None:
         steps[user_id] = step
-        store[user_id] = dict(data)
+        save_data = dict(data)
+        if isinstance(save_data.get("reminders"), set):
+            save_data["reminders"] = list(save_data["reminders"])
+        store[user_id] = save_data
         variants[user_id] = variant
 
     class DummyState:


### PR DESCRIPTION
## Summary
- store onboarding reminders in a list and convert before persisting state
- iterate over reminders list in `_finish`
- adjust onboarding tests for list-based reminders

## Testing
- `BILLING_ADMIN_TOKEN=dummy pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b8958ffd2c832a88030c7d00af88c8