### PR TITLE
[handlers] Handle missing message in remind_log

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -1127,10 +1127,13 @@ async def reminder_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         base_url = (getattr(settings, "ui_base_url", "") or "").strip("/")
         url = f"{origin}/{base_url}/sugar" if base_url else f"{origin}/sugar"
         keyboard = InlineKeyboardMarkup([[InlineKeyboardButton("Открыть", web_app=WebAppInfo(url))]])
-        try:
-            await query.message.reply_text("Введите уровень сахара (ммоль/л).", reply_markup=keyboard)
-        except AttributeError:
-            pass
+        if query.message:
+            await query.message.reply_text(
+                "Введите уровень сахара (ммоль/л).",
+                reply_markup=keyboard,
+            )
+        else:
+            await query.answer("Нет сообщения для ответа", show_alert=True)
     else:
         try:
             await query.edit_message_text("❌ Напоминание отменено")


### PR DESCRIPTION
## Summary
- handle absent callback messages in remind_log with an explicit check and user alert

## Testing
- `ruff check services/api/app/diabetes/handlers/reminder_handlers.py`
- `mypy --strict services/api/app/diabetes/handlers/reminder_handlers.py`
- `pytest -q` *(fails: async def functions are not natively supported; missing async plugin and coverage below threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68b9df2fac64832a8c30c8db4855eca1