### PR TITLE
[handlers] Avoid mutating timezone button

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -121,7 +121,11 @@ def _timezone_keyboard(*, back: bool = True) -> InlineKeyboardMarkup:
     rows: list[list[InlineKeyboardButton]] = []
     auto_btn = build_timezone_webapp_button()
     if auto_btn:
-        auto_btn.text = "Автоопределить (WebApp)"
+        auto_btn = InlineKeyboardButton(
+            text="Автоопределить (WebApp)",
+            callback_data=auto_btn.callback_data,
+            web_app=auto_btn.web_app,
+        )
         rows.append([auto_btn])
     rows.append(_nav_buttons(back=back))
     return InlineKeyboardMarkup(rows)


### PR DESCRIPTION
## Summary
- avoid mutating timezone auto-detect button by creating a new `InlineKeyboardButton`

## Testing
- `pytest --cov --cov-fail-under=85` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b91bb5bf20832aa0edf6014c73a0d5