### PR TITLE
[alembic] Guard version len migration for SQLite

### DIFF
--- a/services/api/alembic/versions/20250816_expand_alembic_version_len_batch_op.py
+++ b/services/api/alembic/versions/20250816_expand_alembic_version_len_batch_op.py
@@ -1,0 +1,23 @@
+"""Expand alembic_version.version_num to VARCHAR(255) on SQLite."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20250816_expand_alembic_version_len_batch_op"
+down_revision = "20250816_expand_alembic_version_len"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if op.get_bind().dialect.name != "sqlite":
+        return
+    with op.batch_alter_table("alembic_version") as batch_op:
+        batch_op.alter_column("version_num", type_=sa.String(255))
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name != "sqlite":
+        return
+    with op.batch_alter_table("alembic_version") as batch_op:
+        batch_op.alter_column("version_num", type_=sa.String(32))


### PR DESCRIPTION
## Summary
- add migration using batch_alter_table for SQLite when expanding `alembic_version.version_num`

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ba7d686980832a8fc095a4d3f071a7