### PR TITLE
[alembic] Fix down_revision for drop_user_timezone

### DIFF
--- a/services/api/alembic/versions/20250902_drop_user_timezone.py
+++ b/services/api/alembic/versions/20250902_drop_user_timezone.py
@@ -6,7 +6,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "20250902_drop_user_timezone"
-down_revision: Union[str, Sequence[str], None] = "20250904_change_description"
+down_revision: Union[str, Sequence[str], None] = "20250902_reminder_log_telegram_foreign_key"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- correct down_revision for drop_user_timezone migration

## Testing
- `pytest -q` *(fails: Coverage failure: total of 57 is less than fail-under=85; async plugin missing)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9d42a793c832aa3418df3cb579bfc