### PR TITLE
[tests] prevent alembic logging side effects

### DIFF
--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging.config as logging_config
 
 from alembic import command
 from alembic.config import Config
@@ -15,6 +16,18 @@ def test_alembic_migrations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     db_file = tmp_path / "test.db"
     db_url = f"sqlite:///{db_file}"
     monkeypatch.setenv("DATABASE_URL", db_url)
+
+    # Alembic's ``command.upgrade`` configures logging via ``fileConfig`` which
+    # by default disables any loggers that already exist.  That side effect
+    # leaks into the remainder of the test suite and breaks ``caplog`` based
+    # assertions.  Ensure existing loggers remain enabled during this test.
+    original_file_config = logging_config.fileConfig
+
+    def _safe_file_config(fname: str, *args: object, **kwargs: object) -> None:
+        kwargs.setdefault("disable_existing_loggers", False)
+        original_file_config(fname, *args, **kwargs)
+
+    monkeypatch.setattr(logging_config, "fileConfig", _safe_file_config)
 
     config = Config("services/api/alembic.ini")
     command.upgrade(config, "head")


### PR DESCRIPTION
## Summary
- avoid Alembic's logging config disabling existing loggers during migration tests

## Testing
- `pytest`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ba70dd0ea0832aab9e355d4c60d620