### PR TITLE
[profiles] Enforce non-null defaults for settings

### DIFF
--- a/services/api/alembic/versions/20250917_profile_not_null_defaults.py
+++ b/services/api/alembic/versions/20250917_profile_not_null_defaults.py
@@ -1,0 +1,110 @@
+"""profile settings columns not null with defaults
+
+Revision ID: 20250917_profile_not_null_defaults
+Revises: 20250916_reminder_type_kind_enum
+Create Date: 2025-09-17
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20250917_profile_not_null_defaults"
+down_revision = "20250916_reminder_type_kind_enum"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "profiles",
+        "timezone",
+        existing_type=sa.String(),
+        nullable=False,
+        server_default="UTC",
+    )
+    op.alter_column(
+        "profiles",
+        "timezone_auto",
+        existing_type=sa.Boolean(),
+        nullable=False,
+        server_default=sa.true(),
+    )
+    op.alter_column(
+        "profiles",
+        "dia",
+        existing_type=sa.Float(),
+        nullable=False,
+        server_default="4.0",
+    )
+    op.alter_column(
+        "profiles",
+        "round_step",
+        existing_type=sa.Float(),
+        nullable=False,
+        server_default="0.5",
+    )
+    op.alter_column(
+        "profiles",
+        "carb_units",
+        existing_type=sa.String(),
+        nullable=False,
+        server_default="g",
+    )
+    op.alter_column(
+        "profiles",
+        "grams_per_xe",
+        existing_type=sa.Float(),
+        nullable=False,
+        server_default="12.0",
+    )
+    op.alter_column(
+        "profiles",
+        "therapy_type",
+        existing_type=sa.String(),
+        nullable=False,
+        server_default="insulin",
+    )
+    op.alter_column(
+        "profiles",
+        "glucose_units",
+        existing_type=sa.String(),
+        nullable=False,
+        server_default="mmol/L",
+    )
+    op.alter_column(
+        "profiles",
+        "prebolus_min",
+        existing_type=sa.Integer(),
+        nullable=False,
+        server_default="0",
+    )
+    op.alter_column(
+        "profiles",
+        "max_bolus",
+        existing_type=sa.Float(),
+        nullable=False,
+        server_default="10.0",
+    )
+    op.alter_column(
+        "profiles",
+        "postmeal_check_min",
+        existing_type=sa.Integer(),
+        nullable=False,
+        server_default="0",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column("profiles", "postmeal_check_min", server_default=None)
+    op.alter_column("profiles", "max_bolus", server_default=None)
+    op.alter_column("profiles", "prebolus_min", server_default=None)
+    op.alter_column("profiles", "glucose_units", server_default=None)
+    op.alter_column("profiles", "therapy_type", server_default=None)
+    op.alter_column("profiles", "grams_per_xe", server_default=None)
+    op.alter_column("profiles", "carb_units", server_default=None)
+    op.alter_column("profiles", "round_step", server_default=None)
+    op.alter_column("profiles", "dia", server_default=None)
+    op.alter_column("profiles", "timezone_auto", server_default=None)
+    op.alter_column("profiles", "timezone", server_default=None)
+

--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -46,6 +46,7 @@ class LocalProfile:
     round_step: float | None = None
     carb_units: str | None = None
     grams_per_xe: float | None = None
+    glucose_units: str | None = None
     therapy_type: str | None = None
     rapid_insulin_type: str | None = None
     prebolus_min: int | None = None
@@ -67,6 +68,7 @@ class LocalProfileSettings:
     round_step: float = 0.5
     carb_units: str = "g"
     grams_per_xe: float = 12.0
+    glucose_units: str = "mmol/L"
 
 
 class LocalProfileAPI:
@@ -98,6 +100,7 @@ class LocalProfileAPI:
                 round_step=profile.round_step,
                 carb_units=profile.carb_units,
                 grams_per_xe=profile.grams_per_xe,
+                glucose_units=profile.glucose_units,
                 therapy_type=profile.therapy_type,
                 rapid_insulin_type=profile.rapid_insulin_type,
                 prebolus_min=profile.prebolus_min,
@@ -130,6 +133,7 @@ class LocalProfileAPI:
                 round_step=prof.round_step,
                 carb_units=prof.carb_units,
                 grams_per_xe=prof.grams_per_xe,
+                glucose_units=prof.glucose_units,
                 therapy_type=prof.therapy_type,
                 rapid_insulin_type=prof.insulin_type,
                 prebolus_min=prof.prebolus_min,
@@ -194,6 +198,7 @@ def save_profile(
     round_step: float | None = None,
     carb_units: str | None = None,
     grams_per_xe: float | None = None,
+    glucose_units: str | None = None,
     therapy_type: str | None = None,
     rapid_insulin_type: str | None = None,
     prebolus_min: int | None = None,
@@ -227,6 +232,8 @@ def save_profile(
         prof.carb_units = carb_units
     if grams_per_xe is not None:
         prof.grams_per_xe = grams_per_xe
+    if glucose_units is not None:
+        prof.glucose_units = glucose_units
     if therapy_type is not None:
         prof.therapy_type = therapy_type
     if rapid_insulin_type is not None:
@@ -272,6 +279,7 @@ def get_profile_settings(session: Session, user_id: int) -> LocalProfileSettings
         round_step=profile.round_step,
         carb_units=profile.carb_units,
         grams_per_xe=profile.grams_per_xe,
+        glucose_units=profile.glucose_units,
     )
 
 

--- a/services/api/app/diabetes/schemas/profile.py
+++ b/services/api/app/diabetes/schemas/profile.py
@@ -27,6 +27,13 @@ class RapidInsulinType(str, Enum):
     REGULAR = "regular"
 
 
+class GlucoseUnits(str, Enum):
+    """Available blood glucose measurement units."""
+
+    MMOL_L = "mmol/L"
+    MG_DL = "mg/dL"
+
+
 class ProfileSettingsIn(BaseModel):
     """Incoming user settings for profile configuration."""
 
@@ -51,6 +58,11 @@ class ProfileSettingsIn(BaseModel):
         default=None,
         alias="gramsPerXe",
         validation_alias=AliasChoices("gramsPerXe", "grams_per_xe"),
+    )
+    glucoseUnits: GlucoseUnits | None = Field(
+        default=None,
+        alias="glucoseUnits",
+        validation_alias=AliasChoices("glucoseUnits", "glucose_units"),
     )
     sosContact: str | None = Field(
         default=None,
@@ -121,6 +133,7 @@ class ProfileSettingsOut(ProfileSettingsIn):
     roundStep: float = Field(alias="roundStep")
     carbUnits: CarbUnits = Field(alias="carbUnits")
     gramsPerXe: float = Field(alias="gramsPerXe")
+    glucoseUnits: GlucoseUnits = Field(alias="glucoseUnits")
     sosContact: str | None = Field(default=None, alias="sosContact")
     sosAlertsEnabled: bool = Field(alias="sosAlertsEnabled")
     therapyType: TherapyType = Field(alias="therapyType")

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -197,18 +197,40 @@ class Profile(Base):
         nullable=False,
         server_default=sa.text("'07:00:00'"),
     )
-    timezone: Mapped[str] = mapped_column(String, default="UTC")
-    timezone_auto: Mapped[bool] = mapped_column(Boolean, default=True)
-    dia: Mapped[float] = mapped_column(Float, default=4.0)
-    round_step: Mapped[float] = mapped_column(Float, default=0.5)
-    carb_units: Mapped[str] = mapped_column(String, default="g")
-    grams_per_xe: Mapped[float] = mapped_column(Float, default=12.0)
-    therapy_type: Mapped[str] = mapped_column(String, default="insulin")
-    glucose_units: Mapped[str] = mapped_column(String, default="mmol/L")
+    timezone: Mapped[str] = mapped_column(
+        String, nullable=False, default="UTC", server_default=sa.text("'UTC'"),
+    )
+    timezone_auto: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa.true(),
+    )
+    dia: Mapped[float] = mapped_column(
+        Float, nullable=False, default=4.0, server_default="4.0",
+    )
+    round_step: Mapped[float] = mapped_column(
+        Float, nullable=False, default=0.5, server_default="0.5",
+    )
+    carb_units: Mapped[str] = mapped_column(
+        String, nullable=False, default="g", server_default=sa.text("'g'"),
+    )
+    grams_per_xe: Mapped[float] = mapped_column(
+        Float, nullable=False, default=12.0, server_default="12.0",
+    )
+    therapy_type: Mapped[str] = mapped_column(
+        String, nullable=False, default="insulin", server_default=sa.text("'insulin'"),
+    )
+    glucose_units: Mapped[str] = mapped_column(
+        String, nullable=False, default="mmol/L", server_default=sa.text("'mmol/L'"),
+    )
     insulin_type: Mapped[Optional[str]] = mapped_column(String)
-    prebolus_min: Mapped[int] = mapped_column(Integer, default=0)
-    max_bolus: Mapped[float] = mapped_column(Float, default=10.0)
-    postmeal_check_min: Mapped[int] = mapped_column(Integer, default=0)
+    prebolus_min: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+    )
+    max_bolus: Mapped[float] = mapped_column(
+        Float, nullable=False, default=10.0, server_default="10.0",
+    )
+    postmeal_check_min: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0",
+    )
 
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
     user: Mapped[User] = relationship("User", back_populates="profile")

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -14,6 +14,7 @@ from ..diabetes.services.repository import CommitError, commit
 from ..schemas.profile import ProfileSchema
 from ..diabetes.schemas.profile import (
     CarbUnits,
+    GlucoseUnits,
     ProfileSettingsIn,
     ProfileSettingsOut,
     TherapyType,
@@ -85,6 +86,8 @@ async def patch_user_settings(
             profile.carb_units = data.carbUnits.value
         if data.gramsPerXe is not None:
             profile.grams_per_xe = data.gramsPerXe
+        if data.glucoseUnits is not None:
+            profile.glucose_units = data.glucoseUnits.value
         if data.sosContact is not None:
             profile.sos_contact = data.sosContact
         if data.sosAlertsEnabled is not None:
@@ -115,6 +118,7 @@ async def patch_user_settings(
             roundStep=profile.round_step,
             carbUnits=CarbUnits(profile.carb_units),
             gramsPerXe=profile.grams_per_xe,
+            glucoseUnits=GlucoseUnits(profile.glucose_units),
             sosContact=profile.sos_contact,
             sosAlertsEnabled=profile.sos_alerts_enabled,
             therapyType=TherapyType(profile.therapy_type),

--- a/tests/utils/profile_factory.py
+++ b/tests/utils/profile_factory.py
@@ -25,6 +25,7 @@ def make_profile(telegram_id: int = 1, **overrides: object) -> Profile:
         "grams_per_xe": 12.0,
         "therapy_type": "insulin",
         "insulin_type": "rapid",
+        "glucose_units": "mmol/L",
         "prebolus_min": 15,
         "max_bolus": 10.0,
         "postmeal_check_min": 120,


### PR DESCRIPTION
## Summary
- ensure profile settings columns are non-null with DB defaults
- expose glucoseUnits in profile schemas and service layer
- add Alembic migration for profile defaults

## Testing
- `pytest -q --cov` *(fails: No module named 'reportlab')*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9c1ff1db4832aa933ade0ce6f0b9f