### PR TITLE
[learning] Add diabetes lessons fixtures loader

### DIFF
--- a/services/api/app/diabetes/content/lessons_v0.json
+++ b/services/api/app/diabetes/content/lessons_v0.json
@@ -1,0 +1,77 @@
+[
+  {
+    "title": "Basics of Diabetes",
+    "steps": [
+      "Diabetes is a condition that affects how your body uses blood glucose.",
+      "Monitor your blood sugar daily to keep levels in check.",
+      "Contact your healthcare provider for unusual readings."
+    ],
+    "quiz": [
+      {
+        "question": "What is diabetes primarily related to?",
+        "options": ["Blood glucose", "Blood pressure", "Cholesterol"],
+        "answer": 0
+      },
+      {
+        "question": "How often should you check your blood sugar?",
+        "options": ["Never", "Once a week", "Regularly as advised"],
+        "answer": 2
+      },
+      {
+        "question": "Who should you contact for treatment advice?",
+        "options": ["Internet forums", "Your healthcare provider", "No one"],
+        "answer": 1
+      }
+    ]
+  },
+  {
+    "title": "Insulin Usage",
+    "steps": [
+      "Store insulin in a cool place.",
+      "Use clean syringes for each injection.",
+      "Rotate injection sites to avoid skin issues."
+    ],
+    "quiz": [
+      {
+        "question": "Where should insulin be stored?",
+        "options": ["Hot car", "Cool place", "Sunlight"],
+        "answer": 1
+      },
+      {
+        "question": "What should be clean for each injection?",
+        "options": ["Syringes", "Hands", "Shoes"],
+        "answer": 0
+      },
+      {
+        "question": "Why rotate injection sites?",
+        "options": ["To avoid skin issues", "For fun", "No reason"],
+        "answer": 0
+      }
+    ]
+  },
+  {
+    "title": "Healthy Eating",
+    "steps": [
+      "Include vegetables in every meal.",
+      "Limit sugary drinks.",
+      "Balance carbohydrates, proteins, and fats."
+    ],
+    "quiz": [
+      {
+        "question": "What should be limited?",
+        "options": ["Sugary drinks", "Water", "Vegetables"],
+        "answer": 0
+      },
+      {
+        "question": "What should meals include?",
+        "options": ["Only carbs", "Vegetables", "Only fats"],
+        "answer": 1
+      },
+      {
+        "question": "How to balance diet?",
+        "options": ["Skip meals", "Balance carbs, proteins, and fats", "Eat only sweets"],
+        "answer": 1
+      }
+    ]
+  }
+]

--- a/services/api/app/diabetes/learning_fixtures.py
+++ b/services/api/app/diabetes/learning_fixtures.py
@@ -1,0 +1,81 @@
+"""Utility to load learning content fixtures into the database.
+
+Usage
+-----
+>>> import asyncio
+>>> from services.api.app.diabetes.learning_fixtures import load_lessons
+>>> asyncio.run(load_lessons())
+
+This reads the JSON file at ``content/lessons_v0.json`` and inserts
+``Lesson`` and ``QuizQuestion`` records using
+:mod:`services.api.app.diabetes.services.db`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TypedDict, cast
+
+from sqlalchemy.orm import Session
+
+from .models_learning import Lesson, QuizQuestion
+from .services.db import SessionLocal, SessionMaker, run_db
+from .services.repository import CommitError, commit
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["load_lessons"]
+
+
+class QuizDict(TypedDict):
+    question: str
+    options: list[str]
+    answer: int
+
+
+class LessonDict(TypedDict):
+    title: str
+    steps: list[str]
+    quiz: list[QuizDict]
+
+
+DEFAULT_CONTENT_FILE = Path(__file__).parent / "content" / "lessons_v0.json"
+
+
+async def load_lessons(
+    content_path: Path | str = DEFAULT_CONTENT_FILE,
+    *,
+    sessionmaker: SessionMaker[Session] = SessionLocal,
+) -> None:
+    """Load lessons and quiz questions from ``content_path`` into the database."""
+
+    path = Path(content_path)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    lessons = cast(list[LessonDict], raw)
+
+    def _load(session: Session) -> None:
+        for item in lessons:
+            lesson = Lesson(
+                title=item["title"],
+                content="\n".join(item["steps"]),
+                is_active=True,
+            )
+            session.add(lesson)
+            session.flush()
+            for q in item["quiz"]:
+                question = QuizQuestion(
+                    lesson_id=lesson.id,
+                    question=q["question"],
+                    options=q["options"],
+                    correct_option=q["answer"],
+                )
+                session.add(question)
+        try:
+            commit(session)
+        except CommitError:
+            logger.exception("Failed to load lessons from %s", path)
+            raise
+
+    await run_db(_load, sessionmaker=sessionmaker)

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -16,6 +16,7 @@ class Lesson(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     title: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
     questions: Mapped[list["QuizQuestion"]] = relationship(
         "QuizQuestion", back_populates="lesson", cascade="all, delete-orphan"

--- a/services/api/tests/test_learning_fixtures.py
+++ b/services/api/tests/test_learning_fixtures.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.learning_fixtures import load_lessons
+from services.api.app.diabetes.models_learning import Lesson, QuizQuestion
+from services.api.app.diabetes.services import db
+
+
+def setup_db() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    return SessionLocal
+
+
+@pytest.mark.asyncio()
+async def test_load_lessons(tmp_path: Path) -> None:
+    sample = [
+        {
+            "title": "Sample",
+            "steps": ["a", "b", "c"],
+            "quiz": [
+                {"question": "q1", "options": ["1", "2", "3"], "answer": 1},
+                {"question": "q2", "options": ["1", "2", "3"], "answer": 2},
+                {"question": "q3", "options": ["1", "2", "3"], "answer": 0},
+            ],
+        }
+    ]
+    path = tmp_path / "lessons.json"
+    path.write_text(json.dumps(sample), encoding="utf-8")
+
+    SessionLocal = setup_db()
+    await load_lessons(path, sessionmaker=SessionLocal)
+
+    with SessionLocal() as session:
+        lessons = session.query(Lesson).all()
+        assert len(lessons) == 1
+        assert lessons[0].is_active is True
+        questions = session.query(QuizQuestion).filter_by(lesson_id=lessons[0].id).all()
+        assert len(questions) == 3

--- a/services/api/tests/test_learning_models.py
+++ b/services/api/tests/test_learning_models.py
@@ -34,6 +34,7 @@ def test_lesson_crud() -> None:
         stored = session.get(Lesson, lesson.id)
         assert stored is not None
         assert stored.title == "Intro"
+        assert stored.is_active is True
 
 
 def test_quiz_question_crud() -> None:


### PR DESCRIPTION
## Summary
- add initial diabetes lessons content JSON
- implement fixture loader that populates lessons and quiz questions
- mark lessons as active and expose loading utility

## Testing
- `pytest services/api/tests/test_learning_models.py services/api/tests/test_learning_fixtures.py -q --override-ini addopts=`
- `mypy --strict .` *(failed: Interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b98077ec0c832a97ac8651803599e5