### PR TITLE
[learning] Add slug field for lessons

### DIFF
--- a/services/api/alembic/versions/20250917_add_slug_to_lessons.py
+++ b/services/api/alembic/versions/20250917_add_slug_to_lessons.py
@@ -1,0 +1,30 @@
+"""add slug to lessons
+
+Revision ID: 20250917_add_slug_to_lessons
+Revises: 20250916_reminder_type_kind_enum
+Create Date: 2025-09-04 16:35:23.605220
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '20250917_add_slug_to_lessons'
+down_revision: Union[str, None] = '20250916_reminder_type_kind_enum'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("lessons", sa.Column("slug", sa.String(), nullable=False))
+    op.create_index(
+        "ix_lessons_slug", "lessons", ["slug"], unique=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_lessons_slug", table_name="lessons")
+    op.drop_column("lessons", "slug")

--- a/services/api/app/diabetes/content/lessons_v0.json
+++ b/services/api/app/diabetes/content/lessons_v0.json
@@ -1,5 +1,6 @@
 [
   {
+    "slug": "basics-of-diabetes",
     "title": "Basics of Diabetes",
     "steps": [
       "Diabetes is a condition that affects how your body uses blood glucose.",
@@ -25,6 +26,7 @@
     ]
   },
   {
+    "slug": "insulin-usage",
     "title": "Insulin Usage",
     "steps": [
       "Store insulin in a cool place.",
@@ -50,6 +52,7 @@
     ]
   },
   {
+    "slug": "healthy-eating",
     "title": "Healthy Eating",
     "steps": [
       "Include vegetables in every meal.",


### PR DESCRIPTION
## Summary
- add slug column to lessons table
- include slugs in lesson fixtures

## Testing
- `alembic upgrade head` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*
- `python - <<'PY' ...` (load lessons fixtures into sqlite)
- `python scripts/probe_learn.py` *(fails: No such file or directory)*
- `pytest -q` *(fails: 528 failed, 462 passed, 9 skipped, 2 warnings)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9bf42fa78832ab89ce6f0a1e20bf8