### PR TITLE
[services] Make onboarding state data mutable

### DIFF
--- a/tests/diabetes/test_onboarding_state.py
+++ b/tests/diabetes/test_onboarding_state.py
@@ -61,3 +61,16 @@ async def test_complete_state_sets_timestamp(session_local: sessionmaker[SASessi
     state = await onboarding_state.load_state(1)
     assert state is not None
     assert state.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_data_mutation_persists(session_local: sessionmaker[SASession]) -> None:
+    await onboarding_state.save_state(1, 1, {"foo": "bar"})
+    with session_local() as session:
+        st = session.get(onboarding_state.OnboardingState, 1)
+        assert st is not None
+        st.data["baz"] = 42
+        session.commit()
+    state = await onboarding_state.load_state(1)
+    assert state is not None
+    assert state.data == {"foo": "bar", "baz": 42}

--- a/tests/services/test_onboarding_state.py
+++ b/tests/services/test_onboarding_state.py
@@ -61,3 +61,16 @@ async def test_complete_state(session_local: sessionmaker[SASession]) -> None:
     state = await onboarding_state.load_state(1)
     assert state is not None
     assert state.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_data_mutation_persists(session_local: sessionmaker[SASession]) -> None:
+    await onboarding_state.save_state(1, 1, {"foo": "bar"})
+    with session_local() as session:
+        st = session.get(onboarding_state.OnboardingState, 1)
+        assert st is not None
+        st.data["baz"] = 42
+        session.commit()
+    state = await onboarding_state.load_state(1)
+    assert state is not None
+    assert state.data == {"foo": "bar", "baz": 42}


### PR DESCRIPTION
## Summary
- track onboarding state `data` field changes with `MutableDict`
- avoid dict reinitialization in `save_state`
- add regression tests for in-place data mutation

## Testing
- `pytest tests/services/test_onboarding_state.py tests/diabetes/test_onboarding_state.py -q --override-ini=addopts="" --cov=services.api.app.services.onboarding_state --cov-report=term-missing --cov-fail-under=0`
- `mypy --strict services/api/app/services/onboarding_state.py tests/services/test_onboarding_state.py tests/diabetes/test_onboarding_state.py`
- `ruff check services/api/app/services/onboarding_state.py tests/services/test_onboarding_state.py tests/diabetes/test_onboarding_state.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc4ccfdc832a84c29696a9db0be4