### PR TITLE
[profile] Skip diabetes_sdk warning without API_URL

### DIFF
--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -146,6 +146,8 @@ def get_api(
     rest of the code can operate without having to handle ``None`` values.
     """
     settings = settings or config.get_settings()
+    if not settings.api_url:
+        return LocalProfileAPI(sessionmaker), Exception, LocalProfile
     try:  # pragma: no cover - exercised in tests but flagged for clarity
         from diabetes_sdk.api.default_api import DefaultApi
         from diabetes_sdk.api_client import ApiClient


### PR DESCRIPTION
## Summary
- avoid diabetes_sdk import warnings unless API_URL configured
- test profile API fallback behavior with and without SDK

## Testing
- `pytest -q --cov` *(fails: hundreds of tests due to missing async plugin and coverage below threshold)*
- `pytest tests/test_profile_no_sdk.py tests/test_profile_api_settings.py -q -o addopts='' --cov=services.api.app.diabetes.handlers.profile.api --cov-report=term-missing --cov-fail-under=0`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b91becb3b8832aa94f3c85c170db69