### PR TITLE
[learning] add lesson fixtures loader test

### DIFF
--- a/services/api/app/diabetes/learning_fixtures.py
+++ b/services/api/app/diabetes/learning_fixtures.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TypedDict, cast
+
+from .models_learning import Lesson, QuizQuestion
+from .services import db
+
+
+class QuizDict(TypedDict):
+    question: str
+    options: list[str]
+    correct_option: int
+
+
+class LessonDict(TypedDict):
+    title: str
+    steps: list[str]
+    quiz: list[QuizDict]
+
+
+def load(path: Path) -> None:
+    """Load lessons and quizzes from a JSON file."""
+    raw = json.loads(path.read_text())
+    data = cast(list[LessonDict], raw)
+    with db.SessionLocal() as session:
+        for entry in data:
+            content = "\n".join(entry["steps"])
+            lesson = Lesson(title=entry["title"], content=content)
+            session.add(lesson)
+            session.flush()
+            for q in entry["quiz"]:
+                question = QuizQuestion(
+                    lesson_id=lesson.id,
+                    question=q["question"],
+                    options=q["options"],
+                    correct_option=q["correct_option"],
+                )
+                session.add(question)
+        session.commit()

--- a/tests/learning/lessons_v0.json
+++ b/tests/learning/lessons_v0.json
@@ -1,0 +1,77 @@
+[
+  {
+    "title": "Basics of Diabetes",
+    "steps": [
+      "What is diabetes?",
+      "Monitoring blood sugar",
+      "Managing diet"
+    ],
+    "quiz": [
+      {
+        "question": "What organ produces insulin?",
+        "options": ["Liver", "Pancreas", "Heart"],
+        "correct_option": 1
+      },
+      {
+        "question": "Normal fasting blood sugar level?",
+        "options": ["70-99 mg/dL", "100-125 mg/dL", "126-140 mg/dL"],
+        "correct_option": 0
+      },
+      {
+        "question": "Which nutrient most affects blood sugar?",
+        "options": ["Carbohydrates", "Proteins", "Fats"],
+        "correct_option": 0
+      }
+    ]
+  },
+  {
+    "title": "Insulin Therapy",
+    "steps": [
+      "Types of insulin",
+      "Injection techniques",
+      "Dosage calculation"
+    ],
+    "quiz": [
+      {
+        "question": "Which is a rapid-acting insulin?",
+        "options": ["Glargine", "Lispro", "NPH"],
+        "correct_option": 1
+      },
+      {
+        "question": "Where is insulin injected?",
+        "options": ["Intravenous", "Subcutaneous", "Intramuscular"],
+        "correct_option": 1
+      },
+      {
+        "question": "What affects dosage?",
+        "options": ["Meal composition", "Weather", "Time of day"],
+        "correct_option": 0
+      }
+    ]
+  },
+  {
+    "title": "Preventing Complications",
+    "steps": [
+      "Regular check-ups",
+      "Foot care",
+      "Healthy lifestyle"
+    ],
+    "quiz": [
+      {
+        "question": "Which is a common complication?",
+        "options": ["Neuropathy", "Asthma", "Arthritis"],
+        "correct_option": 0
+      },
+      {
+        "question": "How often to check feet?",
+        "options": ["Monthly", "Daily", "Weekly"],
+        "correct_option": 1
+      },
+      {
+        "question": "What helps prevent complications?",
+        "options": ["Smoking", "Healthy lifestyle", "Ignoring symptoms"],
+        "correct_option": 1
+      }
+    ]
+  }
+]

--- a/tests/learning/test_load_lessons.py
+++ b/tests/learning/test_load_lessons.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes import learning_fixtures
+from services.api.app.diabetes.models_learning import Lesson
+from services.api.app.diabetes.services import db
+
+
+def test_load_lessons() -> None:
+    path = Path(__file__).with_name("lessons_v0.json")
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.SessionLocal.configure(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+    try:
+        learning_fixtures.load(path)
+        with db.SessionLocal() as session:
+            lessons = session.execute(select(Lesson)).scalars().all()
+            assert len(lessons) == 3
+            for lesson in lessons:
+                assert len(lesson.content.splitlines()) >= 3
+                assert len(lesson.questions) >= 3
+    finally:
+        db.dispose_engine(engine)
+        db.SessionLocal.configure(bind=None)


### PR DESCRIPTION
## Summary
- add `learning_fixtures.load` for importing lessons from JSON
- test that fixture loader stores three lessons with at least three steps and quiz questions

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9807f337c832a9d084b9a7b7e033d