### PR TITLE
[utils] validate split text inputs

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -112,8 +112,12 @@ def split_text_by_width(
     Разбивает строку так, чтобы она не выходила за max_width_mm по ширине в PDF (мм).
 
     Raises:
-        ValueError: если ``font_name`` не зарегистрирован в ReportLab.
+        ValueError: если ``font_name`` не зарегистрирован в ReportLab или
+            ``font_size``/``max_width_mm`` неположительны.
     """
+    if font_size <= 0 or max_width_mm <= 0:
+        raise ValueError("font_size and max_width_mm must be positive")
+
     words = text.split()
     lines: list[str] = []
     current_line = ""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,6 +64,23 @@ def test_split_text_by_width_unknown_font() -> None:
 
 
 @pytest.mark.parametrize(
+    ("font_size", "max_width"),
+    [
+        (0, 50),
+        (12, 0),
+        (-1, 50),
+        (12, -5),
+    ],
+)
+def test_split_text_by_width_invalid_params(font_size: float, max_width: float) -> None:
+    pdfmetrics.registerFont(
+        TTFont("DejaVuSans", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
+    )
+    with pytest.raises(ValueError, match="must be positive"):
+        split_text_by_width("text", "DejaVuSans", font_size, max_width)
+
+
+@pytest.mark.parametrize(
     "text",
     [
         "Supercalifragilisticexpialidocious",


### PR DESCRIPTION
## Summary
- validate font size and width in `split_text_by_width`
- test invalid parameters for `split_text_by_width`

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9ed9329f8832abdefe556615e7333