### PR TITLE
[migrations] Fix down revision for history record FK

### DIFF
--- a/services/api/alembic/versions/20250901_history_record_foreign_key.py
+++ b/services/api/alembic/versions/20250901_history_record_foreign_key.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 
 
 revision: str = "20250901_history_record_foreign_key"
-down_revision: Union[str, Sequence[str], None] = "20250828_add_quiet_time_to_profiles"
+down_revision: Union[str, Sequence[str], None] = "20250828_add_quiet_time"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- fix down_revision reference for history_records FK migration

## Testing
- `make migrate` *(fails: connection refused)*
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9da871090832a900a0a146c7d9c9d