### PR TITLE
[billing] validate webhook IPs with IPvAnyAddress

### DIFF
--- a/services/api/app/billing/service.py
+++ b/services/api/app/billing/service.py
@@ -6,6 +6,7 @@ import asyncio
 import hmac
 import logging
 from collections.abc import Mapping
+from ipaddress import ip_address
 
 from fastapi import HTTPException
 
@@ -44,7 +45,7 @@ async def verify_webhook(
 ) -> bool:
     """Verify webhook payload using the configured provider."""
 
-    if settings.billing_webhook_ips and ip not in settings.billing_webhook_ips:
+    if settings.billing_webhook_ips and ip_address(ip) not in settings.billing_webhook_ips:
         return False
     if not hmac.compare_digest(
         headers.get("X-Webhook-Signature") or "", event.signature

--- a/tests/billing/test_billing_config.py
+++ b/tests/billing/test_billing_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
+from pydantic import IPvAnyAddress, ValidationError
 
 from services.api.app.billing.config import BillingSettings
 
@@ -29,10 +29,19 @@ def test_webhook_ips_empty(monkeypatch) -> None:
 def test_webhook_ips_parsing(monkeypatch) -> None:
     monkeypatch.setenv("BILLING_WEBHOOK_IPS", "1.2.3.4,5.6.7.8")
     settings = BillingSettings()
-    assert settings.billing_webhook_ips == ["1.2.3.4", "5.6.7.8"]
+    assert settings.billing_webhook_ips == [
+        IPvAnyAddress("1.2.3.4"),
+        IPvAnyAddress("5.6.7.8"),
+    ]
 
 
 def test_webhook_ips_from_env(monkeypatch) -> None:
     monkeypatch.setenv("BILLING_WEBHOOK_IPS", "9.9.9.9")
     settings = BillingSettings(_env_file=None)
-    assert settings.billing_webhook_ips == ["9.9.9.9"]
+    assert settings.billing_webhook_ips == [IPvAnyAddress("9.9.9.9")]
+
+
+def test_webhook_ips_invalid(monkeypatch) -> None:
+    monkeypatch.setenv("BILLING_WEBHOOK_IPS", "1.2.3.4,invalid")
+    with pytest.raises(ValidationError):
+        BillingSettings()


### PR DESCRIPTION
## Summary
- validate comma-separated BILLING_WEBHOOK_IPS as IPvAnyAddress list
- check webhook request IP using parsed ipaddress objects
- cover billing settings parsing and invalid IPs in tests

## Testing
- `pytest tests/billing/test_billing_config.py -q --override-ini addopts=""`
- `mypy --strict services/api/app/billing tests/billing`
- `ruff check services/api/app/billing tests/billing`


------
https://chatgpt.com/codex/tasks/task_e_68b9d31f4d70832a94823eabe4a99d9a