### PR TITLE
[learning] add curriculum engine

### DIFF
--- a/services/api/app/diabetes/curriculum_engine.py
+++ b/services/api/app/diabetes/curriculum_engine.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from .learning_prompts import SYSTEM_TUTOR_RU, build_explain_step, build_feedback
+from .llm_router import LLMTask
+from .models_learning import Lesson, LessonProgress, QuizQuestion
+from .services.db import SessionLocal, run_db
+from .services.gpt_client import create_learning_chat_completion
+from .services.repository import CommitError, commit
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["start_lesson", "next_step", "check_answer"]
+
+
+async def start_lesson(user_id: int, lesson_slug: str) -> LessonProgress:
+    """Start or reset a lesson for *user_id*.
+
+    Parameters
+    ----------
+    user_id: int
+        Telegram identifier of the user.
+    lesson_slug: str
+        Slug of the lesson to start.
+    """
+
+    def _start(session: Session) -> LessonProgress:
+        lesson = session.query(Lesson).filter_by(slug=lesson_slug).one()
+        progress = (
+            session.query(LessonProgress)
+            .filter_by(user_id=user_id, lesson_id=lesson.id)
+            .one_or_none()
+        )
+        if progress is None:
+            progress = LessonProgress(user_id=user_id, lesson_id=lesson.id)
+            session.add(progress)
+        progress.current_step = 0
+        progress.current_question = 0
+        progress.completed = False
+        progress.quiz_score = None
+        try:
+            commit(session)
+        except CommitError:
+            logger.exception(
+                "Failed to start lesson %s for user %s", lesson_slug, user_id
+            )
+            raise
+        session.refresh(progress)
+        return progress
+
+    return await run_db(_start, sessionmaker=SessionLocal)
+
+
+async def next_step(user_id: int, lesson_id: int) -> str | None:
+    """Return the next lesson step or quiz question for the user.
+
+    Parameters
+    ----------
+    user_id: int
+        Telegram identifier of the user.
+    lesson_id: int
+        Identifier of the lesson.
+    """
+
+    def _load(session: Session) -> tuple[LessonProgress, Lesson]:
+        progress = (
+            session.query(LessonProgress)
+            .filter_by(user_id=user_id, lesson_id=lesson_id)
+            .one()
+        )
+        lesson = session.get(Lesson, lesson_id)
+        assert lesson is not None
+        # Preload relationships to avoid DetachedInstanceError
+        _ = lesson.steps, lesson.questions
+        return progress, lesson
+
+    progress, lesson = await run_db(_load, sessionmaker=SessionLocal)
+    assert lesson is not None
+
+    if progress.current_step < len(lesson.steps):
+        step = lesson.steps[progress.current_step]
+        completion = await create_learning_chat_completion(
+            task=LLMTask.EXPLAIN_STEP,
+            messages=[
+                {"role": "system", "content": SYSTEM_TUTOR_RU},
+                {"role": "user", "content": build_explain_step(step.content)},
+            ],
+        )
+        text = completion.choices[0].message.content or ""
+
+        def _update(session: Session) -> None:
+            prog = session.get(LessonProgress, progress.id)
+            assert prog is not None
+            prog.current_step += 1
+            try:
+                commit(session)
+            except CommitError:
+                logger.exception(
+                    "Failed to update step %s for user %s", progress.id, user_id
+                )
+                raise
+
+        await run_db(_update, sessionmaker=SessionLocal)
+        return text
+
+    if progress.current_question < len(lesson.questions):
+        question = lesson.questions[progress.current_question]
+        opts = "\n".join(
+            f"{idx + 1}. {opt}" for idx, opt in enumerate(question.options)
+        )
+        return f"{question.question}\n{opts}".strip()
+
+    return None
+
+
+async def check_answer(
+    user_id: int, lesson_id: int, answer_index: int
+) -> tuple[bool, str]:
+    """Check user's quiz answer and provide feedback.
+
+    Parameters
+    ----------
+    user_id: int
+        Telegram identifier of the user.
+    lesson_id: int
+        Identifier of the lesson.
+    answer_index: int
+        Index of the chosen answer.
+    """
+
+    def _load(session: Session) -> tuple[LessonProgress, QuizQuestion]:
+        progress = (
+            session.query(LessonProgress)
+            .filter_by(user_id=user_id, lesson_id=lesson_id)
+            .one()
+        )
+        question = progress.lesson.questions[progress.current_question]
+        return progress, question
+
+    progress, question = await run_db(_load, sessionmaker=SessionLocal)
+    correct = answer_index == question.correct_option
+    explanation = question.options[question.correct_option]
+    completion = await create_learning_chat_completion(
+        task=LLMTask.QUIZ_CHECK,
+        messages=[
+            {"role": "system", "content": SYSTEM_TUTOR_RU},
+            {"role": "user", "content": build_feedback(correct, explanation)},
+        ],
+    )
+    text = completion.choices[0].message.content or ""
+
+    def _update(session: Session) -> None:
+        prog = session.get(LessonProgress, progress.id)
+        assert prog is not None
+        questions = prog.lesson.questions  # preload
+        prog.current_question += 1
+        if prog.quiz_score is None:
+            prog.quiz_score = 0
+        if correct:
+            prog.quiz_score += 1
+        if prog.current_question >= len(questions):
+            prog.completed = True
+        try:
+            commit(session)
+        except CommitError:
+            logger.exception(
+                "Failed to commit quiz answer for user %s lesson %s", user_id, lesson_id
+            )
+            raise
+
+    await run_db(_update, sessionmaker=SessionLocal)
+    return correct, text

--- a/services/api/app/diabetes/learning_fixtures.py
+++ b/services/api/app/diabetes/learning_fixtures.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import TypedDict, cast
+from typing import NotRequired, TypedDict, cast
 
 from sqlalchemy.orm import Session
 
@@ -39,6 +39,7 @@ class LessonDict(TypedDict):
     title: str
     steps: list[str]
     quiz: list[QuizDict]
+    slug: NotRequired[str]
 
 
 DEFAULT_CONTENT_FILE = Path(__file__).parent / "content" / "lessons_v0.json"
@@ -57,8 +58,10 @@ async def load_lessons(
 
     def _load(session: Session) -> None:
         for item in lessons:
+            slug = item.get("slug") or item["title"].lower().replace(" ", "-")
             lesson = Lesson(
                 title=item["title"],
+                slug=slug,
                 content="\n".join(item["steps"]),
                 is_active=True,
             )

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -15,6 +15,7 @@ class Lesson(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     title: Mapped[str] = mapped_column(String, nullable=False)
+    slug: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     content: Mapped[str] = mapped_column(Text, nullable=False)
     is_active: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True, server_default=sa.true()
@@ -74,6 +75,8 @@ class LessonProgress(Base):
     lesson_id: Mapped[int] = mapped_column(
         ForeignKey("lessons.id"), nullable=False, index=True
     )
+    current_step: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    current_question: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     completed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     quiz_score: Mapped[Optional[int]] = mapped_column(Integer)
 

--- a/services/api/tests/test_curriculum_engine.py
+++ b/services/api/tests/test_curriculum_engine.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.services import db
+from services.api.app.diabetes.models_learning import (
+    Lesson,
+    LessonProgress,
+    LessonStep,
+    QuizQuestion,
+)
+from services.api.app.diabetes import curriculum_engine
+from services.api.app.diabetes.curriculum_engine import (
+    start_lesson,
+    next_step,
+    check_answer,
+)
+from services.api.app.diabetes.services.db import run_db
+
+
+class DummyChoice:  # helper for fake LLM response
+    def __init__(self, content: str) -> None:
+        self.message = types.SimpleNamespace(content=content)
+
+
+class DummyCompletion:
+    def __init__(self, content: str) -> None:
+        self.choices = [DummyChoice(content)]
+
+
+@pytest.mark.asyncio()
+async def test_curriculum_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+
+    # patch module sessionmaker and llm client
+    monkeypatch.setattr(curriculum_engine, "SessionLocal", SessionLocal)
+
+    async def fake_completion(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return DummyCompletion("llm")
+
+    monkeypatch.setattr(
+        curriculum_engine, "create_learning_chat_completion", fake_completion
+    )
+
+    with SessionLocal() as session:
+        user = db.User(telegram_id=1, thread_id="t")
+        lesson = Lesson(title="Intro", slug="intro", content="Basics")
+        session.add_all([user, lesson])
+        session.flush()
+        session.add_all(
+            [
+                LessonStep(lesson_id=lesson.id, step_order=1, content="s1"),
+                LessonStep(lesson_id=lesson.id, step_order=2, content="s2"),
+            ]
+        )
+        session.add_all(
+            [
+                QuizQuestion(
+                    lesson_id=lesson.id,
+                    question="q1",
+                    options=["a", "b"],
+                    correct_option=0,
+                ),
+                QuizQuestion(
+                    lesson_id=lesson.id,
+                    question="q2",
+                    options=["c", "d"],
+                    correct_option=1,
+                ),
+            ]
+        )
+        session.commit()
+
+    progress = await start_lesson(1, "intro")
+    assert progress.current_step == 0
+
+    text = await next_step(1, progress.lesson_id)
+    assert text == "llm"
+
+    def _fetch(session: Session, /) -> LessonProgress:
+        obj = session.get(LessonProgress, progress.id)
+        assert obj is not None
+        return obj
+
+    progress = await run_db(_fetch, sessionmaker=SessionLocal)
+    assert progress.current_step == 1
+
+    await next_step(1, progress.lesson_id)  # second step
+    question_text = await next_step(1, progress.lesson_id)
+    assert question_text is not None and "q1" in question_text
+
+    ok, msg = await check_answer(1, progress.lesson_id, 0)
+    assert ok is True and msg == "llm"
+
+    progress = await run_db(_fetch, sessionmaker=SessionLocal)
+    assert progress.quiz_score == 1
+    assert progress.current_question == 1
+
+    question_text = await next_step(1, progress.lesson_id)
+    assert question_text is not None and "q2" in question_text
+    ok, _ = await check_answer(1, progress.lesson_id, 0)
+    assert ok is False
+
+    progress = await run_db(_fetch, sessionmaker=SessionLocal)
+    assert progress.completed is True and progress.quiz_score == 1
+    assert await next_step(1, progress.lesson_id) is None

--- a/services/api/tests/test_learning_models.py
+++ b/services/api/tests/test_learning_models.py
@@ -29,6 +29,7 @@ def test_lesson_crud() -> None:
     with SessionLocal() as session:
         lesson = Lesson(
             title="Intro",
+            slug="intro",
             content="Basics",
             steps=[
                 LessonStep(step_order=1, content="s1"),
@@ -49,7 +50,7 @@ def test_lesson_crud() -> None:
 def test_quiz_question_crud() -> None:
     SessionLocal = setup_db()
     with SessionLocal() as session:
-        lesson = Lesson(title="Intro", content="Basics")
+        lesson = Lesson(title="Intro", slug="intro", content="Basics")
         session.add(lesson)
         session.commit()
         session.refresh(lesson)
@@ -74,12 +75,17 @@ def test_lesson_progress_crud() -> None:
     SessionLocal = setup_db()
     with SessionLocal() as session:
         user = db.User(telegram_id=1, thread_id="t1")
-        lesson = Lesson(title="Intro", content="Basics")
+        lesson = Lesson(title="Intro", slug="intro", content="Basics")
         session.add_all([user, lesson])
         session.commit()
 
         progress = LessonProgress(
-            user_id=user.telegram_id, lesson_id=lesson.id, completed=True, quiz_score=80
+            user_id=user.telegram_id,
+            lesson_id=lesson.id,
+            current_step=1,
+            current_question=1,
+            completed=True,
+            quiz_score=80,
         )
         session.add(progress)
         session.commit()
@@ -89,3 +95,5 @@ def test_lesson_progress_crud() -> None:
         assert stored is not None
         assert stored.completed is True
         assert stored.quiz_score == 80
+        assert stored.current_step == 1
+        assert stored.current_question == 1


### PR DESCRIPTION
## Summary
- add curriculum engine to manage lesson flow and quiz answers
- track lesson progress with step and question counters
- load lessons with auto-generated slugs

## Testing
- `ruff check services/api/app/diabetes/curriculum_engine.py services/api/tests/test_curriculum_engine.py services/api/app/diabetes/models_learning.py services/api/app/diabetes/learning_fixtures.py services/api/tests/test_learning_models.py`
- `mypy --strict services/api/app/diabetes/curriculum_engine.py services/api/tests/test_curriculum_engine.py services/api/app/diabetes/models_learning.py services/api/app/diabetes/learning_fixtures.py services/api/tests/test_learning_models.py`
- `PYTHONPATH=. pytest -q` *(fails: test_billing_trial.py::test_trial_integrity_error - assert 500 == 409)*

------
https://chatgpt.com/codex/tasks/task_e_68b99735b020832a917a5c84fdf9979e