### PR TITLE
[billing] Require billing settings for trial endpoint

### DIFF
--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -62,7 +62,10 @@ async def pay(
 
 
 @router.post("/trial", response_model=SubscriptionSchema)
-async def start_trial(user_id: int) -> SubscriptionSchema:
+async def start_trial(
+    user_id: int,
+    settings: BillingSettings = Depends(_require_billing_enabled),
+) -> SubscriptionSchema:
     """Start a trial subscription for the user."""
 
     now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
- enforce billing settings dependency for `/billing/trial`
- update billing trial tests to inject mocked billing settings via dependency override

## Testing
- `pytest tests/test_billing_trial.py tests/test_billing_status.py tests/test_billing_commands.py -q --cov --cov-fail-under=0`
- `mypy --strict services/api/app/routers/billing.py tests/test_billing_trial.py tests/test_billing_status.py tests/test_billing_commands.py`
- `ruff check services/api/app/routers/billing.py tests/test_billing_trial.py tests/test_billing_status.py tests/test_billing_commands.py`


------
https://chatgpt.com/codex/tasks/task_e_68b99bec0838832a91f2145586082ef4