### PR TITLE
[ci] use Python 3.12

### DIFF
--- a/.github/workflows/billing.yml
+++ b/.github/workflows/billing.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - run: pnpm install
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- use Python 3.12 in all CI workflows

## Testing
- `pytest --cov=services.api.app.diabetes --cov-report=term-missing --cov-report=xml --junitxml=pytest-report.xml`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b935a0e920832a8040c1634f86f927