### PR TITLE
[alembic] Drop telegram_id alter

### DIFF
--- a/services/api/alembic/versions/20250901_history_record_foreign_key.py
+++ b/services/api/alembic/versions/20250901_history_record_foreign_key.py
@@ -16,13 +16,6 @@ def upgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
 
-    op.alter_column(
-        "history_records",
-        "telegram_id",
-        existing_type=sa.BigInteger(),
-        nullable=False,
-    )
-
     fks = inspector.get_foreign_keys("history_records")
     has_fk = any(
         fk["referred_table"] == "users" and fk["constrained_columns"] == ["telegram_id"]


### PR DESCRIPTION
## Summary
- remove redundant column alteration from history_records migration

## Testing
- `sqlite3 test.db "SELECT COUNT(*) FROM history_records WHERE telegram_id IS NULL;"`
- `DATABASE_URL=sqlite:///test.db alembic -c services/api/alembic.ini upgrade 20250901_history_record_foreign_key`
- `sqlite3 test.db "PRAGMA foreign_key_list('history_records');"`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ba90e87b8c832a936f5977f8d045ca