### PR TITLE
[billing] ensure atomic billing logging

### DIFF
--- a/services/api/app/billing/jobs.py
+++ b/services/api/app/billing/jobs.py
@@ -62,7 +62,6 @@ async def expire_subscriptions(_context: ContextTypes.DEFAULT_TYPE) -> None:
         for sub in subs:
             sub.status = cast(SubscriptionStatus, SubscriptionStatus.EXPIRED.value)
         if subs:
-            commit(session)
             for sub in subs:
                 log_billing_event(
                     session,
@@ -70,6 +69,7 @@ async def expire_subscriptions(_context: ContextTypes.DEFAULT_TYPE) -> None:
                     BillingEvent.EXPIRED,
                     {"subscription_id": sub.id},
                 )
+            commit(session)
         return [sub.user_id for sub in subs]
 
     user_ids = await run_db(_expire)

--- a/services/api/app/billing/log.py
+++ b/services/api/app/billing/log.py
@@ -9,7 +9,6 @@ from sqlalchemy import BigInteger, Integer, TIMESTAMP, Enum as SAEnum, JSON, fun
 from sqlalchemy.orm import Mapped, Session, mapped_column
 
 from ..diabetes.services.db import Base
-from ..diabetes.services.repository import commit
 
 logger = logging.getLogger(__name__)
 
@@ -49,4 +48,4 @@ def log_billing_event(
 
     log = BillingLog(user_id=user_id, event=event, context=context)
     session.add(log)
-    commit(session)
+    session.flush()

--- a/tests/billing/test_subscription_atomicity.py
+++ b/tests/billing/test_subscription_atomicity.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+import pytest
+
+from services.api.app.billing.log import BillingLog, BillingEvent, log_billing_event
+from services.api.app.diabetes.services.db import (
+    Base,
+    Subscription,
+    SubscriptionPlan,
+    SubscriptionStatus,
+    run_db,
+)
+
+
+def _setup_db() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[Subscription.__table__, BillingLog.__table__])
+    return sessionmaker(bind=engine)
+
+
+@pytest.mark.asyncio
+async def test_subscription_creation_atomicity() -> None:
+    """Subscription draft and logs should persist atomically."""
+
+    session_local = _setup_db()
+
+    async def _create_and_fail() -> None:
+        def _op(session: Session) -> None:
+            draft = Subscription(
+                user_id=1,
+                plan=SubscriptionPlan.PRO,
+                status=SubscriptionStatus.PENDING,
+                provider="dummy",
+                transaction_id="tx",
+            )
+            session.add(draft)
+            log_billing_event(
+                session,
+                1,
+                BillingEvent.INIT,
+                {"plan": SubscriptionPlan.PRO.value},
+            )
+            log_billing_event(
+                session,
+                1,
+                BillingEvent.CHECKOUT_CREATED,
+                {"plan": SubscriptionPlan.PRO.value, "checkout_id": "tx"},
+            )
+            raise RuntimeError
+
+        await run_db(_op, sessionmaker=session_local)
+
+    with pytest.raises(RuntimeError):
+        await _create_and_fail()
+
+    with session_local() as session:
+        assert session.scalars(select(Subscription)).all() == []
+        assert session.scalars(select(BillingLog)).all() == []


### PR DESCRIPTION
## Summary
- replace commit in `log_billing_event` with `session.flush`
- commit billing session after logging in jobs and router handlers
- add test verifying subscription creation is atomic

## Testing
- `ruff check .`
- `pytest tests/billing/test_subscription_atomicity.py -q --cov=services/api.app.billing.log --cov=services/api.app.billing.jobs --cov=services.api.app.routers.billing --cov-fail-under=0`
- `mypy --strict services/api/app/billing/log.py services/api/app/billing/jobs.py services/api/app/routers/billing.py tests/billing/test_subscription_atomicity.py` *(fails: command hung, environment limitation)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a40814a4832aa9f30784646ba895