### PR TITLE
[migrations] drop alter column in history record fk

### DIFF
--- a/services/api/alembic/versions/20250901_history_record_foreign_key.py
+++ b/services/api/alembic/versions/20250901_history_record_foreign_key.py
@@ -16,13 +16,6 @@ def upgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
 
-    with op.batch_alter_table("history_records") as batch_op:
-        batch_op.alter_column(
-            "telegram_id",
-            existing_type=sa.BigInteger(),
-            nullable=False,
-        )
-
     fks = inspector.get_foreign_keys("history_records")
     has_fk = any(
         fk["referred_table"] == "users" and fk["constrained_columns"] == ["telegram_id"]


### PR DESCRIPTION
## Summary
- remove redundant `alter_column` from history_records migration

## Testing
- `sqlite3 /tmp/test.db "SELECT COUNT(*) FROM history_records WHERE telegram_id IS NULL;"`
- `sqlite3 /tmp/test.db "PRAGMA foreign_key_list('history_records');"`
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ba935f69d8832a9c1f1c53eaf7f7d5