### PR TITLE
[db] Enforce enum types for reminders

### DIFF
--- a/services/api/alembic/versions/20250916_reminder_type_kind_enum.py
+++ b/services/api/alembic/versions/20250916_reminder_type_kind_enum.py
@@ -1,0 +1,103 @@
+"""reminders: enforce enum values for type and kind"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "20250916_reminder_type_kind_enum"
+down_revision: Union[str, Sequence[str], None] = (
+    "20250915_add_unique_transaction_id_to_subscriptions"
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+reminder_type_enum = postgresql.ENUM(
+    "sugar",
+    "insulin_short",
+    "insulin_long",
+    "after_meal",
+    "meal",
+    "sensor_change",
+    "injection_site",
+    "custom",
+    name="reminder_type",
+    create_type=False,
+)
+
+schedule_kind_enum = postgresql.ENUM(
+    "at_time",
+    "every",
+    "after_event",
+    name="schedule_kind",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        reminder_type_enum.create(bind, checkfirst=True)
+        schedule_kind_enum.create(bind, checkfirst=True)
+        op.execute(
+            "ALTER TABLE reminders ALTER COLUMN type TYPE reminder_type USING type::reminder_type"
+        )
+        op.execute(
+            "ALTER TABLE reminders ALTER COLUMN kind TYPE schedule_kind USING kind::schedule_kind"
+        )
+    else:
+        with op.batch_alter_table("reminders") as batch_op:
+            batch_op.alter_column(
+                "type",
+                type_=sa.Enum(
+                    "sugar",
+                    "insulin_short",
+                    "insulin_long",
+                    "after_meal",
+                    "meal",
+                    "sensor_change",
+                    "injection_site",
+                    "custom",
+                    name="reminder_type",
+                    native_enum=False,
+                    create_constraint=True,
+                ),
+                existing_type=sa.String(),
+                nullable=False,
+            )
+            batch_op.alter_column(
+                "kind",
+                type_=sa.Enum(
+                    "at_time",
+                    "every",
+                    "after_event",
+                    name="schedule_kind",
+                    native_enum=False,
+                    create_constraint=True,
+                ),
+                existing_type=sa.String(),
+                nullable=True,
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TABLE reminders ALTER COLUMN type TYPE VARCHAR")
+        op.execute("ALTER TABLE reminders ALTER COLUMN kind TYPE VARCHAR")
+        schedule_kind_enum.drop(bind, checkfirst=True)
+        reminder_type_enum.drop(bind, checkfirst=True)
+    else:
+        with op.batch_alter_table("reminders") as batch_op:
+            batch_op.alter_column(
+                "kind", type_=sa.String(), existing_type=sa.String(), nullable=True
+            )
+            batch_op.alter_column(
+                "type", type_=sa.String(), existing_type=sa.String(), nullable=False
+            )
+

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -39,6 +39,7 @@ from sqlalchemy.orm import (
 )
 
 from services.api.app.config import get_db_password, settings
+from services.api.app.diabetes.schemas.reminders import ReminderType, ScheduleKind
 
 logger = logging.getLogger(__name__)
 
@@ -238,18 +239,38 @@ class Alert(Base):
 class Reminder(Base):
     __tablename__ = "reminders"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    telegram_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("users.telegram_id"))
+    telegram_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id")
+    )
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
-    type: Mapped[str] = mapped_column(String, nullable=False)
+    type: Mapped[ReminderType] = mapped_column(
+        sa.Enum(
+            ReminderType,
+            name="reminder_type",
+            create_type=False,
+            validate_strings=True,
+        ),
+        nullable=False,
+    )
     title: Mapped[Optional[str]] = mapped_column(String)
-    kind: Mapped[Optional[str]] = mapped_column(String)
+    kind: Mapped[ScheduleKind | None] = mapped_column(
+        sa.Enum(
+            ScheduleKind,
+            name="schedule_kind",
+            create_type=False,
+            validate_strings=True,
+        ),
+        nullable=True,
+    )
     time: Mapped[Optional[time]] = mapped_column(Time)
     interval_hours: Mapped[Optional[int]] = mapped_column(Integer)
     interval_minutes: Mapped[Optional[int]] = mapped_column(Integer)
     minutes_after: Mapped[Optional[int]] = mapped_column(Integer)
     days_mask: Mapped[Optional[int]] = mapped_column(Integer)
     is_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
-    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now()
+    )
     user: Mapped[User] = relationship("User")
 
     def set_interval_hours_if_needed(self, hours: int | None) -> None:

--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -19,6 +19,7 @@ from ..diabetes.services.db import (
 )
 from ..diabetes.services.reminders_schedule import compute_next
 from ..diabetes.services.repository import CommitError, commit
+from ..diabetes.schemas.reminders import ReminderType, ScheduleKind
 from ..schemas.reminders import ReminderSchema
 from ..types import SessionProtocol
 
@@ -60,7 +61,7 @@ async def list_reminders(telegram_id: int) -> list[Reminder]:
                 last = datetime.fromisoformat(last)
             setattr(rem, "last_fired_at", last)
             setattr(rem, "fires7d", st["fires7d"] if st else 0)
-            rem.kind = rem.kind or "at_time"
+            rem.kind = rem.kind or ScheduleKind.at_time
             next_ = compute_next(rem, tz)
             setattr(rem, "next_at", next_)
         return reminders_
@@ -81,7 +82,7 @@ async def save_reminder(data: ReminderSchema) -> int:
             cast(Session, session).add(rem)
         if data.orgId is not None:
             rem.org_id = data.orgId
-        rem.type = data.type
+        rem.type = ReminderType(data.type)
         rem.kind = data.kind
         if data.title is not None:
             rem.title = data.title

--- a/tests/test_reminder_enum_constraints.py
+++ b/tests/test_reminder_enum_constraints.py
@@ -1,0 +1,34 @@
+from datetime import time
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import Session, sessionmaker
+
+from services.api.app.diabetes.services.db import Base, Reminder
+
+
+def _session_factory() -> sessionmaker[Session]:
+    engine = sa.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, class_=Session)
+
+
+def test_invalid_reminder_type() -> None:
+    SessionLocal = _session_factory()
+    with SessionLocal() as session:
+        session.add(Reminder(type="sugar", time=time(8, 0)))
+        session.commit()
+        session.add(Reminder(type="bad", time=time(8, 0)))
+        with pytest.raises(sa.exc.StatementError):
+            session.commit()
+
+
+def test_invalid_schedule_kind() -> None:
+    SessionLocal = _session_factory()
+    with SessionLocal() as session:
+        session.add(Reminder(type="sugar", kind="at_time", time=time(9, 0)))
+        session.commit()
+        session.add(Reminder(type="sugar", kind="nope", time=time(9, 0)))
+        with pytest.raises(sa.exc.StatementError):
+            session.commit()
+


### PR DESCRIPTION
## Summary
- use ReminderType and ScheduleKind enums for reminder `type` and `kind`
- add migration to enforce enum values in database
- cover invalid enum values with tests

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q tests/test_reminder_enum_constraints.py -o addopts="" -o asyncio_mode=auto`


------
https://chatgpt.com/codex/tasks/task_e_68b9b494284c832a8df2e2bc08a5f241