### PR TITLE
[tests] Add onboarding flow event coverage

### DIFF
--- a/tests/api/test_onboarding_events.py
+++ b/tests/api/test_onboarding_events.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from typing import Callable, TypeVar
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.services.db import (
+    Base,
+    Profile,
+    Reminder,
+    ReminderType,
+    ScheduleKind,
+    User,
+)
+from services.api.app.models.onboarding_event import OnboardingEvent
+from services.api.app.routers import onboarding
+from services.api.app.telegram_auth import require_tg_user
+
+T = TypeVar("T")
+
+
+def setup_db() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def patch_db(monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]) -> None:
+    async def run_db(
+        fn: Callable[[Session], T],
+        *args: object,
+        sessionmaker: sessionmaker[Session] = session_local,
+        **kwargs: object,
+    ) -> T:
+        with sessionmaker() as session:
+            return fn(session, *args, **kwargs)
+
+    monkeypatch.setattr(onboarding, "SessionLocal", session_local, raising=False)
+    monkeypatch.setattr(onboarding, "run_db", run_db, raising=False)
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    session_local = setup_db()
+    patch_db(monkeypatch, session_local)
+
+    from services.api.app.main import app
+
+    app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
+    return TestClient(app)
+
+
+def test_post_event_records(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    resp = client.post("/api/onboarding/events", json={"event": "start", "step": 1})
+    assert resp.status_code == 200
+
+    SessionLocal = onboarding.SessionLocal
+    with SessionLocal() as session:
+        ev = session.query(OnboardingEvent).one()
+        assert ev.user_id == 1
+        assert ev.event == "start"
+        assert ev.step == "1"
+
+
+def test_status_variants(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    SessionLocal = onboarding.SessionLocal
+    # insert user and profile/reminder combinations
+    with SessionLocal() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.commit()
+
+    # no profile -> expect profile step
+    resp = client.get("/api/onboarding/status")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "completed": False,
+        "step": "profile",
+        "missing": ["profile", "reminders"],
+    }
+
+    # add profile
+    with SessionLocal() as session:
+        session.add(
+            Profile(
+                telegram_id=1,
+                icr=1,
+                cf=1,
+                target_bg=5.5,
+                low_threshold=4.0,
+                high_threshold=8.0,
+                timezone="UTC",
+            )
+        )
+        session.commit()
+
+    resp = client.get("/api/onboarding/status")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "completed": False,
+        "step": "reminders",
+        "missing": ["reminders"],
+    }
+
+    # add reminder
+    with SessionLocal() as session:
+        session.add(
+            Reminder(
+                telegram_id=1,
+                type=ReminderType.custom,
+                kind=ScheduleKind.every,
+                interval_minutes=60,
+            )
+        )
+        session.commit()
+
+    resp = client.get("/api/onboarding/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"completed": True, "step": None, "missing": []}
+
+    with SessionLocal() as session:
+        events = session.query(OnboardingEvent).filter_by(event="onboarding_completed").all()
+        assert len(events) == 1
+        assert events[0].step == str(onboarding.REMINDERS)

--- a/tests/bot/test_start_status.py
+++ b/tests/bot/test_start_status.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import aiohttp
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+import services.api.app.diabetes.bot_start_handlers as start_handlers
+from services.api.app.diabetes.bot_start_handlers import build_start_handler
+from services.api.app.diabetes.bot_status_handlers import build_status_handler
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
+
+
+class DummyResponse:
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.status = 200
+        self._data = data
+
+    async def __aenter__(self) -> DummyResponse:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def json(self) -> dict[str, Any]:
+        return self._data
+
+
+class DummySession:
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    async def __aenter__(self) -> DummySession:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def get(self, url: str, headers: dict[str, str] | None = None) -> DummyResponse:
+        return DummyResponse(self._data)
+
+
+@pytest.mark.asyncio
+async def test_start_renders_cta(monkeypatch: pytest.MonkeyPatch) -> None:
+    start_handlers.choose_variant = lambda _uid: "A"  # type: ignore[assignment]
+    handler = build_start_handler("https://ui.example")
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]], SimpleNamespace()
+    )
+
+    await handler.callback(update, context)
+    assert message.replies == ["👋 Добро пожаловать! Быстрая настройка в приложении:"]
+    buttons = message.kwargs[0]["reply_markup"].inline_keyboard
+    assert "flow=onboarding" in buttons[0][0].web_app.url
+
+
+@pytest.mark.asyncio
+async def test_status_routes_to_missing_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TELEGRAM_TOKEN", "t")
+    resp = {"completed": False, "missing": ["reminders"], "step": "reminders"}
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: DummySession(resp))
+
+    handler = build_status_handler("https://ui.example", api_base="https://api.example")
+    message = DummyMessage()
+    user = SimpleNamespace(id=1)
+    update = cast(Update, SimpleNamespace(message=message, effective_user=user))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]], SimpleNamespace()
+    )
+
+    await handler.callback(update, context)
+    buttons = message.kwargs[0]["reply_markup"].inline_keyboard
+    assert buttons[0][0].web_app.url.endswith(
+        "/reminders?flow=onboarding&step=reminders"
+    )

--- a/tests/ui/test_onboarding_flow.spec.ts
+++ b/tests/ui/test_onboarding_flow.spec.ts
@@ -1,0 +1,123 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEffect } from 'react';
+
+// Mocks for Profile dependencies
+vi.mock('../../services/webapp/ui/src/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+vi.mock('../../services/webapp/ui/src/hooks/useTelegram', () => ({
+  useTelegram: () => ({ user: { id: 1 } }),
+}));
+vi.mock('../../services/webapp/ui/src/hooks/useTelegramInitData', () => ({
+  useTelegramInitData: () => ({}),
+}));
+vi.mock('../../services/webapp/ui/src/i18n', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+vi.mock('../../services/webapp/ui/src/hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+vi.mock('../../services/webapp/ui/src/api/timezones', () => ({
+  getTimezones: () => Promise.resolve([]),
+}));
+vi.mock('../../services/webapp/ui/src/features/profile/api', () => ({
+  saveProfile: vi.fn(),
+  getProfile: () => Promise.resolve(null),
+  patchProfile: vi.fn(),
+}));
+vi.mock('../../services/webapp/ui/src/components/MedicalHeader', () => ({
+  MedicalHeader: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('../../services/webapp/ui/src/components/MedicalButton', () => ({
+  default: ({ children, ...rest }: any) => <button {...rest}>{children}</button>,
+}));
+vi.mock('../../services/webapp/ui/src/components/ui/button', () => ({
+  Button: ({ children, ...rest }: any) => <button {...rest}>{children}</button>,
+}));
+vi.mock('../../services/webapp/ui/src/components/ui/checkbox', () => ({
+  Checkbox: (props: any) => <input type="checkbox" {...props} />, 
+}));
+vi.mock('../../services/webapp/ui/src/components/Modal', () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('../../services/webapp/ui/src/components/HelpHint', () => ({
+  default: () => <div />,
+}));
+vi.mock('../../services/webapp/ui/src/components/ProfileHelpSheet', () => ({
+  default: () => <div />,
+}));
+vi.mock('../../services/webapp/ui/src/pages/resolveTelegramId', () => ({
+  resolveTelegramId: () => 1,
+}));
+
+const postEventProfile = vi.fn();
+vi.mock('../../services/webapp/ui/src/shared/api/onboarding', () => ({
+  postOnboardingEvent: postEventProfile,
+}));
+
+import Profile from '../../services/webapp/ui/src/pages/Profile';
+
+// Reminders dependencies
+const postEventReminders = vi.fn();
+vi.mock('../../services/webapp/ui/src/api/onboarding', () => ({
+  postOnboardingEvent: postEventReminders,
+}));
+vi.mock('../../services/webapp/ui/src/features/reminders/pages/RemindersList', () => ({
+  default: ({ onCountChange, onLimitChange }: any) => {
+    useEffect(() => {
+      onLimitChange(5);
+    }, [onLimitChange]);
+    return (
+      <div>
+        <button onClick={() => onCountChange(1)}>add</button>
+      </div>
+    );
+  },
+}));
+import Reminders from '../../services/webapp/ui/src/pages/Reminders';
+
+describe('onboarding events', () => {
+  beforeEach(() => {
+    postEventProfile.mockClear();
+    postEventReminders.mockClear();
+  });
+  it('Profile sends onboarding_started when flow=onboarding', async () => {
+    render(
+      <MemoryRouter initialEntries={['/profile?flow=onboarding&step=profile']}>
+        <Profile />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(postEventProfile).toHaveBeenCalledWith('onboarding_started', 'profile');
+    });
+  });
+
+  it('Reminders sends first_reminder_created on first reminder', async () => {
+    render(
+      <MemoryRouter initialEntries={['/reminders']}>
+        <Reminders />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByText('add'));
+    await waitFor(() => {
+      expect(postEventReminders).toHaveBeenCalledWith('first_reminder_created', 'reminders');
+    });
+  });
+
+  it('Reminders sends onboarding_completed when skipped', async () => {
+    render(
+      <MemoryRouter initialEntries={['/reminders']}>
+        <Reminders />
+      </MemoryRouter>
+    );
+    const skipBtn = screen.getByText('Пропустить пока');
+    fireEvent.click(skipBtn);
+    await waitFor(() => {
+      expect(postEventReminders).toHaveBeenCalledWith('onboarding_completed', 'reminders', {
+        skippedReminders: true,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- cover API onboarding event recording and status logic
- assert webapp pages send onboarding events
- verify bot start/status commands present onboarding CTA and next step

## Testing
- `pytest -q --ignore=tests/migrations/test_upgrade.py --ignore=tests/test_onboarding_api_auth.py`
- `mypy --strict .`
- `ruff check .`
- ⚠️ `pnpm dlx vitest run tests/ui/test_onboarding_flow.spec.ts` *(missing jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0604b970832a80395a2f7f24d20a