### PR TITLE
[bot] Send webhook event for Telegram payments

### DIFF
--- a/tests/test_telegram_payments.py
+++ b/tests/test_telegram_payments.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -36,17 +39,30 @@ async def test_handle_pre_checkout_query() -> None:
 
 @pytest.mark.asyncio
 async def test_handle_successful_payment(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = "topsecret"
+    monkeypatch.setenv("BILLING_WEBHOOK_SECRET", secret)
     adapter = TelegramPaymentsAdapter()
     message = SimpleNamespace(
-        successful_payment=SimpleNamespace(invoice_payload="payload"),
+        successful_payment=SimpleNamespace(
+            invoice_payload="pro",
+            telegram_payment_charge_id="evt1",
+            provider_payment_charge_id="txn1",
+        ),
         reply_text=AsyncMock(),
     )
     update = SimpleNamespace(message=message)
-    context = SimpleNamespace()
+
+    captured: dict[str, object] = {}
+
+    async def _post(url: str, json: object, headers: dict[str, str]) -> SimpleNamespace:
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        return SimpleNamespace(status_code=200, text="ok")
 
     class DummyClient:
         def __init__(self) -> None:
-            self.post = AsyncMock()
+            self.post = AsyncMock(side_effect=_post)
 
         async def __aenter__(self) -> DummyClient:  # type: ignore[override]
             return self
@@ -57,7 +73,53 @@ async def test_handle_successful_payment(monkeypatch: pytest.MonkeyPatch) -> Non
     dummy_client = DummyClient()
     monkeypatch.setattr(httpx, "AsyncClient", lambda: dummy_client)
 
-    await adapter.handle_successful_payment(update, context)
+    await adapter.handle_successful_payment(update, SimpleNamespace())
 
-    dummy_client.post.assert_called_once()
+    sig = hmac.new(secret.encode(), b"evt1:txn1", hashlib.sha256).hexdigest()
+    assert captured["json"] == {
+        "event_id": "evt1",
+        "transaction_id": "txn1",
+        "plan": "pro",
+        "signature": sig,
+    }
+    assert captured["headers"] == {"X-Webhook-Signature": sig}
+    message.reply_text.assert_called_once_with("✅ Платёж успешно получен")
+
+
+@pytest.mark.asyncio
+async def test_handle_successful_payment_logs_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("BILLING_WEBHOOK_SECRET", "s")
+    adapter = TelegramPaymentsAdapter()
+    message = SimpleNamespace(
+        successful_payment=SimpleNamespace(
+            invoice_payload="pro",
+            telegram_payment_charge_id="evt2",
+            provider_payment_charge_id="txn2",
+        ),
+        reply_text=AsyncMock(),
+    )
+    update = SimpleNamespace(message=message)
+
+    async def _post(url: str, json: object, headers: dict[str, str]) -> SimpleNamespace:
+        return SimpleNamespace(status_code=500, text="boom")
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self.post = AsyncMock(side_effect=_post)
+
+        async def __aenter__(self) -> DummyClient:  # type: ignore[override]
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:  # type: ignore[override]
+            return None
+
+    dummy_client = DummyClient()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: dummy_client)
+
+    caplog.set_level(logging.ERROR)
+    await adapter.handle_successful_payment(update, SimpleNamespace())
+
+    assert any("billing webhook" in r.getMessage() for r in caplog.records)
     message.reply_text.assert_called_once()


### PR DESCRIPTION
## Summary
- Notify backend about successful Telegram payments via WebhookEvent payload
- Sign webhook payload using billing secret and log errors on non-200 responses
- Test Telegram payment success and error paths

## Testing
- `black services/bot/telegram_payments.py tests/test_telegram_payments.py`
- `ruff check services/bot/telegram_payments.py tests/test_telegram_payments.py`
- `mypy --strict services/bot/telegram_payments.py tests/test_telegram_payments.py`
- `pytest -q` *(fails: tests/test_billing_trial.py::test_trial_integrity_error - assert 500 == 409)*

------
https://chatgpt.com/codex/tasks/task_e_68b998f97aa4832a823de07f4486d5ce