### PR TITLE
[tests] Ignore .env API_URL in profile tests

### DIFF
--- a/tests/test_profile_no_sdk.py
+++ b/tests/test_profile_no_sdk.py
@@ -107,6 +107,8 @@ async def test_profile_command_and_view_without_sdk(
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     monkeypatch.delenv("API_URL", raising=False)
+    import services.api.app.config as config_module
+    monkeypatch.setattr(config_module, "settings", Settings(_env_file=None))
     import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
     import importlib
@@ -171,7 +173,8 @@ def test_get_api_uses_local_when_no_api_url(
 
     _patch_import(monkeypatch)
     monkeypatch.delenv("API_URL", raising=False)
-
+    import services.api.app.config as config_module
+    monkeypatch.setattr(config_module, "settings", Settings(_env_file=None))
     from services.api.app.diabetes.handlers.profile.api import (
         LocalProfileAPI,
         LocalProfile,
@@ -179,7 +182,7 @@ def test_get_api_uses_local_when_no_api_url(
     )
 
     with caplog.at_level(logging.WARNING):
-        api, exc, model = get_api(settings=Settings(_env_file=None))
+        api, exc, model = get_api(settings=config_module.settings)
 
     assert isinstance(api, LocalProfileAPI)
     assert exc is Exception


### PR DESCRIPTION
## Summary
- prevent `.env`'s API_URL from affecting no-SDK profile tests

## Testing
- `pytest tests/test_profile_no_sdk.py::test_profile_command_and_view_without_sdk tests/test_profile_no_sdk.py::test_get_api_uses_local_when_no_api_url -q -o addopts=''`
- `mypy --strict tests/test_profile_no_sdk.py` *(fails: interrupted)*
- `ruff check tests/test_profile_no_sdk.py`


------
https://chatgpt.com/codex/tasks/task_e_68b942aa7e6c832a9547d0cc77fbadbd