### PR TITLE
[billing] use enums for config

### DIFF
--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -174,7 +174,7 @@ async def subscribe(
             user_id=user_id,
             plan=plan,
             status=cast(SubscriptionStatus, SubscriptionStatus.PENDING.value),
-            provider=settings.billing_provider,
+            provider=settings.billing_provider.value,
             transaction_id=checkout["id"],
             start_date=now,
             end_date=None,
@@ -244,9 +244,7 @@ async def webhook(
                     "conflict_transaction_id": conflict.transaction_id,
                 },
             )
-            conflict.status = cast(
-                SubscriptionStatus, SubscriptionStatus.EXPIRED.value
-            )
+            conflict.status = cast(SubscriptionStatus, SubscriptionStatus.EXPIRED.value)
             conflict.end_date = now
 
         sub_end = sub.end_date
@@ -382,7 +380,7 @@ async def status(user_id: int, settings: BillingSettings = Depends(get_billing_s
     subscription = await run_db(_get_subscription, sessionmaker=SessionLocal)
     flags = FeatureFlags(
         billingEnabled=settings.billing_enabled,
-        paywallMode=settings.paywall_mode,
+        paywallMode=settings.paywall_mode.value,
         testMode=settings.billing_test_mode,
     )
     if subscription is None:

--- a/tests/billing/test_billing_config.py
+++ b/tests/billing/test_billing_config.py
@@ -20,6 +20,18 @@ def test_real_provider_requires_admin_token(monkeypatch) -> None:
         BillingSettings()
 
 
+def test_invalid_billing_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BILLING_PROVIDER", raising=False)
+    with pytest.raises(ValidationError):
+        BillingSettings(BILLING_PROVIDER="unknown", _env_file=None)
+
+
+def test_invalid_paywall_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PAYWALL_MODE", raising=False)
+    with pytest.raises(ValidationError):
+        BillingSettings(PAYWALL_MODE="invalid", _env_file=None)
+
+
 def test_webhook_ips_empty(monkeypatch) -> None:
     monkeypatch.delenv("BILLING_WEBHOOK_IPS", raising=False)
     settings = BillingSettings(_env_file=None)

--- a/tests/billing/test_service.py
+++ b/tests/billing/test_service.py
@@ -10,14 +10,14 @@ from services.api.app.billing.providers.dummy import DummyBillingProvider
 
 @pytest.mark.asyncio
 async def test_create_payment_unknown_provider() -> None:
-    settings = BillingSettings(BILLING_PROVIDER="other", BILLING_ADMIN_TOKEN="token")
+    settings = BillingSettings(BILLING_PROVIDER="stripe", BILLING_ADMIN_TOKEN="token")
     with pytest.raises(HTTPException):
         await service.create_payment(settings)
 
 
 @pytest.mark.asyncio
 async def test_create_subscription_unknown_provider() -> None:
-    settings = BillingSettings(BILLING_PROVIDER="other", BILLING_ADMIN_TOKEN="token")
+    settings = BillingSettings(BILLING_PROVIDER="stripe", BILLING_ADMIN_TOKEN="token")
     with pytest.raises(HTTPException):
         await service.create_subscription(settings, "pro")
 


### PR DESCRIPTION
## Summary
- use BillingProvider and PaywallMode enums for billing settings
- adjust billing service and router for enums
- test invalid enum values

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9d31c8e44832ab8e1d63a429f2216