### PR TITLE
[alembic] Refactor reminder time column type

### DIFF
--- a/services/api/alembic/versions/20250820_change_reminder_time_type.py
+++ b/services/api/alembic/versions/20250820_change_reminder_time_type.py
@@ -3,6 +3,7 @@
 from typing import Sequence, Union
 
 from alembic import op
+import sqlalchemy as sa
 
 revision: str = "20250820_change_reminder_time_type"
 down_revision: Union[str, None] = "20250819_change_history_date_time_types"
@@ -11,12 +12,10 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        "ALTER TABLE reminders ALTER COLUMN time TYPE TIME USING time::TIME"
-    )
+    with op.batch_alter_table("reminders") as batch_op:
+        batch_op.alter_column("time", type_=sa.Time())
 
 
 def downgrade() -> None:
-    op.execute(
-        "ALTER TABLE reminders ALTER COLUMN time TYPE VARCHAR USING time::TEXT"
-    )
+    with op.batch_alter_table("reminders") as batch_op:
+        batch_op.alter_column("time", type_=sa.String())


### PR DESCRIPTION
## Summary
- replace raw SQL with batch_alter_table to alter reminders.time column type

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'openai', 'fastapi', etc.)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ba8362b244832ab5a20ce568b5f76b