### PR TITLE
[billing] prioritize active subscription in status

### DIFF
--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -339,6 +339,22 @@ async def status(
     """Return billing feature flags and the latest subscription for a user."""
 
     def _get_subscription(session: Session) -> Subscription | None:
+        for status in (
+            SubscriptionStatus.ACTIVE.value,
+            SubscriptionStatus.TRIAL.value,
+        ):
+            stmt = (
+                select(Subscription)
+                .where(
+                    Subscription.user_id == user_id,
+                    Subscription.status == status,
+                )
+                .order_by(Subscription.start_date.desc())
+                .limit(1)
+            )
+            sub = session.scalars(stmt).first()
+            if sub is not None:
+                return sub
         stmt = (
             select(Subscription)
             .where(Subscription.user_id == user_id)


### PR DESCRIPTION
## Summary
- prioritize active subscription, then trial, when returning billing status
- cover status endpoint with active and pending subscriptions

## Testing
- `pytest tests/test_billing_status.py --override-ini addopts='' -q`
- `mypy --strict services/api/app/routers/billing.py tests/test_billing_status.py`
- `ruff check services/api/app/routers/billing.py tests/test_billing_status.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9a93556bc832a83eabcc2aef60d2c