### PR TITLE
[requirements] Remove duplicate prometheus-client entry

### DIFF
--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -42,7 +42,6 @@ fastapi==0.115.0
 uvicorn[standard]==0.35.0
 websockets==15.0.1
 wsproto==1.2.0
-prometheus-client==0.20.0
 
 # 📦 Дополнения для SPA/FastAPI
 aiofiles==23.2.1


### PR DESCRIPTION
## Summary
- remove duplicate `prometheus-client` from API requirements

## Testing
- `pip install -r services/api/app/requirements.txt`
- `pytest -q` *(fails: assert [], TimeoutError, etc.)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9c1e41ee4832a8763763e0d73a3f0