### PR TITLE
[billing] ignore env file in billing tests

### DIFF
--- a/tests/billing/test_billing_config.py
+++ b/tests/billing/test_billing_config.py
@@ -22,7 +22,7 @@ def test_real_provider_requires_admin_token(monkeypatch) -> None:
 
 def test_webhook_ips_empty(monkeypatch) -> None:
     monkeypatch.delenv("BILLING_WEBHOOK_IPS", raising=False)
-    settings = BillingSettings()
+    settings = BillingSettings(_env_file=None)
     assert settings.billing_webhook_ips == []
 
 

--- a/tests/billing/test_billing_webhook.py
+++ b/tests/billing/test_billing_webhook.py
@@ -47,6 +47,7 @@ def make_client(
         BILLING_TEST_MODE=True,
         BILLING_PROVIDER="dummy",
         PAYWALL_MODE="soft",
+        _env_file=None,
         **settings_kwargs,
     )
     client = TestClient(app)


### PR DESCRIPTION
## Summary
- ignore env file in `test_webhook_ips_empty`
- ignore env file when creating billing webhook test client

## Testing
- `pytest tests/billing --override-ini "addopts=--cov=services.api.app.billing --cov-report=term-missing --cov-fail-under=85" -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b942a31208832a8497f736d30a52c3