### PR TITLE
[onboarding] add status helper

### DIFF
--- a/services/api/app/routers/onboarding.py
+++ b/services/api/app/routers/onboarding.py
@@ -9,8 +9,7 @@ from sqlalchemy.orm import Session
 
 from ..schemas.user import UserContext
 from ..telegram_auth import require_tg_user
-from ..services.onboarding_events import OnboardingEvent, log_onboarding_event
-from ..services import onboarding_state
+from ..services.onboarding_events import log_onboarding_event, onboarding_status
 from ..diabetes.services.db import SessionLocal, run_db
 
 logger = logging.getLogger(__name__)
@@ -33,7 +32,7 @@ async def post_event(
     variant = None
     if payload.meta and isinstance(payload.meta.get("variant"), str):
         variant = payload.meta["variant"]
-    step = payload.step or 0
+    step = str(payload.step or 0)
 
     def _log(session: Session) -> None:
         log_onboarding_event(session, user["id"], payload.event, step, variant)
@@ -50,30 +49,5 @@ class StatusResponse(BaseModel):
 
 @router.get("/status", response_model=StatusResponse)
 async def get_status(user: UserContext = Depends(require_tg_user)) -> StatusResponse:
-    user_id = user["id"]
-    state = await onboarding_state.load_state(user_id)
-
-    def _has_finished(session: Session) -> bool:
-        return (
-            session.query(OnboardingEvent)
-            .filter(
-                OnboardingEvent.user_id == user_id,
-                OnboardingEvent.event_name == "onboarding_finished",
-            )
-            .first()
-            is not None
-        )
-
-    finished = await run_db(_has_finished, sessionmaker=SessionLocal)
-
-    if (state and state.completed_at) or finished:
-        return StatusResponse(completed=True, step=None, missing=[])
-
-    if state and state.step == REMINDERS:
-        return StatusResponse(
-            completed=False, step="reminders", missing=["reminders"]
-        )
-
-    return StatusResponse(
-        completed=False, step="profile", missing=["profile", "reminders"]
-    )
+    completed, step, missing = await onboarding_status(user["id"])
+    return StatusResponse(completed=completed, step=step, missing=missing)

--- a/services/api/app/services/onboarding_events.py
+++ b/services/api/app/services/onboarding_events.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
 
+from ..diabetes.services.db import SessionLocal, run_db
 from ..diabetes.services.repository import commit
 from ..models.onboarding_event import OnboardingEvent
+from . import onboarding_state
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["log_onboarding_event"]
+__all__ = ["log_onboarding_event", "onboarding_status"]
 
 
 def log_onboarding_event(
@@ -31,3 +34,52 @@ def log_onboarding_event(
     )
     session.add(event_row)
     commit(session)
+
+
+async def onboarding_status(user_id: int) -> tuple[bool, str | None, list[str]]:
+    """Return onboarding status for ``user_id``.
+
+    Completion is detected if there is a recent ``onboarding_completed`` event
+    or the :class:`~services.api.app.services.onboarding_state.OnboardingState`
+    has ``completed_at`` set.  A recent event is one newer than 14 days.
+    If the most recent event is ``onboarding_canceled`` the onboarding is
+    considered incomplete regardless of state.
+    """
+
+    REMINDERS_STEP = 2
+
+    state = await onboarding_state.load_state(user_id)
+
+    def _last_event(session: Session) -> str | None:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=14)
+        row = (
+            session.query(OnboardingEvent.event)
+            .filter(
+                OnboardingEvent.user_id == user_id,
+                OnboardingEvent.event.in_(
+                    ["onboarding_completed", "onboarding_canceled"]
+                ),
+                OnboardingEvent.ts >= cutoff,
+            )
+            .order_by(OnboardingEvent.ts.desc())
+            .first()
+        )
+        return row[0] if row is not None else None
+
+    last_event = await run_db(_last_event, sessionmaker=SessionLocal)
+
+    if last_event == "onboarding_canceled":
+        state = None
+        completed = False
+    elif last_event == "onboarding_completed":
+        completed = True
+    else:
+        completed = state is not None and state.completed_at is not None
+
+    if completed:
+        return True, None, []
+
+    if state and state.step == REMINDERS_STEP:
+        return False, "reminders", ["reminders"]
+
+    return False, "profile", ["profile", "reminders"]


### PR DESCRIPTION
## Summary
- add helper to derive onboarding status from events or state
- reuse helper in `/status` endpoint
- cover cancellation and stale onboarding states in tests

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `PYTEST_ADDOPTS="--cov-fail-under=0" pytest tests/test_onboarding_router.py -q`
- `mypy --strict services/api/app/routers/onboarding.py services/api/app/services/onboarding_events.py tests/test_onboarding_router.py`
- `ruff check services/api/app/routers/onboarding.py services/api/app/services/onboarding_events.py tests/test_onboarding_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68bae66fb5c4832a92359d0e4d5bd6aa