### PR TITLE
[db] store subscription status values

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -343,6 +343,7 @@ class Subscription(Base):
             SubscriptionStatus,
             name="subscription_status",
             create_type=False,
+            values_callable=lambda enum: [e.value for e in enum],
         ),
         nullable=False,
     )


### PR DESCRIPTION
## Summary
- persist subscription status enums using their lowercase values

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/diabetes_bot alembic -c services/api/alembic.ini upgrade head` *(fails: relation "users" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b98b900804832aaaee83274b08f50f