### PR TITLE
[learning] add learning handlers and commands

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -6,7 +6,6 @@ from typing import cast
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from .handlers.learn_handlers import learn_command
 from .handlers.onboarding_handlers import (
     reset_onboarding as _reset_onboarding,
 )
@@ -18,7 +17,6 @@ HELP_TEXT = "\n".join(
         "Доступные команды:",
         "/start - начать работу с ботом",
         "/help - краткая справка",
-        "/learn - режим обучения",
         "/reset_onboarding - сбросить мастер настройки",
         "",
         "Для работы с WebApp откройте меню и выберите нужную кнопку.",
@@ -54,4 +52,4 @@ async def reset_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     )
 
 
-__all__ = ["help_command", "reset_onboarding", "learn_command"]
+__all__ = ["help_command", "reset_onboarding"]

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -151,9 +151,9 @@ def register_handlers(
         photo_handlers,
         sugar_handlers,
         gpt_handlers,
-        learn_handlers,
         billing_handlers,
     )
+    from .. import learning_handlers
 
     app.add_handler(onboarding_conv)
     app.add_handler(CommandHandlerT("menu", menu_command))
@@ -167,7 +167,10 @@ def register_handlers(
     app.add_handler(sos_handlers.sos_contact_conv)
     app.add_handler(CommandHandlerT("cancel", dose_calc.dose_cancel))
     app.add_handler(CommandHandlerT("help", help_command))
-    app.add_handler(CommandHandlerT("learn", learn_handlers.learn_command))
+    app.add_handler(CommandHandlerT("lesson", learning_handlers.lesson_command))
+    app.add_handler(CommandHandlerT("quiz", learning_handlers.quiz_command))
+    app.add_handler(CommandHandlerT("progress", learning_handlers.progress_command))
+    app.add_handler(CommandHandlerT("exit", learning_handlers.exit_command))
     app.add_handler(CommandHandlerT("gpt", gpt_handlers.chat_with_gpt))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))

--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from services.api.app import config
+
+logger = logging.getLogger(__name__)
+
+
+async def _is_enabled(update: Update) -> bool:
+    """Return ``True`` if learning mode is enabled and message exists."""
+    message = update.message
+    if message is None:
+        return False
+    settings = config.get_settings()
+    if not settings.learning_mode_enabled:
+        await message.reply_text("режим выключен")
+        return False
+    return True
+
+
+async def lesson_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle ``/lesson`` command."""
+    if not await _is_enabled(update):
+        return
+    message = update.message
+    if message:
+        await message.reply_text("📘 Урок начат.")
+
+
+async def quiz_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle ``/quiz`` command."""
+    if not await _is_enabled(update):
+        return
+    message = update.message
+    if message:
+        await message.reply_text("📝 Викторина началась.")
+
+
+async def progress_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle ``/progress`` command."""
+    if not await _is_enabled(update):
+        return
+    message = update.message
+    if message:
+        await message.reply_text("📈 Прогресс недоступен.")
+
+
+async def exit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle ``/exit`` command."""
+    if not await _is_enabled(update):
+        return
+    message = update.message
+    if message:
+        await message.reply_text("🚪 Выход из режима обучения.")
+
+
+__all__ = [
+    "lesson_command",
+    "quiz_command",
+    "progress_command",
+    "exit_command",
+]

--- a/tests/diabetes/test_learning_handlers.py
+++ b/tests/diabetes/test_learning_handlers.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app import config
+from services.api.app.diabetes import learning_handlers
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_lesson_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config, "get_settings", lambda: SimpleNamespace(learning_mode_enabled=False))
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    await learning_handlers.lesson_command(update, context)
+    assert message.replies == ["режим выключен"]
+
+
+@pytest.mark.asyncio
+async def test_quiz_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config, "get_settings", lambda: SimpleNamespace(learning_mode_enabled=False))
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    await learning_handlers.quiz_command(update, context)
+    assert message.replies == ["режим выключен"]
+
+
+@pytest.mark.asyncio
+async def test_progress_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config, "get_settings", lambda: SimpleNamespace(learning_mode_enabled=False))
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    await learning_handlers.progress_command(update, context)
+    assert message.replies == ["режим выключен"]
+
+
+@pytest.mark.asyncio
+async def test_exit_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config, "get_settings", lambda: SimpleNamespace(learning_mode_enabled=True))
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    await learning_handlers.exit_command(update, context)
+    assert message.replies == ["🚪 Выход из режима обучения."]


### PR DESCRIPTION
## Summary
- add learning command handlers for lessons, quizzes, progress and exit
- wire learning command handlers into application registration
- drop legacy /learn command export

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9a3ce0dd8832a8942522c24d08aa1