### PR TITLE
[migrations] add onboarding_events_metrics table

### DIFF
--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -50,6 +50,15 @@ except ImportError:
     )
     from app.diabetes.services.db import Base  # type: ignore
 
+# Ensure models are imported so Alembic's autogenerate can discover them
+try:
+    import services.api.app.diabetes.models  # noqa: F401
+except ImportError:
+    logger.info(
+        "services.api.app.diabetes.models not found; falling back to app.diabetes.models"
+    )
+    import app.diabetes.models  # type: ignore  # noqa: F401
+
 target_metadata = Base.metadata
 
 

--- a/services/api/alembic/versions/20250910_add_onboarding_events_metrics.py
+++ b/services/api/alembic/versions/20250910_add_onboarding_events_metrics.py
@@ -1,0 +1,32 @@
+"""add onboarding_events_metrics"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20250910_add_onboarding_events_metrics"
+down_revision: Union[str, Sequence[str], None] = "20250909_add_subscriptions_table"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "onboarding_events_metrics",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("variant", sa.String(), nullable=False),
+        sa.Column("step", sa.String(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("onboarding_events_metrics")
+


### PR DESCRIPTION
## Summary
- ensure Alembic loads diabetes models for autogenerate
- add migration creating onboarding_events_metrics table

## Testing
- `alembic -c services/api/alembic.ini upgrade head`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b90ed5f574832aa51b272c9ced55a4