### PR TITLE
[alembic] Use batch_alter_table for plan enum

### DIFF
--- a/services/api/alembic/versions/20250917_user_plan_enum.py
+++ b/services/api/alembic/versions/20250917_user_plan_enum.py
@@ -7,7 +7,9 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 revision: str = "20250917_user_plan_enum"
-down_revision: Union[str, Sequence[str], None] = "20250910_add_onboarding_events_metrics"
+down_revision: Union[str, Sequence[str], None] = (
+    "20250910_add_onboarding_events_metrics"
+)
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -24,14 +26,13 @@ def upgrade() -> None:
     bind = op.get_bind()
     if bind.dialect.name == "postgresql":
         plan_enum.create(bind, checkfirst=True)
-        op.execute("ALTER TABLE users ALTER COLUMN plan TYPE subscription_plan USING plan::subscription_plan")
+        with op.batch_alter_table("users") as batch_op:
+            batch_op.alter_column("plan", type_=plan_enum)
     else:
-        op.alter_column("users", "plan", type_=sa.String())
+        with op.batch_alter_table("users") as batch_op:
+            batch_op.alter_column("plan", type_=sa.String())
 
 
 def downgrade() -> None:
-    bind = op.get_bind()
-    if bind.dialect.name == "postgresql":
-        op.alter_column("users", "plan", type_=sa.String())
-    else:
-        op.alter_column("users", "plan", type_=sa.String())
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column("plan", type_=sa.String())


### PR DESCRIPTION
## Summary
- Replace raw SQL with `batch_alter_table` when updating `users.plan` to `subscription_plan` enum
- Use batched alter to revert `users.plan` to `String` on downgrade

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ba8368be90832aa50395009d9362f1