### PR TITLE
[migrations] Use batch alter for quiet columns

### DIFF
--- a/services/api/alembic/versions/20250828_add_quiet_time.py
+++ b/services/api/alembic/versions/20250828_add_quiet_time.py
@@ -12,38 +12,33 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.alter_column(
-        "profiles",
-        "quiet_start",
-        existing_type=sa.Time(),
-        nullable=False,
-        server_default=sa.text("'23:00:00'"),
-    )
-    op.execute(
-        "UPDATE profiles SET quiet_end = '07:00:00' "
-        "WHERE quiet_end IS NULL OR quiet_end = '23:00:00'"
-    )
-    op.alter_column(
-        "profiles",
-        "quiet_end",
-        existing_type=sa.Time(),
-        nullable=False,
-        server_default=sa.text("'07:00:00'"),
-    )
+    op.execute("UPDATE profiles SET quiet_end = '07:00:00' WHERE quiet_end IS NULL OR quiet_end = '23:00:00'")
+    with op.batch_alter_table("profiles") as batch_op:
+        batch_op.alter_column(
+            "quiet_start",
+            existing_type=sa.Time(),
+            nullable=False,
+            server_default=sa.text("'23:00:00'"),
+        )
+        batch_op.alter_column(
+            "quiet_end",
+            existing_type=sa.Time(),
+            nullable=False,
+            server_default=sa.text("'07:00:00'"),
+        )
 
 
 def downgrade() -> None:
-    op.alter_column(
-        "profiles",
-        "quiet_start",
-        existing_type=sa.Time(),
-        nullable=True,
-        server_default=sa.text("'23:00:00'"),
-    )
-    op.alter_column(
-        "profiles",
-        "quiet_end",
-        existing_type=sa.Time(),
-        nullable=True,
-        server_default=sa.text("'07:00:00'"),
-    )
+    with op.batch_alter_table("profiles") as batch_op:
+        batch_op.alter_column(
+            "quiet_start",
+            existing_type=sa.Time(),
+            nullable=True,
+            server_default=sa.text("'23:00:00'"),
+        )
+        batch_op.alter_column(
+            "quiet_end",
+            existing_type=sa.Time(),
+            nullable=True,
+            server_default=sa.text("'07:00:00'"),
+        )


### PR DESCRIPTION
## Summary
- use batch_alter_table for quiet_start and quiet_end migration

## Testing
- `ruff check .`
- `mypy --strict services/api/alembic/versions/20250828_add_quiet_time.py`
- `pytest -q` *(fails: KeyboardInterrupt)*
- `DATABASE_URL=sqlite:///tmp_alembic.db PYTHONPATH=/opt/saharlight-ux alembic -c services/api/alembic.ini upgrade 20250828_add_quiet_time`
- `PYTHONPATH=/opt/saharlight-ux alembic -c services/api/alembic.ini upgrade head` *(fails: (sqlite3.OperationalError) near "ALTER": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8e450b38832aaf2420e5ee99c7a7