### PR TITLE
[gpt] lower api key regex length

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -62,6 +62,9 @@ class Settings(BaseSettings):
     openai_command_model: str = Field(
         default="gpt-4o-mini", alias="OPENAI_COMMAND_MODEL"
     )
+    api_key_min_length: int = Field(
+        default=32, alias="API_KEY_MIN_LENGTH"
+    )
     learning_mode_enabled: bool = Field(default=True, alias="LEARNING_MODE_ENABLED")
     learning_model_default: str = Field(
         default="gpt-4o-mini", alias="LEARNING_MODEL_DEFAULT"

--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -55,11 +55,13 @@ SYSTEM_PROMPT = (
 )
 
 
+API_KEY_MIN_LENGTH = config.get_settings().api_key_min_length
+
 API_KEY_RE = re.compile(
     r"\b(?=[A-Za-z0-9_-]*[a-z])"
     r"(?=[A-Za-z0-9_-]*[A-Z])"
     r"(?=[A-Za-z0-9_-]*\d)"
-    r"[A-Za-z0-9_-]{40,}\b"
+    rf"[A-Za-z0-9_-]{{{API_KEY_MIN_LENGTH},}}\b"
 )
 
 

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -444,6 +444,7 @@ async def test_parse_command_propagates_unexpected_exception(
     [
         "sk-" + "A1b2_" * 8 + "Z9",
         "ghp_" + "A1b2" * 9 + "Cd",
+        "sk-" + "A1b2" * 7 + "C",
     ],
 )
 def test_sanitize_masks_api_like_tokens(token: Any) -> None:
@@ -467,6 +468,12 @@ def test_sanitize_masks_multiple_tokens() -> None:
         gpt_command_parser._sanitize_sensitive_data(text)
         == "[REDACTED] middle [REDACTED]"
     )
+
+
+def test_sanitize_leaves_short_api_like_token() -> None:
+    token = "sk-" + "A1b2" * 7
+    text = f"before {token} after"
+    assert gpt_command_parser._sanitize_sensitive_data(text) == text
 
 
 def test_extract_first_json_array_single_object() -> None:


### PR DESCRIPTION
## Summary
- make API key mask length configurable and drop default to 32
- extend command parser masking tests for different key lengths

## Testing
- `mypy --strict services/api/app/diabetes/gpt_command_parser.py services/api/app/config.py tests/test_gpt_command_parser.py tests/test_gpt_command_parser_errors.py`
- `ruff check services/api/app/diabetes/gpt_command_parser.py services/api/app/config.py tests/test_gpt_command_parser.py tests/test_gpt_command_parser_errors.py`
- `pytest -c /dev/null tests/test_gpt_command_parser.py::test_sanitize_masks_api_like_tokens tests/test_gpt_command_parser.py::test_sanitize_leaves_numeric_strings tests/test_gpt_command_parser.py::test_sanitize_masks_multiple_tokens tests/test_gpt_command_parser.py::test_sanitize_leaves_short_api_like_token tests/test_gpt_command_parser_errors.py::test_sanitize_sensitive_data_masks_token -q`
- `pytest tests/test_gpt_command_parser.py tests/test_gpt_command_parser_errors.py -k "not trio" -q` *(fails: Required test coverage of 85% not reached. Total coverage: 28.25%)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ed91a934832ab9af634cdc5c8307