### PR TITLE
[docs] document WebApp onboarding flow

### DIFF
--- a/docs/onboarding_webapp_flow.md
+++ b/docs/onboarding_webapp_flow.md
@@ -1,0 +1,28 @@
+# Onboarding WebApp Flow
+
+Краткий гайд по онбордингу через WebApp без `timezone.html` и кнопки в меню.
+
+## Старт
+- Пользователь открывает ссылку вида `https://t.me/<bot>?startapp=onboarding` или
+  жмёт кнопку после команды `/start`.
+- WebApp при загрузке отправляет событие `onboarding_started`.
+
+## События
+| Событие | Шаг | Описание |
+| --- | --- | --- |
+| `onboarding_started` | `profile` | WebApp открыт в режиме онбординга |
+| `profile_saved` | `profile` | Пользователь сохранил профиль |
+| `first_reminder_created` | `reminders` | Создано первое напоминание |
+| `onboarding_completed` | `reminders` | Завершение; при пропуске напоминаний передаётся `skippedReminders: true` |
+
+## Завершение
+Онбординг считается завершённым, когда профиль валиден и:
+- создано хотя бы одно напоминание, **или**
+- отправлено `onboarding_completed` с `skippedReminders = true`.
+
+## Проверка статуса
+```bash
+curl -H 'X-Telegram-Init-Data: <init-data>' \
+  http://localhost:8000/api/onboarding/status
+```
+Возвращает `completed`, `step` и `missing`.


### PR DESCRIPTION
## Summary
- describe WebApp-based onboarding flow
- add onboarding event list and status examples
- create short guide for the team in `docs/onboarding_webapp_flow.md`

## Testing
- `pytest -q --cov` *(fails: alembic.util.exc.CommandError: Multiple head revisions are present; sqlite3.OperationalError)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bb05e0dba8832aa0c88cc839072da7