### PR TITLE
[learning] Add slug field to lessons

### DIFF
--- a/services/api/alembic/versions/20250914_add_lesson_slug.py
+++ b/services/api/alembic/versions/20250914_add_lesson_slug.py
@@ -1,0 +1,40 @@
+"""add lesson slug"""
+
+from __future__ import annotations
+
+import re
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250914_add_lesson_slug"
+down_revision: Union[str, Sequence[str], None] = (
+    "20250913_subscription_status_lowercase"
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("lessons", sa.Column("slug", sa.String(), nullable=True))
+    lesson_table = sa.table(
+        "lessons",
+        sa.column("id", sa.Integer()),
+        sa.column("title", sa.String()),
+        sa.column("slug", sa.String()),
+    )
+    conn = op.get_bind()
+    rows = conn.execute(sa.select(lesson_table.c.id, lesson_table.c.title)).fetchall()
+    for row in rows:
+        slug = re.sub(r"[^a-z0-9]+", "-", row.title.lower()).strip("-")
+        conn.execute(
+            sa.update(lesson_table).where(lesson_table.c.id == row.id).values(slug=slug)
+        )
+    op.alter_column("lessons", "slug", nullable=False)
+    op.create_index("ix_lessons_slug", "lessons", ["slug"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_lessons_slug", table_name="lessons")
+    op.drop_column("lessons", "slug")

--- a/services/api/app/diabetes/learning_fixtures.py
+++ b/services/api/app/diabetes/learning_fixtures.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from pathlib import Path
 from typing import TypedDict, cast
 
@@ -55,10 +56,14 @@ async def load_lessons(
     raw = json.loads(path.read_text(encoding="utf-8"))
     lessons = cast(list[LessonDict], raw)
 
+    def _slugify(text: str) -> str:
+        return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+
     def _load(session: Session) -> None:
         for item in lessons:
             lesson = Lesson(
                 title=item["title"],
+                slug=_slugify(item["title"]),
                 content="\n".join(item["steps"]),
                 is_active=True,
             )

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -15,6 +15,7 @@ class Lesson(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     title: Mapped[str] = mapped_column(String, nullable=False)
+    slug: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
     content: Mapped[str] = mapped_column(Text, nullable=False)
     is_active: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True, server_default=sa.true()

--- a/services/api/tests/test_learning_fixtures.py
+++ b/services/api/tests/test_learning_fixtures.py
@@ -46,6 +46,7 @@ async def test_load_lessons(tmp_path: Path) -> None:
     with SessionLocal() as session:
         lessons = session.query(Lesson).all()
         assert len(lessons) == 1
+        assert lessons[0].slug == "sample"
         assert lessons[0].is_active is True
         steps = (
             session.query(LessonStep)

--- a/services/api/tests/test_learning_models.py
+++ b/services/api/tests/test_learning_models.py
@@ -29,6 +29,7 @@ def test_lesson_crud() -> None:
     with SessionLocal() as session:
         lesson = Lesson(
             title="Intro",
+            slug="intro",
             content="Basics",
             steps=[
                 LessonStep(step_order=1, content="s1"),
@@ -42,6 +43,7 @@ def test_lesson_crud() -> None:
         stored = session.get(Lesson, lesson.id)
         assert stored is not None
         assert stored.title == "Intro"
+        assert stored.slug == "intro"
         assert stored.is_active is True
         assert [s.content for s in stored.steps] == ["s1", "s2"]
 
@@ -49,7 +51,7 @@ def test_lesson_crud() -> None:
 def test_quiz_question_crud() -> None:
     SessionLocal = setup_db()
     with SessionLocal() as session:
-        lesson = Lesson(title="Intro", content="Basics")
+        lesson = Lesson(title="Intro", slug="intro", content="Basics")
         session.add(lesson)
         session.commit()
         session.refresh(lesson)
@@ -74,7 +76,7 @@ def test_lesson_progress_crud() -> None:
     SessionLocal = setup_db()
     with SessionLocal() as session:
         user = db.User(telegram_id=1, thread_id="t1")
-        lesson = Lesson(title="Intro", content="Basics")
+        lesson = Lesson(title="Intro", slug="intro", content="Basics")
         session.add_all([user, lesson])
         session.commit()
 

--- a/tests/learning/test_load_lessons.py
+++ b/tests/learning/test_load_lessons.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 import pytest
 from sqlalchemy import create_engine
@@ -30,6 +31,9 @@ async def test_load_lessons_v0() -> None:
             lessons = session.query(Lesson).all()
             assert len(lessons) == 3
             for lesson in lessons:
+                assert lesson.slug == re.sub(
+                    r"[^a-z0-9]+", "-", lesson.title.lower()
+                ).strip("-")
                 steps = lesson.content.splitlines()
                 assert len(steps) >= 3
                 quiz_count = (


### PR DESCRIPTION
## Summary
- add unique `slug` column to `Lesson`
- populate lesson slugs when loading fixtures and tests
- create migration `20250914_add_lesson_slug`

## Testing
- `ruff check .`
- `pytest services/api/tests/test_learning_models.py services/api/tests/test_learning_fixtures.py tests/learning/test_load_lessons.py -q -o addopts='--cov=services.api.app.diabetes.models_learning --cov=services.api.app.diabetes.learning_fixtures --cov-report=term-missing --cov-fail-under=85'`
- `mypy --strict services/api/app/diabetes/models_learning.py services/api/app/diabetes/learning_fixtures.py services/api/tests/test_learning_models.py services/api/tests/test_learning_fixtures.py tests/learning/test_load_lessons.py` *(fails: hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68b9973080c8832ab41f60945908c066