### PR TITLE
[learning] add progress state fields

### DIFF
--- a/services/api/alembic/versions/20250914_add_progress_state_fields.py
+++ b/services/api/alembic/versions/20250914_add_progress_state_fields.py
@@ -1,0 +1,45 @@
+"""add progress state fields
+
+Revision ID: 20250914_add_progress_state_fields
+Revises: 20250913_subscription_status_lowercase
+Create Date: 2025-09-14 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20250914_add_progress_state_fields"
+down_revision: Union[str, None] = "20250913_subscription_status_lowercase"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "lesson_progress",
+        sa.Column(
+            "current_step",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    op.add_column(
+        "lesson_progress",
+        sa.Column(
+            "current_question",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("lesson_progress", "current_question")
+    op.drop_column("lesson_progress", "current_step")

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -16,9 +16,7 @@ class Lesson(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     title: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=True, server_default=sa.true()
-    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.true())
 
     steps: Mapped[list["LessonStep"]] = relationship(
         "LessonStep",
@@ -39,13 +37,9 @@ class QuizQuestion(Base):
     __tablename__ = "quiz_questions"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    lesson_id: Mapped[int] = mapped_column(
-        ForeignKey("lessons.id"), nullable=False, index=True
-    )
+    lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)
     question: Mapped[str] = mapped_column(Text, nullable=False)
-    options: Mapped[Sequence[str]] = mapped_column(
-        sa.JSON().with_variant(JSONB, "postgresql"), nullable=False
-    )
+    options: Mapped[Sequence[str]] = mapped_column(sa.JSON().with_variant(JSONB, "postgresql"), nullable=False)
     correct_option: Mapped[int] = mapped_column(Integer, nullable=False)
 
     lesson: Mapped[Lesson] = relationship("Lesson", back_populates="questions")
@@ -55,9 +49,7 @@ class LessonStep(Base):
     __tablename__ = "lesson_steps"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    lesson_id: Mapped[int] = mapped_column(
-        ForeignKey("lessons.id"), nullable=False, index=True
-    )
+    lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)
     step_order: Mapped[int] = mapped_column(Integer, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
 
@@ -68,13 +60,11 @@ class LessonProgress(Base):
     __tablename__ = "lesson_progress"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True
-    )
-    lesson_id: Mapped[int] = mapped_column(
-        ForeignKey("lessons.id"), nullable=False, index=True
-    )
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True)
+    lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)
     completed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    current_step: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    current_question: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     quiz_score: Mapped[Optional[int]] = mapped_column(Integer)
 
     user: Mapped[User] = relationship("User")

--- a/services/api/tests/test_learning_models.py
+++ b/services/api/tests/test_learning_models.py
@@ -79,7 +79,12 @@ def test_lesson_progress_crud() -> None:
         session.commit()
 
         progress = LessonProgress(
-            user_id=user.telegram_id, lesson_id=lesson.id, completed=True, quiz_score=80
+            user_id=user.telegram_id,
+            lesson_id=lesson.id,
+            completed=True,
+            current_step=0,
+            current_question=0,
+            quiz_score=80,
         )
         session.add(progress)
         session.commit()


### PR DESCRIPTION
## Summary
- track current lesson step and quiz question in `LessonProgress`
- add migration for new progress fields
- update learning model tests for progress state

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b997316ba0832aa0d22ccbe1ff40be