### PR TITLE
[onboarding] track reminders onboarding

### DIFF
--- a/services/webapp/ui/src/api/onboarding.ts
+++ b/services/webapp/ui/src/api/onboarding.ts
@@ -1,0 +1,13 @@
+import { api } from './index';
+
+const STEP_MAP: Record<string, number> = {
+  profile: 0,
+  timezone: 1,
+  reminders: 2,
+};
+
+export const postOnboardingEvent = (
+  event: string,
+  step: keyof typeof STEP_MAP,
+  meta?: Record<string, unknown>,
+) => api.post<{ ok: boolean }>(`/onboarding/events`, { event, step: STEP_MAP[step], meta });

--- a/services/webapp/ui/src/pages/Reminders.tsx
+++ b/services/webapp/ui/src/pages/Reminders.tsx
@@ -2,17 +2,25 @@ import RemindersList from '../features/reminders/pages/RemindersList'
 import { MedicalHeader } from '@/components/MedicalHeader'
 import { useNavigate } from 'react-router-dom'
 import { useState } from 'react'
+import { postOnboardingEvent } from '@/api/onboarding'
 
 export default function Reminders() {
   const navigate = useNavigate()
   const [reminderCount, setReminderCount] = useState(0)
   const [planLimit, setPlanLimit] = useState(5)
 
+  const handleCountChange = (count: number) => {
+    if (count === 1 && reminderCount === 0) {
+      postOnboardingEvent('first_reminder_created', 'reminders')
+    }
+    setReminderCount(count)
+  }
+
   const quotaBadge = `${reminderCount}/${planLimit} 🔔`
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20">
-      <MedicalHeader title={`Напоминания ${quotaBadge}`} showBack onBack={() => navigate('/')}>
+      <MedicalHeader title={`Напоминания ${quotaBadge}`} showBack onBack={() => navigate('/')}> 
         <button
           type="button"
           onClick={() => navigate('/reminders/new')}
@@ -20,10 +28,24 @@ export default function Reminders() {
         >
           + Добавить
         </button>
+        {reminderCount === 0 && (
+          <button
+            type="button"
+            onClick={async () => {
+              await postOnboardingEvent('onboarding_completed', 'reminders', {
+                skippedReminders: true,
+              })
+              navigate('/')
+            }}
+            className="ml-2 px-4 py-2 border rounded-lg text-muted-foreground hover:bg-muted transition-all duration-200"
+          >
+            Пропустить пока
+          </button>
+        )}
       </MedicalHeader>
 
       <main className="container mx-auto px-4 py-6">
-        <RemindersList onCountChange={setReminderCount} onLimitChange={setPlanLimit} />
+        <RemindersList onCountChange={handleCountChange} onLimitChange={setPlanLimit} />
       </main>
     </div>
   )


### PR DESCRIPTION
## Summary
- add API helper for onboarding events
- track first reminder and allow skipping reminders onboarding
- compute onboarding completion from profile and reminders, logging completion event when met

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `pytest tests/test_onboarding_router.py -q` *(fails: Required test coverage of 85% not reached)*
- `pnpm --filter ./services/webapp/ui test` *(fails: JavaScript heap out of memory)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68baefb7a5cc832a8920b9325a49f08f