### PR TITLE
tests: ignore env file in billing settings tests

### DIFF
--- a/tests/billing/test_billing_config.py
+++ b/tests/billing/test_billing_config.py
@@ -9,7 +9,7 @@ from services.api.app.billing.config import BillingSettings
 def test_dummy_provider_allows_missing_admin_token(monkeypatch) -> None:
     monkeypatch.setenv("BILLING_PROVIDER", "dummy")
     monkeypatch.delenv("BILLING_ADMIN_TOKEN", raising=False)
-    settings = BillingSettings()
+    settings = BillingSettings(_env_file=None)
     assert settings.billing_admin_token is None
 
 
@@ -17,7 +17,7 @@ def test_real_provider_requires_admin_token(monkeypatch) -> None:
     monkeypatch.setenv("BILLING_PROVIDER", "stripe")
     monkeypatch.delenv("BILLING_ADMIN_TOKEN", raising=False)
     with pytest.raises(ValidationError):
-        BillingSettings()
+        BillingSettings(_env_file=None)
 
 
 def test_webhook_ips_empty(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- ensure billing settings tests ignore project-level .env by explicitly passing `_env_file=None`

## Testing
- `pytest tests/billing/test_billing_config.py -q --cov-fail-under=0`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9d31c6b58832a9a6ccee22dd0cfc6