### PR TITLE
[learning] add progress command

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import logging
 
+from sqlalchemy.orm import Session
 from telegram import Update
 from telegram.ext import ContextTypes
 
 from services.api.app.config import settings
+from services.api.app.diabetes.models_learning import Lesson, LessonProgress
+from services.api.app.diabetes.services.db import SessionLocal, run_db
 
 logger = logging.getLogger(__name__)
 
@@ -22,4 +25,46 @@ async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     await message.reply_text(f"🤖 Учебный режим активирован. Модель: {model}")
 
 
-__all__ = ["learn_command"]
+async def progress_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Display the user's current lesson progress."""
+    message = update.message
+    user = update.effective_user
+    if message is None or user is None:
+        return
+    user_id = user.id
+
+    def _load_progress(
+        session: Session, user_id: int
+    ) -> tuple[str, int, bool, int | None] | None:
+        progress = (
+            session.query(LessonProgress)
+            .join(Lesson)
+            .filter(LessonProgress.user_id == user_id)
+            .order_by(LessonProgress.id.desc())
+            .first()
+        )
+        if progress is None:
+            return None
+        return (
+            progress.lesson.title,
+            progress.current_step,
+            progress.completed,
+            progress.quiz_score,
+        )
+
+    result = await run_db(_load_progress, user_id, sessionmaker=SessionLocal)
+    if result is None:
+        await message.reply_text("Вы ещё не начали обучение. Отправьте /learn чтобы начать.")
+        return
+    title, current_step, completed, quiz_score = result
+    lines = [
+        f"📘 {title}",
+        f"Шаг: {current_step}",
+        f"Завершено: {'да' if completed else 'нет'}",
+        f"Баллы викторины: {quiz_score if quiz_score is not None else '—'}",
+    ]
+    await message.reply_text("\n".join(lines))
+
+
+__all__ = ["learn_command", "progress_command"]
+

--- a/tests/test_progress_command.py
+++ b/tests/test_progress_command.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from telegram import Update
+from telegram.ext import CallbackContext
+
+import services.api.app.diabetes.handlers.learning_handlers as handlers
+from services.api.app.diabetes.services import db
+from services.api.app.diabetes.models_learning import Lesson, LessonProgress
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:  # pragma: no cover - simple capture
+        self.replies.append(text)
+
+
+@pytest.fixture(autouse=True)
+def setup_db() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.SessionLocal.configure(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+    handlers.SessionLocal = db.SessionLocal  # type: ignore[assignment]
+    yield
+    db.dispose_engine(engine)
+
+
+@pytest.mark.asyncio
+async def test_progress_command_no_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    message = DummyMessage()
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    with db.SessionLocal() as session:
+        session.add(db.User(telegram_id=1, thread_id="t1"))
+        session.commit()
+
+    await handlers.progress_command(update, context)
+
+    assert message.replies == [
+        "Вы ещё не начали обучение. Отправьте /learn чтобы начать."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_progress_command_with_progress() -> None:
+    message = DummyMessage()
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    with db.SessionLocal() as session:
+        user = db.User(telegram_id=1, thread_id="t1")
+        lesson = Lesson(slug="intro", title="Intro", content="c")
+        session.add_all([user, lesson])
+        session.commit()
+        progress = LessonProgress(
+            user_id=user.telegram_id,
+            lesson_id=lesson.id,
+            current_step=2,
+            completed=False,
+            quiz_score=50,
+        )
+        session.add(progress)
+        session.commit()
+
+    await handlers.progress_command(update, context)
+
+    assert message.replies
+    text = message.replies[0]
+    assert "Intro" in text
+    assert "Шаг: 2" in text
+    assert "Завершено: нет" in text
+    assert "Баллы викторины: 50" in text


### PR DESCRIPTION
## Summary
- add `/progress` command to show current lesson progress
- cover new command with tests

## Testing
- `pytest tests/test_progress_command.py -q` *(fails: Coverage failure total of 25 < 85)*
- `pytest -q` *(fails: Coverage failure total of 60 < 85, numerous async plugin warnings)*
- `mypy --strict services/api/app/diabetes/handlers/learning_handlers.py tests/test_progress_command.py`
- `ruff check services/api/app/diabetes/handlers/learning_handlers.py tests/test_progress_command.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9a652e684832a8f67e47b409bc37f