### PR TITLE
[api] Merge alembic heads

### DIFF
--- a/services/api/alembic/versions/11eb7c3deda6_merge_heads.py
+++ b/services/api/alembic/versions/11eb7c3deda6_merge_heads.py
@@ -1,0 +1,26 @@
+"""merge heads
+
+Revision ID: 11eb7c3deda6
+Revises: 20251002_billing_event_lowercase, 20251002_subscription_plan_values_callable
+Create Date: 2025-09-04 19:44:43.266143
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '11eb7c3deda6'
+down_revision: Union[str, None] = ('20251002_billing_event_lowercase', '20251002_subscription_plan_values_callable')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- merge `20251002_billing_event_lowercase` and `20251002_subscription_plan_values_callable` alembic heads

## Testing
- `alembic -c services/api/alembic.ini heads`
- `make migrate` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `pytest -q` *(fails: KeyboardInterrupt)*
- `mypy --strict .` *(fails: Interrupted)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68b9ebdc77a0832a9ece1d20d60766fc