### PR TITLE
[webapp] add user id to billing API

### DIFF
--- a/services/webapp/ui/src/api/billing.ts
+++ b/services/webapp/ui/src/api/billing.ts
@@ -19,11 +19,14 @@ export interface BillingStatus {
   subscription: SubscriptionInfo | null;
 }
 
-export const getBillingStatus = () =>
-  api.get<BillingStatus>('/billing/status');
+export const getBillingStatus = (userId: string) =>
+  api.get<BillingStatus>(`/billing/status?user_id=${userId}`);
 
-export const startTrial = () =>
-  api.post<SubscriptionInfo>('/billing/trial', {});
+export const startTrial = (userId: string) =>
+  api.post<SubscriptionInfo>(`/billing/trial?user_id=${userId}`, {});
 
-export const subscribePlan = (plan: string) =>
-  api.post<{ id: string; url: string }>(`/billing/subscribe?plan=${plan}`, {});
+export const subscribePlan = (userId: string, plan: string) =>
+  api.post<{ id: string; url: string }>(
+    `/billing/subscribe?user_id=${userId}&plan=${plan}`,
+    {},
+  );

--- a/services/webapp/ui/src/pages/Subscription.test.tsx
+++ b/services/webapp/ui/src/pages/Subscription.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, it, vi, beforeEach } from 'vitest';
+import { describe, it, vi, beforeEach, expect } from 'vitest';
 import Subscription from './Subscription';
 import { getBillingStatus } from '@/api/billing';
 
@@ -10,12 +10,29 @@ vi.mock('@/api/billing', () => ({
   startTrial: vi.fn(),
   subscribePlan: vi.fn(),
 }));
+vi.mock('@/hooks/useTelegram', () => ({
+  useTelegram: () => ({ user: null }),
+}));
+vi.mock('@/hooks/useTelegramInitData', () => ({
+  useTelegramInitData: vi.fn(),
+}));
+vi.mock('./resolveTelegramId', () => ({
+  resolveTelegramId: vi.fn(),
+}));
+
+import { resolveTelegramId } from './resolveTelegramId';
+import { useTelegramInitData } from '@/hooks/useTelegramInitData';
 
 const mockedStatus = getBillingStatus as unknown as vi.Mock;
+const mockedResolveTelegramId = resolveTelegramId as unknown as vi.Mock;
+const mockedInitData = useTelegramInitData as unknown as vi.Mock;
 
 describe('Subscription states', () => {
   beforeEach(() => {
     mockedStatus.mockReset();
+    mockedResolveTelegramId.mockReset();
+    mockedResolveTelegramId.mockReturnValue(123);
+    mockedInitData.mockReturnValue(null);
   });
 
   const renderPage = async (status: unknown) => {


### PR DESCRIPTION
## Summary
- pass user id to billing API calls and related page logic
- mock user id in Subscription tests

## Testing
- `pnpm --filter ./services/webapp/ui test` *(failed: JavaScript heap out of memory)*
- `pnpm --filter ./services/webapp/ui typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68b98fb86190832a9a887c04ac74d6ca