### PR TITLE
chore: remove nonexistent aiohttp types

### DIFF
--- a/services/api/app/requirements-dev.txt
+++ b/services/api/app/requirements-dev.txt
@@ -7,4 +7,3 @@ mypy
 playwright
 attrs>=22.0.0
 types-reportlab
-types-aiohttp


### PR DESCRIPTION
## Summary
- remove invalid `types-aiohttp` entry from dev requirements; `aiohttp` already ships types

## Testing
- `pytest -q --cov` *(fails: alembic util command error; sqlite table not found)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bb129059e8832aa26ceea930e3c9a5