### PR TITLE
[services] Cascade delete onboarding state

### DIFF
--- a/services/api/alembic/versions/20250920_onboarding_state_ondelete_cascade.py
+++ b/services/api/alembic/versions/20250920_onboarding_state_ondelete_cascade.py
@@ -1,0 +1,43 @@
+"""onboarding_states user_id ON DELETE CASCADE"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "20250920_onboarding_state_ondelete_cascade"
+down_revision: Union[str, Sequence[str], None] = "20250918_subscriptions_user_status_key"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "onboarding_states_user_id_fkey",
+        "onboarding_states",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "onboarding_states_user_id_fkey",
+        "onboarding_states",
+        "users",
+        ["user_id"],
+        ["telegram_id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "onboarding_states_user_id_fkey",
+        "onboarding_states",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "onboarding_states_user_id_fkey",
+        "onboarding_states",
+        "users",
+        ["user_id"],
+        ["telegram_id"],
+    )

--- a/services/api/app/services/onboarding_state.py
+++ b/services/api/app/services/onboarding_state.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import cast
 
-from sqlalchemy import BigInteger, Integer, String, JSON, TIMESTAMP, func
+from sqlalchemy import BigInteger, Integer, String, JSON, TIMESTAMP, func, ForeignKey
 from sqlalchemy.orm import Mapped, Session, mapped_column
 
 from ..diabetes.services.db import Base, SessionLocal, run_db
@@ -17,7 +17,11 @@ logger = logging.getLogger(__name__)
 class OnboardingState(Base):
     __tablename__ = "onboarding_states"
 
-    user_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.telegram_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
     step: Mapped[int] = mapped_column(Integer, nullable=False)
     data: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False)
     variant: Mapped[str | None] = mapped_column(String)


### PR DESCRIPTION
## Summary
- cascade-delete onboarding state when related user is removed
- add migration to enforce ON DELETE CASCADE on onboarding state FK

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc4b177c832a9bef2b18be309619