### PR TITLE
[alembic] Lowercase subscription status enum

### DIFF
--- a/services/api/alembic/versions/20250913_subscription_status_lowercase.py
+++ b/services/api/alembic/versions/20250913_subscription_status_lowercase.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20250913_subscription_status_lowercase"
+down_revision: Union[str, Sequence[str], None] = "20250912_add_lesson_steps"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+status_enum_new = postgresql.ENUM(
+    "trial",
+    "active",
+    "canceled",
+    "expired",
+    name="subscription_status_new",
+)
+
+status_enum_old = postgresql.ENUM(
+    "trial",
+    "pending",
+    "active",
+    "canceled",
+    "expired",
+    name="subscription_status_old",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        status_enum_new.create(bind, checkfirst=True)
+        op.execute(
+            "ALTER TABLE subscriptions ALTER COLUMN status TYPE subscription_status_new USING lower(status::text)::subscription_status_new"
+        )
+        op.execute("DROP TYPE subscription_status")
+        op.execute("ALTER TYPE subscription_status_new RENAME TO subscription_status")
+    else:
+        op.alter_column("subscriptions", "status", type_=sa.String())
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        status_enum_old.create(bind, checkfirst=True)
+        op.execute(
+            "ALTER TABLE subscriptions ALTER COLUMN status TYPE subscription_status_old USING status::text::subscription_status_old"
+        )
+        op.execute("DROP TYPE subscription_status")
+        op.execute("ALTER TYPE subscription_status_old RENAME TO subscription_status")
+    else:
+        op.alter_column("subscriptions", "status", type_=sa.String())


### PR DESCRIPTION
## Summary
- replace existing `subscription_status` enum via migration with lowercase labels and pending removal

## Testing
- `alembic -c services/api/alembic.ini upgrade head`
- `psql postgresql://testuser:testpass@localhost:5432/saharlight -c "INSERT INTO subscriptions (user_id, plan, status, provider, transaction_id) VALUES (1, 'free', 'trial', 'prov', 'tx1');" && psql postgresql://testuser:testpass@localhost:5432/saharlight -c "SELECT user_id, status FROM subscriptions ORDER BY user_id;"`
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b98eee85ec832a998f69e0401789bc