### PR TITLE
[build] add lesson loader target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ stamp-head:
 
 show:
 	$(PYTHONPATH) $(ALEMBIC) show head
+
+# === DATA ===
+load-lessons:
+	$(PYTHONPATH) python services/api/app/diabetes/learning_fixtures.py services/api/app/diabetes/content/lessons_v0.json


### PR DESCRIPTION
## Summary
- add `load-lessons` target to Makefile for loading lesson fixtures

## Testing
- `pytest -q --cov --maxfail=1` (fails: async plugin missing)
- `mypy --strict .` (execution interrupted)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9807b70c4832a8d898ebedc743326