### PR TITLE
[alembic] batch update quiet time columns

### DIFF
--- a/services/api/alembic/versions/20250828_add_quiet_time.py
+++ b/services/api/alembic/versions/20250828_add_quiet_time.py
@@ -12,34 +12,32 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.alter_column(
-        "profiles",
-        "quiet_start",
-        existing_type=sa.Time(),
-        nullable=False,
-        server_default=sa.text("'23:00:00'"),
-    )
-    op.alter_column(
-        "profiles",
-        "quiet_end",
-        existing_type=sa.Time(),
-        nullable=False,
-        server_default=sa.text("'23:00:00'"),
-    )
+    with op.batch_alter_table("profiles") as batch_op:
+        batch_op.alter_column(
+            "quiet_start",
+            existing_type=sa.Time(),
+            nullable=False,
+            server_default=sa.text("'23:00:00'"),
+        )
+        batch_op.alter_column(
+            "quiet_end",
+            existing_type=sa.Time(),
+            nullable=False,
+            server_default=sa.text("'07:00:00'"),
+        )
 
 
 def downgrade() -> None:
-    op.alter_column(
-        "profiles",
-        "quiet_start",
-        existing_type=sa.Time(),
-        nullable=True,
-        server_default=sa.text("'23:00:00'"),
-    )
-    op.alter_column(
-        "profiles",
-        "quiet_end",
-        existing_type=sa.Time(),
-        nullable=True,
-        server_default=sa.text("'23:00:00'"),
-    )
+    with op.batch_alter_table("profiles") as batch_op:
+        batch_op.alter_column(
+            "quiet_start",
+            existing_type=sa.Time(),
+            nullable=True,
+            server_default=sa.text("'23:00:00'"),
+        )
+        batch_op.alter_column(
+            "quiet_end",
+            existing_type=sa.Time(),
+            nullable=True,
+            server_default=sa.text("'07:00:00'"),
+        )


### PR DESCRIPTION
## Summary
- use batch_alter_table in quiet time migration
- correct default quiet_end value to 07:00:00

## Testing
- `DATABASE_URL=sqlite:///alembic.db PYTHONPATH=/opt/saharlight-ux alembic -c services/api/alembic.ini upgrade 20250828_add_quiet_time`
- `PYTHONPATH=/opt/saharlight-ux alembic -c services/api/alembic.ini upgrade head` *(fails: OperationalError near "ALTER")*
- `pytest -q` *(fails: async def functions are not natively supported; coverage 58% < 85%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ba8c6d5520832a84a1ca4b6313eff4