### PR TITLE
[db] add indexes for entry columns

### DIFF
--- a/services/api/alembic/versions/20250917_add_entry_indexes.py
+++ b/services/api/alembic/versions/20250917_add_entry_indexes.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250917_add_entry_indexes"
+down_revision: Union[str, Sequence[str], None] = "20250916_reminder_type_kind_enum"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    indexes = {idx["name"] for idx in inspector.get_indexes("entries")}
+    if "ix_entries_telegram_id" not in indexes:
+        op.create_index("ix_entries_telegram_id", "entries", ["telegram_id"])
+    if "ix_entries_event_time" not in indexes:
+        op.create_index("ix_entries_event_time", "entries", ["event_time"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    indexes = {idx["name"] for idx in inspector.get_indexes("entries")}
+    if "ix_entries_event_time" in indexes:
+        op.drop_index("ix_entries_event_time", table_name="entries")
+    if "ix_entries_telegram_id" in indexes:
+        op.drop_index("ix_entries_telegram_id", table_name="entries")

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -223,12 +223,12 @@ class Entry(Base):
     __tablename__ = "entries"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     telegram_id: Mapped[Optional[int]] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id")
+        BigInteger, ForeignKey("users.telegram_id"), index=True
     )
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
 
     event_time: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=False
+        TIMESTAMP(timezone=True), nullable=False, index=True
     )
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now()

--- a/tests/test_entry_indexes.py
+++ b/tests/test_entry_indexes.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from services.api.app.diabetes.services.db import Base, dispose_engine
+
+
+def _setup_engine() -> Engine:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def test_entry_uses_indexes() -> None:
+    engine = _setup_engine()
+    try:
+        with engine.connect() as conn:
+            plan = conn.execute(
+                text("EXPLAIN QUERY PLAN SELECT * FROM entries WHERE telegram_id=1")
+            ).fetchall()
+        assert any(
+            "USING INDEX" in row[-1] and "ix_entries_telegram_id" in row[-1]
+            for row in plan
+        )
+
+        with engine.connect() as conn:
+            plan = conn.execute(
+                text(
+                    "EXPLAIN QUERY PLAN SELECT * FROM entries WHERE event_time='2024-01-01 00:00:00'"
+                )
+            ).fetchall()
+        assert any(
+            "USING INDEX" in row[-1] and "ix_entries_event_time" in row[-1]
+            for row in plan
+        )
+    finally:
+        dispose_engine(engine)


### PR DESCRIPTION
## Summary
- index `entries.telegram_id` and `entries.event_time`
- add migration to create the new indexes
- test query plans to ensure indexes are used

## Testing
- `mypy --strict services/api/app/diabetes/services/db.py services/api/alembic/versions/20250917_add_entry_indexes.py tests/test_entry_indexes.py`
- `ruff check services/api/app/diabetes/services/db.py services/api/alembic/versions/20250917_add_entry_indexes.py tests/test_entry_indexes.py`
- `pytest tests/test_entry_indexes.py -q --no-cov` *(fails: ModuleNotFoundError: No module named 'telegram')*


------
https://chatgpt.com/codex/tasks/task_e_68b9c207c3b0832aad7e19cc882703ac