### PR TITLE
[deps] Pin aiohttp

### DIFF
--- a/services/api/app/requirements.txt
+++ b/services/api/app/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.5
+aiohttp>=3.10,<3.11
 alembic==1.14.1
 annotated-types==0.7.0
 anyio==4.9.0


### PR DESCRIPTION
## Summary
- pin aiohttp dependency to v3.10

## Testing
- `pip install -r requirements.txt`
- `pytest tests/bot/test_start_status.py tests/test_bot_status_handler.py` *(fails: async def functions are not natively supported; coverage below threshold)*
- `pytest -q --cov` *(fails: async def functions are not natively supported; 527 failed, 498 passed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bb127a3004832ab2594b2b1d573248