### PR TITLE
[models] Rename onboarding metric event model

### DIFF
--- a/services/api/app/diabetes/models.py
+++ b/services/api/app/diabetes/models.py
@@ -1,7 +1,7 @@
 from services.api.app.services.onboarding_state import OnboardingState  # noqa: F401
 from services.api.app.services.onboarding_events import OnboardingEvent  # noqa: F401
 from services.api.app.models.onboarding_metrics import (  # noqa: F401
-    OnboardingEvent as OnboardingEventMetric,
+    OnboardingMetricEvent,
     OnboardingMetricDaily,
 )
 from .services.db import Base

--- a/services/api/app/management/aggregate_onboarding.py
+++ b/services/api/app/management/aggregate_onboarding.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Session
 from services.api.app.diabetes.services.db import SessionLocal, SessionMaker
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.models.onboarding_metrics import (
-    OnboardingEvent,
+    OnboardingMetricEvent,
     OnboardingMetricDaily,
 )
 
@@ -33,9 +33,14 @@ def _aggregate(
 
     rows = cast(
         list[tuple[str, str, int]],
-        session.query(OnboardingEvent.variant, OnboardingEvent.step, func.count())
-        .filter(OnboardingEvent.created_at >= start, OnboardingEvent.created_at < end)
-        .group_by(OnboardingEvent.variant, OnboardingEvent.step)
+        session.query(
+            OnboardingMetricEvent.variant, OnboardingMetricEvent.step, func.count()
+        )
+        .filter(
+            OnboardingMetricEvent.created_at >= start,
+            OnboardingMetricEvent.created_at < end,
+        )
+        .group_by(OnboardingMetricEvent.variant, OnboardingMetricEvent.step)
         .all(),
     )
     return rows
@@ -44,7 +49,7 @@ def _aggregate(
 def aggregate_for_date(
     target_date: date, *, sessionmaker: SessionMaker[Session] = SessionLocal
 ) -> list[dict[str, object]]:
-    """Aggregate ``OnboardingEvent`` rows for ``target_date``.
+    """Aggregate ``OnboardingMetricEvent`` rows for ``target_date``.
 
     Parameters
     ----------

--- a/services/api/app/models/onboarding_metrics.py
+++ b/services/api/app/models/onboarding_metrics.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from services.api.app.diabetes.services.db import Base
 
 
-class OnboardingEvent(Base):
+class OnboardingMetricEvent(Base):
     """Raw onboarding step event for metrics."""
 
     __tablename__ = "onboarding_events_metrics"
@@ -32,4 +32,4 @@ class OnboardingMetricDaily(Base):
     count: Mapped[int] = mapped_column(Integer, nullable=False)
 
 
-__all__ = ["OnboardingEvent", "OnboardingMetricDaily"]
+__all__ = ["OnboardingMetricEvent", "OnboardingMetricDaily"]

--- a/tests/management/test_aggregate_onboarding.py
+++ b/tests/management/test_aggregate_onboarding.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session as SASession, sessionmaker
 from services.api.app.diabetes.services import db
 from services.api.app.management import aggregate_onboarding
 from services.api.app.models.onboarding_metrics import (
-    OnboardingEvent,
+    OnboardingMetricEvent,
     OnboardingMetricDaily,
 )
 
@@ -32,16 +32,16 @@ def test_aggregate_onboarding(session_local: sessionmaker[SASession]) -> None:
     with session_local() as session:
         session.add_all(
             [
-                OnboardingEvent(
+                OnboardingMetricEvent(
                     variant="A", step="start", created_at=datetime(2024, 1, 2, 1)
                 ),
-                OnboardingEvent(
+                OnboardingMetricEvent(
                     variant="A", step="start", created_at=datetime(2024, 1, 2, 2)
                 ),
-                OnboardingEvent(
+                OnboardingMetricEvent(
                     variant="A", step="finish", created_at=datetime(2024, 1, 2, 3)
                 ),
-                OnboardingEvent(
+                OnboardingMetricEvent(
                     variant="B", step="start", created_at=datetime(2024, 1, 3, 1)
                 ),
             ]


### PR DESCRIPTION
## Summary
- rename onboarding metrics model to `OnboardingMetricEvent`
- update imports and tests for new name

## Testing
- `pytest tests/management/test_aggregate_onboarding.py tests/services/test_onboarding_events.py -q --no-cov`
- `mypy --strict services/api/app/models/onboarding_metrics.py services/api/app/management/aggregate_onboarding.py services/api/app/diabetes/models.py tests/management/test_aggregate_onboarding.py`
- `ruff check services/api/app/models/onboarding_metrics.py services/api/app/management/aggregate_onboarding.py services/api/app/diabetes/models.py tests/management/test_aggregate_onboarding.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9b48621dc832aaf4289310b74bccf