### PR TITLE
docs: add learning-mode feature flag to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Changed `/api/stats`: now returns default stats (or `204`) instead of `404` when no data is available.
 - Enhanced bot command menu with emojis for easier navigation.
 - Updated `ProfileSchema`: field `target` is now optional and aliases `cf`, `targetLow`, `targetHigh` are documented.
+- Added learning-mode feature flag and model configuration. See [docs/BRD.md](docs/BRD.md) and [docs/Концепция_проекта.md](docs/Концепция_проекта.md).


### PR DESCRIPTION
## Summary
- mention learning-mode feature flag and model configuration in changelog with links to BRD and project concept docs

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b975648638832a9669f9927c0617c8