### PR TITLE
[handlers] register interactive learning commands

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -6,7 +6,7 @@ from typing import cast
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from .handlers.learning_handlers import learn_command
+from .learning_handlers import learn_command
 from .handlers.onboarding_handlers import (
     reset_onboarding as _reset_onboarding,
 )

--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -6,7 +6,7 @@ from telegram import Update
 from telegram.ext import ContextTypes
 
 from services.api.app.diabetes.utils.ui import menu_keyboard
-from .learning_handlers import learn_command
+from ..learning_handlers import learn_command
 
 
 async def menu_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -151,9 +151,9 @@ def register_handlers(
         photo_handlers,
         sugar_handlers,
         gpt_handlers,
-        learning_handlers,
         billing_handlers,
     )
+    from .. import learning_handlers
 
     app.add_handler(onboarding_conv)
     app.add_handler(CommandHandlerT("menu", menu_command))
@@ -168,6 +168,10 @@ def register_handlers(
     app.add_handler(CommandHandlerT("cancel", dose_calc.dose_cancel))
     app.add_handler(CommandHandlerT("help", help_command))
     app.add_handler(CommandHandlerT("learn", learning_handlers.learn_command))
+    app.add_handler(CommandHandlerT("lesson", learning_handlers.lesson_command))
+    app.add_handler(CommandHandlerT("quiz", learning_handlers.quiz_command))
+    app.add_handler(CommandHandlerT("progress", learning_handlers.progress_command))
+    app.add_handler(CommandHandlerT("exit", learning_handlers.exit_command))
     app.add_handler(CommandHandlerT("gpt", gpt_handlers.chat_with_gpt))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -32,6 +32,7 @@ from services.api.app.diabetes.handlers import (
     reminder_handlers,
     billing_handlers,
 )
+from services.api.app.diabetes import learning_handlers
 
 
 def test_register_handlers_attaches_expected_handlers(
@@ -77,6 +78,30 @@ def test_register_handlers_attaches_expected_handlers(
     assert security_handlers.hypo_alert_faq in callbacks
     assert billing_handlers.trial_command in callbacks
     assert billing_handlers.upgrade_command in callbacks
+    assert any(
+        isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.lesson_command
+        and "lesson" in h.commands
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.quiz_command
+        and "quiz" in h.commands
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.progress_command
+        and "progress" in h.commands
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.exit_command
+        and "exit" in h.commands
+        for h in handlers
+    )
     # Reminder handlers should be registered
     assert any(
         isinstance(h, CallbackQueryHandler)


### PR DESCRIPTION
## Summary
- use new learning_handlers module for learn-related commands
- register lesson, quiz, progress and exit command handlers
- cover handler registration with tests

## Testing
- `pytest tests/test_utils.py::test_get_coords_and_link_non_blocking -q` (fails: async plugin missing & coverage < 85)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9aa9b7e98832abb9b5cf206b15791