### PR TITLE
[onboarding] Provide onboarding API endpoints and tests

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -38,6 +38,7 @@ from .routers.internal_reminders import router as internal_reminders_router
 from .routers.stats import router as stats_router
 from .routers import metrics
 from .routers.billing import router as billing_router
+from .routers.onboarding import router as onboarding_router
 from .schemas.history import ALLOWED_HISTORY_TYPES, HistoryRecordSchema, HistoryType
 from .schemas.role import RoleSchema
 from .services.profile import patch_user_settings
@@ -101,6 +102,7 @@ api_router.include_router(stats_router)
 api_router.include_router(legacy_router)
 api_router.include_router(metrics.router)
 api_router.include_router(billing_router)
+api_router.include_router(onboarding_router)
 
 # ────────── статические файлы UI ──────────
 BASE_DIR = Path(__file__).resolve().parents[2] / "webapp"

--- a/services/api/app/routers/onboarding.py
+++ b/services/api/app/routers/onboarding.py
@@ -1,0 +1,47 @@
+import logging
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..diabetes.services.db import SessionLocal, run_db
+from ..services.onboarding_events import log_onboarding_event
+from ..services import onboarding_state
+from ..schemas.user import UserContext
+from ..telegram_auth import require_tg_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/onboarding")
+
+
+class EventIn(BaseModel):
+    name: str
+    step: int
+    variant: str | None = None
+
+
+@router.post("/events")
+async def post_event(data: EventIn, user: UserContext = Depends(require_tg_user)) -> dict[str, str]:
+    def _log(session: Session) -> None:
+        log_onboarding_event(session, user["id"], data.name, data.step, data.variant)
+
+    await run_db(_log, sessionmaker=SessionLocal)
+    return {"status": "ok"}
+
+
+class StatusOut(BaseModel):
+    completed: bool
+    step: int
+    variant: str | None = None
+
+
+@router.get("/status")
+async def get_status(user: UserContext = Depends(require_tg_user)) -> StatusOut:
+    state = await onboarding_state.load_state(user["id"])
+    if state is None:
+        return StatusOut(completed=False, step=0, variant=None)
+    return StatusOut(
+        completed=state.completed_at is not None,
+        step=state.step,
+        variant=state.variant,
+    )

--- a/tests/services/test_onboarding_events.py
+++ b/tests/services/test_onboarding_events.py
@@ -20,3 +20,16 @@ def test_log_onboarding_event_persists_event() -> None:
         assert ev.event_name == "onboarding_started"
         assert ev.step == 0
         assert ev.variant == "v1"
+
+
+def test_log_onboarding_event_persists_optional_fields() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+
+    with Session() as session:
+        log_onboarding_event(session, 2, "step_completed_1", 1, None)
+        ev = session.query(OnboardingEvent).one()
+        assert ev.user_id == 2
+        assert ev.variant is None
+        assert ev.created_at is not None

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -1,0 +1,129 @@
+import hashlib
+import hmac
+import json
+import time
+import urllib.parse
+from typing import Generator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.config import settings
+from services.api.app.diabetes.services.db import Base, User
+import services.api.app.services.onboarding_events as onboarding_events
+import services.api.app.services.onboarding_state as onboarding_state
+from services.api.app.diabetes.services import db as db_module
+import services.api.app.routers.onboarding as onboarding_module
+from services.api.app.routers.onboarding import router as onboarding_router
+
+TOKEN = "test-token"
+
+
+def build_init_data(token: str = TOKEN, user_id: int = 1) -> str:
+    user = json.dumps({"id": user_id, "first_name": "A"}, separators=(",", ":"))
+    params = {
+        "auth_date": str(int(time.time())),
+        "query_id": "abc",
+        "user": user,
+    }
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
+    secret = hmac.new(b"WebAppData", token.encode(), hashlib.sha256).digest()
+    params["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return urllib.parse.urlencode(params)
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    monkeypatch.setattr(onboarding_events, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(onboarding_state, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(db_module, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(onboarding_module, "SessionLocal", SessionLocal, raising=False)
+
+    async def run_db(fn, *args, sessionmaker: sessionmaker[Session] = SessionLocal, **kwargs):
+        with sessionmaker() as session:
+            return fn(session, *args, **kwargs)
+
+    monkeypatch.setattr(onboarding_events, "run_db", run_db, raising=False)
+    monkeypatch.setattr(onboarding_state, "run_db", run_db, raising=False)
+    monkeypatch.setattr(db_module, "run_db", run_db, raising=False)
+    monkeypatch.setattr(onboarding_module, "run_db", run_db, raising=False)
+
+    with SessionLocal() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.commit()
+
+    app = FastAPI()
+    app.include_router(onboarding_router, prefix="/api")
+
+    try:
+        with TestClient(app) as test_client:
+            yield test_client
+    finally:
+        engine.dispose()
+
+
+def test_post_event_uses_header_user(client: TestClient) -> None:
+    init_data = build_init_data()
+    resp = client.post(
+        "/api/onboarding/events",
+        json={"name": "onboarding_started", "step": 0, "variant": "A"},
+        headers={"X-Telegram-Init-Data": init_data},
+    )
+    assert resp.status_code == 200
+    with onboarding_events.SessionLocal() as session:
+        ev = session.query(onboarding_events.OnboardingEvent).one()
+        assert ev.user_id == 1
+        assert ev.event_name == "onboarding_started"
+        assert ev.step == 0
+        assert ev.variant == "A"
+
+
+def test_post_event_requires_auth(client: TestClient) -> None:
+    resp = client.post(
+        "/api/onboarding/events",
+        json={"name": "onboarding_started", "step": 0},
+    )
+    assert resp.status_code == 401
+
+
+def test_status_reflects_completion(client: TestClient) -> None:
+    init_data = build_init_data()
+    resp = client.get(
+        "/api/onboarding/status",
+        headers={"X-Telegram-Init-Data": init_data},
+    )
+    data = resp.json()
+    assert resp.status_code == 200
+    assert data["completed"] is False
+    assert data["step"] == 0
+
+    import asyncio
+
+    asyncio.run(onboarding_state.save_state(1, 1, {}))
+    resp2 = client.get(
+        "/api/onboarding/status",
+        headers={"X-Telegram-Init-Data": init_data},
+    )
+    data2 = resp2.json()
+    assert data2["completed"] is False
+    assert data2["step"] == 1
+
+    asyncio.run(onboarding_state.complete_state(1))
+    resp3 = client.get(
+        "/api/onboarding/status",
+        headers={"X-Telegram-Init-Data": init_data},
+    )
+    data3 = resp3.json()
+    assert data3["completed"] is True


### PR DESCRIPTION
## Summary
- add onboarding API router with event logging and status endpoints
- cover onboarding events persistence including optional fields
- test onboarding API authentication and completion logic

## Testing
- `pytest tests/services/test_onboarding_events.py tests/test_onboarding_api.py -q -o addopts="--cov=services.api.app.services.onboarding_events --cov=services.api.app.services.onboarding_state --cov=services.api.app.routers.onboarding --cov-report=term-missing --cov-fail-under=85"`
- `mypy --strict services/api/app/routers/onboarding.py tests/services/test_onboarding_events.py tests/test_onboarding_api.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bae33628c0832a81a051f388c86ab8