### PR TITLE
feat(billing): expose test mode flag

### DIFF
--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -310,7 +310,11 @@ async def status(user_id: int, settings: BillingSettings = Depends(get_billing_s
         return session.scalars(stmt).first()
 
     subscription = await run_db(_get_subscription, sessionmaker=SessionLocal)
-    flags = FeatureFlags(billingEnabled=settings.billing_enabled, paywallMode=settings.paywall_mode)
+    flags = FeatureFlags(
+        billingEnabled=settings.billing_enabled,
+        paywallMode=settings.paywall_mode,
+        testMode=settings.billing_test_mode,
+    )
     if subscription is None:
         return BillingStatusResponse(featureFlags=flags, subscription=None)
     return BillingStatusResponse(

--- a/services/api/app/schemas/billing.py
+++ b/services/api/app/schemas/billing.py
@@ -11,6 +11,7 @@ class FeatureFlags(BaseModel):
 
     billingEnabled: bool = Field(alias="billingEnabled")
     paywallMode: str = Field(alias="paywallMode")
+    testMode: bool = Field(alias="testMode")
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/services/webapp/ui/src/api/billing.ts
+++ b/services/webapp/ui/src/api/billing.ts
@@ -3,7 +3,7 @@ import { api } from './index';
 export interface BillingFeatureFlags {
   billingEnabled: boolean;
   paywallMode: string;
-  testMode?: boolean;
+  testMode: boolean;
 }
 
 export interface SubscriptionInfo {

--- a/services/webapp/ui/src/pages/Subscription.test.tsx
+++ b/services/webapp/ui/src/pages/Subscription.test.tsx
@@ -40,7 +40,7 @@ describe('Subscription states', () => {
 
   it('renders trial subscription', async () => {
     await renderPage({
-      featureFlags: { billingEnabled: true, paywallMode: 'soft' },
+      featureFlags: { billingEnabled: true, paywallMode: 'soft', testMode: false },
       subscription: {
         plan: 'pro',
         status: 'trial',
@@ -55,7 +55,7 @@ describe('Subscription states', () => {
 
   it('renders active subscription', async () => {
     await renderPage({
-      featureFlags: { billingEnabled: true, paywallMode: 'soft' },
+      featureFlags: { billingEnabled: true, paywallMode: 'soft', testMode: false },
       subscription: {
         plan: 'pro',
         status: 'active',
@@ -69,7 +69,7 @@ describe('Subscription states', () => {
 
   it('renders expired subscription', async () => {
     await renderPage({
-      featureFlags: { billingEnabled: true, paywallMode: 'soft' },
+      featureFlags: { billingEnabled: true, paywallMode: 'soft', testMode: false },
       subscription: {
         plan: 'pro',
         status: 'expired',

--- a/services/webapp/ui/src/pages/Subscription.tsx
+++ b/services/webapp/ui/src/pages/Subscription.tsx
@@ -101,7 +101,11 @@ const Subscription = () => {
         prev
           ? { ...prev, subscription: sub }
           : {
-              featureFlags: { billingEnabled: false, paywallMode: 'soft' },
+              featureFlags: {
+                billingEnabled: false,
+                paywallMode: 'soft',
+                testMode: true,
+              },
               subscription: sub,
             },
       );

--- a/tests/test_billing_status.py
+++ b/tests/test_billing_status.py
@@ -64,7 +64,11 @@ def test_status_without_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
         resp = client.get("/api/billing/status", params={"user_id": 1})
     assert resp.status_code == 200
     assert resp.json() == {
-        "featureFlags": {"billingEnabled": False, "paywallMode": "soft"},
+        "featureFlags": {
+            "billingEnabled": False,
+            "paywallMode": "soft",
+            "testMode": True,
+        },
         "subscription": None,
     }
 
@@ -90,7 +94,11 @@ def test_status_with_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
         resp = client.get("/api/billing/status", params={"user_id": 1})
     assert resp.status_code == 200
     data = resp.json()
-    assert data["featureFlags"] == {"billingEnabled": False, "paywallMode": "soft"}
+    assert data["featureFlags"] == {
+        "billingEnabled": False,
+        "paywallMode": "soft",
+        "testMode": True,
+    }
     assert data["subscription"]["plan"] == "pro"
     assert data["subscription"]["status"] == "active"
     assert data["subscription"]["provider"] == "dummy"
@@ -132,6 +140,11 @@ def test_status_with_multiple_subscriptions(
         resp = client.get("/api/billing/status", params={"user_id": 1})
     assert resp.status_code == 200
     data = resp.json()
+    assert data["featureFlags"] == {
+        "billingEnabled": False,
+        "paywallMode": "soft",
+        "testMode": True,
+    }
     assert data["subscription"]["plan"] == "family"
     assert data["subscription"]["status"] == "active"
     assert data["subscription"]["startDate"].startswith("2024-03-01")


### PR DESCRIPTION
## Summary
- add testMode to billing feature flags
- include test mode flag in billing status response
- adjust backend and frontend tests for new flag

## Testing
- `pytest tests/test_billing_status.py -q` *(fails: Required test coverage of 85% not reached)*
- `mypy --strict services/api/app/routers/billing.py services/api/app/schemas/billing.py tests/test_billing_status.py` *(fails: Library stubs not installed for "psycopg2.errors")*
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test` *(fails: Test Files 6 failed | 9 passed (25))*

------
https://chatgpt.com/codex/tasks/task_e_68b98fdbadac832ab9c74d60d0d9dfe1