### PR TITLE
diabetes: add learning mode handlers

### DIFF
--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -1,0 +1,183 @@
+"""Handlers for the interactive learning mode.
+
+The module implements a very small set of asynchronous telegram handlers used in
+unit tests. They expose a primitive learning flow built around the
+``curriculum_engine`` helpers. Real logic in the project is considerably more
+feature rich, however for tests we only need the simplified behaviour defined
+below.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes
+from sqlalchemy.orm import Session
+from typing import Any, MutableMapping, cast
+
+from services.api.app.config import settings
+from . import curriculum_engine
+from .models_learning import Lesson, LessonProgress
+from .services import db
+
+logger = logging.getLogger(__name__)
+
+# Shared message when the learning mode is disabled
+DISABLED_TEXT = "Учебный режим выключен"
+
+
+async def _fetch_active_lessons() -> list[Lesson]:
+    """Return active lessons from the database."""
+
+    def _query(session: Session) -> list[Lesson]:
+        return (
+            session.query(Lesson).filter_by(is_active=True).order_by(Lesson.id).all()
+        )
+
+    return await db.run_db(_query)
+
+
+async def _fetch_progress(user_id: int, lesson_id: int) -> tuple[LessonProgress, Lesson]:
+    """Return progress and related lesson for a user."""
+
+    def _query(session: Session) -> tuple[LessonProgress, Lesson]:
+        progress = (
+            session.query(LessonProgress)
+            .filter_by(user_id=user_id, lesson_id=lesson_id)
+            .one()
+        )
+        lesson = session.query(Lesson).filter_by(id=lesson_id).one()
+        return progress, lesson
+
+    return await db.run_db(_query)
+
+
+async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """List available lessons using an inline keyboard."""
+
+    message = update.message
+    if message is None:
+        return
+    if not settings.learning_mode_enabled:
+        await message.reply_text(DISABLED_TEXT)
+        return
+    lessons = await _fetch_active_lessons()
+    if not lessons:
+        await message.reply_text("Нет активных уроков")
+        return
+    buttons: list[list[InlineKeyboardButton]] = [
+        [InlineKeyboardButton(lesson.title, callback_data=lesson.slug)] for lesson in lessons
+    ]
+    await message.reply_text(
+        "Выберите урок:", reply_markup=InlineKeyboardMarkup(buttons)
+    )
+
+
+async def lesson_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Start or continue a lesson for the user."""
+
+    message = update.message
+    user = update.effective_user
+    if message is None or user is None:
+        return
+    if not settings.learning_mode_enabled:
+        await message.reply_text(DISABLED_TEXT)
+        return
+    user_data = cast(MutableMapping[str, Any], context.user_data)
+    lesson_slug: str | None = None
+    if context.args:
+        lesson_slug = context.args[0]
+        user_data["lesson_slug"] = lesson_slug
+    else:
+        lesson_slug = user_data.get("lesson_slug")
+    lesson_id = user_data.get("lesson_id")
+    if lesson_id is None:
+        if lesson_slug is None:
+            await message.reply_text("Сначала выберите урок командой /learn")
+            return
+        progress = await curriculum_engine.start_lesson(user.id, lesson_slug)
+        lesson_id = progress.lesson_id
+        user_data["lesson_id"] = lesson_id
+    text = await curriculum_engine.next_step(user.id, int(lesson_id))
+    if text is None:
+        await message.reply_text("Урок завершён")
+    else:
+        await message.reply_text(text)
+
+
+async def quiz_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle quiz questions and answers for the current lesson."""
+
+    message = update.message
+    user = update.effective_user
+    if message is None or user is None:
+        return
+    if not settings.learning_mode_enabled:
+        await message.reply_text(DISABLED_TEXT)
+        return
+    user_data = cast(MutableMapping[str, Any], context.user_data)
+    lesson_id = user_data.get("lesson_id")
+    if lesson_id is None:
+        await message.reply_text("Урок не выбран")
+        return
+    if context.args:
+        try:
+            answer = int(context.args[0])
+        except ValueError:
+            await message.reply_text("Ответ должен быть числом")
+            return
+        _correct, feedback = await curriculum_engine.check_answer(
+            user.id, int(lesson_id), answer
+        )
+        await message.reply_text(feedback)
+    question = await curriculum_engine.next_step(user.id, int(lesson_id))
+    if question is None:
+        await message.reply_text("Опрос завершён")
+    else:
+        await message.reply_text(question)
+
+
+async def progress_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Display current progress for the user."""
+
+    message = update.message
+    user = update.effective_user
+    if message is None or user is None:
+        return
+    if not settings.learning_mode_enabled:
+        await message.reply_text(DISABLED_TEXT)
+        return
+    user_data = cast(MutableMapping[str, Any], context.user_data)
+    lesson_id = user_data.get("lesson_id")
+    if lesson_id is None:
+        await message.reply_text("Урок не выбран")
+        return
+    progress, lesson = await _fetch_progress(user.id, int(lesson_id))
+    score = progress.quiz_score or 0
+    await message.reply_text(
+        f"Урок: {lesson.title}\nШаг: {progress.current_step}\nБаллы: {score}"
+    )
+
+
+async def exit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Exit learning mode and clear user state."""
+
+    message = update.message
+    if message is None:
+        return
+    user_data = cast(MutableMapping[str, Any], context.user_data)
+    user_data.clear()
+    if not settings.learning_mode_enabled:
+        await message.reply_text(DISABLED_TEXT)
+    else:
+        await message.reply_text("Вы вышли из учебного режима")
+
+
+__all__ = [
+    "learn_command",
+    "lesson_command",
+    "quiz_command",
+    "progress_command",
+    "exit_command",
+]

--- a/tests/diabetes/test_learning_handlers_new.py
+++ b/tests/diabetes/test_learning_handlers_new.py
@@ -1,0 +1,158 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import InlineKeyboardMarkup, Update
+from telegram.ext import CallbackContext
+
+from services.api.app.config import settings
+from services.api.app.diabetes import learning_handlers
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+        self.reply_markup: InlineKeyboardMarkup | None = None
+
+    async def reply_text(
+        self, text: str, reply_markup: InlineKeyboardMarkup | None = None
+    ) -> None:
+        self.replies.append(text)
+        if reply_markup is not None:
+            self.reply_markup = reply_markup
+
+
+def make_update() -> Update:
+    return cast(Update, SimpleNamespace(message=DummyMessage(), effective_user=SimpleNamespace(id=1)))
+
+
+def make_context(**kwargs: Any) -> CallbackContext[Any, Any, Any, Any]:
+    data = {"user_data": {}, "args": []}
+    data.update(kwargs)
+    return cast(CallbackContext[Any, Any, Any, Any], SimpleNamespace(**data))
+
+
+@pytest.mark.asyncio
+async def test_disabled_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", False)
+    for handler in [
+        learning_handlers.learn_command,
+        learning_handlers.lesson_command,
+        learning_handlers.quiz_command,
+        learning_handlers.progress_command,
+        learning_handlers.exit_command,
+    ]:
+        upd = make_update()
+        ctx = make_context()
+        await handler(upd, ctx)
+        msg = cast(DummyMessage, upd.message)
+        assert msg.replies == [learning_handlers.DISABLED_TEXT]
+
+
+@pytest.mark.asyncio
+async def test_learn_lists_lessons(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+    lessons = [SimpleNamespace(title=f"L{i}", slug=f"l{i}") for i in range(1, 4)]
+
+    async def fake_run_db(fn: Any, *a: Any, **kw: Any) -> list[Any]:
+        return lessons
+
+    monkeypatch.setattr(learning_handlers.db, "run_db", fake_run_db)
+    upd = make_update()
+    ctx = make_context()
+    await learning_handlers.learn_command(upd, ctx)
+    msg = cast(DummyMessage, upd.message)
+    assert msg.reply_markup is not None
+    buttons = [b.text for row in msg.reply_markup.inline_keyboard for b in row]
+    assert buttons == ["L1", "L2", "L3"]
+
+
+@pytest.mark.asyncio
+async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+    calls: list[str] = []
+
+    async def fake_start(user_id: int, slug: str) -> SimpleNamespace:
+        calls.append(f"start:{slug}")
+        return SimpleNamespace(lesson_id=1)
+
+    steps = iter(["step1", "step2"])
+
+    async def fake_next(user_id: int, lesson_id: int) -> str | None:
+        calls.append("next")
+        return next(steps, None)
+
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next)
+
+    upd = make_update()
+    ctx = make_context(args=["l1"])
+    await learning_handlers.lesson_command(upd, ctx)
+    msg = cast(DummyMessage, upd.message)
+    assert msg.replies == ["step1"]
+    assert ctx.user_data["lesson_id"] == 1
+
+    upd2 = make_update()
+    ctx2 = make_context(user_data=ctx.user_data, args=[])
+    await learning_handlers.lesson_command(upd2, ctx2)
+    msg2 = cast(DummyMessage, upd2.message)
+    assert msg2.replies == ["step2"]
+    assert calls.count("start:l1") == 1
+    assert calls.count("next") == 2
+
+
+@pytest.mark.asyncio
+async def test_quiz(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+    questions = iter(["Q1", None])
+
+    async def fake_next(user_id: int, lesson_id: int) -> str | None:
+        return next(questions, None)
+
+    async def fake_check(user_id: int, lesson_id: int, answer: int) -> tuple[bool, str]:
+        return True, "ok"
+
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "check_answer", fake_check)
+
+    upd = make_update()
+    ctx = make_context(user_data={"lesson_id": 1})
+    await learning_handlers.quiz_command(upd, ctx)
+    msg = cast(DummyMessage, upd.message)
+    assert msg.replies == ["Q1"]
+
+    upd2 = make_update()
+    ctx2 = make_context(user_data={"lesson_id": 1}, args=["0"])
+    await learning_handlers.quiz_command(upd2, ctx2)
+    msg2 = cast(DummyMessage, upd2.message)
+    assert msg2.replies == ["ok", "Опрос завершён"]
+
+
+@pytest.mark.asyncio
+async def test_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+    progress = SimpleNamespace(current_step=2, quiz_score=50)
+    lesson = SimpleNamespace(title="L1")
+
+    async def fake_run_db(fn: Any, *a: Any, **kw: Any) -> tuple[Any, Any]:
+        return progress, lesson
+
+    monkeypatch.setattr(learning_handlers.db, "run_db", fake_run_db)
+    upd = make_update()
+    ctx = make_context(user_data={"lesson_id": 1})
+    await learning_handlers.progress_command(upd, ctx)
+    msg = cast(DummyMessage, upd.message)
+    assert "L1" in msg.replies[0]
+    assert "2" in msg.replies[0]
+    assert "50" in msg.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+    upd = make_update()
+    ctx = make_context(user_data={"lesson_id": 1})
+    await learning_handlers.exit_command(upd, ctx)
+    msg = cast(DummyMessage, upd.message)
+    assert msg.replies == ["Вы вышли из учебного режима"]
+    assert ctx.user_data == {}


### PR DESCRIPTION
## Summary
- add dedicated learning mode handlers (/learn, /lesson, /quiz, /progress, /exit)
- track progress and quizzes through curriculum engine
- cover learning mode commands with tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b9a3cd3658832a80af0a4a3a4638aa