### PR TITLE
[migrations] Use date-based naming for Alembic revisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,9 @@
 - Доступ к БД — через `services.api.app.diabetes.services.db` (`SessionLocal`, `run_db`, `commit`).
 - Логгер: `logger = logging.getLogger(__name__)`.
 
+### Миграции
+- Файлы Alembic и идентификаторы `revision`/`down_revision` именуем в формате `YYYYMMDD_<описание>` (дата + snake_case).
+
 ### Тест-утилиты
 - Для проверки «нет предупреждения» используйте `tests/utils/warn_ctx.py::warn_or_not(None)` вместо `pytest.warns`.
 - Временный `xfail` допускается только с причиной и TODO-сроком.

--- a/migrations/versions/20250901_profile_mvp.py
+++ b/migrations/versions/20250901_profile_mvp.py
@@ -8,7 +8,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "20250901_profile_mvp"
-down_revision: Union[str, Sequence[str], None] = "016dca0fbac4"
+down_revision: Union[str, Sequence[str], None] = "20250903_change_description"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20250807_squashed_initial.py
+++ b/services/api/alembic/versions/20250807_squashed_initial.py
@@ -1,6 +1,6 @@
 """squashed initial
 
-Revision ID: 02857aa7fc3e
+Revision ID: 20250807_squashed_initial
 Revises:
 Create Date: 2025-08-07 09:15:17.518654
 
@@ -14,7 +14,7 @@ from typing import Any, cast
 
 
 # revision identifiers, used by Alembic.
-revision: str = "02857aa7fc3e"
+revision: str = "20250807_squashed_initial"
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/services/api/alembic/versions/20250812_add_org_id_to_reminders.py
+++ b/services/api/alembic/versions/20250812_add_org_id_to_reminders.py
@@ -1,7 +1,7 @@
 """add org_id to reminders safely
 
 Revision ID: 20250812_add_org_id_to_reminders
-Revises: 02857aa7fc3e
+Revises: 20250807_squashed_initial
 Create Date: 2025-08-12 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "20250812_add_org_id_to_reminders"
-down_revision: Union[str, None] = "02857aa7fc3e"
+down_revision: Union[str, None] = "20250807_squashed_initial"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20250824_reminders_kind_minutes_days_mask.py
+++ b/services/api/alembic/versions/20250824_reminders_kind_minutes_days_mask.py
@@ -1,6 +1,6 @@
 """reminders: kind + minutes + days_mask
 
-Revision ID: 8db592ddbe51
+Revision ID: 20250824_reminders_kind_minutes_days_mask
 Revises: 20250820_change_reminder_time_type
 Create Date: 2025-08-24 20:37:49.023280
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '8db592ddbe51'
+revision: str = '20250824_reminders_kind_minutes_days_mask'
 down_revision: Union[str, None] = '20250820_change_reminder_time_type'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/services/api/alembic/versions/20250825_add_quiet_hours_to_profiles.py
+++ b/services/api/alembic/versions/20250825_add_quiet_hours_to_profiles.py
@@ -1,7 +1,7 @@
 """add quiet hours to profiles
 
-Revision ID: 1188e4de1729
-Revises: 8db592ddbe51
+Revision ID: 20250825_add_quiet_hours_to_profiles
+Revises: 20250824_reminders_kind_minutes_days_mask
 Create Date: 2025-08-25 15:24:16.293648
 
 """
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '1188e4de1729'
-down_revision: Union[str, None] = '8db592ddbe51'
+revision: str = '20250825_add_quiet_hours_to_profiles'
+down_revision: Union[str, None] = '20250824_reminders_kind_minutes_days_mask'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20250903_change_description.py
+++ b/services/api/alembic/versions/20250903_change_description.py
@@ -1,6 +1,6 @@
 """change description
 
-Revision ID: 016dca0fbac4
+Revision ID: 20250903_change_description
 Revises: 20250903_add_timezone_auto_to_users
 Create Date: 2025-08-31 10:37:36.590628
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision: str = '016dca0fbac4'
+revision: str = '20250903_change_description'
 down_revision: Union[str, None] = '20250903_add_timezone_auto_to_users'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/services/api/alembic/versions/20250904_add_dia_to_users.py
+++ b/services/api/alembic/versions/20250904_add_dia_to_users.py
@@ -4,7 +4,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "20250904_add_dia_to_users"
-down_revision: Union[str, Sequence[str], None] = "016dca0fbac4"
+down_revision: Union[str, Sequence[str], None] = "20250903_change_description"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py
+++ b/services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Connection
 
 # ID предыдущей и текущей миграции
 revision = '20250828_add_quiet_time'
-down_revision = '1188e4de1729'
+down_revision = '20250825_add_quiet_hours_to_profiles'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- rename hashed Alembic migrations to `YYYYMMDD_<description>` and update revision chains
- document migration file naming convention for future work

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b91b848368832ab7510386e17bf695