### PR TITLE
docs: add bot systemd unit example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,8 @@ Telegram WebApp. Обёртка `tgFetch` добавляет его автома
 - `QA_Test_Plan.md` — план тестирования
 - `PERSONAS.md` — пользовательские сегменты
 - `assets/` — медиафайлы для документации и примеров
+- `deploy/` — примеры конфигураций для развёртывания, например systemd unit
+  `diabetes-bot.service` и `diabetes-assistant.service`
 
 > **Примечание.** API WebApp требует заголовок `X-Telegram-Init-Data` с данными
 > инициализации Telegram. Хелпер `tgFetch` добавляет его автоматически;

--- a/docs/deploy/diabetes-bot.service
+++ b/docs/deploy/diabetes-bot.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Diabetes Telegram bot
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+PermissionsStartOnly=true
+WorkingDirectory=/opt/saharlight-ux
+EnvironmentFile=/opt/saharlight-ux/.env
+Environment=MPLCONFIGDIR=/var/cache/diabetes-bot/mpl
+ExecStartPre=/usr/bin/mkdir -p /var/cache/diabetes-bot/mpl
+ExecStartPre=/usr/bin/chown www-data:www-data /var/cache/diabetes-bot/mpl
+ExecStart=/opt/saharlight-ux/scripts/run_bot.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add systemd unit for running the Telegram bot with MPL cache setup
- document deploy configs including new bot unit

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b92fd9fdd8832abb3deabe1a4cf33c