### PR TITLE
[alembic] apply date-based migration naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 - Алиас `DefaultJobQueue = JobQueue[ContextTypes.DEFAULT_TYPE]`.
 - Доступ к БД — через `services.api.app.diabetes.services.db` (`SessionLocal`, `run_db`, `commit`).
 - Логгер: `logger = logging.getLogger(__name__)`.
+- Миграции Alembic именуются как `YYYYMMDD_<описание>`; `revision` совпадает с именем файла.
 
 ### Тест-утилиты
 - Для проверки «нет предупреждения» используйте `tests/utils/warn_ctx.py::warn_or_not(None)` вместо `pytest.warns`.

--- a/services/api/alembic/versions/20250902_drop_user_timezone.py
+++ b/services/api/alembic/versions/20250902_drop_user_timezone.py
@@ -6,7 +6,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "20250902_drop_user_timezone"
-down_revision: Union[str, Sequence[str], None] = "016dca0fbac4"
+down_revision: Union[str, Sequence[str], None] = "20250904_change_description"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20250904_change_description.py
+++ b/services/api/alembic/versions/20250904_change_description.py
@@ -1,8 +1,8 @@
 """change description
 
-Revision ID: 016dca0fbac4
+Revision ID: 20250904_change_description
 Revises: 20250903_add_timezone_auto_to_users
-Create Date: 2025-08-31 10:37:36.590628
+Create Date: 2025-09-04 10:37:36.590628
 
 """
 from typing import Sequence, Union
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision: str = '016dca0fbac4'
-down_revision: Union[str, None] = '20250903_add_timezone_auto_to_users'
+revision: str = "20250904_change_description"
+down_revision: Union[str, None] = "20250903_add_timezone_auto_to_users"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- rename `016dca0fbac4_change_description` migration to `20250904_change_description`
- update `drop_user_timezone` migration to reference new revision
- document date-based Alembic migration naming scheme

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b921e4e0fc832ab4691ed2ae62cd0b