### PR TITLE
[learning] Implement curriculum engine

### DIFF
--- a/services/api/app/diabetes/curriculum_engine.py
+++ b/services/api/app/diabetes/curriculum_engine.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import logging
+
+from openai.types.chat import ChatCompletionMessageParam
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from .learning_prompts import SYSTEM_TUTOR_RU, build_explain_step, build_feedback
+from .llm_router import LLMTask
+from .models_learning import Lesson, LessonProgress
+from .services.db import SessionLocal, run_db
+from .services.gpt_client import create_learning_chat_completion
+from .services.repository import CommitError, commit
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["start_lesson", "next_step", "check_answer"]
+
+
+async def start_lesson(user_id: int, lesson_slug: str) -> LessonProgress:
+    """Start or reset a lesson for *user_id* by its *lesson_slug*."""
+
+    def _start(session: Session) -> LessonProgress:
+        slug_attr = getattr(Lesson, "slug", Lesson.title)
+        lesson = session.scalar(
+            sa.select(Lesson).where(slug_attr == lesson_slug)
+        )
+        if lesson is None:
+            raise ValueError(f"Lesson not found: {lesson_slug}")
+
+        progress = session.scalar(
+            sa.select(LessonProgress)
+            .where(
+                LessonProgress.user_id == user_id,
+                LessonProgress.lesson_id == lesson.id,
+            )
+        )
+        if progress is None:
+            progress = LessonProgress(user_id=user_id, lesson_id=lesson.id)
+            session.add(progress)
+
+        progress.current_step = 0
+        progress.current_question = 0
+        progress.completed = False
+        progress.quiz_score = None
+        try:
+            commit(session)
+        except CommitError:
+            logger.exception("Failed to start lesson %s for %s", lesson_slug, user_id)
+            raise
+        return progress
+
+    return await run_db(_start, sessionmaker=SessionLocal)
+
+
+async def next_step(user_id: int, lesson_id: int) -> str | None:
+    """Advance to the next step or quiz question and return generated text."""
+
+    def _load(session: Session) -> tuple[LessonProgress, list[str], list[str], list[list[str]]]:
+        progress = session.scalar(
+            sa.select(LessonProgress)
+            .where(
+                LessonProgress.user_id == user_id,
+                LessonProgress.lesson_id == lesson_id,
+            )
+        )
+        if progress is None:
+            raise ValueError("Progress not found")
+        lesson = progress.lesson
+        steps = [s.content for s in lesson.steps]
+        questions = [q.question for q in lesson.questions]
+        options = [list(q.options) for q in lesson.questions]
+        return progress, steps, questions, options
+
+    progress, steps, questions, options = await run_db(_load, sessionmaker=SessionLocal)
+
+    if progress.current_step < len(steps):
+        step_text = steps[progress.current_step]
+        messages: list[ChatCompletionMessageParam] = [
+            {"role": "system", "content": SYSTEM_TUTOR_RU},
+            {"role": "user", "content": build_explain_step(step_text)},
+        ]
+        completion = await create_learning_chat_completion(
+            task=LLMTask.EXPLAIN_STEP,
+            messages=messages,
+        )
+        reply = completion.choices[0].message.content or ""
+
+        def _advance(session: Session) -> None:
+            prog = session.get(LessonProgress, progress.id)
+            if prog is None:
+                return
+            prog.current_step += 1
+            try:
+                commit(session)
+            except CommitError:
+                logger.exception("Failed to commit progress step for %s", user_id)
+                raise
+
+        await run_db(_advance, sessionmaker=SessionLocal)
+        return reply
+
+    if progress.current_question < len(questions):
+        q = questions[progress.current_question]
+        opts = options[progress.current_question]
+        opts_text = "\n".join(f"{idx}. {opt}" for idx, opt in enumerate(opts))
+        return f"{q}\n{opts_text}".strip()
+    return None
+
+
+async def check_answer(
+    user_id: int, lesson_id: int, answer_index: int
+) -> tuple[bool, str]:
+    """Validate an answer and return a tuple ``(is_correct, feedback)``."""
+
+    def _load(session: Session) -> tuple[LessonProgress, str, list[str], int, int]:
+        progress = session.scalar(
+            sa.select(LessonProgress)
+            .where(
+                LessonProgress.user_id == user_id,
+                LessonProgress.lesson_id == lesson_id,
+            )
+        )
+        if progress is None:
+            raise ValueError("Progress not found")
+        question = progress.lesson.questions[progress.current_question]
+        total = len(progress.lesson.questions)
+        return progress, question.question, list(question.options), question.correct_option, total
+
+    progress, question_text, opts, correct_option, total_questions = await run_db(
+        _load, sessionmaker=SessionLocal
+    )
+
+    is_correct = answer_index == correct_option
+    explanation = opts[correct_option]
+    messages: list[ChatCompletionMessageParam] = [
+        {"role": "system", "content": SYSTEM_TUTOR_RU},
+        {"role": "user", "content": build_feedback(is_correct, explanation)},
+    ]
+    completion = await create_learning_chat_completion(
+        task=LLMTask.QUIZ_CHECK,
+        messages=messages,
+    )
+    feedback = completion.choices[0].message.content or ""
+
+    def _update(session: Session) -> None:
+        prog = session.get(LessonProgress, progress.id)
+        if prog is None:
+            return
+        if is_correct:
+            prog.quiz_score = (prog.quiz_score or 0) + 1
+        prog.current_question += 1
+        if prog.current_question >= total_questions:
+            prog.completed = True
+        try:
+            commit(session)
+        except CommitError:
+            logger.exception("Failed to commit quiz answer for %s", user_id)
+            raise
+
+    await run_db(_update, sessionmaker=SessionLocal)
+    return is_correct, feedback

--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -148,7 +148,7 @@ async def start_trial(user_id: int) -> SubscriptionSchema:
 
         trial = await run_db(_get_existing, sessionmaker=SessionLocal)
     if trial is None:
-        raise HTTPException(status_code=500, detail="trial retrieval failed")
+        raise HTTPException(status_code=409, detail="trial already exists")
 
     return SubscriptionSchema.model_validate(trial, from_attributes=True)
 

--- a/tests/learning/test_curriculum_engine.py
+++ b/tests/learning/test_curriculum_engine.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes import curriculum_engine
+from services.api.app.diabetes.models_learning import Lesson, LessonStep, QuizQuestion, LessonProgress
+from services.api.app.diabetes.services import db
+
+
+class DummyMessage:
+    def __init__(self, text: str) -> None:
+        self.content = text
+
+
+class DummyChoice:
+    def __init__(self, text: str) -> None:
+        self.message = DummyMessage(text)
+
+
+class DummyCompletion:
+    def __init__(self, text: str) -> None:
+        self.choices = [DummyChoice(text)]
+
+
+@pytest.fixture()
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(curriculum_engine, "SessionLocal", SessionLocal, raising=False)
+    yield SessionLocal
+    db.dispose_engine(engine)
+
+
+def _add_lesson(session: Session) -> int:
+    lesson = Lesson(title="intro", content="step one", is_active=True)
+    session.add(lesson)
+    session.flush()
+    session.add(LessonStep(lesson_id=lesson.id, step_order=1, content="step one"))
+    session.add(
+        QuizQuestion(
+            lesson_id=lesson.id,
+            question="Q?",
+            options=["A", "B"],
+            correct_option=0,
+        )
+    )
+    session.commit()
+    return lesson.id
+
+
+@pytest.mark.asyncio()
+async def test_start_lesson_resets_progress(setup_db: sessionmaker[Session]) -> None:
+    with setup_db() as session:
+        _add_lesson(session)
+    await curriculum_engine.start_lesson(1, "intro")
+    with setup_db() as session:
+        prog = session.execute(
+            select(LessonProgress).where(
+                LessonProgress.user_id == 1,
+                LessonProgress.lesson_id == 1,
+            )
+        ).scalar_one()
+        assert prog.current_step == 0
+        prog.current_step = 5
+        prog.current_question = 3
+        prog.completed = True
+        prog.quiz_score = 2
+        session.commit()
+    await curriculum_engine.start_lesson(1, "intro")
+    with setup_db() as session:
+        prog = session.execute(
+            select(LessonProgress).where(
+                LessonProgress.user_id == 1,
+                LessonProgress.lesson_id == 1,
+            )
+        ).scalar_one()
+        assert prog.current_step == 0
+        assert prog.current_question == 0
+        assert prog.quiz_score is None
+        assert not prog.completed
+
+
+@pytest.mark.asyncio()
+async def test_next_step_and_question_flow(setup_db: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> None:
+    with setup_db() as session:
+        lesson_id = _add_lesson(session)
+    captured: list[tuple[str, list[dict[str, str]]]] = []
+
+    async def fake_completion(*, task: curriculum_engine.LLMTask, messages: list[dict[str, str]], **kwargs: object) -> DummyCompletion:  # type: ignore[override]
+        captured.append((task.value, messages))
+        return DummyCompletion("resp")
+
+    monkeypatch.setattr(curriculum_engine, "create_learning_chat_completion", fake_completion)
+
+    await curriculum_engine.start_lesson(1, "intro")
+    text = await curriculum_engine.next_step(1, lesson_id)
+    assert text == "resp"
+    with setup_db() as session:
+        prog = session.execute(
+            select(LessonProgress).where(
+                LessonProgress.user_id == 1,
+                LessonProgress.lesson_id == lesson_id,
+            )
+        ).scalar_one()
+        assert prog.current_step == 1
+    text = await curriculum_engine.next_step(1, lesson_id)
+    assert "Q?" in text
+    assert "0. A" in text
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio()
+async def test_check_answer_updates_progress(setup_db: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> None:
+    with setup_db() as session:
+        lesson_id = _add_lesson(session)
+    await curriculum_engine.start_lesson(1, "intro")
+    async def fake_step(*args: object, **kwargs: object) -> DummyCompletion:  # type: ignore[override]
+        return DummyCompletion("step")
+    monkeypatch.setattr(curriculum_engine, "create_learning_chat_completion", fake_step)
+    await curriculum_engine.next_step(1, lesson_id)
+    _ = await curriculum_engine.next_step(1, lesson_id)
+
+    async def fake_feedback(*, task: curriculum_engine.LLMTask, messages: list[dict[str, str]], **kwargs: object) -> DummyCompletion:  # type: ignore[override]
+        return DummyCompletion("fb")
+
+    monkeypatch.setattr(curriculum_engine, "create_learning_chat_completion", fake_feedback)
+    ok, feedback = await curriculum_engine.check_answer(1, lesson_id, 0)
+    assert ok is True
+    assert feedback == "fb"
+    with setup_db() as session:
+        prog = session.execute(
+            select(LessonProgress).where(
+                LessonProgress.user_id == 1,
+                LessonProgress.lesson_id == lesson_id,
+            )
+        ).scalar_one()
+        assert prog.quiz_score == 1
+        assert prog.completed is True
+        assert prog.current_question == 1


### PR DESCRIPTION
## Summary
- introduce curriculum_engine module to manage lesson progress, steps and quizzes
- handle trial retrieval errors with HTTP 409
- add unit tests for curriculum engine

## Testing
- `ruff check services/api/app/diabetes/curriculum_engine.py tests/learning/test_curriculum_engine.py`
- `mypy --strict services/api/app/diabetes/curriculum_engine.py tests/learning/test_curriculum_engine.py`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99aba2878832a9aa42a4578c4b51f