### PR TITLE
[billing] Normalize webhook IP and verification

### DIFF
--- a/services/api/app/billing/service.py
+++ b/services/api/app/billing/service.py
@@ -40,13 +40,11 @@ async def verify_webhook(
     settings: BillingSettings,
     event: WebhookEvent,
     headers: Mapping[str, str],
-    ip: str | None,
+    ip: str,
 ) -> bool:
     """Verify webhook payload using the configured provider."""
 
-    if settings.billing_webhook_ips and (
-        ip is None or ip not in settings.billing_webhook_ips
-    ):
+    if settings.billing_webhook_ips and ip not in settings.billing_webhook_ips:
         return False
     if not hmac.compare_digest(
         headers.get("X-Webhook-Signature") or "", event.signature


### PR DESCRIPTION
## Summary
- Normalize X-Forwarded-For header to first IP and verify against allow list
- Update billing webhook verification to accept a single IP
- Add regression test covering comma-separated X-Forwarded-For entries
- Handle trial IntegrityError by returning a 409 when duplicate exists

## Testing
- `ruff check services/api/app/routers/billing.py services/api/app/billing/service.py tests/billing/test_billing_webhook.py`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b998ff79a4832aacee7d6a02b65a99