### PR TITLE
[db] Enforce unique transaction_id for subscriptions

### DIFF
--- a/services/api/alembic/versions/20250915_add_unique_transaction_id_to_subscriptions.py
+++ b/services/api/alembic/versions/20250915_add_unique_transaction_id_to_subscriptions.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250915_add_unique_transaction_id_to_subscriptions"
+down_revision: Union[str, Sequence[str], None] = "20250914_add_progress_state_fields"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_subscriptions_transaction_id", table_name="subscriptions")
+    op.create_index(
+        "ix_subscriptions_transaction_id",
+        "subscriptions",
+        ["transaction_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_subscriptions_transaction_id", table_name="subscriptions")
+    op.create_index(
+        "ix_subscriptions_transaction_id",
+        "subscriptions",
+        ["transaction_id"],
+        unique=False,
+    )

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -351,7 +351,9 @@ class Subscription(Base):
         nullable=False,
     )
     provider: Mapped[str] = mapped_column(String, nullable=False)
-    transaction_id: Mapped[str] = mapped_column(String, index=True, nullable=False)
+    transaction_id: Mapped[str] = mapped_column(
+        String, index=True, unique=True, nullable=False
+    )
     start_date: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
     end_date: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())

--- a/tests/billing/test_billing_webhook.py
+++ b/tests/billing/test_billing_webhook.py
@@ -142,10 +142,9 @@ def test_webhook_duplicate_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
     assert dup.status_code == 200
     assert dup.json() == {"status": "ignored"}
     with session_local() as session:
-        sub = session.scalar(
-            select(Subscription).where(Subscription.transaction_id == checkout_id)
-        )
-        assert sub.end_date == first_end
+        subs = session.scalars(select(Subscription)).all()
+        assert len(subs) == 1
+        assert subs[0].end_date == first_end
 
 
 def test_webhook_invalid_signature(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- make `Subscription.transaction_id` unique
- add Alembic migration adding unique index for `subscriptions.transaction_id`
- adjust duplicate webhook test to assert single subscription row

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9a9248ae0832a9d6db0616122cb2c