### PR TITLE
[migrations] add onboarding metrics indexes

### DIFF
--- a/services/api/alembic/versions/20251001_onboarding_metrics_indexes.py
+++ b/services/api/alembic/versions/20251001_onboarding_metrics_indexes.py
@@ -1,0 +1,71 @@
+"""add indexes for onboarding metrics"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20251001_onboarding_metrics_indexes"
+down_revision: Union[str, Sequence[str], None] = (
+    "20250816_add_org_id_to_alerts",
+    "20250821_add_snooze_minutes_to_reminder_logs",
+    "20250904_billing_log",
+    "20250911_learning_init",
+    "20250915_add_unique_transaction_id_to_subscriptions",
+    "20250916_reminder_type_kind_enum",
+    "20250917_user_plan_enum",
+    "20250918_add_entry_indexes",
+    "20250918_add_learning_unique_constraints",
+    "20250918_add_slug_to_lessons",
+    "20250918_subscriptions_user_status_key",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    indexes_events = {
+        idx["name"] for idx in inspector.get_indexes("onboarding_events_metrics")
+    }
+    if "ix_onboarding_events_metrics_variant_step_created_at" not in indexes_events:
+        op.create_index(
+            "ix_onboarding_events_metrics_variant_step_created_at",
+            "onboarding_events_metrics",
+            ["variant", "step", "created_at"],
+        )
+
+    indexes_daily = {
+        idx["name"] for idx in inspector.get_indexes("onboarding_metrics_daily")
+    }
+    if "ix_onboarding_metrics_daily_date_variant_step" not in indexes_daily:
+        op.create_index(
+            "ix_onboarding_metrics_daily_date_variant_step",
+            "onboarding_metrics_daily",
+            ["date", "variant", "step"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    indexes_daily = {
+        idx["name"] for idx in inspector.get_indexes("onboarding_metrics_daily")
+    }
+    if "ix_onboarding_metrics_daily_date_variant_step" in indexes_daily:
+        op.drop_index(
+            "ix_onboarding_metrics_daily_date_variant_step",
+            table_name="onboarding_metrics_daily",
+        )
+
+    indexes_events = {
+        idx["name"] for idx in inspector.get_indexes("onboarding_events_metrics")
+    }
+    if "ix_onboarding_events_metrics_variant_step_created_at" in indexes_events:
+        op.drop_index(
+            "ix_onboarding_events_metrics_variant_step_created_at",
+            table_name="onboarding_events_metrics",
+        )

--- a/services/api/app/models/onboarding_metrics.py
+++ b/services/api/app/models/onboarding_metrics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
-from sqlalchemy import Date, Integer, String, TIMESTAMP, func
+from sqlalchemy import Date, Integer, String, TIMESTAMP, func, Index
 from sqlalchemy.orm import Mapped, mapped_column
 
 from services.api.app.diabetes.services.db import Base
@@ -20,6 +20,15 @@ class OnboardingMetricEvent(Base):
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
     )
 
+    __table_args__ = (
+        Index(
+            "ix_onboarding_events_metrics_variant_step_created_at",
+            "variant",
+            "step",
+            "created_at",
+        ),
+    )
+
 
 class OnboardingMetricDaily(Base):
     """Aggregated onboarding metrics per day."""
@@ -30,6 +39,15 @@ class OnboardingMetricDaily(Base):
     variant: Mapped[str] = mapped_column(String, primary_key=True)
     step: Mapped[str] = mapped_column(String, primary_key=True)
     count: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    __table_args__ = (
+        Index(
+            "ix_onboarding_metrics_daily_date_variant_step",
+            "date",
+            "variant",
+            "step",
+        ),
+    )
 
 
 __all__ = ["OnboardingMetricEvent", "OnboardingMetricDaily"]

--- a/tests/test_onboarding_metrics_indexes.py
+++ b/tests/test_onboarding_metrics_indexes.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.services import db
+from services.api.app.models.onboarding_metrics import (
+    OnboardingMetricDaily,
+    OnboardingMetricEvent,
+)
+
+
+def setup_db() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(dbapi_connection: Any, connection_record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    return SessionLocal
+
+
+def test_onboarding_events_metrics_index_exists() -> None:
+    SessionLocal = setup_db()
+    with SessionLocal() as session:
+        session.add(
+            OnboardingMetricEvent(
+                variant="v1",
+                step="s1",
+                created_at=datetime.utcnow(),
+            )
+        )
+        session.commit()
+        indexes = session.execute(
+            sa.text("PRAGMA index_list('onboarding_events_metrics')")
+        ).all()
+        assert any(
+            row[1] == "ix_onboarding_events_metrics_variant_step_created_at"
+            for row in indexes
+        )
+
+
+def test_onboarding_metrics_daily_index_exists() -> None:
+    SessionLocal = setup_db()
+    with SessionLocal() as session:
+        session.add(
+            OnboardingMetricDaily(
+                date=date(2024, 1, 1), variant="v1", step="s1", count=1
+            )
+        )
+        session.commit()
+        indexes = session.execute(
+            sa.text("PRAGMA index_list('onboarding_metrics_daily')")
+        ).all()
+        assert any(
+            row[1] == "ix_onboarding_metrics_daily_date_variant_step" for row in indexes
+        )


### PR DESCRIPTION
## Summary
- add SQLAlchemy indexes for onboarding metrics models
- add Alembic migration to create indexes if absent
- test presence of onboarding metrics indexes

## Testing
- `pytest -q` *(fails: assert [], TimeoutError, etc.)*
- `ruff check .`
- `mypy --strict .`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc4dd460832aa8be5b5d19444b14