### PR TITLE
[billing] ensure transactional billing logs

### DIFF
--- a/services/api/app/billing/jobs.py
+++ b/services/api/app/billing/jobs.py
@@ -15,7 +15,6 @@ from services.api.app.diabetes.services.db import (
     SubscriptionStatus,
     run_db,
 )
-from services.api.app.diabetes.services.repository import commit
 from .log import BillingEvent, log_billing_event
 
 logger = logging.getLogger(__name__)
@@ -62,7 +61,6 @@ async def expire_subscriptions(_context: ContextTypes.DEFAULT_TYPE) -> None:
         for sub in subs:
             sub.status = cast(SubscriptionStatus, SubscriptionStatus.EXPIRED.value)
         if subs:
-            commit(session)
             for sub in subs:
                 log_billing_event(
                     session,
@@ -70,6 +68,7 @@ async def expire_subscriptions(_context: ContextTypes.DEFAULT_TYPE) -> None:
                     BillingEvent.EXPIRED,
                     {"subscription_id": sub.id},
                 )
+            session.commit()
         return [sub.user_id for sub in subs]
 
     user_ids = await run_db(_expire)

--- a/services/api/app/billing/log.py
+++ b/services/api/app/billing/log.py
@@ -9,7 +9,6 @@ from sqlalchemy import BigInteger, Integer, TIMESTAMP, Enum as SAEnum, JSON, fun
 from sqlalchemy.orm import Mapped, Session, mapped_column
 
 from ..diabetes.services.db import Base
-from ..diabetes.services.repository import commit
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +30,12 @@ class BillingLog(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
-    event: Mapped[BillingEvent] = mapped_column(SAEnum(BillingEvent, name="billing_event"), nullable=False)
-    ts: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
+    event: Mapped[BillingEvent] = mapped_column(
+        SAEnum(BillingEvent, name="billing_event"), nullable=False
+    )
+    ts: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
     context: Mapped[dict[str, Any] | None] = mapped_column(JSON)
 
 
@@ -49,4 +52,4 @@ def log_billing_event(
 
     log = BillingLog(user_id=user_id, event=event, context=context)
     session.add(log)
-    commit(session)
+    session.flush()

--- a/tests/billing/test_billing_subscribe.py
+++ b/tests/billing/test_billing_subscribe.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine, func, select
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 import pytest
@@ -13,7 +13,7 @@ from services.api.app.diabetes.services.db import (
     SubscriptionPlan,
     SubscriptionStatus,
 )
-from services.api.app.billing.log import BillingLog
+from services.api.app.billing.log import BillingEvent, BillingLog
 from services.api.app.routers import billing
 from services.api.app.billing.config import BillingSettings
 from services.api.app.main import app
@@ -28,12 +28,18 @@ def setup_db() -> sessionmaker[Session]:
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-    Base.metadata.create_all(engine, tables=[Subscription.__table__, BillingLog.__table__])
+    Base.metadata.create_all(
+        engine, tables=[Subscription.__table__, BillingLog.__table__]
+    )
     return sessionmaker(bind=engine)
 
 
-def make_client(monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]) -> TestClient:
-    async def run_db(fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs):
+def make_client(
+    monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]
+) -> TestClient:
+    async def run_db(
+        fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs
+    ):
         with sessionmaker() as session:
             return fn(session, *args, **kwargs)
 
@@ -58,7 +64,9 @@ def test_subscribe_billing_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BILLING_ENABLED", "false")
     reload_billing_settings()
     with TestClient(app) as client:
-        resp = client.post("/api/billing/subscribe", params={"user_id": 1, "plan": "pro"})
+        resp = client.post(
+            "/api/billing/subscribe", params={"user_id": 1, "plan": "pro"}
+        )
     assert resp.status_code == 503
 
 
@@ -66,7 +74,9 @@ def test_subscribe_dummy_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     session_local = setup_db()
     client = make_client(monkeypatch, session_local)
     with client:
-        resp = client.post("/api/billing/subscribe", params={"user_id": 1, "plan": "pro"})
+        resp = client.post(
+            "/api/billing/subscribe", params={"user_id": 1, "plan": "pro"}
+        )
     assert resp.status_code == 200
     data = resp.json()
     assert set(data) == {"id", "url"}
@@ -80,7 +90,9 @@ def test_subscribe_dummy_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     assert webhook.status_code == 200
 
     with session_local() as session:
-        sub = session.scalar(select(Subscription).where(Subscription.transaction_id == data["id"]))
+        sub = session.scalar(
+            select(Subscription).where(Subscription.transaction_id == data["id"])
+        )
         assert sub is not None
         assert sub.status == SubscriptionStatus.ACTIVE
         assert sub.plan == SubscriptionPlan.PRO
@@ -90,10 +102,70 @@ def test_mock_webhook_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:
     session_local = setup_db()
     client = make_client(monkeypatch, session_local)
     with client:
-        resp = client.post("/api/billing/subscribe", params={"user_id": 1, "plan": "pro"})
+        resp = client.post(
+            "/api/billing/subscribe", params={"user_id": 1, "plan": "pro"}
+        )
     assert resp.status_code == 200
     data = resp.json()
 
     with client:
         webhook = client.post(f"/api/billing/mock-webhook/{data['id']}")
     assert webhook.status_code == 403
+
+
+def test_subscribe_log_failure_rolled_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    client = make_client(monkeypatch, session_local)
+    original = billing.log_billing_event
+
+    def failing_log(*args: object, **kwargs: object) -> None:
+        original(*args, **kwargs)
+        raise RuntimeError
+
+    monkeypatch.setattr(billing, "log_billing_event", failing_log)
+    with pytest.raises(RuntimeError):
+        with client:
+            client.post("/api/billing/subscribe", params={"user_id": 1, "plan": "pro"})
+    count_stmt = select(func.count()).select_from(Subscription)
+    log_stmt = select(func.count()).select_from(BillingLog)
+    with session_local() as session:
+        count = session.scalar(count_stmt)
+        log_count = session.scalar(log_stmt)
+    assert count == 0
+    assert log_count == 0
+
+
+def test_mock_webhook_log_failure_rolled_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.post(
+            "/api/billing/subscribe", params={"user_id": 1, "plan": "pro"}
+        )
+    checkout_id = resp.json()["id"]
+    original = billing.log_billing_event
+
+    def failing_log(*args: object, **kwargs: object) -> None:
+        original(*args, **kwargs)
+        raise RuntimeError
+
+    monkeypatch.setattr(billing, "log_billing_event", failing_log)
+    with pytest.raises(RuntimeError):
+        with client:
+            client.post(
+                f"/api/billing/mock-webhook/{checkout_id}",
+                headers={"X-Admin-Token": "secret"},
+            )
+    with session_local() as session:
+        sub = session.scalar(
+            select(Subscription).where(Subscription.transaction_id == checkout_id)
+        )
+        assert sub is not None
+        assert sub.status == SubscriptionStatus.PENDING
+        assert sub.end_date is None
+        log_count = session.scalar(
+            select(func.count())
+            .select_from(BillingLog)
+            .where(BillingLog.event == BillingEvent.WEBHOOK_OK)
+        )
+        assert log_count == 0


### PR DESCRIPTION
## Summary
- ensure `log_billing_event` uses `session.flush()` instead of committing
- commit subscription and logging changes together in billing routes and jobs
- add tests verifying atomic persistence of subscriptions and billing logs

## Testing
- `ruff check tests/test_billing_trial.py tests/billing/test_billing_subscribe.py services/api/app/billing/log.py services/api/app/routers/billing.py services/api/app/billing/jobs.py`
- `mypy --strict tests/billing/test_billing_subscribe.py`
- `mypy --strict tests/test_billing_trial.py`
- `mypy --strict services/api/app/billing/log.py services/api/app/routers/billing.py services/api/app/billing/jobs.py tests/test_billing_trial.py tests/billing/test_billing_subscribe.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9a21c6b30832aad2290cc0691a422