### PR TITLE
[learning] add slug to lessons

### DIFF
--- a/services/api/alembic/versions/20250918_add_slug_to_lessons.py
+++ b/services/api/alembic/versions/20250918_add_slug_to_lessons.py
@@ -1,0 +1,55 @@
+"""add slug to lessons"""
+
+from __future__ import annotations
+
+import re
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20250918_add_slug_to_lessons"
+down_revision: Union[str, Sequence[str], None] = "20250917_profile_not_null_defaults"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+lessons_table = sa.table(
+    "lessons",
+    sa.column("id", sa.Integer),
+    sa.column("title", sa.String),
+    sa.column("slug", sa.String),
+)
+
+
+def _slugify(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower())
+    return slug.strip("-") or "lesson"
+
+
+def upgrade() -> None:
+    op.add_column("lessons", sa.Column("slug", sa.String(), nullable=True))
+    bind = op.get_bind()
+    existing_slugs: set[str] = set()
+    rows = list(bind.execute(sa.select(lessons_table.c.id, lessons_table.c.title)))
+    for lesson_id, title in rows:
+        base = _slugify(title or "lesson")
+        slug = base
+        counter = 1
+        while slug in existing_slugs:
+            slug = f"{base}-{counter}"
+            counter += 1
+        existing_slugs.add(slug)
+        bind.execute(
+            sa.update(lessons_table)
+            .where(lessons_table.c.id == lesson_id)
+            .values(slug=slug)
+        )
+    op.alter_column("lessons", "slug", existing_type=sa.String(), nullable=False)
+    op.create_index("ix_lessons_slug", "lessons", ["slug"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_lessons_slug", table_name="lessons")
+    op.drop_column("lessons", "slug")

--- a/services/api/tests/test_learning_models.py
+++ b/services/api/tests/test_learning_models.py
@@ -40,9 +40,9 @@ def test_lesson_crud() -> None:
         session.commit()
         session.refresh(lesson)
 
-        stored = session.get(Lesson, lesson.id)
-        assert stored is not None
+        stored = session.query(Lesson).filter_by(slug="intro").one()
         assert stored.title == "Intro"
+        assert stored.slug == "intro"
         assert stored.is_active is True
         assert [s.content for s in stored.steps] == ["s1", "s2"]
 

--- a/tests/test_exit_command.py
+++ b/tests/test_exit_command.py
@@ -59,6 +59,7 @@ async def test_exit_command_clears_state_and_marks_progress() -> None:
         lesson = Lesson(slug="intro", title="Intro", content="c")
         session.add_all([user, lesson])
         session.commit()
+        assert session.query(Lesson).filter_by(slug="intro").one().id == lesson.id
         progress = LessonProgress(
             user_id=user.telegram_id,
             lesson_id=lesson.id,

--- a/tests/test_progress_command.py
+++ b/tests/test_progress_command.py
@@ -72,6 +72,7 @@ async def test_progress_command_with_progress() -> None:
         lesson = Lesson(slug="intro", title="Intro", content="c")
         session.add_all([user, lesson])
         session.commit()
+        assert session.query(Lesson).filter_by(slug="intro").one().id == lesson.id
         progress = LessonProgress(
             user_id=user.telegram_id,
             lesson_id=lesson.id,


### PR DESCRIPTION
## Summary
- add slug column to lessons and backfill existing entries
- test Lesson interactions via slug lookups

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named "fastapi.responses" and others)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_68b9c6ca87bc832a81b253f62ac1fa22