### PR TITLE
[payments] use actual plan in invoice payload

### DIFF
--- a/tests/test_telegram_payments.py
+++ b/tests/test_telegram_payments.py
@@ -20,9 +20,10 @@ async def test_create_invoice(monkeypatch: pytest.MonkeyPatch) -> None:
     chat = SimpleNamespace(id=1)
     update = SimpleNamespace(effective_chat=chat)
 
-    await adapter.create_invoice(update, context)
+    await adapter.create_invoice(update, context, plan="pro")
 
     bot.send_invoice.assert_called_once()
+    assert bot.send_invoice.call_args.kwargs["payload"] == "pro"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- pass selected plan in Telegram invoice payload and register handler with plan
- rely on invoice payload for plan value in billing webhook
- verify plan propagated through invoice payload

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9a41029c4832a945ddb0f6128b53b