### PR TITLE
[handlers] Add learning progress command

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.orm import Session, joinedload
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from ..models_learning import LessonProgress
+from ..services import db
+
+logger = logging.getLogger(__name__)
+
+
+async def progress_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Display learning progress for the user."""
+    message = update.effective_message
+    user = update.effective_user
+    if message is None or user is None:
+        return
+
+    def _fetch(session: Session) -> list[LessonProgress]:
+        return (
+            session.query(LessonProgress)
+            .options(joinedload(LessonProgress.lesson))
+            .filter_by(user_id=user.id)
+            .all()
+        )
+
+    progresses = await db.run_db(_fetch)
+    if not progresses:
+        await message.reply_text("Прогресс не найден. Пройдите /learn.")
+        return
+
+    cards: list[str] = []
+    for progress in progresses:
+        score = progress.quiz_score if progress.quiz_score is not None else "-"
+        cards.append(
+            f"{progress.lesson.title}\n"
+            f"current_step: {progress.current_step}\n"
+            f"completed: {progress.completed}\n"
+            f"quiz_score: {score}"
+        )
+
+    await message.reply_text("\n\n".join(cards))
+
+
+__all__ = ["progress_command"]

--- a/tests/learning/test_learning_handlers.py
+++ b/tests/learning/test_learning_handlers.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.diabetes.handlers import learning_handlers
+from services.api.app.diabetes.models_learning import Lesson, LessonProgress
+from services.api.app.diabetes.services import db
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio()
+async def test_progress_no_data() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.SessionLocal.configure(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+    try:
+        message = DummyMessage()
+        user = SimpleNamespace(id=1)
+        update = cast(Update, SimpleNamespace(effective_message=message, effective_user=user))
+        context = cast(
+            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+            SimpleNamespace(),
+        )
+        await learning_handlers.progress_command(update, context)
+        assert "/learn" in message.replies[0]
+    finally:
+        db.dispose_engine(engine)
+
+
+@pytest.mark.asyncio()
+async def test_progress_card() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.SessionLocal.configure(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+    try:
+        with db.SessionLocal() as session:
+            session.add(db.User(telegram_id=1, thread_id="t1"))
+            lesson = Lesson(slug="slug", title="Title", content="c", is_active=True)
+            session.add(lesson)
+            session.flush()
+            session.add(
+                LessonProgress(
+                    user_id=1,
+                    lesson_id=lesson.id,
+                    current_step=3,
+                    completed=True,
+                    quiz_score=80,
+                )
+            )
+            session.commit()
+
+        message = DummyMessage()
+        user = SimpleNamespace(id=1)
+        update = cast(Update, SimpleNamespace(effective_message=message, effective_user=user))
+        context = cast(
+            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+            SimpleNamespace(),
+        )
+        await learning_handlers.progress_command(update, context)
+        reply = message.replies[0]
+        assert "Title" in reply
+        assert "current_step: 3" in reply
+        assert "completed: True" in reply
+        assert "quiz_score: 80" in reply
+    finally:
+        db.dispose_engine(engine)


### PR DESCRIPTION
## Summary
- add `progress_command` to show lesson progress or hint to /learn
- cover progress command with async tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9a3daee90832abda034b6e2c4261d