### PR TITLE
[handlers] Fallback import for TypedDict

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -1,7 +1,11 @@
 """Handlers package public exports and shared types."""
 
 import datetime
-from typing import TypedDict
+
+try:
+    from typing import TypedDict  # Python 3.12+
+except ImportError:  # Python <3.12
+    from typing_extensions import TypedDict
 
 from telegram import CallbackQuery
 


### PR DESCRIPTION
## Summary
- ensure TypedDict is available on Python 3.11 using typing_extensions

## Testing
- `pytest -q --cov` *(fails: Coverage failure: total of 55 is less than fail-under=85)*
- `mypy --strict .`
- `ruff check .`
- `python - <<'PY' import sys, importlib; sys.path.append('services/api/app'); import importlib; h = importlib.import_module('diabetes.handlers'); print('ok', h.EntryData is not None, h.UserData is not None); PY`
- `PYENV_VERSION=3.11.12 pyenv exec python - <<'PY' import sys, importlib; sys.path.append('services/api/app'); h = importlib.import_module('diabetes.handlers'); print('ok', h.EntryData is not None, h.UserData is not None); PY`


------
https://chatgpt.com/codex/tasks/task_e_68b935ab68c4832ab60dae292f85127a