### PR TITLE
[billing] ensure trial creation is atomic

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -327,6 +327,9 @@ class Subscription(Base):
     """
 
     __tablename__ = "subscriptions"
+    __table_args__ = (
+        sa.UniqueConstraint("user_id", "status", name="subscriptions_user_status_key"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), index=True, nullable=False)


### PR DESCRIPTION
## Summary
- guard trial creation with a DB transaction and fetch fallback
- add unique constraint for subscriptions by user and status
- test trial endpoint against parallel requests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b98fcd47fc832ab4e2f088899a15cc