### PR TITLE
[infra] Add learning mode settings

### DIFF
--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -52,3 +52,8 @@ BILLING_WEBHOOK_SECRET=
 BILLING_WEBHOOK_IPS=
 # Timeout in seconds for webhook signature verification
 BILLING_WEBHOOK_TIMEOUT=5
+
+# Learning mode
+LEARNING_MODE_ENABLED=true
+LEARNING_MODEL_DEFAULT=gpt-4o-mini
+LEARNING_PROMPT_CACHE=true


### PR DESCRIPTION
## Summary
- add learning mode variables to env example

## Testing
- `pytest -q --cov` (fails: ModuleNotFoundError: No module named 'sqlalchemy')
- `mypy --strict .` (fails: No module named 'sqlalchemy')
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b97545ac40832aba01d51e59af1ddb