### PR TITLE
[llm] Add router for learning models

### DIFF
--- a/services/api/app/diabetes/llm_router.py
+++ b/services/api/app/diabetes/llm_router.py
@@ -1,0 +1,38 @@
+"""Utilities for choosing LLM models for learning tasks."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from services.api.app import config
+
+
+class LLMTask(str, Enum):
+    """Supported learning tasks routed to different LLM models."""
+
+    EXPLAIN_STEP = "explain_step"
+    QUIZ_CHECK = "quiz_check"
+    LONG_PLAN = "long_plan"
+
+
+class LLMRouter:
+    """Select the model to use for a given :class:`LLMTask`."""
+
+    def __init__(self, default_model: str | None = None) -> None:
+        self._default_model = (
+            default_model
+            if default_model is not None
+            else config.get_settings().learning_model_default
+        )
+
+    def choose_model(self, task: LLMTask) -> str:
+        """Return the model name appropriate for *task*.
+
+        Currently all tasks use the default model, but the router centralizes
+        the decision to simplify future improvements.
+        """
+
+        return self._default_model
+
+
+__all__ = ["LLMRouter", "LLMTask"]

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from services.api.app import config
+from services.api.app.diabetes.llm_router import LLMRouter, LLMTask
+from services.api.app.diabetes.services import gpt_client
+
+
+def test_router_returns_default_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """All tasks should map to the default model unless overridden."""
+    settings = config.get_settings()
+    monkeypatch.setattr(settings, "learning_model_default", "gpt-4o-mini")
+    router = LLMRouter()
+    for task in (
+        LLMTask.EXPLAIN_STEP,
+        LLMTask.QUIZ_CHECK,
+        LLMTask.LONG_PLAN,
+    ):
+        assert router.choose_model(task) == "gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_create_learning_chat_completion_uses_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """gpt_client should delegate model selection to the router."""
+    captured: dict[str, str] = {}
+
+    async def fake_create_chat_completion(
+        *, model: str, **kwargs: object
+    ) -> object:
+        captured["model"] = model
+        return object()
+
+    monkeypatch.setattr(gpt_client, "create_chat_completion", fake_create_chat_completion)
+    monkeypatch.setattr(gpt_client, "_learning_router", LLMRouter())
+
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP,
+        messages=[],
+    )
+
+    assert captured["model"] == "gpt-4o-mini"


### PR DESCRIPTION
## Summary
- route learning tasks to default LLM model
- expose helper for learning chat completions
- cover router behavior with unit tests

## Testing
- `pytest tests/test_llm_router.py tests/test_gpt_client.py::test_send_message_openaierror -q --no-cov`
- `mypy --strict services/api/app/diabetes/llm_router.py services/api/app/diabetes/services/gpt_client.py tests/test_llm_router.py` *(fails: Name "learning_mode_enabled" already defined)*
- `ruff check services/api/app/diabetes/llm_router.py services/api/app/diabetes/services/gpt_client.py tests/test_llm_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9794f370c832a8856f1ae336f75c4