### PR TITLE
[deps] Add aiohttp requirement

### DIFF
--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp==3.9.5
 alembic==1.14.1
 annotated-types==0.7.0
 anyio==4.9.0


### PR DESCRIPTION
## Summary
- add aiohttp to API service requirements

## Testing
- `pip install -r services/api/app/requirements.txt`
- `pip install -r services/api/app/requirements-dev.txt`
- `pytest -q --cov` *(fails: CommandError: Multiple head revisions are present for given argument 'head'; please specify a specific target revision)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bb0f619378832aabed9aee0016e0aa