### PR TITLE
[db] enforce enums for reminders

### DIFF
--- a/services/api/alembic/versions/20250916_reminder_type_kind_enum.py
+++ b/services/api/alembic/versions/20250916_reminder_type_kind_enum.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250916_reminder_type_kind_enum"
+down_revision: Union[str, Sequence[str], None] = (
+    "20250915_add_unique_transaction_id_to_subscriptions"
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+reminder_type_enum = sa.Enum(
+    "sugar",
+    "insulin_short",
+    "insulin_long",
+    "after_meal",
+    "meal",
+    "sensor_change",
+    "injection_site",
+    "custom",
+    name="reminder_type",
+)
+
+schedule_kind_enum = sa.Enum(
+    "at_time",
+    "every",
+    "after_event",
+    name="schedule_kind",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        reminder_type_enum.create(bind, checkfirst=True)
+        schedule_kind_enum.create(bind, checkfirst=True)
+        op.execute(
+            "ALTER TABLE reminders ALTER COLUMN type TYPE reminder_type USING type::text::reminder_type"
+        )
+        op.execute(
+            "ALTER TABLE reminders ALTER COLUMN kind TYPE schedule_kind USING kind::text::schedule_kind"
+        )
+    else:
+        inspector = sa.inspect(bind)
+        constraints = {c["name"] for c in inspector.get_check_constraints("reminders")}
+        if "reminders_type_check" not in constraints:
+            op.create_check_constraint(
+                "reminders_type_check",
+                "reminders",
+                "type IN ('sugar','insulin_short','insulin_long','after_meal','meal','sensor_change','injection_site','custom')",
+            )
+        if "reminders_kind_check" not in constraints:
+            op.create_check_constraint(
+                "reminders_kind_check",
+                "reminders",
+                "(kind IS NULL) OR kind IN ('at_time','every','after_event')",
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            "ALTER TABLE reminders ALTER COLUMN kind TYPE VARCHAR USING kind::text"
+        )
+        op.execute(
+            "ALTER TABLE reminders ALTER COLUMN type TYPE VARCHAR USING type::text"
+        )
+        schedule_kind_enum.drop(bind, checkfirst=True)
+        reminder_type_enum.drop(bind, checkfirst=True)
+    else:
+        inspector = sa.inspect(bind)
+        constraints = {c["name"] for c in inspector.get_check_constraints("reminders")}
+        if "reminders_kind_check" in constraints:
+            op.drop_constraint("reminders_kind_check", "reminders", type_="check")
+        if "reminders_type_check" in constraints:
+            op.drop_constraint("reminders_type_check", "reminders", type_="check")

--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -12,6 +12,7 @@ from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm.exc import DetachedInstanceError
 
 from services.api.app.diabetes.services.db import Reminder, User
+from services.api.app.diabetes.schemas.reminders import ScheduleKind
 
 logger = logging.getLogger(__name__)
 
@@ -67,15 +68,16 @@ def schedule_reminder(
     if kind is None:
         if interval_minutes is None and rem.interval_hours is not None:
             interval_minutes = rem.interval_hours * 60
-            kind = "every"
+            kind = ScheduleKind.every
         elif rem.minutes_after is not None:
-            kind = "after_event"
+            kind = ScheduleKind.after_event
         elif interval_minutes:
-            kind = "every"
+            kind = ScheduleKind.every
         else:
-            kind = "at_time"
+            kind = ScheduleKind.at_time
+    assert kind is not None
 
-    name = f"{base_name}_after" if kind == "after_event" else base_name
+    name = f"{base_name}_after" if kind is ScheduleKind.after_event else base_name
 
     logger.info(
         "PLAN %s kind=%s time=%s interval_min=%s after_min=%s tz=%s",
@@ -97,10 +99,10 @@ def schedule_reminder(
     call_job_kwargs = dict(job_kwargs)
     call_job_kwargs.pop("name", None)
 
-    if kind == "after_event":
+    if kind is ScheduleKind.after_event:
         logger.info("SKIP %s kind=%s", name, kind)
         return
-    if kind == "at_time" and rem.time is not None:
+    if kind is ScheduleKind.at_time and rem.time is not None:
         run_daily_sig = inspect.signature(job_queue.run_daily)
         run_daily_fn = cast(Any, job_queue.run_daily)
         run_daily_kwargs: dict[str, object] = {
@@ -113,7 +115,9 @@ def schedule_reminder(
         if "days" in run_daily_sig.parameters:
             mask = getattr(rem, "days_mask", 0) or 0
             days = (
-                tuple(i for i in range(7) if mask & (1 << i)) if mask else tuple(range(7))
+                tuple(i for i in range(7) if mask & (1 << i))
+                if mask
+                else tuple(range(7))
             )
             run_daily_kwargs["days"] = days
 

--- a/tests/test_reminder_days_mask.py
+++ b/tests/test_reminder_days_mask.py
@@ -1,8 +1,8 @@
-from services.api.app.diabetes.services.db import Reminder
+from services.api.app.diabetes.services.db import Reminder, ReminderType
 
 
 def test_days_of_week_roundtrip() -> None:
-    reminder = Reminder(type="sugar")
+    reminder = Reminder(type=ReminderType.sugar)
     assert reminder.days_mask is None
     assert reminder.daysOfWeek is None
 

--- a/tests/test_reminder_enum_constraints.py
+++ b/tests/test_reminder_enum_constraints.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError, StatementError
+from sqlalchemy.orm import Session, sessionmaker
+
+import pytest
+
+from services.api.app.diabetes.services.db import (
+    Base,
+    Reminder,
+    ReminderType,
+    ScheduleKind,
+)
+
+
+def _setup_session() -> sessionmaker[Session]:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def test_invalid_reminder_type() -> None:
+    Session = _setup_session()
+    with Session() as session:
+        session.add(Reminder(type=ReminderType.sugar))
+        session.commit()
+        session.add(Reminder(type="invalid"))  # type: ignore[arg-type]
+        with pytest.raises((ValueError, StatementError, IntegrityError)):
+            session.commit()
+        session.rollback()
+
+
+def test_invalid_schedule_kind() -> None:
+    Session = _setup_session()
+    with Session() as session:
+        session.add(Reminder(type=ReminderType.sugar, kind=ScheduleKind.at_time))
+        session.commit()
+        session.add(
+            Reminder(type=ReminderType.sugar, kind="bad")  # type: ignore[arg-type]
+        )
+        with pytest.raises((ValueError, StatementError, IntegrityError)):
+            session.commit()
+        session.rollback()


### PR DESCRIPTION
## Summary
- use `ReminderType` and `ScheduleKind` enums for reminder records
- validate enum values and update scheduling logic
- add migration and tests for allowed reminder values

## Testing
- `pytest tests/test_reminder_enum_constraints.py tests/test_reminder_days_mask.py -q --no-cov`
- `mypy --strict services/api/app/diabetes/services/db.py services/api/app/diabetes/handlers/reminder_jobs.py services/api/app/services/reminders.py`
- `ruff check services/api/app/diabetes/services/db.py services/api/app/diabetes/handlers/reminder_jobs.py services/api/app/services/reminders.py tests/test_reminder_days_mask.py tests/test_reminder_enum_constraints.py services/api/alembic/versions/20250916_reminder_type_kind_enum.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9b6f522ac832abd57efb95c62009c