### PR TITLE
[billing] set end date in mock webhook handlers

### DIFF
--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -269,7 +269,10 @@ async def mock_webhook(
         sub = session.scalars(stmt).first()
         if sub is None:
             return False
+        end_date = datetime.now(timezone.utc) + timedelta(days=30)
+        # keep existing plan, set status and end date only
         sub.status = cast(SubscriptionStatus, SubscriptionStatus.ACTIVE.value)
+        sub.end_date = end_date
         session.commit()
         log_billing_event(
             session,
@@ -303,7 +306,10 @@ async def admin_mock_webhook(
         sub = session.scalars(stmt).first()
         if sub is None:
             return False
+        end_date = datetime.now(timezone.utc) + timedelta(days=30)
+        # keep existing plan, set status and end date only
         sub.status = cast(SubscriptionStatus, SubscriptionStatus.ACTIVE.value)
+        sub.end_date = end_date
         session.commit()
         log_billing_event(
             session,


### PR DESCRIPTION
## Summary
- set end date 30 days ahead in mock billing webhooks
- preserve existing plan and log billing after commit

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b99b6419cc832a883948c968ac7a97