### PR TITLE
[learning] Add unique constraint for lesson progress

### DIFF
--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -17,7 +17,9 @@ class Lesson(Base):
     slug: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
     title: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
-    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.true())
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa.true()
+    )
 
     steps: Mapped[list["LessonStep"]] = relationship(
         "LessonStep",
@@ -38,9 +40,13 @@ class QuizQuestion(Base):
     __tablename__ = "quiz_questions"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)
+    lesson_id: Mapped[int] = mapped_column(
+        ForeignKey("lessons.id"), nullable=False, index=True
+    )
     question: Mapped[str] = mapped_column(Text, nullable=False)
-    options: Mapped[Sequence[str]] = mapped_column(sa.JSON().with_variant(JSONB, "postgresql"), nullable=False)
+    options: Mapped[Sequence[str]] = mapped_column(
+        sa.JSON().with_variant(JSONB, "postgresql"), nullable=False
+    )
     correct_option: Mapped[int] = mapped_column(Integer, nullable=False)
 
     lesson: Mapped[Lesson] = relationship("Lesson", back_populates="questions")
@@ -50,7 +56,9 @@ class LessonStep(Base):
     __tablename__ = "lesson_steps"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)
+    lesson_id: Mapped[int] = mapped_column(
+        ForeignKey("lessons.id"), nullable=False, index=True
+    )
     step_order: Mapped[int] = mapped_column(Integer, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
 
@@ -59,10 +67,19 @@ class LessonStep(Base):
 
 class LessonProgress(Base):
     __tablename__ = "lesson_progress"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "user_id", "lesson_id", name="lesson_progress_user_lesson_key"
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True)
-    lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True
+    )
+    lesson_id: Mapped[int] = mapped_column(
+        ForeignKey("lessons.id"), nullable=False, index=True
+    )
     completed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     current_step: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     current_question: Mapped[int] = mapped_column(Integer, default=0, nullable=False)


### PR DESCRIPTION
## Summary
- ensure each user has at most one progress record per lesson

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q` *(fails: tests/test_api_bot.py::test_main_attaches_onboarding_handler_and_runs)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b48e8b00832aae45ba3fe35c6fc8