### PR TITLE
[migrations] fix quiet_end default

### DIFF
--- a/services/api/alembic/versions/20250828_add_quiet_time.py
+++ b/services/api/alembic/versions/20250828_add_quiet_time.py
@@ -19,12 +19,16 @@ def upgrade() -> None:
         nullable=False,
         server_default=sa.text("'23:00:00'"),
     )
+    op.execute(
+        "UPDATE profiles SET quiet_end = '07:00:00' "
+        "WHERE quiet_end IS NULL OR quiet_end = '23:00:00'"
+    )
     op.alter_column(
         "profiles",
         "quiet_end",
         existing_type=sa.Time(),
         nullable=False,
-        server_default=sa.text("'23:00:00'"),
+        server_default=sa.text("'07:00:00'"),
     )
 
 
@@ -41,5 +45,5 @@ def downgrade() -> None:
         "quiet_end",
         existing_type=sa.Time(),
         nullable=True,
-        server_default=sa.text("'23:00:00'"),
+        server_default=sa.text("'07:00:00'"),
     )


### PR DESCRIPTION
## Summary
- ensure `profiles.quiet_end` defaults to 07:00:00
- migrate existing rows with null or 23:00:00 `quiet_end` values to the correct default

## Testing
- `pytest -q --maxfail=1`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ba8c6ee150832a86f68220f3dfefc0