### PR TITLE
[billing] handle duplicate subscriptions

### DIFF
--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -191,7 +191,12 @@ async def subscribe(
         )
         session.commit()
 
-    await run_db(_create_draft, sessionmaker=SessionLocal)
+    try:
+        await run_db(_create_draft, sessionmaker=SessionLocal)
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=409, detail="subscription already exists"
+        ) from exc
     return CheckoutSchema.model_validate(checkout)
 
 


### PR DESCRIPTION
## Summary
- return HTTP 409 when a user tries to create a duplicate subscription
- test repeated subscription attempt

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9a73eb22c832aa2d9b2dba37c61e4