### PR TITLE
[migrations] Move onboarding_state migration to alembic

### DIFF
--- a/services/api/alembic.ini
+++ b/services/api/alembic.ini
@@ -8,7 +8,7 @@
 
 script_location = services/api/alembic
 
-version_locations = %(here)s/alembic/versions:%(here)s/app/db/migrations/versions
+version_locations = %(here)s/alembic/versions
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 # Uncomment the line below if you want the files to be prepended with date and time

--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -14,7 +14,12 @@ logger = logging.getLogger(__name__)
 
 # === ЛОГИРОВАНИЕ ===
 config = context.config
-if config.config_file_name is not None:
+if hasattr(config, "set_main_option"):
+    config.set_main_option("script_location", str(Path(__file__).resolve().parent))
+    config.set_main_option(
+        "version_locations", str(Path(__file__).resolve().parent / "versions")
+    )
+if getattr(config, "config_file_name", None) is not None:
     fileConfig(config.config_file_name)
 
 # === PYTHONPATH: добавим корень репозитория, чтобы импортировать app.* ===
@@ -36,9 +41,7 @@ else:
 try:
     from services.api.app.config import settings  # FastAPI/Pydantic settings
 except ImportError:
-    logger.info(
-        "services.api.app.config not found; falling back to app.config"
-    )
+    logger.info("services.api.app.config not found; falling back to app.config")
     # альтернативный импорт, если пакетная структура другая
     from app.config import settings  # type: ignore
 

--- a/services/api/alembic/versions/20250907_onboarding_state.py
+++ b/services/api/alembic/versions/20250907_onboarding_state.py
@@ -12,7 +12,12 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "onboarding_states",
-        sa.Column("user_id", sa.BigInteger(), sa.ForeignKey("users.telegram_id"), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.BigInteger(),
+            sa.ForeignKey("users.telegram_id"),
+            primary_key=True,
+        ),
         sa.Column("step", sa.String(), nullable=False),
         sa.Column("data_json", sa.JSON(), nullable=True),
         sa.Column(


### PR DESCRIPTION
## Summary
- move onboarding_state migration into central Alembic versions directory
- point alembic.ini/env.py at services/api/alembic/versions

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `DATABASE_URL=sqlite:///tmp.db alembic -c services/api/alembic.ini upgrade head` *(fails: near "ALTER": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68b90ed2c324832abd14ae5a4ace00cd