### PR TITLE
[alembic] use batch ops for version len

### DIFF
--- a/services/api/alembic/versions/20250816_expand_alembic_version_len.py
+++ b/services/api/alembic/versions/20250816_expand_alembic_version_len.py
@@ -1,6 +1,7 @@
 """Expand alembic_version.version_num to VARCHAR(255)."""
 
 from alembic import op
+import sqlalchemy as sa
 
 # NB: новая ревизия вставляется между 20250816 и 20250817
 revision = "20250816_expand_alembic_version_len"
@@ -10,9 +11,11 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute("ALTER TABLE alembic_version ALTER COLUMN version_num TYPE VARCHAR(255);")
+    with op.batch_alter_table("alembic_version") as batch_op:
+        batch_op.alter_column("version_num", type_=sa.String(255))
 
 
 def downgrade() -> None:
     # осторожно: может не влезть, если в истории уже длинные id
-    op.execute("ALTER TABLE alembic_version ALTER COLUMN version_num TYPE VARCHAR(32);")
+    with op.batch_alter_table("alembic_version") as batch_op:
+        batch_op.alter_column("version_num", type_=sa.String(32))


### PR DESCRIPTION
## Summary
- replace raw SQL ALTER TABLE with Alembic batch operations for `alembic_version.version_num`
- add SQLAlchemy import for typed column changes

## Testing
- `alembic -c services/api/alembic.ini upgrade head` *(fails: connection refused)*
- `DATABASE_URL=sqlite:///test.db alembic -c services/api/alembic.ini upgrade 20250816_expand_alembic_version_len`
- `DATABASE_URL=sqlite:///test.db alembic -c services/api/alembic.ini upgrade head` *(fails: SQLite syntax error in later migration)*
- `pytest -x` *(fails: async plugin not installed)*
- `mypy --strict .` *(interrupted: took too long)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ba7a3a2cfc832a871f9a15f3a7b499