### PR TITLE
[billing] Parse webhook IPs from raw string

### DIFF
--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -45,7 +45,7 @@ BILLING_TEST_MODE=true
 BILLING_PROVIDER=dummy
 PAYWALL_MODE=soft
 BILLING_WEBHOOK_SECRET=
-# Comma-separated list of allowed source IPs for billing webhooks, e.g., "1.2.3.4,5.6.7.8"
+# Comma-separated string of allowed source IPs for billing webhooks, e.g., "1.2.3.4,5.6.7.8"
 BILLING_WEBHOOK_IPS=
 # Timeout in seconds for webhook signature verification
 BILLING_WEBHOOK_TIMEOUT=5

--- a/tests/billing/test_billing_config.py
+++ b/tests/billing/test_billing_config.py
@@ -18,3 +18,15 @@ def test_real_provider_requires_admin_token(monkeypatch) -> None:
     monkeypatch.delenv("BILLING_ADMIN_TOKEN", raising=False)
     with pytest.raises(ValidationError):
         BillingSettings()
+
+
+def test_webhook_ips_empty(monkeypatch) -> None:
+    monkeypatch.delenv("BILLING_WEBHOOK_IPS", raising=False)
+    settings = BillingSettings()
+    assert settings.billing_webhook_ips == []
+
+
+def test_webhook_ips_parsing(monkeypatch) -> None:
+    monkeypatch.setenv("BILLING_WEBHOOK_IPS", "1.2.3.4,5.6.7.8")
+    settings = BillingSettings()
+    assert settings.billing_webhook_ips == ["1.2.3.4", "5.6.7.8"]


### PR DESCRIPTION
## Summary
- parse billing webhook IPs from raw env string
- document billing webhook IP env var format
- test billing webhook IP parsing

## Testing
- `ruff check services/api/app/billing/config.py tests/billing/test_billing_config.py`
- `mypy --strict services/api/app/billing/config.py tests/billing/test_billing_config.py`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*


------
https://chatgpt.com/codex/tasks/task_e_68b92b467c08832aa2d6241f864df973