### PR TITLE
[stats] clarify Entry vs HistoryRecord usage

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -200,6 +200,11 @@ class Profile(Base):
 
 
 class Entry(Base):
+    """Primary diary entry with detailed nutrition information.
+
+    Records created by the bot and used for statistics and reports.
+    """
+
     __tablename__ = "entries"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     telegram_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("users.telegram_id"))
@@ -357,6 +362,12 @@ class Subscription(Base):
 
 
 class HistoryRecord(Base):
+    """User-maintained history record for the Web UI.
+
+    Separate from :class:`Entry` to allow manual editing without affecting
+    statistics. Contains overlapping columns but serves a distinct purpose.
+    """
+
     __tablename__ = "history_records"
     id: Mapped[str] = mapped_column(String, primary_key=True)
     telegram_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), index=True, nullable=False)

--- a/services/api/app/schemas/history.py
+++ b/services/api/app/schemas/history.py
@@ -14,7 +14,12 @@ ALLOWED_HISTORY_TYPES: set[HistoryType] = cast(
 
 
 class HistoryRecordSchema(BaseModel):
-    """Schema for user history records."""
+    """Schema for user-maintained history records in the Web UI.
+
+    These records are stored separately from :class:`~diabetes.services.db.Entry`
+    and do not affect statistics or reporting. They allow manual edits without
+    mutating the canonical diary entries.
+    """
 
     id: str
     date: date

--- a/tests/test_stats_service.py
+++ b/tests/test_stats_service.py
@@ -6,7 +6,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session as SASession, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from services.api.app.diabetes.services.db import Base, HistoryRecord, SessionMaker
+from services.api.app.diabetes.services.db import Base, Entry, SessionMaker
 from services.api.app.services import stats
 
 
@@ -34,27 +34,25 @@ async def test_get_day_stats(
     today = datetime.date.today()
     with cast(ContextManager[SASession], session_factory()) as session:
         session.add(
-            HistoryRecord(
-                id="1",
+            Entry(
                 telegram_id=1,
-                date=today,
-                time=datetime.time(8, 0),
-                sugar=5.0,
-                bread_units=1.0,
-                insulin=2.0,
-                type="sugar",
+                event_time=datetime.datetime.combine(
+                    today, datetime.time(8, 0), tzinfo=datetime.timezone.utc
+                ),
+                sugar_before=5.0,
+                xe=1.0,
+                dose=2.0,
             )
         )
         session.add(
-            HistoryRecord(
-                id="2",
+            Entry(
                 telegram_id=1,
-                date=today,
-                time=datetime.time(12, 0),
-                sugar=7.0,
-                bread_units=2.0,
-                insulin=3.0,
-                type="sugar",
+                event_time=datetime.datetime.combine(
+                    today, datetime.time(12, 0), tzinfo=datetime.timezone.utc
+                ),
+                sugar_before=7.0,
+                xe=2.0,
+                dose=3.0,
             )
         )
         session.commit()
@@ -88,15 +86,14 @@ async def test_get_day_stats_tz_ahead(
 
     with cast(ContextManager[SASession], session_factory()) as session:
         session.add(
-            HistoryRecord(
-                id="1",
+            Entry(
                 telegram_id=1,
-                date=day,
-                time=datetime.time(8, 0),
-                sugar=5.0,
-                bread_units=1.0,
-                insulin=2.0,
-                type="sugar",
+                event_time=datetime.datetime.combine(
+                    day, datetime.time(8, 0), tzinfo=datetime.timezone.utc
+                ),
+                sugar_before=5.0,
+                xe=1.0,
+                dose=2.0,
             )
         )
         session.commit()
@@ -128,15 +125,14 @@ async def test_get_day_stats_tz_behind(
 
     with cast(ContextManager[SASession], session_factory()) as session:
         session.add(
-            HistoryRecord(
-                id="1",
+            Entry(
                 telegram_id=1,
-                date=day,
-                time=datetime.time(8, 0),
-                sugar=5.0,
-                bread_units=1.0,
-                insulin=2.0,
-                type="sugar",
+                event_time=datetime.datetime.combine(
+                    day, datetime.time(8, 0), tzinfo=datetime.timezone.utc
+                ),
+                sugar_before=5.0,
+                xe=1.0,
+                dose=2.0,
             )
         )
         session.commit()


### PR DESCRIPTION
## Summary
- document the distinct roles of `Entry` and `HistoryRecord`
- compute day stats from `Entry` records
- adjust history schema and tests accordingly

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9b7509a30832ab8a815e6dc001c8c