### PR TITLE
docs: clarify diabetes sdk installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ cp infra/env/.env.example .env
 ```
 Заполните `.env` своими значениями.
 
+### Установка `diabetes_sdk`
+Для доступа к внешнему API нужен приватный пакет `diabetes_sdk`. 
+Получите доступ у мейнтейнеров и установите его вручную, например:
+
+```bash
+# через приватный репозиторий
+pip install git+https://github.com/Offonika/diabetes_sdk.git
+
+# либо из локальной сборки SDK
+pip install -r libs/py-sdk/requirements.txt
+pip install -e libs/py-sdk
+```
+Если SDK не установлен, функциональность, требующая внешнего API, будет недоступна.
+
 ## Запуск API
 ```bash
 uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000

--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -5,7 +5,7 @@ APScheduler>=3.10,<3.11
 certifi==2025.4.26
 contourpy==1.3.2
 cycler==0.12.1
-diabetes_sdk
+# diabetes_sdk  # Private SDK, see README for installation instructions
 distro==1.9.0
 fonttools==4.58.4
 greenlet==3.2.1

--- a/services/worker/requirements.txt
+++ b/services/worker/requirements.txt
@@ -1,4 +1,4 @@
-diabetes_sdk
+# diabetes_sdk  # Private SDK, see README for installation instructions
 
 # Optional: use local SDK for development
 # -e ../../libs/py-sdk


### PR DESCRIPTION
## Summary
- comment out `diabetes_sdk` in requirements files
- document how to install the private `diabetes_sdk` in the README

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b941875b08832a88d2659c2d75756c