### PR TITLE
[alembic] fix quiet hours migrations

### DIFF
--- a/services/api/alembic/versions/1188e4de1729_add_quiet_hours_to_profiles.py
+++ b/services/api/alembic/versions/1188e4de1729_add_quiet_hours_to_profiles.py
@@ -1,56 +1,38 @@
-"""add quiet hours to profiles
+"""add quiet hours to profiles"""
 
-Revision ID: 1188e4de1729
-Revises: 8db592ddbe51
-Create Date: 2025-08-25 15:24:16.293648
-
-"""
 from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
-revision: str = '1188e4de1729'
-down_revision: Union[str, None] = '8db592ddbe51'
+revision: str = "1188e4de1729"
+down_revision: Union[str, None] = "8db592ddbe51"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    bind = op.get_bind()
-    inspector = sa.inspect(bind)
-
-    columns = [col["name"] for col in inspector.get_columns("profiles")]
-    if "quiet_start" not in columns:
-        op.add_column(
-            "profiles",
-            sa.Column(
-                "quiet_start",
-                sa.Time(),
-                nullable=True,
-                server_default=sa.text("'23:00'"),
-            ),
-        )
-    if "quiet_end" not in columns:
-        op.add_column(
-            "profiles",
-            sa.Column(
-                "quiet_end",
-                sa.Time(),
-                nullable=True,
-                server_default=sa.text("'07:00'"),
-            ),
-        )
+    op.add_column(
+        "profiles",
+        sa.Column(
+            "quiet_start",
+            sa.Time(),
+            nullable=True,
+            server_default=sa.text("'23:00:00'"),
+        ),
+    )
+    op.add_column(
+        "profiles",
+        sa.Column(
+            "quiet_end",
+            sa.Time(),
+            nullable=True,
+            server_default=sa.text("'07:00:00'"),
+        ),
+    )
 
 
 def downgrade() -> None:
-    bind = op.get_bind()
-    inspector = sa.inspect(bind)
-
-    columns = [col["name"] for col in inspector.get_columns("profiles")]
-    if "quiet_end" in columns:
-        op.drop_column("profiles", "quiet_end")
-    if "quiet_start" in columns:
-        op.drop_column("profiles", "quiet_start")
+    op.drop_column("profiles", "quiet_end")
+    op.drop_column("profiles", "quiet_start")

--- a/services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py
+++ b/services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py
@@ -1,42 +1,45 @@
 """add quiet_start and quiet_end to profiles"""
 
-from collections.abc import Mapping, Sequence
+from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy import inspect
-from sqlalchemy.engine import Connection
 
-
-# ID предыдущей и текущей миграции
-revision = '20250828_add_quiet_time'
-down_revision = '1188e4de1729'
-branch_labels = None
-depends_on = None
-
-
-def column_exists(conn: Connection, table_name: str, column_name: str) -> bool:
-    insp = inspect(conn)
-    columns: Sequence[Mapping[str, object]] = insp.get_columns(table_name)
-    return column_name in [col["name"] for col in columns]
+revision: str = "20250828_add_quiet_time"
+down_revision: Union[str, None] = "1188e4de1729"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    bind: Connection = op.get_bind()
-    
-    if not column_exists(bind, "profiles", "quiet_start"):
-        op.add_column(
-            "profiles",
-            sa.Column("quiet_start", sa.Time(), nullable=False, server_default="23:00:00"),
-        )
-
-    if not column_exists(bind, "profiles", "quiet_end"):
-        op.add_column(
-            "profiles",
-            sa.Column("quiet_end", sa.Time(), nullable=False, server_default="07:00:00"),
-        )
+    op.alter_column(
+        "profiles",
+        "quiet_start",
+        existing_type=sa.Time(),
+        nullable=False,
+        server_default=sa.text("'23:00:00'"),
+    )
+    op.alter_column(
+        "profiles",
+        "quiet_end",
+        existing_type=sa.Time(),
+        nullable=False,
+        server_default=sa.text("'07:00:00'"),
+    )
 
 
 def downgrade() -> None:
-    op.drop_column("profiles", "quiet_end")
-    op.drop_column("profiles", "quiet_start")
+    op.alter_column(
+        "profiles",
+        "quiet_start",
+        existing_type=sa.Time(),
+        nullable=True,
+        server_default=sa.text("'23:00:00'"),
+    )
+    op.alter_column(
+        "profiles",
+        "quiet_end",
+        existing_type=sa.Time(),
+        nullable=True,
+        server_default=sa.text("'07:00:00'"),
+    )


### PR DESCRIPTION
## Summary
- simplify quiet hours migration to add columns
- enforce non-null quiet hours with defaults

## Testing
- `alembic -c services/api/alembic.ini upgrade 20250828_add_quiet_time` *(fails: near "ALTER": syntax error)*
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'openai')*
- `mypy --strict services/api/alembic/versions/1188e4de1729_add_quiet_hours_to_profiles.py services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b9c6c27684832aa66dc35636ed498f