### PR TITLE
[metrics] add onboarding conversion metrics

### DIFF
--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tests/api/test_onboarding_metrics.py
+++ b/tests/api/test_onboarding_metrics.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Callable, TypeVar
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import Column, Date, Integer, MetaData, String, Table, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.routers import metrics
+
+T = TypeVar("T")
+
+
+def setup_db() -> tuple[sessionmaker[Session], date, date]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    metadata = MetaData()
+    table = Table(
+        "onboarding_metrics_daily",
+        metadata,
+        Column("date", Date),
+        Column("variant", String),
+        Column("step", String),
+        Column("count", Integer),
+    )
+    metadata.create_all(engine)
+    session_local = sessionmaker(bind=engine)
+    d1 = date(2024, 1, 1)
+    d2 = date(2024, 1, 2)
+    with engine.begin() as conn:
+        conn.execute(
+            table.insert(),
+            [
+                {"date": d1, "variant": "A", "step": "start", "count": 10},
+                {"date": d1, "variant": "A", "step": "step1", "count": 8},
+                {"date": d1, "variant": "A", "step": "step2", "count": 6},
+                {"date": d1, "variant": "A", "step": "finish", "count": 4},
+                {"date": d1, "variant": "B", "step": "start", "count": 20},
+                {"date": d1, "variant": "B", "step": "step1", "count": 10},
+                {"date": d1, "variant": "B", "step": "finish", "count": 5},
+                {"date": d2, "variant": "A", "step": "start", "count": 5},
+                {"date": d2, "variant": "A", "step": "step1", "count": 3},
+                {"date": d2, "variant": "A", "step": "finish", "count": 2},
+            ],
+        )
+    return session_local, d1, d2
+
+
+def patch_run_db(
+    monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]
+) -> None:
+    async def run_db(
+        fn: Callable[[Session], T],
+        *args: object,
+        sessionmaker: sessionmaker[Session] = session_local,
+        **kwargs: object,
+    ) -> T:
+        with sessionmaker() as session:
+            return fn(session)
+
+    monkeypatch.setattr(metrics, "SessionLocal", session_local, raising=False)
+    monkeypatch.setattr(metrics, "run_db", run_db, raising=False)
+
+
+def test_onboarding_metrics_by_day(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local, d1, d2 = setup_db()
+    patch_run_db(monkeypatch, session_local)
+
+    from services.api.app.main import app
+
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/metrics/onboarding",
+            params={"from": d1.isoformat(), "to": d2.isoformat()},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        d1.isoformat(): {
+            "A": {"step1": 0.8, "step2": 0.6, "step3": 0.0, "completed": 0.4},
+            "B": {"step1": 0.5, "step2": 0.0, "step3": 0.0, "completed": 0.25},
+        },
+        d2.isoformat(): {
+            "A": {"step1": 0.6, "step2": 0.0, "step3": 0.0, "completed": 0.4},
+        },
+    }
+
+
+def test_onboarding_metrics_variant_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local, d1, d2 = setup_db()
+    patch_run_db(monkeypatch, session_local)
+
+    from services.api.app.main import app
+
+    with TestClient(app) as client:
+        resp = client.get(
+            "/api/metrics/onboarding",
+            params={"from": d1.isoformat(), "to": d2.isoformat(), "variant": "A"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        d1.isoformat(): {
+            "A": {"step1": 0.8, "step2": 0.6, "step3": 0.0, "completed": 0.4},
+        },
+        d2.isoformat(): {
+            "A": {"step1": 0.6, "step2": 0.0, "step3": 0.0, "completed": 0.4},
+        },
+    }

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -1,13 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-from typing import Callable, TypeVar
-
-import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import Column, MetaData, String, Table, TIMESTAMP, create_engine
-from sqlalchemy.orm import Session, sessionmaker
-from sqlalchemy.pool import StaticPool
 
 from prometheus_client import CONTENT_TYPE_LATEST
 
@@ -16,87 +9,11 @@ from services.api.app.diabetes.metrics import (
     lessons_started,
     quiz_avg_score,
 )
-from services.api.app.routers import metrics
-
-
-def setup_db() -> tuple[sessionmaker[Session], datetime]:
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    metadata = MetaData()
-    events = Table(
-        "onboarding_events",
-        metadata,
-        Column("variant", String),
-        Column("step", String),
-        Column("created_at", TIMESTAMP(timezone=True)),
-    )
-    metadata.create_all(engine)
-    session_local = sessionmaker(bind=engine)
-    now = datetime.now()
-    with engine.begin() as conn:
-        conn.execute(
-            events.insert(),
-            [
-                {"variant": "A", "step": "start", "created_at": now},
-                {"variant": "A", "step": "step1", "created_at": now},
-                {"variant": "A", "step": "finish", "created_at": now},
-                {"variant": "B", "step": "start", "created_at": now},
-            ],
-        )
-    return session_local, now
-
-
-T = TypeVar("T")
-
-
-def test_onboarding_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
-    session_local, now = setup_db()
-
-    async def run_db(
-        fn: Callable[[Session], T],
-        *args: object,
-        sessionmaker: sessionmaker[Session] = session_local,
-        **kwargs: object,
-    ) -> T:
-        with sessionmaker() as session:
-            return fn(session)
-
-    monkeypatch.setattr(metrics, "SessionLocal", session_local, raising=False)
-    monkeypatch.setattr(metrics, "run_db", run_db, raising=False)
-
-    from services.api.app.main import app
-
-    later = now + timedelta(days=1)
-    with TestClient(app) as client:
-        resp = client.get(
-            "/api/metrics/onboarding",
-            params={"from": now.isoformat(), "to": later.isoformat()},
-        )
-    assert resp.status_code == 200
-    assert resp.json() == {
-        "A": {
-            "onboarding_started": 1,
-            "step_completed_1": 1,
-            "step_completed_2": 0,
-            "step_completed_3": 0,
-            "onboarding_finished": 1,
-            "onboarding_cancelled": 0,
-        },
-        "B": {
-            "onboarding_started": 1,
-            "step_completed_1": 0,
-            "step_completed_2": 0,
-            "step_completed_3": 0,
-            "onboarding_finished": 0,
-            "onboarding_cancelled": 0,
-        },
-    }
 
 
 def test_prometheus_metrics_endpoint() -> None:
+    """Prometheus metrics are exposed on /metrics."""
+
     lessons_started.inc()
     lessons_completed.inc()
     quiz_avg_score.observe(50)


### PR DESCRIPTION
## Summary
- add /metrics/onboarding endpoint returning per-day onboarding conversions with variant filter
- simplify Prometheus metrics test and add unit tests for onboarding metrics

## Testing
- `ruff check services/api/app/routers/metrics.py tests/test_metrics_api.py tests/api/test_onboarding_metrics.py`
- `pytest tests/api/test_onboarding_metrics.py tests/test_metrics_api.py -q --override-ini="addopts="`


------
https://chatgpt.com/codex/tasks/task_e_68bafcfa8848832ab651862b2cb3c2ba