### PR TITLE
[handlers] add rate-limited lesson and quiz commands

### DIFF
--- a/services/api/app/bot.py
+++ b/services/api/app/bot.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import logging
 import os
 
-from telegram.ext import Application
+from telegram.ext import Application, CommandHandler
 
+from .diabetes.handlers.learning_handlers import lesson_command, quiz_command
 from .diabetes.handlers.onboarding_handlers import onboarding_conv
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,8 @@ def main() -> None:
     token = os.environ["TELEGRAM_TOKEN"]
     application = Application.builder().token(token).build()
     application.add_handler(onboarding_conv)
+    application.add_handler(CommandHandler("lesson", lesson_command))
+    application.add_handler(CommandHandler("quiz", quiz_command))
     application.run_polling()
 
 

--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -1,19 +1,35 @@
 from __future__ import annotations
 
 import logging
-from typing import cast
+import time
+from typing import Any, MutableMapping, cast
 
 from sqlalchemy.orm import Session
 from telegram import Update
 from telegram.ext import ContextTypes
 
 from services.api.app.config import settings
+from services.api.app.diabetes import curriculum_engine
 from services.api.app.diabetes.models_learning import Lesson, LessonProgress
 from services.api.app.diabetes.services.db import SessionLocal, run_db
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
 logger = logging.getLogger(__name__)
+
+RATE_LIMIT_SECONDS = 3.0
+RATE_LIMIT_MESSAGE = "⏳ Подождите немного перед следующим запросом."
+
+
+def _rate_limited(user_data: MutableMapping[str, Any], key: str) -> bool:
+    """Return ``True`` if the command with ``key`` is called too often."""
+
+    now = time.monotonic()
+    last = cast(float | None, user_data.get(key))
+    if last is not None and now - last < RATE_LIMIT_SECONDS:
+        return True
+    user_data[key] = now
+    return False
 
 
 async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -26,6 +42,76 @@ async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         return
     model = settings.learning_command_model
     await message.reply_text(f"🤖 Учебный режим активирован. Модель: {model}")
+
+
+async def lesson_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Start or continue a lesson for the user."""
+
+    message = update.message
+    user = update.effective_user
+    if message is None or user is None:
+        return
+    if not settings.learning_enabled:
+        await message.reply_text("🚫 Обучение недоступно.")
+        return
+    user_data = cast(MutableMapping[str, Any], context.user_data)
+    if _rate_limited(user_data, "_lesson_ts"):
+        await message.reply_text(RATE_LIMIT_MESSAGE)
+        return
+    lesson_slug: str | None = None
+    if context.args:
+        lesson_slug = context.args[0]
+        user_data["lesson_slug"] = lesson_slug
+    else:
+        lesson_slug = cast(str | None, user_data.get("lesson_slug"))
+    lesson_id = cast(int | None, user_data.get("lesson_id"))
+    if lesson_id is None:
+        if lesson_slug is None:
+            await message.reply_text("Сначала выберите урок командой /learn")
+            return
+        progress = await curriculum_engine.start_lesson(user.id, lesson_slug)
+        lesson_id = progress.lesson_id
+        user_data["lesson_id"] = lesson_id
+    text = await curriculum_engine.next_step(user.id, lesson_id)
+    if text is None:
+        await message.reply_text("Урок завершён")
+    else:
+        await message.reply_text(text)
+
+
+async def quiz_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle quiz questions and answers for the current lesson."""
+
+    message = update.message
+    user = update.effective_user
+    if message is None or user is None:
+        return
+    if not settings.learning_enabled:
+        await message.reply_text("🚫 Обучение недоступно.")
+        return
+    user_data = cast(MutableMapping[str, Any], context.user_data)
+    if _rate_limited(user_data, "_quiz_ts"):
+        await message.reply_text(RATE_LIMIT_MESSAGE)
+        return
+    lesson_id = cast(int | None, user_data.get("lesson_id"))
+    if lesson_id is None:
+        await message.reply_text("Урок не выбран")
+        return
+    if context.args:
+        try:
+            answer = int(context.args[0])
+        except ValueError:
+            await message.reply_text("Ответ должен быть числом")
+            return
+        _correct, feedback = await curriculum_engine.check_answer(
+            user.id, lesson_id, answer
+        )
+        await message.reply_text(feedback)
+    question = await curriculum_engine.next_step(user.id, lesson_id)
+    if question is None:
+        await message.reply_text("Опрос завершён")
+    else:
+        await message.reply_text(question)
 
 
 async def progress_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -100,4 +186,10 @@ async def exit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await message.reply_text("Учебная сессия завершена.", reply_markup=menu_keyboard())
 
 
-__all__ = ["learn_command", "progress_command", "exit_command"]
+__all__ = [
+    "learn_command",
+    "lesson_command",
+    "quiz_command",
+    "progress_command",
+    "exit_command",
+]

--- a/tests/diabetes/test_learning_handlers_rate_limit.py
+++ b/tests/diabetes/test_learning_handlers_rate_limit.py
@@ -1,0 +1,131 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.config import settings
+from services.api.app.diabetes.handlers import learning_handlers
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+
+def make_update() -> Update:
+    user = SimpleNamespace(id=1)
+    return cast(Update, SimpleNamespace(message=DummyMessage(), effective_user=user))
+
+
+def make_context(**kwargs: Any) -> CallbackContext[Any, Any, Any, Any]:
+    data: dict[str, Any] = {"user_data": {}, "args": []}
+    data.update(kwargs)
+    return cast(CallbackContext[Any, Any, Any, Any], SimpleNamespace(**data))
+
+
+@pytest.mark.asyncio
+async def test_lesson_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_enabled", True)
+
+    calls: list[str] = []
+
+    async def fake_start(user_id: int, slug: str) -> SimpleNamespace:
+        calls.append("start")
+        return SimpleNamespace(lesson_id=1)
+
+    steps = iter(["step1", "step2"])
+
+    async def fake_next(user_id: int, lesson_id: int) -> str | None:
+        calls.append("next")
+        return next(steps, None)
+
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next)
+
+    times = iter([0.0, 1.0, 4.0])
+
+    def fake_monotonic() -> float:
+        try:
+            return next(times)
+        except StopIteration:
+            return 1000.0
+
+    monkeypatch.setattr(learning_handlers.time, "monotonic", fake_monotonic)
+
+    ctx = make_context(args=["l1"])
+    upd1 = make_update()
+    await learning_handlers.lesson_command(upd1, ctx)
+    msg1 = cast(DummyMessage, upd1.message)
+    assert msg1.replies == ["step1"]
+
+    upd2 = make_update()
+    ctx2 = make_context(user_data=ctx.user_data, args=[])
+    await learning_handlers.lesson_command(upd2, ctx2)
+    msg2 = cast(DummyMessage, upd2.message)
+    assert msg2.replies == [learning_handlers.RATE_LIMIT_MESSAGE]
+
+    upd3 = make_update()
+    ctx3 = make_context(user_data=ctx.user_data, args=[])
+    await learning_handlers.lesson_command(upd3, ctx3)
+    msg3 = cast(DummyMessage, upd3.message)
+    assert msg3.replies == ["step2"]
+
+    assert calls.count("start") == 1
+    assert calls.count("next") == 2
+
+
+@pytest.mark.asyncio
+async def test_quiz_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_enabled", True)
+
+    questions = iter(["Q1", "Q2"])
+
+    async def fake_next(user_id: int, lesson_id: int) -> str | None:
+        return next(questions, None)
+
+    answers: list[int] = []
+
+    async def fake_check(user_id: int, lesson_id: int, answer: int) -> tuple[bool, str]:
+        answers.append(answer)
+        return True, "ok"
+
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "check_answer", fake_check)
+
+    times = iter([0.0, 1.0, 4.0])
+
+    def fake_monotonic() -> float:
+        try:
+            return next(times)
+        except StopIteration:
+            return 1000.0
+
+    monkeypatch.setattr(learning_handlers.time, "monotonic", fake_monotonic)
+
+    user_data = {"lesson_id": 1}
+
+    upd1 = make_update()
+    ctx1 = make_context(user_data=user_data, args=[])
+    await learning_handlers.quiz_command(upd1, ctx1)
+    msg1 = cast(DummyMessage, upd1.message)
+    assert msg1.replies == ["Q1"]
+
+    upd2 = make_update()
+    ctx2 = make_context(user_data=user_data, args=["0"])
+    await learning_handlers.quiz_command(upd2, ctx2)
+    msg2 = cast(DummyMessage, upd2.message)
+    assert msg2.replies == [learning_handlers.RATE_LIMIT_MESSAGE]
+    assert answers == []
+
+    upd3 = make_update()
+    ctx3 = make_context(user_data=user_data, args=["0"])
+    await learning_handlers.quiz_command(upd3, ctx3)
+    msg3 = cast(DummyMessage, upd3.message)
+    assert msg3.replies == ["ok", "Q2"]
+    assert answers == [0]
+


### PR DESCRIPTION
## Summary
- add `/lesson` and `/quiz` handlers with simple per-user rate limiting
- wire new commands into bot setup
- test throttling for both commands

## Testing
- `pytest -q tests/diabetes/test_learning_handlers_rate_limit.py --cov=services.api.app.diabetes.handlers.learning_handlers --cov-report=term-missing --cov-fail-under=0`
- `mypy --strict services/api/app/diabetes/handlers/learning_handlers.py tests/diabetes/test_learning_handlers_rate_limit.py`
- `ruff check services/api/app/diabetes/handlers/learning_handlers.py tests/diabetes/test_learning_handlers_rate_limit.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9ac38a4d4832a9cc186329e190e58