### PR TITLE
[handlers] Distinguish initial GPT flag cleanup job

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -281,7 +281,7 @@ def register_handlers(
         jq.run_once(
             _clear_waiting_flags,
             when=datetime.timedelta(seconds=0),
-            name="clear_waiting_gpt_flags",
+            name="clear_waiting_gpt_flags_once",
         )
         jq.run_repeating(
             _clear_waiting_flags,

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -410,9 +410,11 @@ def test_register_handlers_schedules_cleanup(monkeypatch: pytest.MonkeyPatch) ->
 
     def fake_run_once(self, callback: Any, *args: Any, **kwargs: Any) -> None:
         run_once_called["callback"] = callback
+        run_once_called["name"] = kwargs.get("name")
 
     def fake_run_repeating(self, callback: Any, *args: Any, **kwargs: Any) -> None:
         run_repeating_called["callback"] = callback
+        run_repeating_called["name"] = kwargs.get("name")
 
     monkeypatch.setattr(JobQueue, "run_once", fake_run_once)
     monkeypatch.setattr(JobQueue, "run_repeating", fake_run_repeating)
@@ -421,4 +423,6 @@ def test_register_handlers_schedules_cleanup(monkeypatch: pytest.MonkeyPatch) ->
     register_handlers(app)
 
     assert run_once_called.get("callback") is not None
+    assert run_once_called.get("name") == "clear_waiting_gpt_flags_once"
     assert run_repeating_called.get("callback") is not None
+    assert run_repeating_called.get("name") == "clear_waiting_gpt_flags"


### PR DESCRIPTION
## Summary
- rename initial GPT flag cleanup job to `clear_waiting_gpt_flags_once`
- test registration schedules cleanup jobs with distinct names

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b92fe71dc4832a85505e0f661508e7