### PR TITLE
[billing] ensure atomic billing logs

### DIFF
--- a/services/api/app/billing/jobs.py
+++ b/services/api/app/billing/jobs.py
@@ -62,7 +62,6 @@ async def expire_subscriptions(_context: ContextTypes.DEFAULT_TYPE) -> None:
         for sub in subs:
             sub.status = cast(SubscriptionStatus, SubscriptionStatus.EXPIRED.value)
         if subs:
-            commit(session)
             for sub in subs:
                 log_billing_event(
                     session,
@@ -70,6 +69,7 @@ async def expire_subscriptions(_context: ContextTypes.DEFAULT_TYPE) -> None:
                     BillingEvent.EXPIRED,
                     {"subscription_id": sub.id},
                 )
+            commit(session)
         return [sub.user_id for sub in subs]
 
     user_ids = await run_db(_expire)

--- a/services/api/app/billing/log.py
+++ b/services/api/app/billing/log.py
@@ -9,7 +9,6 @@ from sqlalchemy import BigInteger, Integer, TIMESTAMP, Enum as SAEnum, JSON, fun
 from sqlalchemy.orm import Mapped, Session, mapped_column
 
 from ..diabetes.services.db import Base
-from ..diabetes.services.repository import commit
 
 logger = logging.getLogger(__name__)
 
@@ -49,4 +48,4 @@ def log_billing_event(
 
     log = BillingLog(user_id=user_id, event=event, context=context)
     session.add(log)
-    commit(session)
+    session.flush()

--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -103,7 +103,6 @@ async def start_trial(user_id: int) -> SubscriptionSchema:
             BillingEvent.INIT,
             {"plan": SubscriptionPlan.PRO.value, "source": "trial"},
         )
-        session.flush()
         return trial
 
     def _get_or_create(session: Session) -> Subscription:
@@ -175,7 +174,6 @@ async def subscribe(
             end_date=None,
         )
         session.add(draft)
-        session.commit()
         log_billing_event(
             session,
             user_id,
@@ -188,6 +186,7 @@ async def subscribe(
             BillingEvent.CHECKOUT_CREATED,
             {"plan": plan.value, "checkout_id": checkout["id"]},
         )
+        session.commit()
 
     await run_db(_create_draft, sessionmaker=SessionLocal)
     return CheckoutSchema.model_validate(checkout)
@@ -233,7 +232,6 @@ async def webhook(
         sub.plan = event.plan
         sub.status = cast(SubscriptionStatus, SubscriptionStatus.ACTIVE.value)
         sub.end_date = base + timedelta(days=30)
-        session.commit()
         log_billing_event(
             session,
             sub.user_id,
@@ -243,6 +241,7 @@ async def webhook(
                 "plan": event.plan,
             },
         )
+        session.commit()
         return True
 
     updated = await run_db(_activate, sessionmaker=SessionLocal)
@@ -270,13 +269,13 @@ async def mock_webhook(
         if sub is None:
             return False
         sub.status = cast(SubscriptionStatus, SubscriptionStatus.ACTIVE.value)
-        session.commit()
         log_billing_event(
             session,
             sub.user_id,
             BillingEvent.WEBHOOK_OK,
             {"transaction_id": checkout_id},
         )
+        session.commit()
         return True
 
     updated = await run_db(_activate, sessionmaker=SessionLocal)
@@ -304,13 +303,13 @@ async def admin_mock_webhook(
         if sub is None:
             return False
         sub.status = cast(SubscriptionStatus, SubscriptionStatus.ACTIVE.value)
-        session.commit()
         log_billing_event(
             session,
             sub.user_id,
             BillingEvent.WEBHOOK_OK,
             {"transaction_id": transaction_id},
         )
+        session.commit()
         return True
 
     updated = await run_db(_activate, sessionmaker=SessionLocal)

--- a/tests/billing/test_billing_atomic.py
+++ b/tests/billing/test_billing_atomic.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.orm import Session as SASession
+
+from services.api.app.billing.config import BillingSettings
+from services.api.app.billing.log import BillingEvent, BillingLog
+from services.api.app.diabetes.services.db import Base, Subscription
+from services.api.app.routers import billing
+from services.api.app.main import app
+
+
+# --- helpers ---------------------------------------------------------------
+
+def setup_db() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[Subscription.__table__, BillingLog.__table__])
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def make_client(
+    monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]
+) -> TestClient:
+    async def run_db(fn, *args, **kwargs):
+        kwargs.pop("sessionmaker", None)
+        with session_local() as session:
+            return fn(session, *args, **kwargs)
+
+    monkeypatch.setattr(billing, "run_db", run_db, raising=False)
+    settings = BillingSettings(
+        billing_enabled=True,
+        billing_test_mode=True,
+        billing_provider="dummy",
+        paywall_mode="soft",
+        BILLING_ADMIN_TOKEN="secret",
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+    client.app.dependency_overrides[billing._require_billing_enabled] = lambda: settings
+    return client
+
+
+# --- tests -----------------------------------------------------------------
+
+
+def test_subscribe_persists_subscription_and_logs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_local = setup_db()
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.post(
+            "/api/billing/subscribe", params={"user_id": 1, "plan": "pro"}
+        )
+    assert resp.status_code == 200
+    client.app.dependency_overrides.clear()
+    with session_local() as session:
+        sub = session.scalar(select(Subscription))
+        assert sub is not None
+        logs = session.scalars(select(BillingLog)).all()
+        assert [log.event for log in logs] == [
+            BillingEvent.INIT,
+            BillingEvent.CHECKOUT_CREATED,
+        ]
+
+
+def test_subscribe_rollback_on_commit_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_local = setup_db()
+    client = make_client(monkeypatch, session_local)
+
+    def fail_commit(self) -> None:  # type: ignore[unused-argument]
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(SASession, "commit", fail_commit, raising=False)
+
+    with client:
+        resp = client.post(
+            "/api/billing/subscribe", params={"user_id": 1, "plan": "pro"}
+        )
+    assert resp.status_code == 500
+    client.app.dependency_overrides.clear()
+    with session_local() as session:
+        assert session.scalar(select(Subscription)) is None
+        assert session.scalar(select(BillingLog)) is None


### PR DESCRIPTION
## Summary
- replace commit with flush in billing log helper
- commit subscription and logging changes together
- cover billing subscribe flow with atomicity tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b99cfbc68c832aabea372176e38445