### PR TITLE
[migrations] enforce defaults for quiet time

### DIFF
--- a/services/api/alembic/versions/1188e4de1729_add_quiet_hours_to_profiles.py
+++ b/services/api/alembic/versions/1188e4de1729_add_quiet_hours_to_profiles.py
@@ -29,8 +29,8 @@ def upgrade() -> None:
             sa.Column(
                 "quiet_start",
                 sa.Time(),
-                nullable=True,
-                server_default=sa.text("'23:00'"),
+                nullable=False,
+                server_default=sa.text("'23:00:00'"),
             ),
         )
     if "quiet_end" not in columns:
@@ -39,8 +39,8 @@ def upgrade() -> None:
             sa.Column(
                 "quiet_end",
                 sa.Time(),
-                nullable=True,
-                server_default=sa.text("'07:00'"),
+                nullable=False,
+                server_default=sa.text("'07:00:00'"),
             ),
         )
 

--- a/services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py
+++ b/services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py
@@ -24,19 +24,57 @@ def column_exists(conn: Connection, table_name: str, column_name: str) -> bool:
 def upgrade() -> None:
     bind: Connection = op.get_bind()
     
-    if not column_exists(bind, "profiles", "quiet_start"):
+    if column_exists(bind, "profiles", "quiet_start"):
+        op.alter_column(
+            "profiles",
+            "quiet_start",
+            existing_type=sa.Time(),
+            nullable=False,
+            server_default=sa.text("'23:00:00'"),
+        )
+    else:
         op.add_column(
             "profiles",
-            sa.Column("quiet_start", sa.Time(), nullable=False, server_default="23:00:00"),
+            sa.Column(
+                "quiet_start",
+                sa.Time(),
+                nullable=False,
+                server_default=sa.text("'23:00:00'"),
+            ),
         )
 
-    if not column_exists(bind, "profiles", "quiet_end"):
+    if column_exists(bind, "profiles", "quiet_end"):
+        op.alter_column(
+            "profiles",
+            "quiet_end",
+            existing_type=sa.Time(),
+            nullable=False,
+            server_default=sa.text("'07:00:00'"),
+        )
+    else:
         op.add_column(
             "profiles",
-            sa.Column("quiet_end", sa.Time(), nullable=False, server_default="07:00:00"),
+            sa.Column(
+                "quiet_end",
+                sa.Time(),
+                nullable=False,
+                server_default=sa.text("'07:00:00'"),
+            ),
         )
 
 
 def downgrade() -> None:
-    op.drop_column("profiles", "quiet_end")
-    op.drop_column("profiles", "quiet_start")
+    op.alter_column(
+        "profiles",
+        "quiet_end",
+        existing_type=sa.Time(),
+        nullable=True,
+        server_default=sa.text("'07:00'"),
+    )
+    op.alter_column(
+        "profiles",
+        "quiet_start",
+        existing_type=sa.Time(),
+        nullable=True,
+        server_default=sa.text("'23:00'"),
+    )


### PR DESCRIPTION
## Summary
- set quiet_start and quiet_end as non-null with uniform defaults
- adjust migration to alter existing columns when present

## Testing
- `alembic -c services/api/alembic.ini revision --autogenerate -m "check profiles"` *(fails: Target database is not up to date)*
- `pytest -q` *(fails: No module named 'openai')*
- `mypy --strict .` *(fails: Cannot find module 'prometheus_client')*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9c6d68064832ab045ed13d55c4228