### PR TITLE
[webapp] show onboarding progress in header

### DIFF
--- a/services/webapp/ui/src/components/MedicalHeader.tsx
+++ b/services/webapp/ui/src/components/MedicalHeader.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import ThemeToggle from '@/components/ThemeToggle';
+import OnboardingProgress from '@/components/OnboardingProgress';
 
 interface MedicalHeaderProps {
   title: string;
@@ -27,10 +28,11 @@ export const MedicalHeader = ({ title, showBack, onBack, children }: MedicalHead
             )}
             <h1 className="text-xl font-semibold text-foreground">{title}</h1>
           </div>
-          <div className="flex items-center gap-2">
-            {children}
-            <ThemeToggle />
-          </div>
+            <div className="flex items-center gap-2">
+              <OnboardingProgress />
+              {children}
+              <ThemeToggle />
+            </div>
         </div>
       </div>
     </header>

--- a/services/webapp/ui/src/components/OnboardingProgress.tsx
+++ b/services/webapp/ui/src/components/OnboardingProgress.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+
+interface OnboardingStatus {
+  completed: boolean;
+  step: 'profile' | 'reminders' | null;
+  missing: string[];
+}
+
+const steps: Array<{ key: 'profile' | 'reminders'; label: string }> = [
+  { key: 'profile', label: 'Профиль' },
+  { key: 'reminders', label: 'Напоминания' },
+];
+
+const OnboardingProgress = () => {
+  const [data, setData] = useState<OnboardingStatus | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    import('@/shared/api/onboarding')
+      .then((mod) => mod.getOnboardingStatus?.())
+      .then((res) => {
+        if (active && res) setData(res);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (!data) return null;
+
+  if (data.completed) {
+    return (
+      <span className="text-xs px-2 py-1 rounded-full bg-medical-success/20 text-medical-success border border-medical-success/30">
+        Завершено
+      </span>
+    );
+  }
+
+  const currentIndex = steps.findIndex((s) => s.key === data.step);
+
+  return (
+    <div className="flex items-center gap-2" aria-label="Onboarding progress">
+      {steps.map((step, index) => {
+        const done = index < currentIndex;
+        const active = index === currentIndex;
+        return (
+          <div key={step.key} className="flex items-center gap-1">
+            <div
+              className={`w-4 h-4 rounded-full text-[10px] flex items-center justify-center ${
+                done
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground'
+              }`}
+            >
+              {done ? '✓' : index + 1}
+            </div>
+            <span
+              className={`text-xs ${
+                done || active ? 'text-foreground' : 'text-muted-foreground'
+              }`}
+            >
+              {step.label}
+            </span>
+            {index < steps.length - 1 && (
+              <span className="text-muted-foreground">→</span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default OnboardingProgress;

--- a/services/webapp/ui/src/components/index.ts
+++ b/services/webapp/ui/src/components/index.ts
@@ -5,3 +5,4 @@ export { default as ThemeToggle } from './ThemeToggle';
 export { default as Sheet } from './Sheet';
 export { default as TimeInput } from './TimeInput';
 export { default as HelpHint } from './HelpHint';
+export { default as OnboardingProgress } from './OnboardingProgress';

--- a/services/webapp/ui/tests/OnboardingProgress.test.tsx
+++ b/services/webapp/ui/tests/OnboardingProgress.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import OnboardingProgress from '../src/components/OnboardingProgress';
+import { getOnboardingStatus } from '../src/shared/api/onboarding';
+import '@testing-library/jest-dom';
+
+vi.mock('@/shared/api/onboarding');
+
+describe('OnboardingProgress', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('shows completed badge', async () => {
+    (getOnboardingStatus as any).mockResolvedValue({
+      completed: true,
+      step: null,
+      missing: [],
+    });
+    render(<OnboardingProgress />);
+    expect(await screen.findByText('Завершено')).toBeInTheDocument();
+  });
+
+  it('shows steps when not completed', async () => {
+    (getOnboardingStatus as any).mockResolvedValue({
+      completed: false,
+      step: 'profile',
+      missing: ['profile', 'reminders'],
+    });
+    render(<OnboardingProgress />);
+    expect(await screen.findByText('Профиль')).toBeInTheDocument();
+    expect(screen.getByText('Напоминания')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add onboarding progress widget for profile/reminders steps
- expose new component via index and render in MedicalHeader
- cover onboarding status display with unit tests

## Testing
- `pnpm test` *(fails: numerous warnings/errors; see logs)*
- `pytest -q --cov` *(fails: missing pytest-cov or heavy suite)*
- `mypy --strict .` *(incomplete due to time)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68baf6b74560832aa999e3e94ed0fd7c