### PR TITLE
[migrations] Align quiet time defaults

### DIFF
--- a/services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py
+++ b/services/api/alembic/versions/2025_08_28_add_quiet_time_to_profiles.py
@@ -24,7 +24,7 @@ def upgrade() -> None:
         "quiet_end",
         existing_type=sa.Time(),
         nullable=False,
-        server_default=sa.text("'07:00:00'"),
+        server_default=sa.text("'23:00:00'"),
     )
 
 
@@ -41,5 +41,5 @@ def downgrade() -> None:
         "quiet_end",
         existing_type=sa.Time(),
         nullable=True,
-        server_default=sa.text("'07:00:00'"),
+        server_default=sa.text("'23:00:00'"),
     )


### PR DESCRIPTION
## Summary
- ensure quiet_start and quiet_end columns share non-null default values

## Testing
- `alembic revision --autogenerate -m "temp"` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `pytest -q --cov` *(fails: 15 failed, 980 passed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9c95c55b8832ab6082d5db84e561b