### PR TITLE
[bot] Handle httpx errors in payment webhook

### DIFF
--- a/services/bot/telegram_payments.py
+++ b/services/bot/telegram_payments.py
@@ -88,19 +88,30 @@ class TelegramPaymentsAdapter:
             "signature": signature,
         }
 
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{api_url}/billing/webhook",
-                json=event,
-                headers={"X-Webhook-Signature": signature},
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    f"{api_url}/billing/webhook",
+                    json=event,
+                    headers={"X-Webhook-Signature": signature},
+                )
+            if resp.status_code != 200:
+                logger.error(
+                    "billing webhook %s failed: %s %s",
+                    transaction_id,
+                    resp.status_code,
+                    resp.text,
+                )
+                await msg.reply_text(
+                    "⚠️ Не удалось подтвердить платёж, попробуйте позже",
+                )
+                return
+        except httpx.HTTPError:
+            logger.exception("billing webhook %s failed", transaction_id)
+            await msg.reply_text(
+                "⚠️ Не удалось подтвердить платёж, попробуйте позже",
             )
-        if resp.status_code != 200:
-            logger.error(
-                "billing webhook %s failed: %s %s",
-                transaction_id,
-                resp.status_code,
-                resp.text,
-            )
+            return
 
         await msg.reply_text("✅ Платёж успешно получен")
 

--- a/tests/test_telegram_payments.py
+++ b/tests/test_telegram_payments.py
@@ -122,4 +122,47 @@ async def test_handle_successful_payment_logs_error(
     await adapter.handle_successful_payment(update, SimpleNamespace())
 
     assert any("billing webhook" in r.getMessage() for r in caplog.records)
-    message.reply_text.assert_called_once()
+    message.reply_text.assert_called_once_with(
+        "⚠️ Не удалось подтвердить платёж, попробуйте позже",
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_successful_payment_http_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("BILLING_WEBHOOK_SECRET", "s")
+    adapter = TelegramPaymentsAdapter()
+    message = SimpleNamespace(
+        successful_payment=SimpleNamespace(
+            invoice_payload="pro",
+            telegram_payment_charge_id="evt3",
+            provider_payment_charge_id="txn3",
+        ),
+        reply_text=AsyncMock(),
+    )
+    update = SimpleNamespace(message=message)
+
+    async def _post(url: str, json: object, headers: dict[str, str]) -> SimpleNamespace:
+        raise httpx.HTTPError("boom")
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self.post = AsyncMock(side_effect=_post)
+
+        async def __aenter__(self) -> DummyClient:  # type: ignore[override]
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:  # type: ignore[override]
+            return None
+
+    dummy_client = DummyClient()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: dummy_client)
+
+    caplog.set_level(logging.ERROR)
+    await adapter.handle_successful_payment(update, SimpleNamespace())
+
+    assert any("billing webhook" in r.getMessage() for r in caplog.records)
+    message.reply_text.assert_called_once_with(
+        "⚠️ Не удалось подтвердить платёж, попробуйте позже",
+    )


### PR DESCRIPTION
## Summary
- handle HTTP request failures in Telegram payment webhook
- test payment webhook error handling

## Testing
- `ruff check services/bot/telegram_payments.py tests/test_telegram_payments.py`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9a4173df4832ab2885faf1a9854dc