### PR TITLE
[alembic] Link history record migration

### DIFF
--- a/services/api/alembic/versions/20250901_history_record_foreign_key.py
+++ b/services/api/alembic/versions/20250901_history_record_foreign_key.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 
 
 revision: str = "20250901_history_record_foreign_key"
-down_revision: Union[str, Sequence[str], None] = "20250828_add_quiet_time"
+down_revision: Union[str, Sequence[str], None] = "20250828_add_quiet_time_to_profiles"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- link history record FK migration to profiles quiet time revision

## Testing
- `PYTHONPATH=/opt/saharlight-ux alembic -c services/api/alembic.ini heads`
- `pytest -q --cov` *(fails: Required test coverage of 85% not reached. Total coverage: 55.07%)*
- `mypy --strict .` *(fails: Interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9d7ae0ed8832ab9e8847422edcb9e