### PR TITLE
api: add onboarding router

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -38,6 +38,7 @@ from .routers.internal_reminders import router as internal_reminders_router
 from .routers.stats import router as stats_router
 from .routers import metrics
 from .routers.billing import router as billing_router
+from .routers.onboarding import router as onboarding_router
 from .schemas.history import ALLOWED_HISTORY_TYPES, HistoryRecordSchema, HistoryType
 from .schemas.role import RoleSchema
 from .services.profile import patch_user_settings
@@ -348,6 +349,7 @@ async def delete_history(
 # ────────── include router ──────────
 app.include_router(internal_reminders_router)
 app.include_router(metrics.router)
+app.include_router(onboarding_router)
 app.include_router(api_router, prefix="/api")
 
 # ────────── run (for local testing) ──────────

--- a/services/api/app/routers/onboarding.py
+++ b/services/api/app/routers/onboarding.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..schemas.user import UserContext
+from ..telegram_auth import require_tg_user
+from ..services.onboarding_events import OnboardingEvent, log_onboarding_event
+from ..services import onboarding_state
+from ..diabetes.services.db import SessionLocal, run_db
+
+logger = logging.getLogger(__name__)
+
+PROFILE, TIMEZONE, REMINDERS = range(3)
+
+router = APIRouter(prefix="/api/onboarding")
+
+
+class EventPayload(BaseModel):
+    event: str
+    step: int | None = None
+    meta: dict[str, Any] | None = None
+
+
+@router.post("/events")
+async def post_event(
+    payload: EventPayload, user: UserContext = Depends(require_tg_user)
+) -> dict[str, bool]:
+    variant = None
+    if payload.meta and isinstance(payload.meta.get("variant"), str):
+        variant = payload.meta["variant"]
+    step = payload.step or 0
+
+    def _log(session: Session) -> None:
+        log_onboarding_event(session, user["id"], payload.event, step, variant)
+
+    await run_db(_log, sessionmaker=SessionLocal)
+    return {"ok": True}
+
+
+class StatusResponse(BaseModel):
+    completed: bool
+    step: str | None
+    missing: list[str]
+
+
+@router.get("/status", response_model=StatusResponse)
+async def get_status(user: UserContext = Depends(require_tg_user)) -> StatusResponse:
+    user_id = user["id"]
+    state = await onboarding_state.load_state(user_id)
+
+    def _has_finished(session: Session) -> bool:
+        return (
+            session.query(OnboardingEvent)
+            .filter(
+                OnboardingEvent.user_id == user_id,
+                OnboardingEvent.event_name == "onboarding_finished",
+            )
+            .first()
+            is not None
+        )
+
+    finished = await run_db(_has_finished, sessionmaker=SessionLocal)
+
+    if (state and state.completed_at) or finished:
+        return StatusResponse(completed=True, step=None, missing=[])
+
+    if state and state.step == REMINDERS:
+        return StatusResponse(
+            completed=False, step="reminders", missing=["reminders"]
+        )
+
+    return StatusResponse(
+        completed=False, step="profile", missing=["profile", "reminders"]
+    )

--- a/tests/test_onboarding_router.py
+++ b/tests/test_onboarding_router.py
@@ -1,0 +1,124 @@
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.services.db import Base, User
+from services.api.app.routers import onboarding as onboarding_router
+from services.api.app.services import onboarding_state
+from services.api.app.services.onboarding_events import OnboardingEvent
+from services.api.app.telegram_auth import require_tg_user
+from services.api.app.main import app
+
+
+_PROFILE, _TIMEZONE, REMINDERS = range(3)
+
+
+def setup_db() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            User.__table__,
+            onboarding_state.OnboardingState.__table__,
+            OnboardingEvent.__table__,
+        ],
+    )
+    return sessionmaker(bind=engine, class_=Session)
+
+
+def make_client(monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]) -> TestClient:
+    async def run_db(fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs):
+        with sessionmaker() as session:
+            return fn(session, *args, **kwargs)
+
+    monkeypatch.setattr(onboarding_router, "run_db", run_db, raising=False)
+    monkeypatch.setattr(onboarding_router, "SessionLocal", session_local, raising=False)
+    monkeypatch.setattr(onboarding_state, "run_db", run_db, raising=False)
+    monkeypatch.setattr(onboarding_state, "SessionLocal", session_local, raising=False)
+
+    app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
+    return TestClient(app)
+
+
+def teardown_client() -> None:
+    app.dependency_overrides.clear()
+
+
+def add_user(session_local: sessionmaker[Session]) -> None:
+    with session_local() as session:
+        session.add(User(telegram_id=1, thread_id="webapp"))
+        session.commit()
+
+
+def test_post_event_persists(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    add_user(session_local)
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.post("/api/onboarding/events", json={"event": "onboarding_started"})
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    with session_local() as session:
+        ev = session.query(OnboardingEvent).one()
+        assert ev.event_name == "onboarding_started"
+        assert ev.user_id == 1
+    teardown_client()
+
+
+def test_status_initial(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    add_user(session_local)
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.get("/api/onboarding/status")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "completed": False,
+        "step": "profile",
+        "missing": ["profile", "reminders"],
+    }
+    teardown_client()
+
+
+def test_status_reminders_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    with session_local() as session:
+        session.add(User(telegram_id=1, thread_id="webapp"))
+        session.add(
+            onboarding_state.OnboardingState(user_id=1, step=REMINDERS, data={}, variant=None)
+        )
+        session.commit()
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.get("/api/onboarding/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"completed": False, "step": "reminders", "missing": ["reminders"]}
+    teardown_client()
+
+
+def test_status_completed(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    with session_local() as session:
+        session.add(User(telegram_id=1, thread_id="webapp"))
+        session.add(
+            onboarding_state.OnboardingState(
+                user_id=1,
+                step=REMINDERS,
+                data={},
+                variant=None,
+                completed_at=datetime.now(timezone.utc),
+            )
+        )
+        session.commit()
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.get("/api/onboarding/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"completed": True, "step": None, "missing": []}
+    teardown_client()


### PR DESCRIPTION
## Summary
- add onboarding router with event logging and status querying
- expose onboarding endpoints and register router in FastAPI app
- cover onboarding API with tests

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q` *(fails: async functions require plugin; coverage 58% <85%)*

------
https://chatgpt.com/codex/tasks/task_e_68bae3328f1c832a88bcc42c83c20011