### PR TITLE
[learning] Add disclaimer helper

### DIFF
--- a/services/api/app/diabetes/learning_prompts.py
+++ b/services/api/app/diabetes/learning_prompts.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+
+def disclaimer() -> str:
+    """Return the standard medical warning."""
+    return "Проконсультируйтесь с врачом."
+
+
 SYSTEM_TUTOR_RU = (
     "Ты — репетитор по диабету. "
     "Говори короткими предложениями. "
     "Сначала спрашивай, потом объясняй. "
     "Не давай советов по терапии. "
-    "Всегда добавляй предупреждение: 'Проконсультируйтесь с врачом.'"
+    f"Всегда добавляй предупреждение: '{disclaimer()}'"
 )
-
-_DISCLAIMER_RU = "Проконсультируйтесь с врачом."
 
 
 def _with_disclaimer(text: str) -> str:
@@ -22,7 +26,8 @@ def _with_disclaimer(text: str) -> str:
         Base text that requires the disclaimer.
     """
     base = text.strip()
-    return f"{base} {_DISCLAIMER_RU}" if base else _DISCLAIMER_RU
+    tail = disclaimer()
+    return f"{base} {tail}" if base else tail
 
 
 def build_explain_step(step: str) -> str:

--- a/tests/test_learning_prompts.py
+++ b/tests/test_learning_prompts.py
@@ -1,19 +1,23 @@
 from services.api.app.diabetes.learning_prompts import (
     SYSTEM_TUTOR_RU,
-    _DISCLAIMER_RU,
     build_explain_step,
-    build_quiz_check,
     build_feedback,
+    build_quiz_check,
+    disclaimer,
 )
 
 
+def test_disclaimer_returns_warning() -> None:
+    assert disclaimer() == "Проконсультируйтесь с врачом."
+
+
 def test_system_tutor_contains_disclaimer() -> None:
-    assert _DISCLAIMER_RU in SYSTEM_TUTOR_RU
+    assert disclaimer() in SYSTEM_TUTOR_RU
 
 
 def test_build_explain_step_appends_disclaimer() -> None:
     text = build_explain_step("инсулин")
-    assert text.endswith(_DISCLAIMER_RU)
+    assert text.endswith(disclaimer())
     assert text
 
 
@@ -21,12 +25,12 @@ def test_build_quiz_check_lists_options() -> None:
     options = ["утром", "вечером"]
     text = build_quiz_check("Когда измерять сахар", options)
     assert all(opt in text for opt in options)
-    assert text.endswith(_DISCLAIMER_RU)
+    assert text.endswith(disclaimer())
     assert text
 
 
 def test_build_feedback_prefix_and_disclaimer() -> None:
     text = build_feedback(True, "Все верно")
     assert text.startswith("Верно.")
-    assert text.endswith(_DISCLAIMER_RU)
+    assert text.endswith(disclaimer())
     assert text


### PR DESCRIPTION
## Summary
- add `disclaimer()` helper returning standard warning
- use helper across learning prompt builders
- test that prompts append disclaimer

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b98838ed5c832aafc86086a236d369