### PR TITLE
[learning] Add tests for models and handlers

### DIFF
--- a/tests/learning/test_curriculum.py
+++ b/tests/learning/test_curriculum.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.curriculum_engine import (
+    check_answer,
+    next_step,
+    start_lesson,
+)
+from services.api.app.diabetes.learning_fixtures import load_lessons
+from services.api.app.diabetes.learning_prompts import disclaimer
+from services.api.app.diabetes.models_learning import Lesson, LessonProgress, QuizQuestion
+from services.api.app.diabetes.services import db, gpt_client
+
+
+@pytest.mark.asyncio()
+async def test_happy_path_one_lesson(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.SessionLocal.configure(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+
+    await load_lessons(
+        "services/api/app/diabetes/content/lessons_v0.json",
+        sessionmaker=db.SessionLocal,
+    )
+
+    with db.SessionLocal() as session:
+        session.add(db.User(telegram_id=1, thread_id="t1"))
+        session.commit()
+        lesson = session.query(Lesson).first()
+        assert lesson is not None
+        slug = lesson.slug
+        lesson_id = lesson.id
+
+    async def fake_completion(**kwargs: object) -> str:
+        fake_completion.calls += 1
+        return f"text {fake_completion.calls}"
+
+    fake_completion.calls = 0  # type: ignore[attr-defined]
+    monkeypatch.setattr(gpt_client, "create_learning_chat_completion", fake_completion)
+
+    progress = await start_lesson(1, slug)
+    assert progress.current_step == 0
+
+    assert await next_step(1, lesson_id) == f"{disclaimer()}\n\ntext 1"
+    assert await next_step(1, lesson_id) == "text 2"
+    assert await next_step(1, lesson_id) == "text 3"
+
+    question_text = await next_step(1, lesson_id)
+    assert question_text and question_text.startswith(disclaimer())
+
+    with db.SessionLocal() as session:
+        questions = session.query(QuizQuestion).filter_by(lesson_id=lesson_id).all()
+
+    for q in questions:
+        correct, feedback = await check_answer(1, lesson_id, q.correct_option)
+        assert correct is True
+        assert feedback
+        await next_step(1, lesson_id)
+
+    assert await next_step(1, lesson_id) is None
+
+    with db.SessionLocal() as session:
+        prog = (
+            session.query(LessonProgress)
+            .filter_by(user_id=1, lesson_id=lesson_id)
+            .one()
+        )
+        assert prog.completed is True
+        assert prog.quiz_score == 100

--- a/tests/learning/test_handlers.py
+++ b/tests/learning/test_handlers.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from telegram import InlineKeyboardMarkup, Update
+from telegram.ext import CallbackContext
+
+from services.api.app.config import settings
+from services.api.app.diabetes import learning_handlers
+from services.api.app.diabetes.learning_fixtures import load_lessons
+from services.api.app.diabetes.models_learning import Lesson, QuizQuestion
+from services.api.app.diabetes.services import db, gpt_client
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+        self.reply_markup: InlineKeyboardMarkup | None = None
+
+    async def reply_text(
+        self, text: str, reply_markup: InlineKeyboardMarkup | None = None
+    ) -> None:
+        self.replies.append(text)
+        if reply_markup is not None:
+            self.reply_markup = reply_markup
+
+
+def make_update() -> Update:
+    return cast(
+        Update,
+        SimpleNamespace(message=DummyMessage(), effective_user=SimpleNamespace(id=1)),
+    )
+
+
+def make_context(
+    *, args: list[str] | None = None, user_data: dict[str, Any] | None = None
+) -> CallbackContext[Any, Any, Any, Any]:
+    data: dict[str, Any] = {"args": args or [], "user_data": user_data or {}}
+    return cast(CallbackContext[Any, Any, Any, Any], SimpleNamespace(**data))
+
+
+@pytest.mark.asyncio()
+async def test_handler_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.SessionLocal.configure(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+
+    await load_lessons(
+        "services/api/app/diabetes/content/lessons_v0.json",
+        sessionmaker=db.SessionLocal,
+    )
+
+    with db.SessionLocal() as session:
+        session.add(db.User(telegram_id=1, thread_id="t1"))
+        session.commit()
+        lesson = session.query(Lesson).first()
+        assert lesson is not None
+        slug = lesson.slug
+        lesson_id = lesson.id
+
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+
+    async def fake_completion(**kwargs: object) -> str:
+        fake_completion.calls += 1
+        return f"text {fake_completion.calls}"
+
+    fake_completion.calls = 0  # type: ignore[attr-defined]
+    monkeypatch.setattr(gpt_client, "create_learning_chat_completion", fake_completion)
+
+    ctx = make_context()
+    upd = make_update()
+    await learning_handlers.learn_command(upd, ctx)
+    msg = cast(DummyMessage, upd.message)
+    assert msg.reply_markup is not None
+    button = msg.reply_markup.inline_keyboard[0][0]
+    assert button.callback_data == slug
+
+    ctx.args = [slug]
+    upd = make_update()
+    await learning_handlers.lesson_command(upd, ctx)
+    assert "text 1" in cast(DummyMessage, upd.message).replies[-1]
+
+    for _ in range(2):
+        upd = make_update()
+        ctx.args = []
+        await learning_handlers.lesson_command(upd, ctx)
+
+    upd = make_update()
+    ctx.args = []
+    await learning_handlers.lesson_command(upd, ctx)
+    question_text = cast(DummyMessage, upd.message).replies[-1]
+    assert "?" in question_text
+
+    with db.SessionLocal() as session:
+        questions = session.query(QuizQuestion).filter_by(lesson_id=lesson_id).all()
+
+    for q in questions:
+        upd = make_update()
+        ctx.args = [str(q.correct_option)]
+        await learning_handlers.quiz_command(upd, ctx)
+
+    assert "Опрос завершён" in cast(DummyMessage, upd.message).replies[-1]
+
+    upd = make_update()
+    ctx.args = []
+    await learning_handlers.progress_command(upd, ctx)
+    progress_reply = cast(DummyMessage, upd.message).replies[0]
+    assert str(len(questions)) in progress_reply
+    assert "100" in progress_reply

--- a/tests/learning/test_models.py
+++ b/tests/learning/test_models.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.models_learning import (
+    Lesson,
+    LessonProgress,
+    LessonStep,
+    QuizQuestion,
+)
+from services.api.app.diabetes.services import db
+
+
+@pytest.fixture()
+def setup_db() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.SessionLocal.configure(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+
+
+def test_models_crud(setup_db: None) -> None:
+    with db.SessionLocal() as session:
+        user = db.User(telegram_id=1, thread_id="t1")
+        session.add(user)
+        lesson = Lesson(slug="intro", title="Intro", content="c", is_active=True)
+        session.add(lesson)
+        session.flush()
+        step = LessonStep(lesson_id=lesson.id, step_order=1, content="step1")
+        question = QuizQuestion(
+            lesson_id=lesson.id,
+            question="Q?",
+            options=["A", "B"],
+            correct_option=0,
+        )
+        session.add_all([step, question])
+        progress = LessonProgress(user_id=1, lesson_id=lesson.id)
+        session.add(progress)
+        session.commit()
+
+        fetched = session.query(Lesson).filter_by(slug="intro").one()
+        assert fetched.steps[0].content == "step1"
+        assert fetched.questions[0].correct_option == 0
+
+        progress.current_step = 1
+        session.commit()
+        assert session.get(LessonProgress, progress.id).current_step == 1
+
+        session.delete(fetched)
+        session.commit()
+        assert session.query(Lesson).count() == 0
+        assert session.query(LessonStep).count() == 0
+        assert session.query(QuizQuestion).count() == 0


### PR DESCRIPTION
## Summary
- add CRUD tests for learning models
- cover curriculum engine happy path
- test handler flow /learn -> /lesson -> /quiz -> /progress

## Testing
- `pytest -q tests/learning -o addopts= -p no:cov`
- `coverage run --source=services/api/app/diabetes -m pytest tests/learning -q -o addopts= -p no:cov`
- `coverage report --include=services/api/app/diabetes/curriculum_engine.py,services/api/app/diabetes/learning_handlers.py,services/api/app/diabetes/models_learning.py --fail-under=85`
- `mypy --strict tests/learning/test_models.py tests/learning/test_curriculum.py tests/learning/test_handlers.py`
- `ruff check tests/learning services/api/app/diabetes/curriculum_engine.py services/api/app/diabetes/learning_handlers.py services/api/app/diabetes/models_learning.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9bb89cdec832a8048fbd38b9525c4