### PR TITLE
[handlers] add learn command

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -72,6 +72,10 @@ class Settings(BaseSettings):
         default=None, alias="TELEGRAM_PAYMENTS_PROVIDER_TOKEN"
     )
     admin_id: Optional[int] = Field(default=None, alias="ADMIN_ID")
+    learning_mode_enabled: bool = Field(default=False, alias="LEARNING_MODE_ENABLED")
+    learning_model_default: str = Field(
+        default="gpt-4o-mini", alias="LEARNING_MODEL_DEFAULT"
+    )
 
     @field_validator("log_level", mode="before")
     @classmethod

--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -6,6 +6,7 @@ from typing import cast
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from .handlers.learn_handlers import learn_command
 from .handlers.onboarding_handlers import (
     reset_onboarding as _reset_onboarding,
 )
@@ -17,6 +18,7 @@ HELP_TEXT = "\n".join(
         "Доступные команды:",
         "/start - начать работу с ботом",
         "/help - краткая справка",
+        "/learn - режим обучения",
         "/reset_onboarding - сбросить мастер настройки",
         "",
         "Для работы с WebApp откройте меню и выберите нужную кнопку.",
@@ -52,4 +54,4 @@ async def reset_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     )
 
 
-__all__ = ["help_command", "reset_onboarding"]
+__all__ = ["help_command", "reset_onboarding", "learn_command"]

--- a/services/api/app/diabetes/handlers/learn_handlers.py
+++ b/services/api/app/diabetes/handlers/learn_handlers.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from services.api.app import config
+
+logger = logging.getLogger(__name__)
+
+
+async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Reply with learning mode status or greeting."""
+    message = update.message
+    if message is None:
+        return
+    settings = config.get_settings()
+    if not settings.learning_mode_enabled:
+        await message.reply_text("режим выключен")
+        return
+    model = settings.learning_model_default
+    await message.reply_text(f"🤖 Учебный режим активирован. Модель: {model}")
+
+
+__all__ = ["learn_command"]

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -37,7 +37,9 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     CommandHandlerT: TypeAlias = CommandHandler[ContextTypes.DEFAULT_TYPE, object]
     MessageHandlerT: TypeAlias = MessageHandler[ContextTypes.DEFAULT_TYPE, object]
-    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, object]
+    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[
+        ContextTypes.DEFAULT_TYPE, object
+    ]
     PollAnswerHandlerT: TypeAlias = PollAnswerHandler[ContextTypes.DEFAULT_TYPE, object]
 else:
     CommandHandlerT = CommandHandler
@@ -68,14 +70,10 @@ def register_profile_handlers(
         )
     )
     app.add_handler(
-        CallbackQueryHandlerT(
-            profile.profile_security, pattern="^profile_security"
-        )
+        CallbackQueryHandlerT(profile.profile_security, pattern="^profile_security")
     )
     app.add_handler(
-        CallbackQueryHandlerT(
-            profile.profile_back, pattern="^profile_back$"
-        )
+        CallbackQueryHandlerT(profile.profile_back, pattern="^profile_back$")
     )
 
 
@@ -93,23 +91,11 @@ def register_reminder_handlers(
 
     from . import reminder_handlers
 
-    app.add_handler(
-        CommandHandlerT(
-            "reminders", reminder_handlers.reminders_list
-        )
-    )
-    app.add_handler(
-        CommandHandlerT(
-            "addreminder", reminder_handlers.add_reminder
-        )
-    )
+    app.add_handler(CommandHandlerT("reminders", reminder_handlers.reminders_list))
+    app.add_handler(CommandHandlerT("addreminder", reminder_handlers.add_reminder))
     app.add_handler(reminder_handlers.reminder_action_handler)
     app.add_handler(reminder_handlers.reminder_webapp_handler)
-    app.add_handler(
-        CommandHandlerT(
-            "delreminder", reminder_handlers.delete_reminder
-        )
-    )
+    app.add_handler(CommandHandlerT("delreminder", reminder_handlers.delete_reminder))
     app.add_handler(
         MessageHandlerT(
             filters.Regex(re.escape(REMINDERS_BUTTON_TEXT)),
@@ -117,9 +103,7 @@ def register_reminder_handlers(
         )
     )
     app.add_handler(
-        CallbackQueryHandlerT(
-            reminder_handlers.reminder_callback, pattern="^remind_"
-        )
+        CallbackQueryHandlerT(reminder_handlers.reminder_callback, pattern="^remind_")
     )
 
     # --- DEBUG HANDLERS ---
@@ -127,6 +111,7 @@ def register_reminder_handlers(
         from services.api.app.diabetes.handlers.reminder_debug import (
             register_debug_reminder_handlers,
         )
+
         register_debug_reminder_handlers(app)
     except ImportError as e:
         logger.warning("⚠️ Could not load debug reminder handlers: %s", e)
@@ -141,7 +126,6 @@ def register_reminder_handlers(
             reminder_handlers.schedule_all(job_queue)
         except SQLAlchemyError:
             logger.exception("Failed to schedule reminders")
-
 
 
 def register_handlers(
@@ -167,50 +151,30 @@ def register_handlers(
         photo_handlers,
         sugar_handlers,
         gpt_handlers,
+        learn_handlers,
         billing_handlers,
     )
 
     app.add_handler(onboarding_conv)
     app.add_handler(CommandHandlerT("menu", menu_command))
-    app.add_handler(
-        CommandHandlerT(
-            "report", reporting_handlers.report_request
-        )
-    )
-    app.add_handler(
-        CommandHandlerT(
-            "history", reporting_handlers.history_view
-        )
-    )
+    app.add_handler(CommandHandlerT("report", reporting_handlers.report_request))
+    app.add_handler(CommandHandlerT("history", reporting_handlers.history_view))
     app.add_handler(dose_calc.dose_conv)
     # Register profile conversation before sugar conversation so that numeric
     # inputs for profile aren't captured by sugar logging
     register_profile_handlers(app)
     app.add_handler(sugar_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
-    app.add_handler(
-        CommandHandlerT("cancel", dose_calc.dose_cancel)
-    )
+    app.add_handler(CommandHandlerT("cancel", dose_calc.dose_cancel))
     app.add_handler(CommandHandlerT("help", help_command))
-    app.add_handler(
-        CommandHandlerT("gpt", gpt_handlers.chat_with_gpt)
-    )
+    app.add_handler(CommandHandlerT("learn", learn_handlers.learn_command))
+    app.add_handler(CommandHandlerT("gpt", gpt_handlers.chat_with_gpt))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))
     register_reminder_handlers(app)
-    app.add_handler(
-        CommandHandlerT(
-            "alertstats", alert_handlers.alert_stats
-        )
-    )
-    app.add_handler(
-        CommandHandlerT(
-            "hypoalert", security_handlers.hypo_alert_faq
-        )
-    )
-    app.add_handler(
-        PollAnswerHandlerT(onboarding_poll_answer)
-    )
+    app.add_handler(CommandHandlerT("alertstats", alert_handlers.alert_stats))
+    app.add_handler(CommandHandlerT("hypoalert", security_handlers.hypo_alert_faq))
+    app.add_handler(PollAnswerHandlerT(onboarding_poll_answer))
     app.add_handler(
         MessageHandlerT(
             filters.Regex(re.escape(REPORT_BUTTON_TEXT)),
@@ -234,9 +198,7 @@ def register_handlers(
         )
     )
     app.add_handler(
-        MessageHandlerT(
-            filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command
-        )
+        MessageHandlerT(filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command)
     )
     app.add_handler(
         MessageHandlerT(
@@ -245,20 +207,10 @@ def register_handlers(
         )
     )
     app.add_handler(
-        MessageHandlerT(
-            filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler
-        )
+        MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler)
     )
-    app.add_handler(
-        MessageHandlerT(
-            filters.PHOTO, photo_handlers.photo_handler
-        )
-    )
-    app.add_handler(
-        MessageHandlerT(
-            filters.Document.IMAGE, photo_handlers.doc_handler
-        )
-    )
+    app.add_handler(MessageHandlerT(filters.PHOTO, photo_handlers.photo_handler))
+    app.add_handler(MessageHandlerT(filters.Document.IMAGE, photo_handlers.doc_handler))
     app.add_handler(
         CallbackQueryHandlerT(
             reporting_handlers.report_period_callback, pattern="^report_back$"

--- a/tests/diabetes/test_learn_handlers.py
+++ b/tests/diabetes/test_learn_handlers.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.config import settings
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "learn_handlers",
+    Path(__file__).resolve().parents[2]
+    / "services/api/app/diabetes/handlers/learn_handlers.py",
+)
+assert spec and spec.loader
+learn_handlers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(learn_handlers)  # type: ignore[misc]
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_learn_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", False)
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    await learn_handlers.learn_command(update, context)
+    assert message.replies == ["режим выключен"]
+
+
+@pytest.mark.asyncio
+async def test_learn_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+    monkeypatch.setattr(settings, "learning_model_default", "super-model")
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    await learn_handlers.learn_command(update, context)
+    assert "super-model" in message.replies[0]


### PR DESCRIPTION
## Summary
- add /learn handler with learning-mode check
- configure learning mode settings and expose command
- cover enabled and disabled behaviour with unit tests

## Testing
- `ruff check services/api/app/config.py services/api/app/diabetes/commands.py services/api/app/diabetes/handlers/registration.py services/api/app/diabetes/handlers/learn_handlers.py tests/diabetes/test_learn_handlers.py`
- `mypy --strict --follow-imports=skip services/api/app/config.py services/api/app/diabetes/commands.py services/api/app/diabetes/handlers/registration.py services/api/app/diabetes/handlers/learn_handlers.py tests/diabetes/test_learn_handlers.py` *(fails: Class cannot subclass "BaseSettings" (has type "Any"))*
- `pytest tests/diabetes/test_learn_handlers.py -q` *(fails: ModuleNotFoundError: No module named 'reportlab')*

------
https://chatgpt.com/codex/tasks/task_e_68b97562669c832a8527d1904075958f