### PR TITLE
[alembic] Use batch alter for history date and time

### DIFF
--- a/services/api/alembic/versions/20250819_change_history_date_time_types.py
+++ b/services/api/alembic/versions/20250819_change_history_date_time_types.py
@@ -3,6 +3,7 @@
 from typing import Sequence, Union
 
 from alembic import op
+import sqlalchemy as sa
 
 revision: str = "20250819_change_history_date_time_types"
 down_revision: Union[str, None] = "20250818_add_name_fields_to_users"
@@ -11,18 +12,12 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        "ALTER TABLE history_records ALTER COLUMN date TYPE DATE USING date::DATE"
-    )
-    op.execute(
-        "ALTER TABLE history_records ALTER COLUMN time TYPE TIME USING time::TIME"
-    )
+    with op.batch_alter_table("history_records") as batch:
+        batch.alter_column("date", existing_type=sa.String(), type_=sa.Date())
+        batch.alter_column("time", existing_type=sa.String(), type_=sa.Time())
 
 
 def downgrade() -> None:
-    op.execute(
-        "ALTER TABLE history_records ALTER COLUMN date TYPE VARCHAR USING date::TEXT"
-    )
-    op.execute(
-        "ALTER TABLE history_records ALTER COLUMN time TYPE VARCHAR USING time::TEXT"
-    )
+    with op.batch_alter_table("history_records") as batch:
+        batch.alter_column("date", existing_type=sa.Date(), type_=sa.String())
+        batch.alter_column("time", existing_type=sa.Time(), type_=sa.String())


### PR DESCRIPTION
## Summary
- use batch_alter_table to convert history_records date/time columns to native types
- restore string types in downgrade

## Testing
- `DATABASE_URL=sqlite:// PYTHONPATH=/opt/saharlight-ux alembic -c services/api/alembic.ini upgrade 20250819_change_history_date_time_types`
- `DATABASE_URL=sqlite:// pytest -q --cov` *(fails: async def functions are not natively supported and coverage < 85%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ba80923298832a9a8364079a68abf6