### PR TITLE
[handlers] Add learning exit command

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -42,6 +42,8 @@ class UserData(TypedDict, total=False):
     profile_cf: float
     profile_target: float
     profile_low: float
+    lesson_id: int
+    lesson_slug: str
     __file_path: str
     reminder_id: int
     chat_id: int

--- a/services/api/app/diabetes/handlers/learn_handlers.py
+++ b/services/api/app/diabetes/handlers/learn_handlers.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
+from sqlalchemy.orm import Session
 from telegram import Update
 from telegram.ext import ContextTypes
 
 from services.api.app import config
+from services.api.app.diabetes.handlers import UserData
+from services.api.app.diabetes.models_learning import LessonProgress
+from services.api.app.diabetes.services import db
+from services.api.app.diabetes.services.repository import commit
+from services.api.app.diabetes.utils.ui import menu_keyboard
 
 logger = logging.getLogger(__name__)
 
@@ -23,4 +30,33 @@ async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     await message.reply_text(f"🤖 Учебный режим активирован. Модель: {model}")
 
 
-__all__ = ["learn_command"]
+async def exit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Exit current lesson and reset user state."""
+    message = update.effective_message
+    if message is None:
+        return
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        context.user_data = {}
+        user_data_raw = context.user_data
+    user_data = cast(UserData, user_data_raw)
+    lesson_id: int | None = user_data.pop("lesson_id", None)
+    user_data.pop("lesson_slug", None)
+    if lesson_id is not None and update.effective_user is not None:
+        user_id = update.effective_user.id
+
+        def _complete(session: Session) -> None:
+            progress = (
+                session.query(LessonProgress)
+                .filter_by(user_id=user_id, lesson_id=lesson_id)
+                .one_or_none()
+            )
+            if progress is not None and not progress.completed:
+                progress.completed = True
+                commit(session)
+
+        await db.run_db(_complete)
+    await message.reply_text("📚 Урок завершён.", reply_markup=menu_keyboard())
+
+
+__all__ = ["learn_command", "exit_command"]

--- a/tests/diabetes/test_learn_handlers.py
+++ b/tests/diabetes/test_learn_handlers.py
@@ -2,10 +2,14 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-from telegram import Update
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from telegram import ReplyKeyboardMarkup, Update
 from telegram.ext import CallbackContext
 
 from services.api.app.config import settings
+from services.api.app.diabetes.models_learning import Lesson, LessonProgress
+from services.api.app.diabetes.services import db
 import importlib.util
 from pathlib import Path
 
@@ -21,10 +25,10 @@ spec.loader.exec_module(learn_handlers)  # type: ignore[misc]
 
 class DummyMessage:
     def __init__(self) -> None:
-        self.replies: list[str] = []
+        self.replies: list[tuple[str, object | None]] = []
 
-    async def reply_text(self, text: str) -> None:
-        self.replies.append(text)
+    async def reply_text(self, text: str, reply_markup: object | None = None) -> None:
+        self.replies.append((text, reply_markup))
 
 
 @pytest.mark.asyncio
@@ -37,7 +41,7 @@ async def test_learn_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(),
     )
     await learn_handlers.learn_command(update, context)
-    assert message.replies == ["режим выключен"]
+    assert message.replies == [("режим выключен", None)]
 
 
 @pytest.mark.asyncio
@@ -51,4 +55,49 @@ async def test_learn_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(),
     )
     await learn_handlers.learn_command(update, context)
-    assert "super-model" in message.replies[0]
+    assert "super-model" in message.replies[0][0]
+
+
+@pytest.mark.asyncio
+async def test_exit_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.SessionLocal.configure(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+    with db.SessionLocal() as session:
+        lesson = Lesson(slug="intro", title="Intro", content="Basics")
+        session.add_all([db.User(telegram_id=1, thread_id="t"), lesson])
+        session.commit()
+        progress = LessonProgress(user_id=1, lesson_id=lesson.id, completed=False)
+        session.add(progress)
+        session.commit()
+        lesson_id = lesson.id
+        lesson_slug = lesson.slug
+    message = DummyMessage()
+    update = cast(
+        Update,
+        SimpleNamespace(
+            message=message,
+            effective_message=message,
+            effective_user=SimpleNamespace(id=1),
+        ),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={"lesson_id": lesson_id, "lesson_slug": lesson_slug}),
+    )
+    await learn_handlers.exit_command(update, context)
+    assert context.user_data == {}
+    text, markup = message.replies[0]
+    assert "Урок завершён" in text
+    assert isinstance(markup, ReplyKeyboardMarkup)
+    with db.SessionLocal() as session:
+        progress = (
+            session.query(LessonProgress)
+            .filter_by(user_id=1, lesson_id=lesson_id)
+            .one()
+        )
+        assert progress.completed is True


### PR DESCRIPTION
## Summary
- add lesson exit command to clear user state and finish progress
- record lesson info in UserData mapping
- cover learning handlers with unit tests

## Testing
- `pytest tests/diabetes/test_learn_handlers.py -q --cov=services/api/app/diabetes/handlers/learn_handlers.py --cov-report=term-missing --cov-fail-under=0`
- `mypy --strict services/api/app/diabetes/handlers/learn_handlers.py tests/diabetes/test_learn_handlers.py services/api/app/diabetes/handlers/__init__.py`
- `ruff check services/api/app/diabetes/handlers/learn_handlers.py tests/diabetes/test_learn_handlers.py services/api/app/diabetes/handlers/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9a3de2258832a8c34cf5b87d94445