### PR TITLE
[learning] add curriculum engine test

### DIFF
--- a/services/api/app/diabetes/curriculum_engine.py
+++ b/services/api/app/diabetes/curriculum_engine.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+
+from .learning_prompts import build_explain_step, build_quiz_check
+from .llm_router import LLMTask
+from .models_learning import LessonProgress, LessonStep, QuizQuestion
+from .services import db, gpt_client
+
+_state: dict[int, dict[str, Any]] = defaultdict(dict)
+
+
+async def _ask_llm(task: LLMTask, content: str) -> str:
+    completion = await gpt_client.create_learning_chat_completion(
+        task=task, messages=[{"role": "user", "content": content}]
+    )
+    return completion.choices[0].message.content or ""
+
+
+async def start_lesson(user_id: int, lesson_id: int) -> str:
+    with db.SessionLocal() as session:
+        steps = (
+            session.query(LessonStep)
+            .filter_by(lesson_id=lesson_id)
+            .order_by(LessonStep.step_order)
+            .all()
+        )
+    if not steps:
+        raise ValueError("no steps")
+    _state[user_id] = {
+        "lesson_id": lesson_id,
+        "steps": [s.content for s in steps],
+        "step_idx": 0,
+        "quiz_idx": 0,
+        "score": 0,
+    }
+    prompt = build_explain_step(steps[0].content)
+    return await _ask_llm(LLMTask.EXPLAIN_STEP, prompt)
+
+
+async def next_step(user_id: int) -> str:
+    data = _state[user_id]
+    data["step_idx"] += 1
+    steps: list[str] = data["steps"]
+    idx = data["step_idx"]
+    if idx < len(steps):
+        prompt = build_explain_step(steps[idx])
+        return await _ask_llm(LLMTask.EXPLAIN_STEP, prompt)
+    return "Quiz time"
+
+
+async def check_answer(user_id: int, answer: int) -> str:
+    data = _state[user_id]
+    lesson_id = data["lesson_id"]
+    with db.SessionLocal() as session:
+        questions = (
+            session.query(QuizQuestion)
+            .filter_by(lesson_id=lesson_id)
+            .order_by(QuizQuestion.id)
+            .all()
+        )
+    question = questions[data["quiz_idx"]]
+    correct = question.correct_option == answer
+    prompt = build_quiz_check(question.question, question.options)
+    data["quiz_idx"] += 1
+    if correct:
+        data["score"] += 1
+    feedback = await _ask_llm(LLMTask.QUIZ_CHECK, prompt)
+    if data["quiz_idx"] >= len(questions):
+        score = int(100 * data["score"] / len(questions))
+        with db.SessionLocal() as session:
+            session.add(
+                LessonProgress(
+                    user_id=user_id,
+                    lesson_id=lesson_id,
+                    completed=True,
+                    quiz_score=score,
+                )
+            )
+            session.commit()
+    return feedback
+
+
+__all__ = ["start_lesson", "next_step", "check_answer"]

--- a/tests/learning/test_curriculum_engine.py
+++ b/tests/learning/test_curriculum_engine.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.curriculum_engine import (
+    check_answer,
+    next_step,
+    start_lesson,
+)
+from services.api.app.diabetes.learning_fixtures import load_lessons
+from services.api.app.diabetes.models_learning import LessonProgress, QuizQuestion
+from services.api.app.diabetes.services import db, gpt_client
+
+
+@pytest.mark.asyncio()
+async def test_curriculum_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.SessionLocal.configure(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+
+    await load_lessons(
+        "services/api/app/diabetes/content/lessons_v0.json",
+        sessionmaker=db.SessionLocal,
+    )
+
+    with db.SessionLocal() as session:
+        session.add(db.User(telegram_id=1, thread_id="t1"))
+        session.commit()
+
+    async def fake_completion(**kwargs: object) -> object:
+        fake_completion.calls += 1
+        return types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(
+                        content=f"text {fake_completion.calls}",
+                    )
+                )
+            ]
+        )
+
+    fake_completion.calls = 0  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        gpt_client, "create_learning_chat_completion", fake_completion
+    )
+
+    text = await start_lesson(1, 1)
+    assert text
+
+    for _ in range(3):
+        step = await next_step(1)
+        assert step
+
+    with db.SessionLocal() as session:
+        answers = [
+            q.correct_option
+            for q in session.query(QuizQuestion)
+            .filter_by(lesson_id=1)
+            .order_by(QuizQuestion.id)
+        ]
+
+    score = 0
+    for ans in answers:
+        feedback = await check_answer(1, ans)
+        assert feedback
+        score += 1
+    expected = int(100 * score / len(answers))
+
+    with db.SessionLocal() as session:
+        progress = (
+            session.query(LessonProgress)
+            .filter_by(user_id=1, lesson_id=1)
+            .one()
+        )
+        assert progress.completed is True
+        assert progress.quiz_score == expected


### PR DESCRIPTION
## Summary
- implement simple curriculum engine to drive lessons and quiz scoring
- add async test for curriculum engine covering lesson steps and quiz answers

## Testing
- `ruff check services/api/app/diabetes/curriculum_engine.py tests/learning/test_curriculum_engine.py`
- `mypy --strict tests/learning/test_curriculum_engine.py services/api/app/diabetes/curriculum_engine.py`
- `pytest tests/learning/test_curriculum_engine.py -q --cov=services.api.app.diabetes.curriculum_engine --cov-fail-under=0`
- `pytest -q` *(fails: tests/test_billing_trial.py::test_trial_integrity_error)*

------
https://chatgpt.com/codex/tasks/task_e_68b99737b8ec832aaf97e881f8c1fe26