### PR TITLE
[migration] Correct down_revision references

### DIFF
--- a/services/api/alembic/versions/20250901_history_record_foreign_key.py
+++ b/services/api/alembic/versions/20250901_history_record_foreign_key.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 
 
 revision: str = "20250901_history_record_foreign_key"
-down_revision: Union[str, Sequence[str], None] = "20250828_add_quiet_time"
+down_revision: Union[str, Sequence[str], None] = "20250828_add_quiet_time_to_profiles"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20250906_move_user_settings_to_profile.py
+++ b/services/api/alembic/versions/20250906_move_user_settings_to_profile.py
@@ -1,7 +1,7 @@
 """move user settings to profile
 
 Revision ID: 20250906_move_user_settings_to_profile
-Revises: 20250904_billing_log
+Revises: ("20250904_billing_log", "20250904_change_description")
 Create Date: 2025-09-06
 """
 
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 revision = "20250906_move_user_settings_to_profile"
-down_revision = "20250904_billing_log"
+down_revision = ("20250904_billing_log", "20250904_change_description")
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- Link `move_user_settings_to_profile` to both `20250904_billing_log` and `20250904_change_description`
- Fix missing down revision for `history_record_foreign_key`

## Testing
- `PYTHONPATH=/opt/saharlight-ux alembic -c services/api/alembic.ini heads`
- `pytest -q --cov` *(fails: async functions are not natively supported, coverage below threshold)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9d7aee4a8832a924939f4c79725a4