### PR TITLE
[learning] add lesson steps and active flag

### DIFF
--- a/services/api/alembic/versions/20250912_add_lesson_steps.py
+++ b/services/api/alembic/versions/20250912_add_lesson_steps.py
@@ -1,0 +1,43 @@
+"""add lesson steps and is_active
+
+Revision ID: 20250912_add_lesson_steps
+Revises: 20250911_learning_init
+Create Date: 2025-09-04 12:16:26.097239
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '20250912_add_lesson_steps'
+down_revision: Union[str, None] = '20250911_learning_init'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "lessons",
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+    )
+    op.create_table(
+        "lesson_steps",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("lesson_id", sa.Integer(), sa.ForeignKey("lessons.id"), nullable=False),
+        sa.Column("step_order", sa.Integer(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+    )
+    op.create_index(
+        "ix_lesson_steps_lesson_id", "lesson_steps", ["lesson_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_lesson_steps_lesson_id", table_name="lesson_steps")
+    op.drop_table("lesson_steps")
+    op.drop_column("lessons", "is_active")

--- a/services/api/app/diabetes/learning_fixtures.py
+++ b/services/api/app/diabetes/learning_fixtures.py
@@ -20,7 +20,7 @@ from typing import TypedDict, cast
 
 from sqlalchemy.orm import Session
 
-from .models_learning import Lesson, QuizQuestion
+from .models_learning import Lesson, LessonStep, QuizQuestion
 from .services.db import SessionLocal, SessionMaker, run_db
 from .services.repository import CommitError, commit
 
@@ -64,6 +64,10 @@ async def load_lessons(
             )
             session.add(lesson)
             session.flush()
+            for idx, step in enumerate(item["steps"], start=1):
+                session.add(
+                    LessonStep(lesson_id=lesson.id, step_order=idx, content=step)
+                )
             for q in item["quiz"]:
                 question = QuizQuestion(
                     lesson_id=lesson.id,

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -16,7 +16,16 @@ class Lesson(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     title: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
-    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa.true()
+    )
+
+    steps: Mapped[list["LessonStep"]] = relationship(
+        "LessonStep",
+        back_populates="lesson",
+        cascade="all, delete-orphan",
+        order_by="LessonStep.step_order",
+    )
 
     questions: Mapped[list["QuizQuestion"]] = relationship(
         "QuizQuestion", back_populates="lesson", cascade="all, delete-orphan"
@@ -40,6 +49,19 @@ class QuizQuestion(Base):
     correct_option: Mapped[int] = mapped_column(Integer, nullable=False)
 
     lesson: Mapped[Lesson] = relationship("Lesson", back_populates="questions")
+
+
+class LessonStep(Base):
+    __tablename__ = "lesson_steps"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    lesson_id: Mapped[int] = mapped_column(
+        ForeignKey("lessons.id"), nullable=False, index=True
+    )
+    step_order: Mapped[int] = mapped_column(Integer, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+
+    lesson: Mapped[Lesson] = relationship("Lesson", back_populates="steps")
 
 
 class LessonProgress(Base):

--- a/services/api/tests/test_learning_fixtures.py
+++ b/services/api/tests/test_learning_fixtures.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from services.api.app.diabetes.learning_fixtures import load_lessons
-from services.api.app.diabetes.models_learning import Lesson, QuizQuestion
+from services.api.app.diabetes.models_learning import Lesson, LessonStep, QuizQuestion
 from services.api.app.diabetes.services import db
 
 
@@ -47,5 +47,12 @@ async def test_load_lessons(tmp_path: Path) -> None:
         lessons = session.query(Lesson).all()
         assert len(lessons) == 1
         assert lessons[0].is_active is True
+        steps = (
+            session.query(LessonStep)
+            .filter_by(lesson_id=lessons[0].id)
+            .order_by(LessonStep.step_order)
+            .all()
+        )
+        assert [s.content for s in steps] == ["a", "b", "c"]
         questions = session.query(QuizQuestion).filter_by(lesson_id=lessons[0].id).all()
         assert len(questions) == 3

--- a/services/api/tests/test_learning_models.py
+++ b/services/api/tests/test_learning_models.py
@@ -7,6 +7,7 @@ from sqlalchemy.pool import StaticPool
 from services.api.app.diabetes.services import db
 from services.api.app.diabetes.models_learning import (
     Lesson,
+    LessonStep,
     QuizQuestion,
     LessonProgress,
 )
@@ -26,7 +27,14 @@ def setup_db() -> sessionmaker[Session]:
 def test_lesson_crud() -> None:
     SessionLocal = setup_db()
     with SessionLocal() as session:
-        lesson = Lesson(title="Intro", content="Basics")
+        lesson = Lesson(
+            title="Intro",
+            content="Basics",
+            steps=[
+                LessonStep(step_order=1, content="s1"),
+                LessonStep(step_order=2, content="s2"),
+            ],
+        )
         session.add(lesson)
         session.commit()
         session.refresh(lesson)
@@ -35,6 +43,7 @@ def test_lesson_crud() -> None:
         assert stored is not None
         assert stored.title == "Intro"
         assert stored.is_active is True
+        assert [s.content for s in stored.steps] == ["s1", "s2"]
 
 
 def test_quiz_question_crud() -> None:


### PR DESCRIPTION
## Summary
- add `LessonStep` model and `is_active` flag to lessons
- load lesson steps from fixtures and persist with lessons
- create Alembic migration for new columns and table

## Testing
- `PYTHONPATH=. pytest services/api/tests/test_learning_models.py services/api/tests/test_learning_fixtures.py -q`
- `mypy --strict services/api/app/diabetes/models_learning.py services/api/app/diabetes/learning_fixtures.py services/api/tests/test_learning_models.py services/api/tests/test_learning_fixtures.py`
- `ruff check services/api/app/diabetes/models_learning.py services/api/app/diabetes/learning_fixtures.py services/api/tests/test_learning_models.py services/api/tests/test_learning_fixtures.py`


------
https://chatgpt.com/codex/tasks/task_e_68b982937828832ab99d231535ad1cfe