### PR TITLE
[api] Add onboarding status endpoint

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -38,6 +38,7 @@ from .routers.internal_reminders import router as internal_reminders_router
 from .routers.stats import router as stats_router
 from .routers import metrics
 from .routers.billing import router as billing_router
+from .routers.onboarding import router as onboarding_router
 from .schemas.history import ALLOWED_HISTORY_TYPES, HistoryRecordSchema, HistoryType
 from .schemas.role import RoleSchema
 from .services.profile import patch_user_settings
@@ -101,6 +102,7 @@ api_router.include_router(stats_router)
 api_router.include_router(legacy_router)
 api_router.include_router(metrics.router)
 api_router.include_router(billing_router)
+api_router.include_router(onboarding_router)
 
 # ────────── статические файлы UI ──────────
 BASE_DIR = Path(__file__).resolve().parents[2] / "webapp"

--- a/services/api/app/routers/onboarding.py
+++ b/services/api/app/routers/onboarding.py
@@ -1,0 +1,28 @@
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from ..schemas.user import UserContext
+from ..services.onboarding_events import get_onboarding_status
+from ..telegram_auth import require_tg_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class OnboardingStatusResponse(BaseModel):
+    step: int | None = None
+    missingSteps: list[int] = Field(default_factory=list)
+
+
+@router.get("/onboarding/status", response_model=OnboardingStatusResponse)
+async def status(
+    telegram_id: int = Query(alias="telegramId"),
+    user: UserContext = Depends(require_tg_user),
+) -> OnboardingStatusResponse:
+    if telegram_id != user["id"]:
+        raise HTTPException(status_code=403, detail="telegram id mismatch")
+    step, missing = await get_onboarding_status(telegram_id)
+    return OnboardingStatusResponse(step=step, missingSteps=missing)

--- a/services/api/app/services/onboarding_events.py
+++ b/services/api/app/services/onboarding_events.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
-from sqlalchemy import BigInteger, ForeignKey, Integer, String, TIMESTAMP, func
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import BigInteger, ForeignKey, Integer, String, TIMESTAMP, func, select
 from sqlalchemy.orm import Mapped, Session, mapped_column
 
-from ..diabetes.services.db import Base
+from ..diabetes.services.db import Base, SessionLocal, run_db
 from ..diabetes.services.repository import commit
+from . import onboarding_state
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +33,24 @@ class OnboardingEvent(Base):
     )
 
 
-__all__ = ["OnboardingEvent", "log_onboarding_event"]
+PROFILE, TIMEZONE, REMINDERS = range(3)
+
+VARIANT_ORDER: dict[str | None, list[int]] = {
+    "A": [PROFILE, TIMEZONE, REMINDERS],
+    "B": [TIMEZONE, PROFILE, REMINDERS],
+    None: [PROFILE, TIMEZONE, REMINDERS],
+}
+
+STALE_PERIOD = timedelta(days=14)
+
+__all__ = [
+    "OnboardingEvent",
+    "log_onboarding_event",
+    "get_onboarding_status",
+    "PROFILE",
+    "TIMEZONE",
+    "REMINDERS",
+]
 
 
 def log_onboarding_event(
@@ -48,3 +67,38 @@ def log_onboarding_event(
     )
     session.add(event)
     commit(session)
+
+
+async def get_onboarding_status(user_id: int) -> tuple[int | None, list[int]]:
+    """Return next onboarding step and list of missing steps."""
+
+    state = await onboarding_state.load_state(user_id)
+    now = datetime.now(timezone.utc)
+
+    if state is not None and state.completed_at is not None:
+        return None, []
+
+    def _latest_event(session: Session) -> OnboardingEvent | None:
+        stmt = (
+            select(OnboardingEvent)
+            .where(OnboardingEvent.user_id == user_id)
+            .order_by(OnboardingEvent.created_at.desc())
+            .limit(1)
+        )
+        return session.scalars(stmt).first()
+
+    last = await run_db(_latest_event, sessionmaker=SessionLocal)
+
+    if last is not None and last.event_name == "onboarding_completed":
+        created = last.created_at
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=timezone.utc)
+        if now - created < STALE_PERIOD:
+            return None, []
+
+    variant = state.variant if state is not None else (last.variant if last else None)
+    order = VARIANT_ORDER.get(variant, VARIANT_ORDER[None])
+    step = state.step if state is not None else order[0]
+    idx = order.index(step)
+    missing = order[idx:]
+    return step, missing

--- a/tests/test_onboarding_status.py
+++ b/tests/test_onboarding_status.py
@@ -1,0 +1,130 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as SASession, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.services.db import Base
+from services.api.app.services import onboarding_state
+from services.api.app.services.onboarding_events import (
+    OnboardingEvent,
+    PROFILE,
+    TIMEZONE,
+)
+import services.api.app.services.onboarding_events as onboarding_events
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient, sessionmaker[SASession]]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=SASession)
+    Base.metadata.create_all(
+        engine,
+        tables=[OnboardingEvent.__table__, onboarding_state.OnboardingState.__table__],
+    )
+
+    async def run_db(fn, *args, sessionmaker: sessionmaker[SASession] = SessionLocal, **kwargs):
+        with sessionmaker() as session:
+            return fn(session, *args, **kwargs)
+
+    monkeypatch.setattr(onboarding_events, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(onboarding_events, "run_db", run_db, raising=False)
+    monkeypatch.setattr(onboarding_state, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(onboarding_state, "run_db", run_db, raising=False)
+
+    from services.api.app.telegram_auth import require_tg_user as real_require
+    from services.api.app.main import app
+
+    app.dependency_overrides[real_require] = lambda: {"id": 1}
+
+    client = TestClient(app)
+    yield client, SessionLocal
+    client.close()
+    app.dependency_overrides.clear()
+    engine.dispose()
+
+
+def test_status_completed_event(client: tuple[TestClient, sessionmaker[SASession]]) -> None:
+    client_app, SessionLocal = client
+    with SessionLocal() as session:
+        session.add(OnboardingEvent(user_id=1, event_name="onboarding_completed", step=2, variant=None))
+        session.commit()
+    resp = client_app.get("/api/onboarding/status", params={"telegramId": 1})
+    assert resp.status_code == 200
+    assert resp.json() == {"step": None, "missingSteps": []}
+
+
+def test_status_returns_missing_steps(client: tuple[TestClient, sessionmaker[SASession]]) -> None:
+    client_app, SessionLocal = client
+    now = datetime.now(timezone.utc)
+    with SessionLocal() as session:
+        session.add(
+            onboarding_state.OnboardingState(
+                user_id=1,
+                step=TIMEZONE,
+                data={},
+                variant="A",
+                completed_at=None,
+                updated_at=now,
+            )
+        )
+        session.commit()
+    resp = client_app.get("/api/onboarding/status", params={"telegramId": 1})
+    assert resp.status_code == 200
+    assert resp.json() == {"step": TIMEZONE, "missingSteps": [TIMEZONE, onboarding_events.REMINDERS]}
+
+
+def test_status_canceled_after_completion(client: tuple[TestClient, sessionmaker[SASession]]) -> None:
+    client_app, SessionLocal = client
+    now = datetime.now(timezone.utc)
+    with SessionLocal() as session:
+        session.add_all(
+            [
+                OnboardingEvent(
+                    user_id=1,
+                    event_name="onboarding_completed",
+                    step=2,
+                    variant=None,
+                    created_at=now - timedelta(seconds=1),
+                ),
+                OnboardingEvent(
+                    user_id=1,
+                    event_name="onboarding_canceled",
+                    step=2,
+                    variant=None,
+                    created_at=now,
+                ),
+            ]
+        )
+        session.commit()
+    resp = client_app.get("/api/onboarding/status", params={"telegramId": 1})
+    assert resp.status_code == 200
+    assert resp.json() == {"step": PROFILE, "missingSteps": [PROFILE, TIMEZONE, onboarding_events.REMINDERS]}
+
+
+def test_status_stale_state(client: tuple[TestClient, sessionmaker[SASession]]) -> None:
+    client_app, SessionLocal = client
+    old = datetime.now(timezone.utc) - timedelta(days=15)
+    with SessionLocal() as session:
+        session.add(
+            onboarding_state.OnboardingState(
+                user_id=1,
+                step=TIMEZONE,
+                data={},
+                variant=None,
+                completed_at=None,
+                updated_at=old,
+            )
+        )
+        session.commit()
+    resp = client_app.get("/api/onboarding/status", params={"telegramId": 1})
+    assert resp.status_code == 200
+    assert resp.json() == {"step": PROFILE, "missingSteps": [PROFILE, TIMEZONE, onboarding_events.REMINDERS]}
+    with SessionLocal() as session:
+        assert session.get(onboarding_state.OnboardingState, 1) is None


### PR DESCRIPTION
## Summary
- add `get_onboarding_status` helper to determine next onboarding step and pending steps
- expose `/api/onboarding/status` endpoint using the helper
- test onboarding status edge cases such as cancellation and stale states

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bae3384cf0832a93322e6e8f8af4e1