### PR TITLE
[alembic] Remove redundant alter_column from reminder log migration

### DIFF
--- a/services/api/alembic/versions/20250902_reminder_log_telegram_foreign_key.py
+++ b/services/api/alembic/versions/20250902_reminder_log_telegram_foreign_key.py
@@ -27,13 +27,6 @@ def upgrade() -> None:
         )
     )
 
-    op.alter_column(
-        "reminder_logs",
-        "telegram_id",
-        existing_type=sa.BigInteger(),
-        nullable=True,
-    )
-
     indexes = [idx["name"] for idx in inspector.get_indexes("reminder_logs")]
     if "ix_reminder_logs_telegram_id" not in indexes:
         op.create_index(


### PR DESCRIPTION
## Summary
- drop unnecessary `op.alter_column` from reminder log migration
- keep index and foreign-key creation intact

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*
- `mypy --strict .` *(fails: Interrupted)*
- `ruff check .`
- `PYTHONPATH=/opt/saharlight-ux alembic -c services/api/alembic.ini upgrade head` *(fails: no such column "timezone" on SQLite)*
- `DATABASE_URL=sqlite:///tmp.db PYTHONPATH=/opt/saharlight-ux alembic -c services/api/alembic.ini upgrade 20250902_reminder_log_telegram_foreign_key`


------
https://chatgpt.com/codex/tasks/task_e_68ba971b5314832abf8dbd00bc9981cb