### PR TITLE
[handlers] Remove poll from onboarding skip

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -450,7 +450,6 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     await onboarding_state.complete_state(user.id)
     await _mark_user_complete(user.id)
     await _log_event(user.id, "onboarding_finished", 3, variant)
-    await message.reply_poll("Пропущено", ["OK"])
     await message.reply_text("Пропущено", reply_markup=menu_keyboard())
     return ConversationHandler.END
 

--- a/tests/handlers/test_wizard_navigation.py
+++ b/tests/handlers/test_wizard_navigation.py
@@ -18,10 +18,12 @@ class DummyMessage:
         self.text = text
         self.texts: list[str] = []
         self.polls: list[tuple[str, list[str]]] = []
+        self.reply_markups: list[Any] = []
         self.deleted = False
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
+        self.reply_markups.append(kwargs.get("reply_markup"))
 
     async def reply_poll(self, question: str, options: list[str], **kwargs: Any) -> Any:
         self.polls.append((question, options))
@@ -181,8 +183,9 @@ async def test_onboarding_skip_sends_final(
 
     state = await onboarding.onboarding_skip(update, context)
     assert state == ConversationHandler.END
-    assert message.polls
-    assert any("Пропущено" in text for text in message.texts)
+    assert not message.polls
+    assert message.texts == ["Пропущено"]
+    assert message.reply_markups == ["MK"]
     engine.dispose()
 
 


### PR DESCRIPTION
## Summary
- eliminate single-option poll in onboarding skip and just show menu
- cover onboarding_skip flow without poll errors

## Testing
- `pytest -q --cov` (fails: BillingSettings validation errors in billing tests)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b895972ba8832a91d3d75d9fe86dd1