### PR TITLE
tests: add learning settings and command coverage

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -63,6 +63,13 @@ class Settings(BaseSettings):
         default="gpt-4o-mini", alias="OPENAI_COMMAND_MODEL"
     )
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
+    learning_enabled: bool = Field(default=False, alias="LEARNING_ENABLED")
+    learning_assistant_id: Optional[str] = Field(
+        default=None, alias="LEARNING_ASSISTANT_ID"
+    )
+    learning_command_model: str = Field(
+        default="gpt-4o-mini", alias="LEARNING_COMMAND_MODEL"
+    )
     font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
     onboarding_video_url: Optional[str] = Field(
         default=None, alias="ONBOARDING_VIDEO_URL"

--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from services.api.app.config import settings
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
 
@@ -74,9 +75,22 @@ async def smart_input_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         await message.reply_text(text, parse_mode="Markdown")
 
 
+async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Provide learning resources if the feature is enabled."""
+
+    message = update.message
+    if message is None:
+        return
+    if not settings.learning_enabled:
+        await message.reply_text("🚫 Обучение недоступно.")
+        return
+    await message.reply_text("📘 Учебный режим активен.")
+
+
 __all__ = [
     "menu_keyboard",
     "menu_command",
     "help_command",
     "smart_input_help",
+    "learn_command",
 ]

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+import services.api.app.diabetes.handlers.common_handlers as handlers
+from services.api.app.config import Settings
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:  # pragma: no cover - simple capture
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_learn_command_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When flag is disabled the command should warn the user."""
+
+    monkeypatch.setattr(handlers, "settings", Settings(_env_file=None))
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+
+    await handlers.learn_command(update, context)
+
+    assert message.replies == ["🚫 Обучение недоступно."]
+
+
+@pytest.mark.asyncio
+async def test_learn_command_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With flag enabled the command should return training info."""
+
+    monkeypatch.setattr(
+        handlers, "settings", Settings(LEARNING_ENABLED="1", _env_file=None)
+    )
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+
+    await handlers.learn_command(update, context)
+
+    assert message.replies == ["📘 Учебный режим активен."]

--- a/tests/test_settings_learning.py
+++ b/tests/test_settings_learning.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from services.api.app.config import Settings
+
+
+def test_learning_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Settings should use built-in defaults for learning variables."""
+
+    monkeypatch.delenv("LEARNING_ENABLED", raising=False)
+    monkeypatch.delenv("LEARNING_ASSISTANT_ID", raising=False)
+    monkeypatch.delenv("LEARNING_COMMAND_MODEL", raising=False)
+    settings = Settings(_env_file=None)
+    assert settings.learning_enabled is False
+    assert settings.learning_assistant_id is None
+    assert settings.learning_command_model == "gpt-4o-mini"
+
+
+def test_learning_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Environment variables should override learning defaults."""
+
+    monkeypatch.setenv("LEARNING_ENABLED", "1")
+    monkeypatch.setenv("LEARNING_ASSISTANT_ID", "abc")
+    monkeypatch.setenv("LEARNING_COMMAND_MODEL", "gpt-4o")
+    settings = Settings(_env_file=None)
+    assert settings.learning_enabled is True
+    assert settings.learning_assistant_id == "abc"
+    assert settings.learning_command_model == "gpt-4o"


### PR DESCRIPTION
## Summary
- support learning feature flags in configuration
- add tests validating LEARNING_* defaults and overrides
- test /learn command behavior when disabled and enabled

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b975630d50832aa302172fc2043486