### PR TITLE
[billing] handle bad trial date

### DIFF
--- a/services/api/app/diabetes/handlers/billing_handlers.py
+++ b/services/api/app/diabetes/handlers/billing_handlers.py
@@ -37,13 +37,19 @@ async def trial_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         )
         return
 
-    end_raw = data.get("endDate")
     try:
+        end_raw = data["endDate"]
+        if not isinstance(end_raw, str):
+            raise TypeError("endDate must be str")
         end_dt = datetime.fromisoformat(end_raw)
-    except Exception:  # pragma: no cover - defensive
+    except (KeyError, TypeError, ValueError):
         await message.reply_text(
             "❌ Ошибка сервера: неверный формат даты trial."
         )
+        return
+    except Exception:  # pragma: no cover - unexpected
+        logger.exception("unexpected error parsing trial end date")
+        await message.reply_text("❌ Ошибка сервера.")
         return
     end_str = end_dt.strftime("%d.%m.%Y")
     await message.reply_text(f"🎉 Пробный период активирован до {end_str}")


### PR DESCRIPTION
## Summary
- validate `endDate` in trial response and log unexpected errors
- test missing or malformed end dates when starting a trial

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9df2a4954832a88d0b3c3024896ee