### PR TITLE
[billing] lowercase billing event enum

### DIFF
--- a/services/api/alembic/versions/20251002_billing_event_lowercase.py
+++ b/services/api/alembic/versions/20251002_billing_event_lowercase.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20251002_billing_event_lowercase"
+down_revision: Union[str, Sequence[str], None] = "3539fae8f7b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+billing_event_enum_new = postgresql.ENUM(
+    "init",
+    "checkout_created",
+    "webhook_ok",
+    "expired",
+    "canceled",
+    name="billing_event_new",
+)
+
+billing_event_enum_old = postgresql.ENUM(
+    "INIT",
+    "CHECKOUT_CREATED",
+    "WEBHOOK_OK",
+    "EXPIRED",
+    "CANCELED",
+    name="billing_event_old",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        billing_event_enum_new.create(bind, checkfirst=True)
+        op.execute(
+            "ALTER TABLE billing_logs ALTER COLUMN event TYPE billing_event_new "
+            "USING lower(event::text)::billing_event_new"
+        )
+        op.execute("DROP TYPE billing_event")
+        op.execute("ALTER TYPE billing_event_new RENAME TO billing_event")
+    else:
+        op.alter_column("billing_logs", "event", type_=sa.String())
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        billing_event_enum_old.create(bind, checkfirst=True)
+        op.execute(
+            "ALTER TABLE billing_logs ALTER COLUMN event TYPE billing_event_old "
+            "USING upper(event::text)::billing_event_old"
+        )
+        op.execute("DROP TYPE billing_event")
+        op.execute("ALTER TYPE billing_event_old RENAME TO billing_event")
+    else:
+        op.alter_column("billing_logs", "event", type_=sa.String())
+

--- a/services/api/app/billing/log.py
+++ b/services/api/app/billing/log.py
@@ -30,7 +30,14 @@ class BillingLog(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[int] = mapped_column(BigInteger, index=True, nullable=False)
-    event: Mapped[BillingEvent] = mapped_column(SAEnum(BillingEvent, name="billing_event"), nullable=False)
+    event: Mapped[BillingEvent] = mapped_column(
+        SAEnum(
+            BillingEvent,
+            name="billing_event",
+            values_callable=lambda e: [i.value for i in e],
+        ),
+        nullable=False,
+    )
     ts: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
     context: Mapped[dict[str, Any] | None] = mapped_column(JSON)
 


### PR DESCRIPTION
## Summary
- use enum values when persisting billing log events
- add migration to convert existing billing_event type to lowercase values

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9e1efb980832ab1bd725178f476f4