### PR TITLE
[services] Track onboarding state JSON mutations

### DIFF
--- a/services/api/app/services/onboarding_state.py
+++ b/services/api/app/services/onboarding_state.py
@@ -6,6 +6,7 @@ from typing import cast
 
 from sqlalchemy import BigInteger, Integer, String, JSON, TIMESTAMP, func, ForeignKey
 from sqlalchemy.orm import Mapped, Session, mapped_column
+from sqlalchemy.ext.mutable import MutableDict
 
 from ..diabetes.services.db import Base, SessionLocal, run_db
 from ..diabetes.services.repository import commit
@@ -23,7 +24,7 @@ class OnboardingState(Base):
         primary_key=True,
     )
     step: Mapped[int] = mapped_column(Integer, nullable=False)
-    data: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False)
+    data: Mapped[dict[str, object]] = mapped_column(MutableDict.as_mutable(JSON), nullable=False)
     variant: Mapped[str | None] = mapped_column(String)
     completed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
     updated_at: Mapped[datetime] = mapped_column(

--- a/tests/diabetes/test_onboarding_state.py
+++ b/tests/diabetes/test_onboarding_state.py
@@ -61,3 +61,16 @@ async def test_complete_state_sets_timestamp(session_local: sessionmaker[SASessi
     state = await onboarding_state.load_state(1)
     assert state is not None
     assert state.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_mutate_data_in_place(session_local: sessionmaker[SASession]) -> None:
+    await onboarding_state.save_state(1, 1, {"foo": "bar"})
+    with session_local() as session:
+        st = session.get(onboarding_state.OnboardingState, 1)
+        assert st is not None
+        st.data["foo"] = "baz"
+        session.commit()
+    state = await onboarding_state.load_state(1)
+    assert state is not None
+    assert state.data == {"foo": "baz"}

--- a/tests/services/test_onboarding_state.py
+++ b/tests/services/test_onboarding_state.py
@@ -61,3 +61,16 @@ async def test_complete_state(session_local: sessionmaker[SASession]) -> None:
     state = await onboarding_state.load_state(1)
     assert state is not None
     assert state.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_mutate_data_in_place(session_local: sessionmaker[SASession]) -> None:
+    await onboarding_state.save_state(1, 1, {"foo": "bar"})
+    with session_local() as session:
+        st = session.get(onboarding_state.OnboardingState, 1)
+        assert st is not None
+        st.data["foo"] = "baz"
+        session.commit()
+    state = await onboarding_state.load_state(1)
+    assert state is not None
+    assert state.data == {"foo": "baz"}


### PR DESCRIPTION
## Summary
- use SQLAlchemy MutableDict to track onboarding state data mutations
- test mutating onboarding state data in-place

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/services/test_onboarding_state.py tests/diabetes/test_onboarding_state.py --cov --cov-fail-under=0 -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9ce27b720832abf403b1ea2b7e084