### PR TITLE
[services] Preserve variant when not provided

### DIFF
--- a/services/api/app/services/onboarding_state.py
+++ b/services/api/app/services/onboarding_state.py
@@ -39,7 +39,8 @@ async def save_state(user_id: int, step: int, data: dict[str, object], variant: 
             cast(Session, session).add(state)
         state.step = step
         state.data = dict(data)
-        state.variant = variant
+        if variant is not None:
+            state.variant = variant
         state.updated_at = datetime.now(timezone.utc)
         commit(cast(Session, session))
 

--- a/tests/diabetes/test_onboarding_state.py
+++ b/tests/diabetes/test_onboarding_state.py
@@ -32,6 +32,15 @@ async def test_save_and_load(session_local: sessionmaker[SASession]) -> None:
 
 
 @pytest.mark.asyncio
+async def test_save_state_preserves_variant(session_local: sessionmaker[SASession]) -> None:
+    await onboarding_state.save_state(1, 1, {}, "v1")
+    await onboarding_state.save_state(1, 2, {})
+    state = await onboarding_state.load_state(1)
+    assert state is not None
+    assert state.variant == "v1"
+
+
+@pytest.mark.asyncio
 async def test_expired_state_removed(session_local: sessionmaker[SASession]) -> None:
     await onboarding_state.save_state(1, 1, {})
     with session_local() as session:

--- a/tests/services/test_onboarding_state.py
+++ b/tests/services/test_onboarding_state.py
@@ -32,6 +32,15 @@ async def test_save_and_load(session_local: sessionmaker[SASession]) -> None:
 
 
 @pytest.mark.asyncio
+async def test_save_state_preserves_variant(session_local: sessionmaker[SASession]) -> None:
+    await onboarding_state.save_state(1, 1, {}, "v1")
+    await onboarding_state.save_state(1, 2, {})
+    state = await onboarding_state.load_state(1)
+    assert state is not None
+    assert state.variant == "v1"
+
+
+@pytest.mark.asyncio
 async def test_load_state_expired(session_local: sessionmaker[SASession]) -> None:
     await onboarding_state.save_state(1, 1, {})
     with session_local() as session:


### PR DESCRIPTION
## Summary
- avoid clearing `OnboardingState.variant` when `save_state` is called without a variant
- add regression tests ensuring existing variant persists

## Testing
- `pytest -q` *(fails: 13 failed, 979 passed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9c1f95484832a891957cc409a34f6