### PR TITLE
[alembic] Fix down revision for dropping user timezone

### DIFF
--- a/services/api/alembic/versions/20250902_drop_user_timezone.py
+++ b/services/api/alembic/versions/20250902_drop_user_timezone.py
@@ -6,7 +6,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "20250902_drop_user_timezone"
-down_revision: Union[str, Sequence[str], None] = "20250904_change_description"
+down_revision: Union[str, Sequence[str], None] = "20250902_reminder_log_telegram_foreign_key"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- fix down_revision for `20250902_drop_user_timezone` migration

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9d3163ca0832a8c779bae80dd1e24