### PR TITLE
[db] use enum values_callable for subscription plan

### DIFF
--- a/services/api/alembic/versions/20251002_subscription_plan_values_callable.py
+++ b/services/api/alembic/versions/20251002_subscription_plan_values_callable.py
@@ -1,0 +1,27 @@
+"""20251002_subscription_plan_values_callable
+
+Revision ID: 20251002_subscription_plan_values_callable
+Revises: 3539fae8f7b6
+Create Date: 2025-09-04 19:03:02.753378
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20251002_subscription_plan_values_callable"
+down_revision: Union[str, None] = "3539fae8f7b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -51,9 +51,7 @@ def _register_sqlite_adapters() -> None:
     sqlite3.register_adapter(date, lambda val: val.isoformat())
     sqlite3.register_adapter(time, lambda val: val.isoformat())
 
-    sqlite3.register_converter(
-        "timestamp", lambda b: datetime.fromisoformat(b.decode())
-    )
+    sqlite3.register_converter("timestamp", lambda b: datetime.fromisoformat(b.decode()))
     sqlite3.register_converter("date", lambda b: date.fromisoformat(b.decode()))
     sqlite3.register_converter("time", lambda b: time.fromisoformat(b.decode()))
 
@@ -111,12 +109,8 @@ async def run_db(
         with sessionmaker() as _session:
             bind = _session.get_bind()
     except UnboundExecutionError as exc:
-        logger.error(
-            "Database engine is not initialized. Call init_db() to configure it."
-        )
-        raise RuntimeError(
-            "Database engine is not initialized; run init_db() before calling run_db()."
-        ) from exc
+        logger.error("Database engine is not initialized. Call init_db() to configure it.")
+        raise RuntimeError("Database engine is not initialized; run init_db() before calling run_db().") from exc
 
     if bind.url.drivername == "sqlite" and bind.url.database == ":memory:":
         with sqlite_memory_lock:
@@ -165,32 +159,29 @@ class User(Base):
     username: Mapped[Optional[str]] = mapped_column(String)
     onboarding_complete: Mapped[bool] = mapped_column(Boolean, default=False)
     plan: Mapped[SubscriptionPlan] = mapped_column(
-        sa.Enum(SubscriptionPlan, name="subscription_plan", create_type=False),
+        sa.Enum(
+            SubscriptionPlan,
+            name="subscription_plan",
+            create_type=False,
+            values_callable=lambda e: [i.value for i in e],
+        ),
         default=SubscriptionPlan.FREE,
         nullable=False,
     )
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
-    profile: Mapped["Profile"] = relationship(
-        "Profile", back_populates="user", uselist=False
-    )
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
+    profile: Mapped["Profile"] = relationship("Profile", back_populates="user", uselist=False)
 
 
 class UserRole(Base):
     __tablename__ = "user_roles"
-    user_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
-    )
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), primary_key=True)
     role: Mapped[str] = mapped_column(String, nullable=False, default="patient")
 
 
 class Profile(Base):
     __tablename__ = "profiles"
-    telegram_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
-    )
+    telegram_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), primary_key=True)
     icr: Mapped[Optional[float]] = mapped_column(Float)
     cf: Mapped[Optional[float]] = mapped_column(Float)
     target_bg: Mapped[Optional[float]] = mapped_column(Float)
@@ -289,20 +280,12 @@ class Entry(Base):
 
     __tablename__ = "entries"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    telegram_id: Mapped[Optional[int]] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), index=True
-    )
+    telegram_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), index=True)
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
 
-    event_time: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=False, index=True
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
-    updated_at: Mapped[Optional[datetime]] = mapped_column(
-        TIMESTAMP(timezone=True), onupdate=func.now()
-    )
+    event_time: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), onupdate=func.now())
 
     photo_path: Mapped[Optional[str]] = mapped_column(String)
     carbs_g: Mapped[Optional[float]] = mapped_column(Float)
@@ -319,16 +302,12 @@ class Entry(Base):
 class Alert(Base):
     __tablename__ = "alerts"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[Optional[int]] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id")
-    )
+    user_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("users.telegram_id"))
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
     sugar: Mapped[Optional[float]] = mapped_column(Float)
     type: Mapped[Optional[str]] = mapped_column(String)
 
-    ts: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
+    ts: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
 
     resolved: Mapped[bool] = mapped_column(Boolean, default=False)
     user: Mapped[User] = relationship("User")
@@ -337,9 +316,7 @@ class Alert(Base):
 class Reminder(Base):
     __tablename__ = "reminders"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    telegram_id: Mapped[Optional[int]] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id")
-    )
+    telegram_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("users.telegram_id"))
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
     type: Mapped[ReminderType] = mapped_column(
         sa.Enum(
@@ -368,9 +345,7 @@ class Reminder(Base):
     minutes_after: Mapped[Optional[int]] = mapped_column(Integer)
     days_mask: Mapped[Optional[int]] = mapped_column(Integer)
     is_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
     user: Mapped[User] = relationship("User")
 
     @property
@@ -396,9 +371,7 @@ class Reminder(Base):
 class ReminderLog(Base):
     __tablename__ = "reminder_logs"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    reminder_id: Mapped[Optional[int]] = mapped_column(
-        Integer, ForeignKey("reminders.id")
-    )
+    reminder_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("reminders.id"))
     telegram_id: Mapped[Optional[int]] = mapped_column(
         BigInteger,
         ForeignKey("users.telegram_id"),
@@ -408,9 +381,7 @@ class ReminderLog(Base):
     org_id: Mapped[Optional[int]] = mapped_column(Integer)
     action: Mapped[Optional[str]] = mapped_column(String)
     snooze_minutes: Mapped[Optional[int]] = mapped_column(Integer)
-    event_time: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
+    event_time: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
 
 
 class Timezone(Base):
@@ -440,19 +411,16 @@ class Subscription(Base):
     """
 
     __tablename__ = "subscriptions"
-    __table_args__ = (
-        sa.UniqueConstraint("user_id", "status", name="subscriptions_user_status_key"),
-    )
+    __table_args__ = (sa.UniqueConstraint("user_id", "status", name="subscriptions_user_status_key"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), index=True, nullable=False
-    )
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), index=True, nullable=False)
     plan: Mapped[SubscriptionPlan] = mapped_column(
         sa.Enum(
             SubscriptionPlan,
             name="subscription_plan",
             create_type=False,
+            values_callable=lambda e: [i.value for i in e],
         ),
         nullable=False,
     )
@@ -466,19 +434,11 @@ class Subscription(Base):
         nullable=False,
     )
     provider: Mapped[str] = mapped_column(String, nullable=False)
-    transaction_id: Mapped[str] = mapped_column(
-        String, index=True, unique=True, nullable=False
-    )
-    start_date: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
+    transaction_id: Mapped[str] = mapped_column(String, index=True, unique=True, nullable=False)
+    start_date: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
     end_date: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=func.now()
-    )
-    updated_at: Mapped[Optional[datetime]] = mapped_column(
-        TIMESTAMP(timezone=True), onupdate=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), onupdate=func.now())
 
     user: Mapped["User"] = relationship("User")
 
@@ -492,9 +452,7 @@ class HistoryRecord(Base):
 
     __tablename__ = "history_records"
     id: Mapped[str] = mapped_column(String, primary_key=True)
-    telegram_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), index=True, nullable=False
-    )
+    telegram_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), index=True, nullable=False)
     date: Mapped[date] = mapped_column(Date, nullable=False)
     time: Mapped[time] = mapped_column(Time, nullable=False)
     sugar: Mapped[Optional[float]] = mapped_column(Float)


### PR DESCRIPTION
## Summary
- ensure subscription plan enums use their values for persistence
- add empty Alembic revision

## Testing
- `alembic revision --autogenerate` *(fails: OperationalError – connection refused)*
- `pytest -q` *(fails: async def functions are not natively supported; 526 failed, 480 passed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9e1efba74832a92c2aefc70956e97