### PR TITLE
[billing] Parse webhook IPs via BeforeValidator

### DIFF
--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -45,7 +45,7 @@ BILLING_TEST_MODE=true
 BILLING_PROVIDER=dummy
 PAYWALL_MODE=soft
 BILLING_WEBHOOK_SECRET=
-# Comma-separated list of allowed source IPs for billing webhooks
+# Comma-separated list of allowed source IPs for billing webhooks, e.g., "1.2.3.4,5.6.7.8"
 BILLING_WEBHOOK_IPS=
 # Timeout in seconds for webhook signature verification
 BILLING_WEBHOOK_TIMEOUT=5

--- a/services/api/app/billing/config.py
+++ b/services/api/app/billing/config.py
@@ -2,8 +2,22 @@
 
 from __future__ import annotations
 
-from pydantic import Field, field_validator, model_validator
+from typing import Annotated
+
+from pydantic import BeforeValidator, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+CommaSeparatedIPs = Annotated[
+    list[str],
+    BeforeValidator(
+        lambda v: (
+            [ip.strip() for ip in v.split(",") if ip.strip()]
+            if isinstance(v, str)
+            else (v or [])
+        )
+    ),
+]
 
 
 class BillingSettings(BaseSettings):
@@ -15,18 +29,14 @@ class BillingSettings(BaseSettings):
     billing_test_mode: bool = Field(default=True, alias="BILLING_TEST_MODE")
     billing_provider: str = Field(default="dummy", alias="BILLING_PROVIDER")
     paywall_mode: str = Field(default="soft", alias="PAYWALL_MODE")
-    billing_admin_token: str | None = Field(
-        default=None, alias="BILLING_ADMIN_TOKEN"
-    )
+    billing_admin_token: str | None = Field(default=None, alias="BILLING_ADMIN_TOKEN")
     billing_webhook_secret: str | None = Field(
         default=None, alias="BILLING_WEBHOOK_SECRET"
     )
-    billing_webhook_ips: list[str] = Field(
+    billing_webhook_ips: CommaSeparatedIPs = Field(
         default_factory=list, alias="BILLING_WEBHOOK_IPS"
     )
-    billing_webhook_timeout: float = Field(
-        default=5.0, alias="BILLING_WEBHOOK_TIMEOUT"
-    )
+    billing_webhook_timeout: float = Field(default=5.0, alias="BILLING_WEBHOOK_TIMEOUT")
 
     @model_validator(mode="after")
     def _require_admin_token(self) -> "BillingSettings":
@@ -34,14 +44,6 @@ class BillingSettings(BaseSettings):
         if self.billing_provider != "dummy" and not self.billing_admin_token:
             raise ValueError("BILLING_ADMIN_TOKEN is required for non-dummy providers")
         return self
-
-    @field_validator("billing_webhook_ips", mode="before")
-    @classmethod
-    def _split_ips(cls, v: str | list[str]) -> list[str]:
-        """Split comma-separated IP list from env."""
-        if isinstance(v, str):
-            return [ip.strip() for ip in v.split(",") if ip.strip()]
-        return v
 
 
 billing_settings = BillingSettings()


### PR DESCRIPTION
## Summary
- parse `BILLING_WEBHOOK_IPS` using `BeforeValidator`
- document webhook IP format in env example

## Testing
- `ruff check services/api/app/billing/config.py`
- `mypy --strict services/api/app/billing/config.py`
- `pytest --no-cov tests/billing`


------
https://chatgpt.com/codex/tasks/task_e_68b926a9166c832a8089e587b0bc2332