### PR TITLE
[scripts] add learning probe script

### DIFF
--- a/scripts/probe_learn.py
+++ b/scripts/probe_learn.py
@@ -1,0 +1,78 @@
+"""Command-line utility to walk through learning lessons."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+
+from sqlalchemy.orm import Session
+
+from services.api.app import config
+from services.api.app.diabetes import curriculum_engine
+from services.api.app.diabetes.models_learning import (
+    LessonProgress,
+    LessonStep,
+    QuizQuestion,
+)
+from services.api.app.diabetes.services import db
+
+
+async def _fetch_lesson_data(
+    lesson_id: int,
+) -> tuple[int, list[QuizQuestion]]:
+    """Return number of steps and list of questions for a lesson."""
+
+    def _query(session: Session) -> tuple[int, list[QuizQuestion]]:
+        step_count = session.query(LessonStep).filter_by(lesson_id=lesson_id).count()
+        questions = session.query(QuizQuestion).filter_by(lesson_id=lesson_id).order_by(QuizQuestion.id).all()
+        return step_count, list(questions)
+
+    return await db.run_db(_query)
+
+
+async def _get_progress(user_id: int, lesson_id: int) -> LessonProgress:
+    """Fetch lesson progress for a user."""
+
+    def _query(session: Session) -> LessonProgress:
+        return session.query(LessonProgress).filter_by(user_id=user_id, lesson_id=lesson_id).one()
+
+    return await db.run_db(_query)
+
+
+async def main(user_id: int, lesson_slug: str) -> None:
+    os.environ.setdefault("LEARNING_MODEL_DEFAULT", "gpt-4o-mini")
+    os.environ.setdefault("LEARNING_PROMPT_CACHE", "1")
+    config.reload_settings()
+
+    progress = await curriculum_engine.start_lesson(user_id, lesson_slug)
+    lesson_id = progress.lesson_id
+
+    step_total, questions = await _fetch_lesson_data(lesson_id)
+
+    steps_done = 0
+    quiz_index = 0
+
+    while True:
+        text = await curriculum_engine.next_step(user_id, lesson_id)
+        if text is None:
+            break
+        print(text)
+        if steps_done >= step_total and quiz_index < len(questions):
+            answer = questions[quiz_index].correct_option
+            _, feedback = await curriculum_engine.check_answer(user_id, lesson_id, answer)
+            print(feedback)
+            quiz_index += 1
+        else:
+            steps_done += 1
+
+    final_progress = await _get_progress(user_id, lesson_id)
+    print(f"Final score: {final_progress.quiz_score}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Probe learning lessons")
+    parser.add_argument("--user", type=int, required=True, help="User identifier")
+    parser.add_argument("--lesson", required=True, help="Lesson slug to start")
+    args = parser.parse_args()
+    asyncio.run(main(args.user, args.lesson))


### PR DESCRIPTION
## Summary
- add scripts/probe_learn.py for probing curriculum lessons

## Testing
- `pytest -q` *(fails: assert [] == [datetime.time(8, 0)]...)*
- `mypy --strict scripts/probe_learn.py`
- `ruff check scripts/probe_learn.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9bf414f50832aa814a0faab0988e8