### PR TITLE
[tests] Add coverage for learning prompt builders

### DIFF
--- a/tests/test_learning_prompts.py
+++ b/tests/test_learning_prompts.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import pytest
+
 from services.api.app.diabetes.learning_prompts import (
     SYSTEM_TUTOR_RU,
     _DISCLAIMER_RU,
     build_explain_step,
-    build_quiz_check,
     build_feedback,
+    build_quiz_check,
 )
 
 
@@ -11,22 +17,30 @@ def test_system_tutor_contains_disclaimer() -> None:
     assert _DISCLAIMER_RU in SYSTEM_TUTOR_RU
 
 
-def test_build_explain_step_appends_disclaimer() -> None:
-    text = build_explain_step("инсулин")
-    assert text.endswith(_DISCLAIMER_RU)
+@pytest.mark.parametrize(
+    ("builder", "args"),
+    [
+        (build_explain_step, ("инсулин",)),
+        (build_quiz_check, ("Когда измерять сахар", ["утром", "вечером"])),
+    ],
+)
+def test_builders_return_text_with_disclaimer(
+    builder: Callable[..., str], args: tuple[Any, ...]
+) -> None:
+    text = builder(*args)
     assert text
-
-
-def test_build_quiz_check_lists_options() -> None:
-    options = ["утром", "вечером"]
-    text = build_quiz_check("Когда измерять сахар", options)
-    assert all(opt in text for opt in options)
     assert text.endswith(_DISCLAIMER_RU)
+
+
+@pytest.mark.parametrize(
+    ("correct", "prefix"),
+    [
+        (True, "Верно."),
+        (False, "Неверно."),
+    ],
+)
+def test_build_feedback_paths(correct: bool, prefix: str) -> None:
+    text = build_feedback(correct, "Пояснение")
     assert text
-
-
-def test_build_feedback_prefix_and_disclaimer() -> None:
-    text = build_feedback(True, "Все верно")
-    assert text.startswith("Верно.")
+    assert text.startswith(prefix)
     assert text.endswith(_DISCLAIMER_RU)
-    assert text


### PR DESCRIPTION
## Summary
- test all learning prompt builders for non-empty results with disclaimer
- cover feedback builder paths for correct and incorrect answers

## Testing
- `pytest -q tests/test_learning_prompts.py`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b989efc380832a9273aa2fb65af7f2