### PR TITLE
[billing] commit event log

### DIFF
--- a/services/api/app/billing/log.py
+++ b/services/api/app/billing/log.py
@@ -8,6 +8,7 @@ from typing import Any
 from sqlalchemy import BigInteger, Integer, TIMESTAMP, Enum as SAEnum, JSON, func
 from sqlalchemy.orm import Mapped, Session, mapped_column
 
+from ..diabetes.services import repository
 from ..diabetes.services.db import Base
 
 logger = logging.getLogger(__name__)
@@ -48,4 +49,8 @@ def log_billing_event(
 
     log = BillingLog(user_id=user_id, event=event, context=context)
     session.add(log)
-    session.flush()
+    try:
+        repository.commit(session)
+    except repository.CommitError:  # pragma: no cover - logging only
+        logger.exception("Failed to persist billing event %s for user %s", event.value, user_id)
+        raise

--- a/tests/billing/test_log_billing_event.py
+++ b/tests/billing/test_log_billing_event.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.billing.log import BillingLog, BillingEvent, log_billing_event
+from services.api.app.diabetes.services.db import Base
+
+
+def _session_local() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine, tables=[BillingLog.__table__])
+    return sessionmaker(bind=engine)
+
+
+def test_log_billing_event_persists() -> None:
+    session_local = _session_local()
+    with session_local() as session:
+        log_billing_event(session, 1, BillingEvent.INIT, {"foo": "bar"})
+    with session_local() as session:
+        logs = session.scalars(select(BillingLog)).all()
+        assert len(logs) == 1
+        log = logs[0]
+        assert log.user_id == 1
+        assert log.event is BillingEvent.INIT
+        assert log.context == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- commit billing log events instead of flush
- test that billing event persists after logging

## Testing
- `ruff check .`
- `mypy --strict services/api/app/billing/log.py tests/billing/test_log_billing_event.py`
- `pytest tests/billing/test_log_billing_event.py -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68b9c201542c832a8333b07e7d0bc15e