### PR TITLE
[onboarding] Extract onboarding event model

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -157,7 +157,9 @@ def _reminders_keyboard() -> InlineKeyboardMarkup:
 
 async def _log_event(user_id: int, name: str, step: int, variant: str | None) -> None:
     def _log(session: SessionProtocol) -> None:
-        log_onboarding_event(cast(Session, session), user_id, name, step, variant)
+        log_onboarding_event(
+            cast(Session, session), user_id, name, step=str(step), variant=variant
+        )
 
     try:
         await run_db(_log, sessionmaker=SessionLocal)

--- a/services/api/app/diabetes/models.py
+++ b/services/api/app/diabetes/models.py
@@ -1,5 +1,5 @@
 from services.api.app.services.onboarding_state import OnboardingState  # noqa: F401
-from services.api.app.services.onboarding_events import OnboardingEvent  # noqa: F401
+from services.api.app.models.onboarding_event import OnboardingEvent  # noqa: F401
 from services.api.app.models.onboarding_metrics import (  # noqa: F401
     OnboardingMetricEvent,
     OnboardingMetricDaily,

--- a/services/api/app/models/onboarding_event.py
+++ b/services/api/app/models/onboarding_event.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import BigInteger, ForeignKey, Integer, String, TIMESTAMP, JSON, func
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column
+
+from services.api.app.diabetes.services.db import Base
+
+
+class OnboardingEvent(Base):
+    """DB model for recorded onboarding events."""
+
+    __tablename__ = "onboarding_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.telegram_id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    event: Mapped[str] = mapped_column(String, nullable=False)
+    step: Mapped[str | None] = mapped_column(String)
+    ts: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    meta_json: Mapped[dict[str, object] | None] = mapped_column(
+        MutableDict.as_mutable(JSON), nullable=True
+    )
+    variant: Mapped[str | None] = mapped_column(String)
+
+
+__all__ = ["OnboardingEvent"]

--- a/services/api/app/services/onboarding_events.py
+++ b/services/api/app/services/onboarding_events.py
@@ -1,50 +1,33 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
-from sqlalchemy import BigInteger, ForeignKey, Integer, String, TIMESTAMP, func
-from sqlalchemy.orm import Mapped, Session, mapped_column
 
-from ..diabetes.services.db import Base
+from sqlalchemy.orm import Session
+
 from ..diabetes.services.repository import commit
+from ..models.onboarding_event import OnboardingEvent
 
 logger = logging.getLogger(__name__)
 
-
-class OnboardingEvent(Base):
-    """DB model for recorded onboarding events."""
-
-    __tablename__ = "onboarding_events"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(
-        BigInteger,
-        ForeignKey("users.telegram_id", ondelete="CASCADE"),
-        index=True,
-        nullable=False,
-    )
-    event_name: Mapped[str] = mapped_column(String, nullable=False)
-    step: Mapped[int] = mapped_column(Integer, nullable=False)
-    variant: Mapped[str | None] = mapped_column(String)
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
-    )
-
-
-__all__ = ["OnboardingEvent", "log_onboarding_event"]
+__all__ = ["log_onboarding_event"]
 
 
 def log_onboarding_event(
     session: Session,
     user_id: int,
-    event_name: str,
-    step: int,
-    variant: str | None,
+    event: str,
+    step: str | None = None,
+    meta: dict[str, object] | None = None,
+    variant: str | None = None,
 ) -> None:
     """Persist an onboarding analytics event."""
 
-    event = OnboardingEvent(
-        user_id=user_id, event_name=event_name, step=step, variant=variant
+    event_row = OnboardingEvent(
+        user_id=user_id,
+        event=event,
+        step=step,
+        meta_json=dict(meta) if meta is not None else None,
+        variant=variant,
     )
-    session.add(event)
+    session.add(event_row)
     commit(session)

--- a/tests/services/test_onboarding_events.py
+++ b/tests/services/test_onboarding_events.py
@@ -2,10 +2,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from services.api.app.diabetes.services.db import Base
-from services.api.app.services.onboarding_events import (
-    OnboardingEvent,
-    log_onboarding_event,
-)
+from services.api.app.models.onboarding_event import OnboardingEvent
+from services.api.app.services.onboarding_events import log_onboarding_event
 
 
 def test_log_onboarding_event_persists_event() -> None:
@@ -14,9 +12,12 @@ def test_log_onboarding_event_persists_event() -> None:
     Session = sessionmaker(bind=engine)
 
     with Session() as session:
-        log_onboarding_event(session, 1, "onboarding_started", 0, "v1")
+        log_onboarding_event(
+            session, 1, "onboarding_started", step="0", meta={"a": 1}, variant="v1"
+        )
         ev = session.query(OnboardingEvent).one()
         assert ev.user_id == 1
-        assert ev.event_name == "onboarding_started"
-        assert ev.step == 0
+        assert ev.event == "onboarding_started"
+        assert ev.step == "0"
+        assert ev.meta_json == {"a": 1}
         assert ev.variant == "v1"


### PR DESCRIPTION
## Summary
- move onboarding events table into its own model
- adjust service helper to log events with optional step/meta/variant
- update handlers and tests to use new model

## Testing
- `pytest tests/services/test_onboarding_events.py -q -o addopts=`
- `mypy --strict services/api/app/models/onboarding_event.py services/api/app/services/onboarding_events.py services/api/app/diabetes/models.py services/api/app/diabetes/handlers/onboarding_handlers.py tests/services/test_onboarding_events.py`
- `ruff check services/api/app/models/onboarding_event.py services/api/app/services/onboarding_events.py services/api/app/diabetes/models.py services/api/app/diabetes/handlers/onboarding_handlers.py tests/services/test_onboarding_events.py`

------
https://chatgpt.com/codex/tasks/task_e_68bae32f4284832a9f00868a3b7a532d