### PR TITLE
[migrations] avoid enum type creation for subscription plan

### DIFF
--- a/services/api/alembic/versions/20250909_add_subscriptions_table.py
+++ b/services/api/alembic/versions/20250909_add_subscriptions_table.py
@@ -14,7 +14,13 @@ down_revision: Union[str, Sequence[str], None] = (
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-plan_enum = sa.Enum("free", "pro", "family", name="subscription_plan")
+plan_enum = sa.Enum(
+    "free",
+    "pro",
+    "family",
+    name="subscription_plan",
+    create_type=False,
+)
 status_enum = sa.Enum(
     "trial",
     "pending",


### PR DESCRIPTION
## Summary
- avoid recreating Postgres enum type for subscription plans

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `make migrate` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b89d4b95e4832a8f38feb28f0d6c9a