### PR TITLE
[handlers] add status command

### DIFF
--- a/services/api/app/bot.py
+++ b/services/api/app/bot.py
@@ -6,17 +6,20 @@ import os
 from telegram.ext import Application
 
 from .diabetes.bot_start_handlers import build_start_handler
+from .diabetes.bot_status_handlers import build_status_handler
 
 logger = logging.getLogger(__name__)
 
 
 def main() -> None:
-    """Run the telegram bot with the /start WebApp links."""
+    """Run the telegram bot with the /start WebApp links and status command."""
 
     token = os.environ["TELEGRAM_TOKEN"]
     ui_base_url = os.environ.get("UI_BASE_URL", "/ui")
+    api_base_url = os.environ.get("API_BASE_URL", "/api")
     application = Application.builder().token(token).build()
     application.add_handler(build_start_handler(ui_base_url))
+    application.add_handler(build_status_handler(ui_base_url, api_base_url))
     application.run_polling()
 
 

--- a/services/api/app/diabetes/bot_status_handlers.py
+++ b/services/api/app/diabetes/bot_status_handlers.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import time
+import urllib.parse
+from typing import Any, TypeAlias
+
+import aiohttp
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, WebAppInfo
+from telegram.ext import CommandHandler, ContextTypes
+
+from ..telegram_auth import TG_INIT_DATA_HEADER
+
+
+CommandHandlerT: TypeAlias = CommandHandler[ContextTypes.DEFAULT_TYPE, object]
+
+
+def _build_init_data(user_id: int, token: str) -> str:
+    """Return WebApp init data for ``user_id`` signed with ``token``."""
+
+    user = json.dumps({"id": user_id}, separators=(",", ":"))
+    params = {"auth_date": str(int(time.time())), "query_id": "status", "user": user}
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
+    secret = hmac.new(b"WebAppData", token.encode(), hashlib.sha256).digest()
+    params["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return urllib.parse.urlencode(params)
+
+
+def build_status_handler(ui_base_url: str, api_base: str = "/api") -> CommandHandlerT:
+    """Return a /status handler that shows onboarding progress."""
+
+    async def _status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not update.message or not update.effective_user:
+            return
+
+        token = os.environ.get("TELEGRAM_TOKEN")
+        if not token:
+            await update.message.reply_text("Server misconfigured")
+            return
+
+        user_id = update.effective_user.id
+        init_data = _build_init_data(user_id, token)
+        url = f"{api_base.rstrip('/')}/onboarding/status"
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    url, headers={TG_INIT_DATA_HEADER: init_data}
+                ) as resp:
+                    data: dict[str, Any] = await resp.json()
+        except Exception:
+            await update.message.reply_text("Не удалось получить статус онбординга")
+            return
+
+        completed = bool(data.get("completed"))
+        missing = [str(s) for s in data.get("missing", [])]
+
+        profile_url = f"{ui_base_url.rstrip('/')}/profile?flow=onboarding&step=profile"
+        reminders_url = (
+            f"{ui_base_url.rstrip('/')}/reminders?flow=onboarding&step=reminders"
+        )
+
+        if not completed:
+            btns: list[list[InlineKeyboardButton]] = []
+            if "profile" in missing:
+                btns.append(
+                    [
+                        InlineKeyboardButton(
+                            "🧾 Открыть профиль",
+                            web_app=WebAppInfo(url=profile_url),
+                        )
+                    ]
+                )
+            if "reminders" in missing:
+                btns.append(
+                    [
+                        InlineKeyboardButton(
+                            "⏰ Открыть напоминания",
+                            web_app=WebAppInfo(url=reminders_url),
+                        )
+                    ]
+                )
+            await update.message.reply_text(
+                "Ещё пара шагов — продолжим настройку:",
+                reply_markup=InlineKeyboardMarkup(btns),
+            )
+        else:
+            btns = [
+                [
+                    InlineKeyboardButton(
+                        "🧾 Открыть профиль", web_app=WebAppInfo(url=profile_url)
+                    )
+                ],
+                [
+                    InlineKeyboardButton(
+                        "⏰ Открыть напоминания",
+                        web_app=WebAppInfo(url=reminders_url),
+                    )
+                ],
+            ]
+            await update.message.reply_text(
+                "✅ Онбординг завершён. Чем помочь дальше?",
+                reply_markup=InlineKeyboardMarkup(btns),
+            )
+
+    return CommandHandlerT("status", _status)

--- a/tests/test_bot_status_handler.py
+++ b/tests/test_bot_status_handler.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import aiohttp
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.diabetes.bot_status_handlers import build_status_handler
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
+
+
+class DummyResponse:
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.status = 200
+        self._data = data
+
+    async def __aenter__(self) -> DummyResponse:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def json(self) -> dict[str, Any]:
+        return self._data
+
+
+class DummySession:
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    async def __aenter__(self) -> DummySession:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def get(self, url: str, headers: dict[str, str] | None = None) -> DummyResponse:
+        return DummyResponse(self._data)
+
+
+@pytest.mark.asyncio
+async def test_status_incomplete(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_TOKEN", "t")
+    resp = {"completed": False, "missing": ["profile", "reminders"]}
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: DummySession(resp))
+
+    handler = build_status_handler("https://ui.example", api_base="https://api.example")
+    message = DummyMessage()
+    user = SimpleNamespace(id=1)
+    update = cast(Update, SimpleNamespace(message=message, effective_user=user))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+
+    await handler.callback(update, context)
+
+    assert message.replies == ["Ещё пара шагов — продолжим настройку:"]
+    markup = message.kwargs[0]["reply_markup"]
+    buttons = markup.inline_keyboard
+    assert buttons[0][0].web_app.url == (
+        "https://ui.example/profile?flow=onboarding&step=profile"
+    )
+    assert buttons[1][0].web_app.url == (
+        "https://ui.example/reminders?flow=onboarding&step=reminders"
+    )
+
+
+@pytest.mark.asyncio
+async def test_status_completed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_TOKEN", "t")
+    resp = {"completed": True, "missing": []}
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: DummySession(resp))
+
+    handler = build_status_handler("https://ui.example", api_base="https://api.example")
+    message = DummyMessage()
+    user = SimpleNamespace(id=1)
+    update = cast(Update, SimpleNamespace(message=message, effective_user=user))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+
+    await handler.callback(update, context)
+
+    assert message.replies == ["✅ Онбординг завершён. Чем помочь дальше?"]
+    markup = message.kwargs[0]["reply_markup"]
+    buttons = markup.inline_keyboard
+    assert buttons[0][0].web_app.url == (
+        "https://ui.example/profile?flow=onboarding&step=profile"
+    )
+    assert buttons[1][0].web_app.url == (
+        "https://ui.example/reminders?flow=onboarding&step=reminders"
+    )


### PR DESCRIPTION
## Summary
- add /status handler fetching onboarding status and linking to WebApp steps
- register new handler in bot
- cover handler with tests

## Testing
- `ruff check services/api/app/diabetes/bot_status_handlers.py services/api/app/bot.py tests/test_bot_status_handler.py`
- `mypy --strict services/api/app/diabetes/bot_status_handlers.py tests/test_bot_status_handler.py services/api/app/bot.py`
- `pytest tests/test_bot_status_handler.py -q --cov=services.api.app.diabetes.bot_status_handlers --cov-fail-under=85 -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68baf3c8b090832a97bdcc95e01e66e0