### PR TITLE
[profile] Normalize dict-based quiet times

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import time as dt_time
 from collections.abc import Awaitable, Callable
 from typing import cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -263,6 +264,10 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     postmeal_check_min = getattr(profile, "postmeal_check_min", None)
     quiet_start = getattr(profile, "quiet_start", None)
     quiet_end = getattr(profile, "quiet_end", None)
+    if isinstance(quiet_start, dict):
+        quiet_start = dt_time(**quiet_start)
+    if isinstance(quiet_end, dict):
+        quiet_end = dt_time(**quiet_end)
     timezone = getattr(profile, "timezone", None)
     sos_contact = getattr(profile, "sos_contact", None)
     sos_alerts_enabled = getattr(profile, "sos_alerts_enabled", None)

--- a/tests/test_profile_view_dict_times.py
+++ b/tests/test_profile_view_dict_times.py
@@ -1,0 +1,41 @@
+import pytest
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+from services.api.app.diabetes.handlers import profile as handlers
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+        self.markups: list[Any] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.texts.append(text)
+        self.markups.append(kwargs.get("reply_markup"))
+
+
+@pytest.mark.asyncio
+async def test_profile_view_handles_dict_times(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_profile = SimpleNamespace(
+        icr=8,
+        cf=3,
+        target=6,
+        low=4,
+        high=9,
+        quiet_start={"hour": 8, "minute": 30},
+        quiet_end={"hour": 22, "minute": 15},
+    )
+    dummy_api = SimpleNamespace(profiles_get=lambda telegram_id: dummy_profile)
+    monkeypatch.setattr(handlers, "get_api", lambda: (dummy_api, Exception, MagicMock))
+
+    msg = DummyMessage()
+    update = cast(
+        Any, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(Any, SimpleNamespace())
+
+    await handlers.profile_view(update, context)
+
+    assert any("08:30-22:15" in text for text in msg.texts)


### PR DESCRIPTION
## Summary
- Normalize `quiet_start` and `quiet_end` by converting any dict inputs to `datetime.time`
- Add regression test for dict-formatted quiet times in profile view

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b942c33d14832a94522bf5b5d25b9f