### PR TITLE
[metrics] expose lesson metrics via Prometheus

### DIFF
--- a/services/api/app/diabetes/metrics.py
+++ b/services/api/app/diabetes/metrics.py
@@ -1,0 +1,15 @@
+"""Prometheus metrics for the learning subsystem."""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Summary
+
+lessons_started: Counter = Counter(
+    "lessons_started", "Total number of lessons started"
+)
+lessons_completed: Counter = Counter(
+    "lessons_completed", "Total number of lessons completed"
+)
+quiz_avg_score: Summary = Summary(
+    "quiz_avg_score", "Average quiz score across completed lessons"
+)

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -347,6 +347,7 @@ async def delete_history(
 
 # ────────── include router ──────────
 app.include_router(internal_reminders_router)
+app.include_router(metrics.router)
 app.include_router(api_router, prefix="/api")
 
 # ────────── run (for local testing) ──────────

--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -41,6 +41,7 @@ fastapi==0.115.0
 uvicorn[standard]==0.35.0
 websockets==15.0.1
 wsproto==1.2.0
+prometheus-client==0.20.0
 
 # 📦 Дополнения для SPA/FastAPI
 aiofiles==23.2.1

--- a/services/api/app/routers/metrics.py
+++ b/services/api/app/routers/metrics.py
@@ -2,7 +2,8 @@ import logging
 from datetime import datetime
 from typing import cast
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -20,6 +21,13 @@ STEP_MAP = {
     "finish": "onboarding_finished",
     "cancel": "onboarding_cancelled",
 }
+
+
+@router.get("/metrics")
+def get_metrics() -> Response:
+    """Return Prometheus metrics."""
+
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 
 @router.get("/metrics/onboarding")

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -9,6 +9,13 @@ from sqlalchemy import Column, MetaData, String, Table, TIMESTAMP, create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from prometheus_client import CONTENT_TYPE_LATEST
+
+from services.api.app.diabetes.metrics import (
+    lessons_completed,
+    lessons_started,
+    quiz_avg_score,
+)
 from services.api.app.routers import metrics
 
 
@@ -87,3 +94,21 @@ def test_onboarding_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
             "onboarding_cancelled": 0,
         },
     }
+
+
+def test_prometheus_metrics_endpoint() -> None:
+    lessons_started.inc()
+    lessons_completed.inc()
+    quiz_avg_score.observe(50)
+
+    from services.api.app.main import app
+
+    with TestClient(app) as client:
+        resp = client.get("/metrics")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == CONTENT_TYPE_LATEST
+    body = resp.text
+    assert "lessons_started" in body
+    assert "lessons_completed" in body
+    assert "quiz_avg_score_sum" in body


### PR DESCRIPTION
## Summary
- add Prometheus counters/summary for lessons started, completed and quiz scores
- instrument learning flow and expose `/metrics` endpoint
- add tests for metrics tracking and endpoint

## Testing
- `pytest tests/learning/test_curriculum_engine.py tests/test_metrics_api.py -q -o addopts=''`
- `mypy --strict services/api/app/diabetes/curriculum_engine.py services/api/app/diabetes/metrics.py services/api/app/routers/metrics.py tests/learning/test_curriculum_engine.py tests/test_metrics_api.py`
- `ruff check services/api/app/diabetes/curriculum_engine.py services/api/app/diabetes/metrics.py services/api/app/routers/metrics.py tests/learning/test_curriculum_engine.py tests/test_metrics_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9b79a81e0832a8ffde17759d5080d