### PR TITLE
[migrations] Condition drop timezone column

### DIFF
--- a/services/api/alembic/versions/20250902_drop_user_timezone.py
+++ b/services/api/alembic/versions/20250902_drop_user_timezone.py
@@ -12,12 +12,18 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.drop_column("users", "timezone")
+    inspector = sa.inspect(op.get_bind())
+    cols = [c["name"] for c in inspector.get_columns("users")]
+    if "timezone" in cols:
+        op.drop_column("users", "timezone")
 
 
 def downgrade() -> None:
-    op.add_column(
-        "users",
-        sa.Column("timezone", sa.String(), nullable=False, server_default="UTC"),
-    )
-    op.alter_column("users", "timezone", server_default=None)
+    inspector = sa.inspect(op.get_bind())
+    cols = [c["name"] for c in inspector.get_columns("users")]
+    if "timezone" not in cols:
+        op.add_column(
+            "users",
+            sa.Column("timezone", sa.String(), nullable=False, server_default="UTC"),
+        )
+        op.alter_column("users", "timezone", server_default=None)


### PR DESCRIPTION
## Summary
- only drop users.timezone if the column exists
- mirror conditional logic in downgrade

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `PYTHONPATH=/opt/saharlight-ux alembic -c services/api/alembic.ini upgrade head` *(fails: duplicate column name: weight_g)*

------
https://chatgpt.com/codex/tasks/task_e_68ba99e34c60832aa3ead108e5cca4cc