### PR TITLE
[onboarding] Add optional onboarding video

### DIFF
--- a/config.py
+++ b/config.py
@@ -23,6 +23,7 @@ from services.api.app.config import settings
 # reference them directly if needed.  Values default to ``None`` when not
 # provided which is convenient for tests where most variables are unset.
 TELEGRAM_TOKEN = settings.telegram_token
+ONBOARDING_VIDEO_URL = settings.onboarding_video_url
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 DB_HOST = os.getenv("DB_HOST")
 DB_PORT = os.getenv("DB_PORT")
@@ -56,4 +57,6 @@ def validate_tokens(required: Iterable[str] | None = None) -> None:
         elif not os.getenv(var):
             missing.append(var)
     if missing:
-        raise RuntimeError("Missing required environment variables: " + ", ".join(missing))
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(missing)
+        )

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -35,6 +35,9 @@ OPENAI_PROXY=  # e.g., http://proxy.local:8080
 # Custom font directory
 FONT_DIR=infra/fonts
 
+# Onboarding
+ONBOARDING_VIDEO_URL=
+
 # Telegram
 TELEGRAM_TOKEN=your-telegram-bot-token
 TELEGRAM_PAYMENTS_PROVIDER_TOKEN=your-telegram-payments-token

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -11,7 +11,9 @@ from pydantic import Field, field_validator
 try:  # pragma: no cover - import guard
     from pydantic_settings import BaseSettings, SettingsConfigDict
 except ModuleNotFoundError as exc:  # pragma: no cover - executed at import time
-    raise ImportError("`pydantic-settings` is required. Install it with `pip install pydantic-settings`.") from exc
+    raise ImportError(
+        "`pydantic-settings` is required. Install it with `pip install pydantic-settings`."
+    ) from exc
 
 
 logger = logging.getLogger(__name__)
@@ -54,17 +56,28 @@ class Settings(BaseSettings):
     ui_base_url: str = Field(default="/ui", alias="UI_BASE_URL")
     api_url: Optional[str] = Field(default=None, alias="API_URL")
     openai_api_key: Optional[str] = Field(default=None, alias="OPENAI_API_KEY")
-    openai_assistant_id: Optional[str] = Field(default=None, alias="OPENAI_ASSISTANT_ID")
-    openai_command_model: str = Field(default="gpt-4o-mini", alias="OPENAI_COMMAND_MODEL")
+    openai_assistant_id: Optional[str] = Field(
+        default=None, alias="OPENAI_ASSISTANT_ID"
+    )
+    openai_command_model: str = Field(
+        default="gpt-4o-mini", alias="OPENAI_COMMAND_MODEL"
+    )
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
     font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
+    onboarding_video_url: Optional[str] = Field(
+        default=None, alias="ONBOARDING_VIDEO_URL"
+    )
     telegram_token: Optional[str] = Field(default=None, alias="TELEGRAM_TOKEN")
-    telegram_payments_provider_token: Optional[str] = Field(default=None, alias="TELEGRAM_PAYMENTS_PROVIDER_TOKEN")
+    telegram_payments_provider_token: Optional[str] = Field(
+        default=None, alias="TELEGRAM_PAYMENTS_PROVIDER_TOKEN"
+    )
     admin_id: Optional[int] = Field(default=None, alias="ADMIN_ID")
 
     @field_validator("log_level", mode="before")
     @classmethod
-    def parse_log_level(cls, v: int | str | None) -> int:  # pragma: no cover - simple parsing
+    def parse_log_level(
+        cls, v: int | str | None
+    ) -> int:  # pragma: no cover - simple parsing
         if isinstance(v, str):
             v_lower = v.lower()
             level_map: dict[str, int] = {

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -32,6 +32,7 @@ from telegram.ext import (
 )
 from telegram.warnings import PTBUserWarning
 
+import config
 from services.api.app.diabetes.services.db import SessionLocal, User, run_db
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.services import onboarding_state
@@ -169,6 +170,12 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     user = update.effective_user
     if message is None or user is None:
         return ConversationHandler.END
+    video_url = config.ONBOARDING_VIDEO_URL
+    if video_url:
+        try:
+            await message.reply_video(video_url)
+        except Exception:  # pragma: no cover - fallback
+            await message.reply_text(video_url)
     user_id = user.id
     user_data = cast(dict[str, Any], context.user_data)
     args = getattr(context, "args", [])
@@ -433,9 +440,7 @@ async def reminders_chosen(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if data in {CB_SKIP, CB_DONE}:
         save_data = dict(user_data)
         if "reminders" in save_data:
-            save_data["reminders"] = list(
-                cast(Iterable[str], save_data["reminders"])
-            )
+            save_data["reminders"] = list(cast(Iterable[str], save_data["reminders"]))
         await onboarding_state.save_state(user_id, REMINDERS, save_data, variant)
         return await _finish(
             message,
@@ -463,9 +468,7 @@ async def reminders_chosen(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         return REMINDERS
     save_data = dict(user_data)
     if "reminders" in save_data:
-        save_data["reminders"] = list(
-            cast(Iterable[str], save_data["reminders"])
-        )
+        save_data["reminders"] = list(cast(Iterable[str], save_data["reminders"]))
     await onboarding_state.save_state(user_id, REMINDERS, save_data, variant)
     return REMINDERS
 
@@ -503,9 +506,7 @@ async def onboarding_reminders(
     variant = cast(str | None, user_data.get("variant"))
     save_data = dict(user_data)
     if "reminders" in save_data:
-        save_data["reminders"] = list(
-            cast(Iterable[str], save_data["reminders"])
-        )
+        save_data["reminders"] = list(cast(Iterable[str], save_data["reminders"]))
     await onboarding_state.save_state(user.id, REMINDERS, save_data, variant)
     return await _finish(
         message,

--- a/tests/test_onboarding_video.py
+++ b/tests/test_onboarding_video.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext, ConversationHandler
+
+import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.videos: list[str] = []
+        self.texts: list[str] = []
+
+    async def reply_video(self, url: str, **kwargs: Any) -> None:
+        self.videos.append(url)
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.texts.append(text)
+
+
+async def _noop_prompt(*args: Any, **kwargs: Any) -> int:
+    return ConversationHandler.END
+
+
+@pytest.mark.asyncio
+async def test_start_command_sends_video(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        onboarding.config, "ONBOARDING_VIDEO_URL", "https://e.co/v.mp4", raising=False
+    )
+
+    async def _load_state(uid: int) -> None:
+        return None
+
+    monkeypatch.setattr(onboarding.onboarding_state, "load_state", _load_state)
+    monkeypatch.setattr(onboarding, "_prompt_profile", _noop_prompt)
+    monkeypatch.setattr(onboarding, "_prompt_timezone", _noop_prompt)
+    monkeypatch.setattr(onboarding, "_prompt_reminders", _noop_prompt)
+
+    message = DummyMessage()
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}, job_queue=None),
+    )
+
+    await onboarding.start_command(update, context)
+    assert message.videos == ["https://e.co/v.mp4"]
+    assert not message.texts
+
+
+@pytest.mark.asyncio
+async def test_start_command_sends_link_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        onboarding.config, "ONBOARDING_VIDEO_URL", "https://e.co/v.mp4", raising=False
+    )
+
+    async def _load_state(uid: int) -> None:
+        return None
+
+    monkeypatch.setattr(onboarding.onboarding_state, "load_state", _load_state)
+    monkeypatch.setattr(onboarding, "_prompt_profile", _noop_prompt)
+    monkeypatch.setattr(onboarding, "_prompt_timezone", _noop_prompt)
+    monkeypatch.setattr(onboarding, "_prompt_reminders", _noop_prompt)
+
+    message = DummyMessage()
+
+    async def fail_video(
+        url: str, **kwargs: Any
+    ) -> None:  # pragma: no cover - forced error
+        raise RuntimeError
+
+    message.reply_video = fail_video  # type: ignore[assignment]
+
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}, job_queue=None),
+    )
+
+    await onboarding.start_command(update, context)
+    assert message.texts == ["https://e.co/v.mp4"]
+    assert not message.videos


### PR DESCRIPTION
## Summary
- add `ONBOARDING_VIDEO_URL` to settings and root config
- send onboarding video or link during `/start`
- document new env var and test video/link behaviour

## Testing
- `make ci` *(fails: No rule to make target 'ci')*
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b937c1375c832abc70ffda4d1dba64