### PR TITLE
[services] Add FK for onboarding event user

### DIFF
--- a/services/api/alembic/versions/20250919_onboarding_events_user_fk.py
+++ b/services/api/alembic/versions/20250919_onboarding_events_user_fk.py
@@ -1,0 +1,47 @@
+"""add foreign key to onboarding_events.user_id
+
+Revision ID: 20250919_onboarding_events_user_fk
+Revises: 20250918_add_entry_indexes
+Create Date: 2025-09-19
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250919_onboarding_events_user_fk"
+down_revision: Union[str, Sequence[str], None] = "20250918_add_entry_indexes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    fks = inspector.get_foreign_keys("onboarding_events")
+    has_fk = any(
+        fk["referred_table"] == "users" and fk["constrained_columns"] == ["user_id"]
+        for fk in fks
+    )
+    if not has_fk:
+        op.create_foreign_key(
+            "onboarding_events_user_id_fkey",
+            "onboarding_events",
+            "users",
+            ["user_id"],
+            ["telegram_id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    fks = [fk["name"] for fk in inspector.get_foreign_keys("onboarding_events")]
+    if "onboarding_events_user_id_fkey" in fks:
+        op.drop_constraint(
+            "onboarding_events_user_id_fkey",
+            "onboarding_events",
+            type_="foreignkey",
+        )

--- a/services/api/app/services/onboarding_events.py
+++ b/services/api/app/services/onboarding_events.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from sqlalchemy import BigInteger, Integer, String, TIMESTAMP, func
+from sqlalchemy import BigInteger, ForeignKey, Integer, String, TIMESTAMP, func
 from sqlalchemy.orm import Mapped, Session, mapped_column
 
 from ..diabetes.services.db import Base
@@ -17,7 +17,12 @@ class OnboardingEvent(Base):
     __tablename__ = "onboarding_events"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.telegram_id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
     event_name: Mapped[str] = mapped_column(String, nullable=False)
     step: Mapped[int] = mapped_column(Integer, nullable=False)
     variant: Mapped[str | None] = mapped_column(String)


### PR DESCRIPTION
## Summary
- add user foreign key to onboarding_events model
- create Alembic migration to enforce onboarding_events.user_id referencing users.telegram_id with cascade

## Testing
- `ruff check .`
- `mypy --strict services/api/app/services/onboarding_events.py services/api/alembic/versions/20250919_onboarding_events_user_fk.py`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cc4ac948832aa04c19f3a092f046