### PR TITLE
[billing] Load webhook IPs from env via alias

### DIFF
--- a/services/api/app/billing/config.py
+++ b/services/api/app/billing/config.py
@@ -20,7 +20,7 @@ class BillingSettings(BaseSettings):
         default=None, alias="BILLING_WEBHOOK_SECRET"
     )
     billing_webhook_ips_raw: str = Field(
-        default="", validation_alias="BILLING_WEBHOOK_IPS"
+        default="", alias="BILLING_WEBHOOK_IPS"
     )
     billing_webhook_timeout: float = Field(default=5.0, alias="BILLING_WEBHOOK_TIMEOUT")
 

--- a/tests/billing/test_billing_config.py
+++ b/tests/billing/test_billing_config.py
@@ -30,3 +30,9 @@ def test_webhook_ips_parsing(monkeypatch) -> None:
     monkeypatch.setenv("BILLING_WEBHOOK_IPS", "1.2.3.4,5.6.7.8")
     settings = BillingSettings()
     assert settings.billing_webhook_ips == ["1.2.3.4", "5.6.7.8"]
+
+
+def test_webhook_ips_from_env(monkeypatch) -> None:
+    monkeypatch.setenv("BILLING_WEBHOOK_IPS", "9.9.9.9")
+    settings = BillingSettings(_env_file=None)
+    assert settings.billing_webhook_ips == ["9.9.9.9"]


### PR DESCRIPTION
## Summary
- use Field alias for `BILLING_WEBHOOK_IPS`
- test loading webhook IPs from environment

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b9a41decb0832a9b96a2c66c71f91c