### PR TITLE
[learning] add tests for learning prompts

### DIFF
--- a/services/api/app/diabetes/learning_prompts.py
+++ b/services/api/app/diabetes/learning_prompts.py
@@ -1,0 +1,57 @@
+"""Prompt templates for diabetes learning module."""
+
+from __future__ import annotations
+
+SYSTEM_TUTOR_RU = (
+    "Ты — репетитор по диабету. "
+    "Говори короткими предложениями. "
+    "Сначала спрашивай, потом объясняй. "
+    "Не давай советов по терапии. "
+    "Всегда добавляй предупреждение: 'Проконсультируйтесь с врачом.'"
+)
+
+_DISCLAIMER_RU = "Проконсультируйтесь с врачом."
+
+
+
+def _with_disclaimer(text: str) -> str:
+    """Append a common disclaimer to *text*.
+
+    Parameters
+    ----------
+    text: str
+        Base text that requires the disclaimer.
+    """
+    base = text.strip()
+    return f"{base} {_DISCLAIMER_RU}" if base else _DISCLAIMER_RU
+
+
+
+def build_explain_step(step: str) -> str:
+    """Build a prompt asking and explaining a learning step."""
+    prompt = f"Что ты знаешь о {step}? Объясни.".strip()
+    return _with_disclaimer(prompt)
+
+
+
+def build_quiz_check(question: str, options: list[str]) -> str:
+    """Build a prompt that checks knowledge with multiple options."""
+    opts = "; ".join(options)
+    prompt = f"{question}? Варианты: {opts}. Выбери один.".strip()
+    return _with_disclaimer(prompt)
+
+
+
+def build_feedback(correct: bool, explanation: str) -> str:
+    """Build feedback for quiz answers."""
+    prefix = "Верно." if correct else "Неверно."
+    prompt = f"{prefix} {explanation}".strip()
+    return _with_disclaimer(prompt)
+
+
+__all__ = [
+    "SYSTEM_TUTOR_RU",
+    "build_explain_step",
+    "build_quiz_check",
+    "build_feedback",
+]

--- a/tests/test_learning_prompts.py
+++ b/tests/test_learning_prompts.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from services.api.app.diabetes.learning_prompts import (
+    _DISCLAIMER_RU,
+    build_explain_step,
+    build_feedback,
+    build_quiz_check,
+)
+
+
+@pytest.mark.parametrize(
+    "builder,args",
+    [
+        (build_explain_step, ("углеводы",)),
+        (build_quiz_check, ("Что такое ХЕ", ["12", "24"])),
+    ],
+)
+def test_builders_include_disclaimer(builder, args) -> None:
+    result = builder(*args)
+    assert result
+    assert _DISCLAIMER_RU in result
+
+
+@pytest.mark.parametrize("correct,prefix", [(True, "Верно."), (False, "Неверно.")])
+def test_build_feedback_paths(correct: bool, prefix: str) -> None:
+    result = build_feedback(correct, "объяснение")
+    assert result
+    assert prefix in result
+    assert _DISCLAIMER_RU in result


### PR DESCRIPTION
## Summary
- add prompt builders with disclaimer helper
- cover learning prompt builders with parameterized tests

## Testing
- `pytest -q tests/test_learning_prompts.py`
- `mypy --strict services/api/app/diabetes/learning_prompts.py tests/test_learning_prompts.py`
- `ruff check services/api/app/diabetes/learning_prompts.py tests/test_learning_prompts.py`


------
https://chatgpt.com/codex/tasks/task_e_68b986694568832a98b161b2def14374