### PR TITLE
[migrations] add unique constraints for lessons

### DIFF
--- a/services/api/alembic/versions/20250918_add_learning_unique_constraints.py
+++ b/services/api/alembic/versions/20250918_add_learning_unique_constraints.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20250918_add_learning_unique_constraints"
+down_revision: Union[str, Sequence[str], None] = "20250917_profile_not_null_defaults"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        "lesson_steps_lesson_order_key",
+        "lesson_steps",
+        ["lesson_id", "step_order"],
+    )
+    op.create_unique_constraint(
+        "lesson_progress_user_lesson_key",
+        "lesson_progress",
+        ["user_id", "lesson_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "lesson_progress_user_lesson_key",
+        table_name="lesson_progress",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "lesson_steps_lesson_order_key",
+        table_name="lesson_steps",
+        type_="unique",
+    )


### PR DESCRIPTION
## Summary
- add unique constraint on lesson steps order within a lesson
- add unique constraint on user and lesson pair for lesson progress

## Testing
- `PYTHONPATH=/workspace/saharlight-ux DATABASE_URL=sqlite:///tmp_alembic.db alembic revision --autogenerate -m "check" --head 20250918_add_learning_unique_constraints`
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'openai')*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9c6ce3cc8832ab59bf8d1bc4e67c0