### PR TITLE
[alembic] Replace subscription status enum

### DIFF
--- a/services/api/alembic/versions/20250913_lowercase_subscription_status.py
+++ b/services/api/alembic/versions/20250913_lowercase_subscription_status.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "20250913_lowercase_subscription_status"
+down_revision: Union[str, Sequence[str], None] = "20250912_add_lesson_steps"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE TYPE subscription_status_new AS ENUM ('trial','active','canceled','expired')")
+    op.execute(
+        "ALTER TABLE subscriptions ALTER COLUMN status TYPE subscription_status_new USING lower(status::text)::subscription_status_new"
+    )
+    op.execute("DROP TYPE subscription_status")
+    op.execute("ALTER TYPE subscription_status_new RENAME TO subscription_status")
+
+
+def downgrade() -> None:
+    op.execute("CREATE TYPE subscription_status_old AS ENUM ('trial','pending','active','canceled','expired')")
+    op.execute(
+        "ALTER TABLE subscriptions ALTER COLUMN status TYPE subscription_status_old USING status::text::subscription_status_old"
+    )
+    op.execute("DROP TYPE subscription_status")
+    op.execute("ALTER TYPE subscription_status_old RENAME TO subscription_status")

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -312,7 +312,6 @@ class SubscriptionPlan(str, Enum):
 
 class SubscriptionStatus(str, Enum):
     TRIAL = "trial"
-    PENDING = "pending"
     ACTIVE = "active"
     CANCELED = "canceled"
     EXPIRED = "expired"

--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -121,7 +121,7 @@ async def subscribe(
         draft = Subscription(
             user_id=user_id,
             plan=plan,
-            status=SubscriptionStatus.PENDING,
+            status=SubscriptionStatus.TRIAL,
             provider=settings.billing_provider,
             transaction_id=checkout["id"],
             start_date=now,

--- a/tests/billing/test_admin_mock_webhook.py
+++ b/tests/billing/test_admin_mock_webhook.py
@@ -68,7 +68,7 @@ def test_admin_mock_webhook(monkeypatch: pytest.MonkeyPatch) -> None:
             Subscription(
                 user_id=1,
                 plan=SubscriptionPlan.PRO,
-                status=SubscriptionStatus.PENDING,
+                status=SubscriptionStatus.TRIAL,
                 provider="dummy",
                 transaction_id="tx1",
                 start_date=datetime.now(timezone.utc),


### PR DESCRIPTION
## Summary
- replace subscription status enum with lowercase values and remove pending
- update billing draft creation and tests for new status
- add Alembic migration to convert existing data

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `alembic -c services/api/alembic.ini upgrade head` *(fails: relation "users" does not exist)*
- manual SQL to verify enum conversion


------
https://chatgpt.com/codex/tasks/task_e_68b98b9174f8832a968d843ba1a9bb08