### PR TITLE
[learning] Add diabetes learning prompt templates

### DIFF
--- a/services/api/app/diabetes/learning_prompts.py
+++ b/services/api/app/diabetes/learning_prompts.py
@@ -1,0 +1,45 @@
+"""Prompt templates for diabetes learning module."""
+
+from __future__ import annotations
+
+SYSTEM_TUTOR_RU = (
+    "Ты — репетитор по диабету. "
+    "Говори короткими предложениями. "
+    "Сначала спрашивай, потом объясняй. "
+    "Не давай советов по терапии. "
+    "Всегда добавляй предупреждение: 'Проконсультируйтесь с врачом.'"
+)
+
+_DISCLAIMER_RU = "Проконсультируйтесь с врачом."
+
+
+def _with_disclaimer(text: str) -> str:
+    """Append a common disclaimer to *text*.
+
+    Parameters
+    ----------
+    text: str
+        Base text that requires the disclaimer.
+    """
+    base = text.strip()
+    return f"{base} {_DISCLAIMER_RU}" if base else _DISCLAIMER_RU
+
+
+def build_explain_step(step: str) -> str:
+    """Build a prompt asking and explaining a learning step."""
+    prompt = f"Что ты знаешь о {step}? Объясни.".strip()
+    return _with_disclaimer(prompt)
+
+
+def build_quiz_check(question: str, options: list[str]) -> str:
+    """Build a prompt that checks knowledge with multiple options."""
+    opts = "; ".join(options)
+    prompt = f"{question}? Варианты: {opts}. Выбери один.".strip()
+    return _with_disclaimer(prompt)
+
+
+def build_feedback(correct: bool, explanation: str) -> str:
+    """Build feedback for quiz answers."""
+    prefix = "Верно." if correct else "Неверно."
+    prompt = f"{prefix} {explanation}".strip()
+    return _with_disclaimer(prompt)

--- a/tests/test_learning_prompts.py
+++ b/tests/test_learning_prompts.py
@@ -1,0 +1,32 @@
+from services.api.app.diabetes.learning_prompts import (
+    SYSTEM_TUTOR_RU,
+    _DISCLAIMER_RU,
+    build_explain_step,
+    build_quiz_check,
+    build_feedback,
+)
+
+
+def test_system_tutor_contains_disclaimer() -> None:
+    assert _DISCLAIMER_RU in SYSTEM_TUTOR_RU
+
+
+def test_build_explain_step_appends_disclaimer() -> None:
+    text = build_explain_step("инсулин")
+    assert text.endswith(_DISCLAIMER_RU)
+    assert text
+
+
+def test_build_quiz_check_lists_options() -> None:
+    options = ["утром", "вечером"]
+    text = build_quiz_check("Когда измерять сахар", options)
+    assert all(opt in text for opt in options)
+    assert text.endswith(_DISCLAIMER_RU)
+    assert text
+
+
+def test_build_feedback_prefix_and_disclaimer() -> None:
+    text = build_feedback(True, "Все верно")
+    assert text.startswith("Верно.")
+    assert text.endswith(_DISCLAIMER_RU)
+    assert text


### PR DESCRIPTION
## Summary
- add Russian system prompt for diabetes tutor
- implement learning prompt builders with common disclaimer
- cover templates with unit tests

## Testing
- `ruff check services/api/app/diabetes/learning_prompts.py tests/test_learning_prompts.py`
- `mypy --strict services/api/app/diabetes/learning_prompts.py tests/test_learning_prompts.py`
- `pytest tests/test_learning_prompts.py -q` *(fails: Coverage failure: total of 24 is less than fail-under=85)*
- `pytest -q` *(fails: 495 failed, 454 passed, async functions not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b98666a63c832aaf8611558c7be6f9