### PR TITLE
[gpt_client] Format replies and return strings

### DIFF
--- a/services/api/app/diabetes/curriculum_engine.py
+++ b/services/api/app/diabetes/curriculum_engine.py
@@ -95,14 +95,14 @@ async def next_step(user_id: int, lesson_id: int) -> str | None:
 
     step_content, question_text = await db.run_db(_advance)
     if step_content is not None:
-        completion = await gpt_client.create_learning_chat_completion(
+        text = await gpt_client.create_learning_chat_completion(
             task=LLMTask.EXPLAIN_STEP,
             messages=[
                 {"role": "system", "content": SYSTEM_TUTOR_RU},
                 {"role": "user", "content": build_explain_step(step_content)},
             ],
         )
-        return completion.choices[0].message.content or ""
+        return text
     if question_text is not None:
         return question_text
     return None
@@ -140,16 +140,14 @@ async def check_answer(
         return correct, explanation
 
     correct, explanation = await db.run_db(_check)
-    completion = await gpt_client.create_learning_chat_completion(
+    message = await gpt_client.create_learning_chat_completion(
         task=LLMTask.QUIZ_CHECK,
         messages=[
             {"role": "system", "content": SYSTEM_TUTOR_RU},
             {"role": "user", "content": build_feedback(correct, explanation)},
         ],
     )
-    message = completion.choices[0].message.content or ""
     return correct, message
 
 
 __all__ = ["start_lesson", "next_step", "check_answer"]
-

--- a/tests/test_format_reply.py
+++ b/tests/test_format_reply.py
@@ -1,0 +1,7 @@
+from services.api.app.diabetes.services.gpt_client import format_reply
+
+
+def test_format_reply_truncates_and_splits() -> None:
+    text = "one\n\n" + "x" * 900 + "\n\n\nthree"
+    result = format_reply(text, max_len=10)
+    assert result == "one\n\n" + "x" * 10 + "\n\nthree"

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+import types
+
 from services.api.app import config
 from services.api.app.diabetes.llm_router import LLMRouter, LLMTask
 from services.api.app.diabetes.services import gpt_client
@@ -27,13 +29,15 @@ async def test_create_learning_chat_completion_uses_router(
     """gpt_client should delegate model selection to the router."""
     captured: dict[str, str] = {}
 
-    async def fake_create_chat_completion(
-        *, model: str, **kwargs: object
-    ) -> object:
+    async def fake_create_chat_completion(*, model: str, **kwargs: object) -> object:
         captured["model"] = model
-        return object()
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="ok"))]
+        )
 
-    monkeypatch.setattr(gpt_client, "create_chat_completion", fake_create_chat_completion)
+    monkeypatch.setattr(
+        gpt_client, "create_chat_completion", fake_create_chat_completion
+    )
     monkeypatch.setattr(gpt_client, "_learning_router", LLMRouter())
 
     await gpt_client.create_learning_chat_completion(


### PR DESCRIPTION
## Summary
- Add `format_reply` helper to structure and truncate LLM output
- Have `create_learning_chat_completion` return a formatted string
- Update curriculum engine and tests for string-based completions

## Testing
- `python -m pytest tests/test_format_reply.py tests/test_llm_router.py tests/learning/test_curriculum_engine.py -q --cov` *(fails: Required test coverage of 85% not reached. Total coverage: 39.99%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9ac32c270832aa7dd6b610be19878