### PR TITLE
[db] remove obsolete UserSettings model

### DIFF
--- a/migrations/versions/20250905_drop_user_settings.py
+++ b/migrations/versions/20250905_drop_user_settings.py
@@ -1,0 +1,41 @@
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250905_drop_user_settings"
+down_revision: Union[str, Sequence[str], None] = "20250904_billing_log"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_table("user_settings")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "user_settings",
+        sa.Column(
+            "telegram_id",
+            sa.BigInteger(),
+            sa.ForeignKey("users.telegram_id"),
+            primary_key=True,
+        ),
+        sa.Column("icr", sa.Float(), nullable=False, server_default="1.0"),
+        sa.Column("cf", sa.Float(), nullable=False, server_default="1.0"),
+        sa.Column("target_bg", sa.Float(), nullable=False, server_default="5.5"),
+        sa.Column("low_threshold", sa.Float(), nullable=False, server_default="4.0"),
+        sa.Column("high_threshold", sa.Float(), nullable=False, server_default="8.0"),
+        sa.Column("quiet_start", sa.Time(), nullable=False, server_default="23:00:00"),
+        sa.Column("quiet_end", sa.Time(), nullable=False, server_default="07:00:00"),
+        sa.Column("sos_alerts_enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.alter_column("user_settings", "icr", server_default=None)
+    op.alter_column("user_settings", "cf", server_default=None)
+    op.alter_column("user_settings", "target_bg", server_default=None)
+    op.alter_column("user_settings", "low_threshold", server_default=None)
+    op.alter_column("user_settings", "high_threshold", server_default=None)
+    op.alter_column("user_settings", "quiet_start", server_default=None)
+    op.alter_column("user_settings", "quiet_end", server_default=None)
+    op.alter_column("user_settings", "sos_alerts_enabled", server_default=None)

--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -46,7 +46,7 @@ class LocalProfile:
 
 
 @dataclass
-class LocalUserSettings:
+class LocalProfileSettings:
     """Local representation of profile settings when SDK is unavailable."""
 
     telegram_id: int
@@ -246,12 +246,12 @@ def set_timezone(session: Session, user_id: int, tz: str) -> tuple[bool, bool]:
     return patch_user_settings(session, user_id, ProfileSettingsIn(timezone=tz))
 
 
-def get_user_settings(session: Session, user_id: int) -> LocalUserSettings | None:
+def get_profile_settings(session: Session, user_id: int) -> LocalProfileSettings | None:
     """Fetch user settings from the database."""
     profile = session.get(Profile, user_id)
     if not profile:
         return None
-    return LocalUserSettings(
+    return LocalProfileSettings(
         telegram_id=profile.telegram_id,
         timezone=profile.timezone,
         timezone_auto=profile.timezone_auto,

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -50,9 +50,7 @@ def _register_sqlite_adapters() -> None:
     sqlite3.register_adapter(date, lambda val: val.isoformat())
     sqlite3.register_adapter(time, lambda val: val.isoformat())
 
-    sqlite3.register_converter(
-        "timestamp", lambda b: datetime.fromisoformat(b.decode())
-    )
+    sqlite3.register_converter("timestamp", lambda b: datetime.fromisoformat(b.decode()))
     sqlite3.register_converter("date", lambda b: date.fromisoformat(b.decode()))
     sqlite3.register_converter("time", lambda b: time.fromisoformat(b.decode()))
 
@@ -110,12 +108,8 @@ async def run_db(
         with sessionmaker() as _session:
             bind = _session.get_bind()
     except UnboundExecutionError as exc:
-        logger.error(
-            "Database engine is not initialized. Call init_db() to configure it."
-        )
-        raise RuntimeError(
-            "Database engine is not initialized; run init_db() before calling run_db()."
-        ) from exc
+        logger.error("Database engine is not initialized. Call init_db() to configure it.")
+        raise RuntimeError("Database engine is not initialized; run init_db() before calling run_db().") from exc
 
     if bind.url.drivername == "sqlite" and bind.url.database == ":memory:":
         with sqlite_memory_lock:
@@ -157,27 +151,19 @@ class User(Base):
     onboarding_complete: Mapped[bool] = mapped_column(Boolean, default=False)
     plan: Mapped[str] = mapped_column(String, default="free")
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
-    profile: Mapped["Profile"] = relationship(
-        "Profile", back_populates="user", uselist=False
-    )
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
+    profile: Mapped["Profile"] = relationship("Profile", back_populates="user", uselist=False)
 
 
 class UserRole(Base):
     __tablename__ = "user_roles"
-    user_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
-    )
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), primary_key=True)
     role: Mapped[str] = mapped_column(String, nullable=False, default="patient")
 
 
 class Profile(Base):
     __tablename__ = "profiles"
-    telegram_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
-    )
+    telegram_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), primary_key=True)
     icr: Mapped[Optional[float]] = mapped_column(Float)
     cf: Mapped[Optional[float]] = mapped_column(Float)
     target_bg: Mapped[Optional[float]] = mapped_column(Float)
@@ -213,43 +199,15 @@ class Profile(Base):
     user: Mapped[User] = relationship("User", back_populates="profile")
 
 
-class UserSettings(Base):
-    """Per-user configurable settings."""
-
-    __tablename__ = "user_settings"
-
-    telegram_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
-    )
-    icr: Mapped[float] = mapped_column(Float, default=1.0)
-    cf: Mapped[float] = mapped_column(Float, default=1.0)
-    target_bg: Mapped[float] = mapped_column(Float, default=5.5)
-    low_threshold: Mapped[float] = mapped_column(Float, default=4.0)
-    high_threshold: Mapped[float] = mapped_column(Float, default=8.0)
-    quiet_start: Mapped[time] = mapped_column(Time, default=time(23, 0))
-    quiet_end: Mapped[time] = mapped_column(Time, default=time(7, 0))
-    sos_alerts_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
-
-    user: Mapped[User] = relationship("User")
-
-
 class Entry(Base):
     __tablename__ = "entries"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    telegram_id: Mapped[Optional[int]] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id")
-    )
+    telegram_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("users.telegram_id"))
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
 
-    event_time: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=False
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
-    updated_at: Mapped[Optional[datetime]] = mapped_column(
-        TIMESTAMP(timezone=True), onupdate=func.now()
-    )
+    event_time: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), onupdate=func.now())
 
     photo_path: Mapped[Optional[str]] = mapped_column(String)
     carbs_g: Mapped[Optional[float]] = mapped_column(Float)
@@ -266,16 +224,12 @@ class Entry(Base):
 class Alert(Base):
     __tablename__ = "alerts"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    user_id: Mapped[Optional[int]] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id")
-    )
+    user_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("users.telegram_id"))
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
     sugar: Mapped[Optional[float]] = mapped_column(Float)
     type: Mapped[Optional[str]] = mapped_column(String)
 
-    ts: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
+    ts: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
 
     resolved: Mapped[bool] = mapped_column(Boolean, default=False)
     user: Mapped[User] = relationship("User")
@@ -284,9 +238,7 @@ class Alert(Base):
 class Reminder(Base):
     __tablename__ = "reminders"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    telegram_id: Mapped[Optional[int]] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id")
-    )
+    telegram_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("users.telegram_id"))
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
     type: Mapped[str] = mapped_column(String, nullable=False)
     title: Mapped[Optional[str]] = mapped_column(String)
@@ -297,9 +249,7 @@ class Reminder(Base):
     minutes_after: Mapped[Optional[int]] = mapped_column(Integer)
     days_mask: Mapped[Optional[int]] = mapped_column(Integer)
     is_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
     user: Mapped[User] = relationship("User")
 
     def set_interval_hours_if_needed(self, hours: int | None) -> None:
@@ -330,9 +280,7 @@ class Reminder(Base):
 class ReminderLog(Base):
     __tablename__ = "reminder_logs"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    reminder_id: Mapped[Optional[int]] = mapped_column(
-        Integer, ForeignKey("reminders.id")
-    )
+    reminder_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("reminders.id"))
     telegram_id: Mapped[Optional[int]] = mapped_column(
         BigInteger,
         ForeignKey("users.telegram_id"),
@@ -342,9 +290,7 @@ class ReminderLog(Base):
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
     action: Mapped[Optional[str]] = mapped_column(String)
     snooze_minutes: Mapped[Optional[int]] = mapped_column(Integer)
-    event_time: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
+    event_time: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
 
 
 class Timezone(Base):
@@ -383,9 +329,7 @@ class Subscription(Base):
     __tablename__ = "subscriptions"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), index=True, nullable=False
-    )
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), index=True, nullable=False)
     plan: Mapped[SubscriptionPlan] = mapped_column(
         sa.Enum(
             SubscriptionPlan,
@@ -404,16 +348,10 @@ class Subscription(Base):
     )
     provider: Mapped[str] = mapped_column(String, nullable=False)
     transaction_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
-    start_date: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
+    start_date: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
     end_date: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
-    updated_at: Mapped[Optional[datetime]] = mapped_column(
-        TIMESTAMP(timezone=True), onupdate=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), onupdate=func.now())
 
     user: Mapped["User"] = relationship("User")
 
@@ -421,9 +359,7 @@ class Subscription(Base):
 class HistoryRecord(Base):
     __tablename__ = "history_records"
     id: Mapped[str] = mapped_column(String, primary_key=True, index=True)
-    telegram_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), index=True, nullable=False
-    )
+    telegram_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), index=True, nullable=False)
     date: Mapped[date] = mapped_column(Date, nullable=False)
     time: Mapped[time] = mapped_column(Time, nullable=False)
     sugar: Mapped[Optional[float]] = mapped_column(Float)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,18 +26,7 @@ class _DummyBaseHandler:  # pragma: no cover - minimal stub
 dummy.BaseHandler = _DummyBaseHandler
 sys.modules.setdefault("telegram.ext._basehandler", dummy)
 
-dummy_db_models = ModuleType("services.api.app.diabetes.services.db_models")
-class _DummyUserSettings:  # pragma: no cover - minimal stub
-    pass
-
-dummy_db_models.UserSettings = _DummyUserSettings
-sys.modules.setdefault(
-    "services.api.app.diabetes.services.db_models", dummy_db_models
-)
-
-warnings.filterwarnings(
-    "ignore", category=ResourceWarning, module=r"anyio\.streams\.memory"
-)
+warnings.filterwarnings("ignore", category=ResourceWarning, module=r"anyio\.streams\.memory")
 
 from services.api.app.diabetes.services import db as db_module  # noqa: E402
 
@@ -55,9 +44,7 @@ setattr(sqlite3, "connect", _tracking_sqlite_connect)
 
 
 _engines: list[sqlalchemy.engine.Engine] = []
-_original_create_engine: Callable[..., sqlalchemy.engine.Engine] = (
-    sqlalchemy.create_engine
-)
+_original_create_engine: Callable[..., sqlalchemy.engine.Engine] = sqlalchemy.create_engine
 
 
 def _tracking_create_engine(*args: Any, **kwargs: Any) -> sqlalchemy.engine.Engine:
@@ -239,4 +226,5 @@ def _dispose_openai_clients_after_test() -> Iterator[None]:
     """Dispose OpenAI clients after each test."""
     yield
     from services.api.app.diabetes.services.gpt_client import dispose_openai_clients
+
     asyncio.run(dispose_openai_clients())


### PR DESCRIPTION
## Summary
- drop UserSettings SQLAlchemy model and replace its usage with Profile
- drop user_settings table via Alembic migration
- clean up tests and handlers to reference Profile settings

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68b915b2713c832aa4f7640856b77a19