### PR TITLE
[alembic] merge heads

### DIFF
--- a/services/api/alembic/versions/3539fae8f7b6_merge_heads.py
+++ b/services/api/alembic/versions/3539fae8f7b6_merge_heads.py
@@ -1,0 +1,26 @@
+"""merge heads
+
+Revision ID: 3539fae8f7b6
+Revises: 20250919_onboarding_events_user_fk, 20250920_onboarding_state_ondelete_cascade, 20251001_onboarding_metrics_indexes
+Create Date: 2025-09-04 17:54:48.210001
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3539fae8f7b6'
+down_revision: Union[str, None] = ('20250919_onboarding_events_user_fk', '20250920_onboarding_state_ondelete_cascade', '20251001_onboarding_metrics_indexes')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- merge Alembic heads into single revision

## Testing
- `DATABASE_URL=sqlite:///tmp.db make migrate` *(fails: sqlite3.OperationalError near "ALTER": syntax error)*
- `DATABASE_URL=postgresql:///postgres make migrate` *(fails: sqlalchemy.exc.ProgrammingError relation "users" does not exist)*
- `DATABASE_URL=sqlite:///tmp.db pytest -q` *(fails: async def functions are not natively supported; coverage 57.06% < 85%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9d23f16b8832ab9548691bad77890