### PR TITLE
[migrations] Normalize revision naming

### DIFF
--- a/services/api/alembic/versions/20250807_squashed_initial.py
+++ b/services/api/alembic/versions/20250807_squashed_initial.py
@@ -1,6 +1,6 @@
 """squashed initial
 
-Revision ID: 02857aa7fc3e
+Revision ID: 20250807_squashed_initial
 Revises:
 Create Date: 2025-08-07 09:15:17.518654
 
@@ -14,7 +14,7 @@ from typing import Any, cast
 
 
 # revision identifiers, used by Alembic.
-revision: str = "02857aa7fc3e"
+revision: str = "20250807_squashed_initial"
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/services/api/alembic/versions/20250812_add_org_id_to_reminders.py
+++ b/services/api/alembic/versions/20250812_add_org_id_to_reminders.py
@@ -1,7 +1,7 @@
 """add org_id to reminders safely
 
 Revision ID: 20250812_add_org_id_to_reminders
-Revises: 02857aa7fc3e
+Revises: 20250807_squashed_initial
 Create Date: 2025-08-12 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "20250812_add_org_id_to_reminders"
-down_revision: Union[str, None] = "02857aa7fc3e"
+down_revision: Union[str, None] = "20250807_squashed_initial"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20250816_expand_alembic_version_len.py
+++ b/services/api/alembic/versions/20250816_expand_alembic_version_len.py
@@ -3,7 +3,7 @@
 from alembic import op
 
 # NB: новая ревизия ВСТАВЛЯЕТСЯ между 20250816 и 20250817
-revision = "20250816a_expand_alembic_version_len"
+revision = "20250816_expand_alembic_version_len"
 down_revision = "20250816_add_org_id_to_alerts"
 branch_labels = None
 depends_on = None

--- a/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
+++ b/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
@@ -1,7 +1,7 @@
 """add timezone and history tables
 
 Revision ID: 20250817_add_timezone_and_history_tables
-Revises: 20250816a_expand_alembic_version_len
+Revises: 20250816_expand_alembic_version_len
 Create Date: 2025-08-17 00:00:00.000000
 
 """
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "20250817_add_timezone_and_history_tables"
-down_revision: Union[str, None] = "20250816a_expand_alembic_version_len"
+down_revision: Union[str, None] = "20250816_expand_alembic_version_len"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20250824_reminders_kind_minutes_days_mask.py
+++ b/services/api/alembic/versions/20250824_reminders_kind_minutes_days_mask.py
@@ -1,7 +1,7 @@
 """reminders: kind + minutes + days_mask
 
-Revision ID: 8db592ddbe51
-Revises: 20250820_change_reminder_time_type
+Revision ID: 20250824_reminders_kind_minutes_days_mask
+Revises: 20250821_add_snooze_minutes_to_reminder_logs
 Create Date: 2025-08-24 20:37:49.023280
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '8db592ddbe51'
+revision: str = '20250824_reminders_kind_minutes_days_mask'
 down_revision: Union[str, None] = '20250821_add_snooze_minutes_to_reminder_logs'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/services/api/alembic/versions/20250825_add_quiet_hours_to_profiles.py
+++ b/services/api/alembic/versions/20250825_add_quiet_hours_to_profiles.py
@@ -6,8 +6,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = "1188e4de1729"
-down_revision: Union[str, None] = "8db592ddbe51"
+revision: str = "20250825_add_quiet_hours_to_profiles"
+down_revision: Union[str, None] = "20250824_reminders_kind_minutes_days_mask"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20250828_add_quiet_time_to_profiles.py
+++ b/services/api/alembic/versions/20250828_add_quiet_time_to_profiles.py
@@ -5,8 +5,8 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = "20250828_add_quiet_time"
-down_revision: Union[str, None] = "1188e4de1729"
+revision: str = "20250828_add_quiet_time_to_profiles"
+down_revision: Union[str, None] = "20250825_add_quiet_hours_to_profiles"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20250901_history_record_foreign_key.py
+++ b/services/api/alembic/versions/20250901_history_record_foreign_key.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 
 
 revision: str = "20250901_history_record_foreign_key"
-down_revision: Union[str, Sequence[str], None] = "20250828_add_quiet_time"
+down_revision: Union[str, Sequence[str], None] = "20250828_add_quiet_time_to_profiles"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- rename alembic migration files to `YYYYMMDD_description` format
- align `revision` variables and downstream `down_revision` references

## Testing
- `pytest -q --cov` (fails: async plugin missing, coverage 23.80%)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9d42a153c832a930b8d0261bfe8fb