### PR TITLE
[learning] Add lesson steps and activation flag

### DIFF
--- a/services/api/alembic/versions/20250912_lesson_steps_is_active.py
+++ b/services/api/alembic/versions/20250912_lesson_steps_is_active.py
@@ -1,0 +1,42 @@
+"""add lesson steps and is_active to lessons"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20250912_lesson_steps_is_active"
+down_revision: Union[str, Sequence[str], None] = ("20250911_learning_init",)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "lessons",
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.create_table(
+        "lesson_steps",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "lesson_id", sa.Integer(), sa.ForeignKey("lessons.id"), nullable=False
+        ),
+        sa.Column("step_number", sa.Integer(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+    )
+    op.create_index(
+        "ix_lesson_steps_lesson_id", "lesson_steps", ["lesson_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_lesson_steps_lesson_id", table_name="lesson_steps")
+    op.drop_table("lesson_steps")
+    op.drop_column("lessons", "is_active")

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -16,6 +16,16 @@ class Lesson(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     title: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa.text("true")
+    )
+
+    steps: Mapped[list["LessonStep"]] = relationship(
+        "LessonStep",
+        back_populates="lesson",
+        cascade="all, delete-orphan",
+        order_by="LessonStep.step_number",
+    )
 
     questions: Mapped[list["QuizQuestion"]] = relationship(
         "QuizQuestion", back_populates="lesson", cascade="all, delete-orphan"
@@ -23,6 +33,19 @@ class Lesson(Base):
     progresses: Mapped[list["LessonProgress"]] = relationship(
         "LessonProgress", back_populates="lesson", cascade="all, delete-orphan"
     )
+
+
+class LessonStep(Base):
+    __tablename__ = "lesson_steps"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    lesson_id: Mapped[int] = mapped_column(
+        ForeignKey("lessons.id"), nullable=False, index=True
+    )
+    step_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+
+    lesson: Mapped[Lesson] = relationship("Lesson", back_populates="steps")
 
 
 class QuizQuestion(Base):

--- a/services/api/tests/test_learning_models.py
+++ b/services/api/tests/test_learning_models.py
@@ -7,8 +7,9 @@ from sqlalchemy.pool import StaticPool
 from services.api.app.diabetes.services import db
 from services.api.app.diabetes.models_learning import (
     Lesson,
-    QuizQuestion,
     LessonProgress,
+    LessonStep,
+    QuizQuestion,
 )
 
 
@@ -26,7 +27,11 @@ def setup_db() -> sessionmaker[Session]:
 def test_lesson_crud() -> None:
     SessionLocal = setup_db()
     with SessionLocal() as session:
-        lesson = Lesson(title="Intro", content="Basics")
+        lesson = Lesson(
+            title="Intro",
+            content="Basics",
+            steps=[LessonStep(step_number=1, content="Step 1")],
+        )
         session.add(lesson)
         session.commit()
         session.refresh(lesson)
@@ -34,12 +39,18 @@ def test_lesson_crud() -> None:
         stored = session.get(Lesson, lesson.id)
         assert stored is not None
         assert stored.title == "Intro"
+        assert stored.is_active is True
+        assert stored.steps[0].content == "Step 1"
 
 
 def test_quiz_question_crud() -> None:
     SessionLocal = setup_db()
     with SessionLocal() as session:
-        lesson = Lesson(title="Intro", content="Basics")
+        lesson = Lesson(
+            title="Intro",
+            content="Basics",
+            steps=[LessonStep(step_number=1, content="Step 1")],
+        )
         session.add(lesson)
         session.commit()
         session.refresh(lesson)
@@ -64,7 +75,11 @@ def test_lesson_progress_crud() -> None:
     SessionLocal = setup_db()
     with SessionLocal() as session:
         user = db.User(telegram_id=1, thread_id="t1")
-        lesson = Lesson(title="Intro", content="Basics")
+        lesson = Lesson(
+            title="Intro",
+            content="Basics",
+            steps=[LessonStep(step_number=1, content="Step 1")],
+        )
         session.add_all([user, lesson])
         session.commit()
 


### PR DESCRIPTION
## Summary
- add `is_active` flag and ordered steps relationship to `Lesson`
- introduce `LessonStep` table and migration
- extend lesson model tests for new fields

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9807c742c832aaebf10ade0bb383d