### PR TITLE
[migrations] rename quiet time revision

### DIFF
--- a/services/api/alembic/versions/20250828_add_quiet_time.py
+++ b/services/api/alembic/versions/20250828_add_quiet_time.py
@@ -5,7 +5,7 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = "20250828_add_quiet_time_to_profiles"
+revision: str = "20250828_add_quiet_time"
 down_revision: Union[str, None] = "20250825_add_quiet_hours_to_profiles"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None


### PR DESCRIPTION
## Summary
- rename 20250828_add_quiet_time_to_profiles -> 20250828_add_quiet_time
- keep chain so 20250901_history_record_foreign_key points to new revision

## Testing
- `make migrate` *(fails: connection to server at "localhost" (::1), port 5432 failed)*
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9d7b6f2e0832a99f4c91be4cd4370