### PR TITLE
[models] Ensure unique lesson step ordering

### DIFF
--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -48,6 +48,11 @@ class QuizQuestion(Base):
 
 class LessonStep(Base):
     __tablename__ = "lesson_steps"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "lesson_id", "step_order", name="lesson_steps_lesson_order_key"
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)


### PR DESCRIPTION
## Summary
- enforce unique step order within each lesson

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9b49084bc832a9ad341809b7ac435