### PR TITLE
[learning] log lesson steps

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -51,6 +51,7 @@ async def lesson_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     user = update.effective_user
     if message is None or user is None:
         return
+    logger.info("lesson_command_start", extra={"user_id": user.id})
     if not settings.learning_enabled:
         await message.reply_text("🚫 Обучение недоступно.")
         return
@@ -77,6 +78,10 @@ async def lesson_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await message.reply_text("Урок завершён")
     else:
         await message.reply_text(text)
+    logger.info(
+        "lesson_command_complete",
+        extra={"user_id": user.id, "lesson_id": lesson_id},
+    )
 
 
 async def quiz_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -165,6 +170,10 @@ async def exit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return
 
     user_data = cast(dict[str, object], context.user_data)
+    lesson_id = cast(int | None, user_data.get("lesson_id"))
+    logger.info(
+        "exit_command_start", extra={"user_id": user.id, "lesson_id": lesson_id}
+    )
     lesson_id = cast(int | None, user_data.pop("lesson_id", None))
     user_data.pop("lesson_slug", None)
     user_data.pop("lesson_step", None)
@@ -184,6 +193,10 @@ async def exit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         await run_db(_complete, user.id, lesson_id, sessionmaker=SessionLocal)
 
     await message.reply_text("Учебная сессия завершена.", reply_markup=menu_keyboard())
+    logger.info(
+        "exit_command_complete",
+        extra={"user_id": user.id, "lesson_id": lesson_id},
+    )
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- add start/stop logging for lesson and exit commands
- measure LLM call latency and log structured lesson_step events

## Testing
- `ruff check services/api/app/diabetes/handlers/learning_handlers.py services/api/app/diabetes/curriculum_engine.py`
- `mypy --strict services/api/app/diabetes/handlers/learning_handlers.py services/api/app/diabetes/curriculum_engine.py`
- `pytest -q` *(fails: tests/test_api_bot.py::test_main_attaches_onboarding_handler_and_runs)*


------
https://chatgpt.com/codex/tasks/task_e_68b9b4a231a8832ab7dfb652fd081516