### PR TITLE
[alembic] rename revision to batch op

### DIFF
--- a/services/api/alembic/versions/20250816_expand_alembic_version_len_batch_op.py
+++ b/services/api/alembic/versions/20250816_expand_alembic_version_len_batch_op.py
@@ -4,7 +4,7 @@ from alembic import op
 import sqlalchemy as sa
 
 # NB: новая ревизия вставляется между 20250816 и 20250817
-revision = "20250816_expand_alembic_version_len"
+revision = "20250816_expand_alembic_version_len_batch_op"
 down_revision = "20250816_add_org_id_to_alerts"
 branch_labels = None
 depends_on = None

--- a/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
+++ b/services/api/alembic/versions/20250817_add_timezone_and_history_tables.py
@@ -1,7 +1,7 @@
 """add timezone and history tables
 
 Revision ID: 20250817_add_timezone_and_history_tables
-Revises: 20250816_expand_alembic_version_len
+Revises: 20250816_expand_alembic_version_len_batch_op
 Create Date: 2025-08-17 00:00:00.000000
 
 """
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "20250817_add_timezone_and_history_tables"
-down_revision: Union[str, None] = "20250816_expand_alembic_version_len"
+down_revision: Union[str, None] = "20250816_expand_alembic_version_len_batch_op"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- rename Alembic migration to 20250816_expand_alembic_version_len_batch_op
- update dependent migration to reference new revision ID

## Testing
- `pytest -q --cov` *(fails: KeyboardInterrupt)*
- `mypy --strict .` *(fails: interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ba7d75a5c8832a9f8404de7543b079