### PR TITLE
[handlers] Use per-chat onboarding convo

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -641,7 +641,6 @@ onboarding_conv = ConversationHandler(
     fallbacks=[
         MessageHandler(filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), _photo_fallback)
     ],
-    per_message=True,
 )
 __all__ = [
     "PROFILE",

--- a/tests/test_onboarding_conversation.py
+++ b/tests/test_onboarding_conversation.py
@@ -219,4 +219,4 @@ async def test_resume_from_saved_step() -> None:
 
 
 def test_onboarding_conv_per_message() -> None:
-    assert onboarding.onboarding_conv.per_message is True
+    assert onboarding.onboarding_conv.per_message is False


### PR DESCRIPTION
## Summary
- remove per-message mode from `onboarding_conv` for default per-chat behavior
- adjust onboarding conversation test

## Testing
- `ruff check .`
- `pytest -q --cov` *(fails: 138 errors during collection)*
- `mypy --strict .` *(interrupted)*
- `TELEGRAM_TOKEN=bogus python -m services.api.app.bot` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b948d44ae8832ab96b9fdc04f2f307