### PR TITLE
[alembic] handle sqlite in version length migration

### DIFF
--- a/services/api/alembic/versions/20250816_expand_alembic_version_len.py
+++ b/services/api/alembic/versions/20250816_expand_alembic_version_len.py
@@ -1,7 +1,6 @@
 """Expand alembic_version.version_num to VARCHAR(255)."""
 
 from alembic import op
-import sqlalchemy as sa
 
 # NB: новая ревизия вставляется между 20250816 и 20250817
 revision = "20250816_expand_alembic_version_len"
@@ -11,11 +10,16 @@ depends_on = None
 
 
 def upgrade() -> None:
-    with op.batch_alter_table("alembic_version") as batch_op:
-        batch_op.alter_column("version_num", type_=sa.String(255))
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        return
+
+    op.execute("ALTER TABLE alembic_version ALTER COLUMN version_num TYPE VARCHAR(255)")
 
 
 def downgrade() -> None:
-    # осторожно: может не влезть, если в истории уже длинные id
-    with op.batch_alter_table("alembic_version") as batch_op:
-        batch_op.alter_column("version_num", type_=sa.String(32))
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        return
+
+    op.execute("ALTER TABLE alembic_version ALTER COLUMN version_num TYPE VARCHAR(32)")


### PR DESCRIPTION
## Summary
- skip altering `alembic_version.version_num` for SQLite
- run explicit SQL to change `version_num` length for other dialects

## Testing
- `pytest -q` *(fails: async functions require a plugin)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ba7d623c44832ab147b992b6abb339