### PR TITLE
[metrics] instrument lessons

### DIFF
--- a/services/api/app/diabetes/metrics.py
+++ b/services/api/app/diabetes/metrics.py
@@ -1,0 +1,18 @@
+"""Prometheus metrics for learning lessons."""
+
+from prometheus_client import Counter, Summary
+
+lessons_started = Counter(
+    "lessons_started",
+    "Number of lessons started by users",
+)
+lessons_completed = Counter(
+    "lessons_completed",
+    "Number of lessons successfully completed",
+)
+quiz_avg_score = Summary(
+    "quiz_avg_score",
+    "Average quiz score percentage upon lesson completion",
+)
+
+__all__ = ["lessons_started", "lessons_completed", "quiz_avg_score"]

--- a/services/api/app/routers/metrics.py
+++ b/services/api/app/routers/metrics.py
@@ -2,7 +2,8 @@ import logging
 from datetime import datetime
 from typing import cast
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -11,6 +12,11 @@ from ..diabetes.services.db import SessionLocal, run_db
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+@router.get("/metrics")
+async def prometheus_metrics() -> Response:
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 STEP_MAP = {
     "start": "onboarding_started",


### PR DESCRIPTION
## Summary
- add Prometheus counters and summary for lesson progress
- track lesson start/completion and quiz score
- expose `/api/metrics` endpoint returning Prometheus data

## Testing
- `pytest -q` *(fails: 110 errors during collection)*
- `mypy --strict services/api/app/diabetes/metrics.py services/api/app/diabetes/curriculum_engine.py services/api/app/routers/metrics.py tests/learning/test_curriculum_engine.py tests/test_metrics_api.py`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b9b4a590f4832a9ccfa7e3e1011503