### PR TITLE
[learning] add exit command to clear lesson state

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 import logging
+from typing import Any, cast
 
 from telegram import Update
 from telegram.ext import ContextTypes
+from sqlalchemy.orm import Session
 
 from services.api.app.config import settings
+from services.api.app.diabetes.models_learning import LessonProgress
+from services.api.app.diabetes.services import db
+from services.api.app.diabetes.services.repository import commit
+from services.api.app.diabetes.utils.ui import menu_keyboard
 
 logger = logging.getLogger(__name__)
 
@@ -22,4 +28,39 @@ async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     await message.reply_text(f"🤖 Учебный режим активирован. Модель: {model}")
 
 
-__all__ = ["learn_command"]
+async def exit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Exit the current lesson and show the main menu."""
+    message = update.message
+    if message is None:
+        return
+
+    user_data_raw = context.user_data
+    if user_data_raw is None:
+        return
+    user_data = cast(dict[str, Any], user_data_raw)
+
+    lesson_id = cast(int | None, user_data.get("lesson_id"))
+    for key in list(user_data.keys()):
+        if key.startswith("lesson_"):
+            user_data.pop(key, None)
+
+    from_user = message.from_user
+    if from_user and lesson_id is not None:
+        user_id = from_user.id
+
+        def _finish(session: Session) -> None:
+            progress = (
+                session.query(LessonProgress)
+                .filter_by(user_id=user_id, lesson_id=lesson_id)
+                .one_or_none()
+            )
+            if progress is not None and not progress.completed:
+                progress.completed = True
+                commit(session)
+
+        await db.run_db(_finish)
+
+    await message.reply_text("✅ Учебный режим завершён.", reply_markup=menu_keyboard())
+
+
+__all__ = ["learn_command", "exit_command"]

--- a/tests/diabetes/test_learning_handlers.py
+++ b/tests/diabetes/test_learning_handlers.py
@@ -4,17 +4,26 @@ from typing import Any, cast
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
 
 from services.api.app.config import settings
 from services.api.app.diabetes.handlers import learning_handlers
+from services.api.app.diabetes.learning_fixtures import load_lessons
+from services.api.app.diabetes.models_learning import Lesson, LessonProgress
+from services.api.app.diabetes.services import db
+from services.api.app.diabetes.utils.ui import menu_keyboard
 
 
 class DummyMessage:
     def __init__(self) -> None:
         self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
+        self.from_user = SimpleNamespace(id=1)
 
-    async def reply_text(self, text: str) -> None:
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
+        self.kwargs.append(kwargs)
 
 
 @pytest.mark.asyncio
@@ -42,3 +51,48 @@ async def test_learn_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     await learning_handlers.learn_command(update, context)
     assert "super-model" in message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_exit_command_clears_state_and_marks_progress() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.SessionLocal.configure(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+    await load_lessons(
+        "services/api/app/diabetes/content/lessons_v0.json",
+        sessionmaker=db.SessionLocal,
+    )
+    with db.SessionLocal() as session:
+        session.add(db.User(telegram_id=1, thread_id="t1"))
+        lesson = session.query(Lesson).first()
+        assert lesson is not None
+        lesson_id = lesson.id
+        session.add(LessonProgress(user_id=1, lesson_id=lesson_id, completed=False))
+        session.commit()
+
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={"lesson_id": lesson_id, "foo": "bar"}),
+    )
+
+    await learning_handlers.exit_command(update, context)
+
+    assert message.replies == ["✅ Учебный режим завершён."]
+    assert message.kwargs[0]["reply_markup"].keyboard == menu_keyboard().keyboard
+    assert context.user_data is not None
+    assert "lesson_id" not in context.user_data
+    assert context.user_data.get("foo") == "bar"
+
+    with db.SessionLocal() as session:
+        progress = (
+            session.query(LessonProgress)
+            .filter_by(user_id=1, lesson_id=lesson_id)
+            .one()
+        )
+        assert progress.completed is True


### PR DESCRIPTION
## Summary
- add `exit_command` to end lesson and return user to main menu
- mark lesson progress as completed in DB
- cover exit path with tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9a66172c8832abe535af6133d84bb