### PR TITLE
[migrations] use batch alter for history_records telegram_id

### DIFF
--- a/services/api/alembic/versions/20250901_history_record_foreign_key.py
+++ b/services/api/alembic/versions/20250901_history_record_foreign_key.py
@@ -16,12 +16,12 @@ def upgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
 
-    op.alter_column(
-        "history_records",
-        "telegram_id",
-        existing_type=sa.BigInteger(),
-        nullable=False,
-    )
+    with op.batch_alter_table("history_records") as batch_op:
+        batch_op.alter_column(
+            "telegram_id",
+            existing_type=sa.BigInteger(),
+            nullable=False,
+        )
 
     fks = inspector.get_foreign_keys("history_records")
     has_fk = any(


### PR DESCRIPTION
## Summary
- use batch_alter_table for history_records.telegram_id foreign key migration

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: many errors during collection)*
- `mypy --strict .` *(fails: Cannot find implementation or library stub for module named "fastapi.middleware.cors")*
- `ruff check .`
- `PYTHONPATH=/opt/saharlight-ux alembic -c services/api/alembic.ini upgrade head` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68ba90e113d8832aa4d70b7401196e07