### PR TITLE
handlers: unify learn command

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -6,7 +6,7 @@ from typing import cast
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from .handlers.learn_handlers import learn_command
+from .handlers.learning_handlers import learn_command
 from .handlers.onboarding_handlers import (
     reset_onboarding as _reset_onboarding,
 )

--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from services.api.app.config import settings
 from services.api.app.diabetes.utils.ui import menu_keyboard
+from .learning_handlers import learn_command
 
 
 async def menu_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -73,18 +73,6 @@ async def smart_input_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     message = update.message
     if message:
         await message.reply_text(text, parse_mode="Markdown")
-
-
-async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Provide learning resources if the feature is enabled."""
-
-    message = update.message
-    if message is None:
-        return
-    if not settings.learning_enabled:
-        await message.reply_text("🚫 Обучение недоступно.")
-        return
-    await message.reply_text("📘 Учебный режим активен.")
 
 
 __all__ = [

--- a/services/api/app/diabetes/handlers/learn_handlers.py
+++ b/services/api/app/diabetes/handlers/learn_handlers.py
@@ -1,26 +1,5 @@
 from __future__ import annotations
 
-import logging
-
-from telegram import Update
-from telegram.ext import ContextTypes
-
-from services.api.app import config
-
-logger = logging.getLogger(__name__)
-
-
-async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Reply with learning mode status or greeting."""
-    message = update.message
-    if message is None:
-        return
-    settings = config.get_settings()
-    if not settings.learning_mode_enabled:
-        await message.reply_text("режим выключен")
-        return
-    model = settings.learning_model_default
-    await message.reply_text(f"🤖 Учебный режим активирован. Модель: {model}")
-
+from .learning_handlers import learn_command
 
 __all__ = ["learn_command"]

--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import logging
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from services.api.app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Reply with learning mode status or greeting."""
+    message = update.message
+    if message is None:
+        return
+    if not settings.learning_enabled:
+        await message.reply_text("🚫 Обучение недоступно.")
+        return
+    model = settings.learning_command_model
+    await message.reply_text(f"🤖 Учебный режим активирован. Модель: {model}")
+
+
+__all__ = ["learn_command"]

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -151,7 +151,7 @@ def register_handlers(
         photo_handlers,
         sugar_handlers,
         gpt_handlers,
-        learn_handlers,
+        learning_handlers,
         billing_handlers,
     )
 
@@ -167,7 +167,7 @@ def register_handlers(
     app.add_handler(sos_handlers.sos_contact_conv)
     app.add_handler(CommandHandlerT("cancel", dose_calc.dose_cancel))
     app.add_handler(CommandHandlerT("help", help_command))
-    app.add_handler(CommandHandlerT("learn", learn_handlers.learn_command))
+    app.add_handler(CommandHandlerT("learn", learning_handlers.learn_command))
     app.add_handler(CommandHandlerT("gpt", gpt_handlers.chat_with_gpt))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))

--- a/tests/diabetes/test_learning_handlers.py
+++ b/tests/diabetes/test_learning_handlers.py
@@ -6,17 +6,7 @@ from telegram import Update
 from telegram.ext import CallbackContext
 
 from services.api.app.config import settings
-import importlib.util
-from pathlib import Path
-
-spec = importlib.util.spec_from_file_location(
-    "learn_handlers",
-    Path(__file__).resolve().parents[2]
-    / "services/api/app/diabetes/handlers/learn_handlers.py",
-)
-assert spec and spec.loader
-learn_handlers = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(learn_handlers)  # type: ignore[misc]
+from services.api.app.diabetes.handlers import learning_handlers
 
 
 class DummyMessage:
@@ -29,26 +19,26 @@ class DummyMessage:
 
 @pytest.mark.asyncio
 async def test_learn_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "learning_mode_enabled", False)
+    monkeypatch.setattr(settings, "learning_enabled", False)
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
     )
-    await learn_handlers.learn_command(update, context)
-    assert message.replies == ["режим выключен"]
+    await learning_handlers.learn_command(update, context)
+    assert message.replies == ["🚫 Обучение недоступно."]
 
 
 @pytest.mark.asyncio
 async def test_learn_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(settings, "learning_mode_enabled", True)
-    monkeypatch.setattr(settings, "learning_model_default", "super-model")
+    monkeypatch.setattr(settings, "learning_enabled", True)
+    monkeypatch.setattr(settings, "learning_command_model", "super-model")
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
     )
-    await learn_handlers.learn_command(update, context)
+    await learning_handlers.learn_command(update, context)
     assert "super-model" in message.replies[0]

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -7,7 +7,7 @@ import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
 
-import services.api.app.diabetes.handlers.common_handlers as handlers
+import services.api.app.diabetes.handlers.learning_handlers as handlers
 from services.api.app.config import Settings
 
 
@@ -41,7 +41,9 @@ async def test_learn_command_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     """With flag enabled the command should return training info."""
 
     monkeypatch.setattr(
-        handlers, "settings", Settings(LEARNING_ENABLED="1", _env_file=None)
+        handlers,
+        "settings",
+        Settings(LEARNING_ENABLED="1", LEARNING_COMMAND_MODEL="test-model", _env_file=None),
     )
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message))
@@ -52,4 +54,4 @@ async def test_learn_command_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await handlers.learn_command(update, context)
 
-    assert message.replies == ["📘 Учебный режим активен."]
+    assert message.replies == ["🤖 Учебный режим активирован. Модель: test-model"]


### PR DESCRIPTION
## Summary
- consolidate learn command into new `learning_handlers`
- redirect old learn handlers and common handlers to shared implementation
- adjust imports and tests for new learning handler

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/test_learn_command.py tests/diabetes/test_learning_handlers.py -q` *(fails: Coverage failure: total of 23 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a3d86930832a9378042d0090016d