### PR TITLE
[learning] switch quiz options to 1-based

### DIFF
--- a/tests/diabetes/test_learning_handlers_rate_limit.py
+++ b/tests/diabetes/test_learning_handlers_rate_limit.py
@@ -116,16 +116,15 @@ async def test_quiz_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     assert msg1.replies == ["Q1"]
 
     upd2 = make_update()
-    ctx2 = make_context(user_data=user_data, args=["0"])
+    ctx2 = make_context(user_data=user_data, args=["1"])
     await learning_handlers.quiz_command(upd2, ctx2)
     msg2 = cast(DummyMessage, upd2.message)
     assert msg2.replies == [learning_handlers.RATE_LIMIT_MESSAGE]
     assert answers == []
 
     upd3 = make_update()
-    ctx3 = make_context(user_data=user_data, args=["0"])
+    ctx3 = make_context(user_data=user_data, args=["1"])
     await learning_handlers.quiz_command(upd3, ctx3)
     msg3 = cast(DummyMessage, upd3.message)
     assert msg3.replies == ["ok", "Q2"]
-    assert answers == [0]
-
+    assert answers == [1]


### PR DESCRIPTION
## Summary
- enumerate quiz options from 1
- normalize quiz answers to accept 1-based indices
- adjust quiz-related tests for new numbering

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b9ed90ec08832aaf81a614f8983528