### PR TITLE
refactor(api): extract misc endpoints into routers

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from datetime import time as dt_time
 import logging
 from pathlib import Path
 import sys
 from typing import cast
-import zoneinfo
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 # ────────── Path-хаки, когда файл запускают напрямую ──────────
 if __name__ == "__main__" and __package__ is None:  # pragma: no cover
@@ -16,39 +13,31 @@ if __name__ == "__main__" and __package__ is None:  # pragma: no cover
     __package__ = "services.api.app"
 
 # ────────── std / 3-rd party ──────────
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse
-from pydantic import AliasChoices, BaseModel, Field, ValidationError
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
 
 # ────────── local ──────────
 from . import config, reminder_events
-from .diabetes.services.db import (
-    HistoryRecord as HistoryRecordDB,
-    Timezone as TimezoneDB,
-    User as UserDB,
-    init_db,
-    run_db,
-)
-from .diabetes.services.repository import CommitError, commit
-from .legacy import router as legacy_router
-from .routers.internal_reminders import router as internal_reminders_router
-from .routers.stats import router as stats_router
-from .routers import metrics
-from .routers.billing import router as billing_router
-from .routers.onboarding import router as onboarding_router
-from .schemas.history import ALLOWED_HISTORY_TYPES, HistoryRecordSchema, HistoryType
-from .schemas.role import RoleSchema
-from .services.profile import patch_user_settings
-from .diabetes.schemas.profile import ProfileSettingsIn, ProfileSettingsOut
-from .schemas.user import UserContext
-from .services.user_roles import get_user_role, set_user_role
-from .telegram_auth import require_tg_user
+from .diabetes.handlers.reminder_jobs import DefaultJobQueue
+from .diabetes.services.db import init_db, run_db  # noqa: F401
 from services.api.app.diabetes.services.gpt_client import dispose_openai_clients
 from services.api.app.diabetes.utils.openai_utils import dispose_http_client
-from .diabetes.handlers.reminder_jobs import DefaultJobQueue
+from .telegram_auth import require_tg_user  # noqa: F401
+from .legacy import router as legacy_router
+from .routers import metrics
+from .routers.billing import router as billing_router
+from .routers.health import router as health_router
+from .routers.history import router as history_router
+from .routers.internal_reminders import router as internal_reminders_router
+from .routers.onboarding import router as onboarding_router
+from .routers.profile import router as profile_router
+from .routers.stats import router as stats_router
+from .routers.timezones import router as timezones_router
+from .routers.users import router as users_router
+from .routers.webapp import router as webapp_router
 
 # ────────── init ──────────
 logger = logging.getLogger(__name__)
@@ -102,255 +91,18 @@ api_router.include_router(stats_router)
 api_router.include_router(legacy_router)
 api_router.include_router(metrics.router)
 api_router.include_router(billing_router)
-
-# ────────── статические файлы UI ──────────
-BASE_DIR = Path(__file__).resolve().parents[2] / "webapp"
-DIST_DIR = BASE_DIR / "ui" / "dist"
-UI_DIR = DIST_DIR if (DIST_DIR / "index.html").exists() else BASE_DIR / "ui"
-UI_DIR = UI_DIR.resolve()
-
-
-def get_ui_base_url() -> str:
-    """Return the UI base URL without a trailing slash."""
-
-    return config.get_settings().ui_base_url.rstrip("/")
-
-
-# ────────── Schemas ──────────
-class Timezone(BaseModel):
-    tz: str
-
-
-class WebUser(BaseModel):
-    telegramId: int = Field(
-        alias="telegramId", validation_alias=AliasChoices("telegramId", "telegram_id")
-    )
-
-
-# ────────── helpers ──────────
-def _validate_history_type(value: str, status_code: int = 400) -> HistoryType:
-    if value not in ALLOWED_HISTORY_TYPES:
-        raise HTTPException(status_code=status_code, detail="invalid history type")
-    return cast(HistoryType, value)
-
-
-# ────────── health & misc ──────────
-@api_router.get("/health")
-async def health() -> dict[str, str]:
-    return {"status": "ok"}
-
-
-# ────────── timezones list ──────────
-@api_router.get("/timezones")
-async def get_timezones() -> list[str]:
-    return sorted(zoneinfo.available_timezones())
-
-
-# ────────── timezone ──────────
-@api_router.get("/timezone")
-async def get_timezone(_: UserContext = Depends(require_tg_user)) -> dict[str, str]:
-    def _get_timezone(session: Session) -> TimezoneDB | None:
-        return session.get(TimezoneDB, 1)
-
-    tz_row = await run_db(_get_timezone)
-    if not tz_row:
-        raise HTTPException(status_code=404, detail="timezone not set")
-    try:
-        ZoneInfo(tz_row.tz)
-    except ZoneInfoNotFoundError as exc:
-        raise HTTPException(status_code=400, detail="invalid timezone entry") from exc
-    return {"tz": tz_row.tz}
-
-
-@api_router.put("/timezone")
-async def put_timezone(
-    data: Timezone, _: UserContext = Depends(require_tg_user)
-) -> dict[str, str]:
-    try:
-        ZoneInfo(data.tz)
-    except ZoneInfoNotFoundError as exc:
-        raise HTTPException(status_code=400, detail="invalid timezone") from exc
-
-    def _save_timezone(session: Session) -> None:
-        obj = session.get(TimezoneDB, 1)
-        if obj is None:
-            obj = TimezoneDB(id=1, tz=data.tz)
-            session.add(obj)
-        else:
-            obj.tz = data.tz
-        try:
-            commit(session)
-        except CommitError:
-            raise HTTPException(status_code=500, detail="db commit failed")
-
-    await run_db(_save_timezone)
-    return {"status": "ok"}
-
-
-# ────────── profile/self ──────────
-@api_router.get("/profile/self")
-async def profile_self(user: UserContext = Depends(require_tg_user)) -> UserContext:
-    return user
-
-
-@api_router.patch("/profile", response_model=ProfileSettingsOut)
-async def profile_patch(
-    data: ProfileSettingsIn,
-    device_tz: str | None = Query(None, alias="deviceTz"),
-    user: UserContext = Depends(require_tg_user),
-) -> ProfileSettingsOut:
-    return await patch_user_settings(user["id"], data, device_tz)
-
-
-# ────────── static UI files ──────────
-@app.get(f"{get_ui_base_url()}/{{full_path:path}}", include_in_schema=False)
-async def catch_all_ui(full_path: str) -> FileResponse:
-    requested_file = (UI_DIR / full_path).resolve()
-    try:
-        requested_file.relative_to(UI_DIR)
-    except ValueError as exc:
-        raise HTTPException(status_code=404) from exc
-    if requested_file.is_file():
-        if requested_file.suffix == ".js":
-            return FileResponse(requested_file, media_type="text/javascript")
-        return FileResponse(requested_file)
-    return FileResponse(UI_DIR / "index.html")
-
-
-@app.get(get_ui_base_url() or "/", include_in_schema=False)
-async def catch_root_ui() -> FileResponse:
-    return await catch_all_ui("")
-
-
-# ────────── user CRUD / roles ──────────
-@api_router.post("/user")
-async def create_user(
-    data: WebUser, user: UserContext = Depends(require_tg_user)
-) -> dict[str, str]:
-    if data.telegramId != user["id"]:
-        raise HTTPException(status_code=403, detail="telegram id mismatch")
-
-    def _create_user(session: Session) -> None:
-        db_user = session.get(UserDB, data.telegramId)
-        if db_user is None:
-            session.add(UserDB(telegram_id=data.telegramId, thread_id="webapp"))
-        try:
-            commit(session)
-        except CommitError:
-            raise HTTPException(status_code=500, detail="db commit failed")
-
-    await run_db(_create_user)
-    return {"status": "ok"}
-
-
-@api_router.get("/user/{user_id}/role")
-async def get_role(user_id: int) -> RoleSchema:
-    role = await get_user_role(user_id)
-    return RoleSchema(role=role or "patient")
-
-
-@api_router.put("/user/{user_id}/role")
-async def put_role(user_id: int, data: RoleSchema) -> RoleSchema:
-    await set_user_role(user_id, data.role)
-    return RoleSchema(role=data.role)
-
-
-# ────────── history (CRUD) ──────────
-@api_router.post("/history", operation_id="historyPost", tags=["History"])
-async def post_history(
-    data: HistoryRecordSchema, user: UserContext = Depends(require_tg_user)
-) -> dict[str, str]:
-    validated_type = _validate_history_type(data.type)
-
-    def _save(session: Session) -> None:
-        obj = session.get(HistoryRecordDB, data.id)
-        if obj and obj.telegram_id != user["id"]:
-            raise HTTPException(status_code=403, detail="forbidden")
-        if obj is None:
-            obj = HistoryRecordDB(id=data.id, telegram_id=user["id"])
-            session.add(obj)
-        obj.date = data.date
-        obj.time = dt_time.fromisoformat(data.time)
-        obj.sugar = data.sugar
-        obj.carbs = data.carbs
-        obj.bread_units = data.breadUnits
-        obj.insulin = data.insulin
-        obj.notes = data.notes
-        obj.type = validated_type
-        try:
-            commit(session)
-        except CommitError:
-            raise HTTPException(status_code=500, detail="db commit failed")
-
-    await run_db(_save)
-    return {"status": "ok"}
-
-
-@api_router.get("/history", operation_id="historyGet", tags=["History"])
-async def get_history(
-    limit: int | None = Query(None, ge=1),
-    user: UserContext = Depends(require_tg_user),
-) -> list[HistoryRecordSchema]:
-    def _query(session: Session) -> list[HistoryRecordDB]:
-        query = (
-            session.query(HistoryRecordDB)
-            .filter(HistoryRecordDB.telegram_id == user["id"])
-            .order_by(HistoryRecordDB.date.desc(), HistoryRecordDB.time.desc())
-        )
-        if limit is not None:
-            query = query.limit(limit)
-        return query.all()
-
-    records = await run_db(_query)
-
-    result: list[HistoryRecordSchema] = []
-    for r in records:
-        if r.type in ALLOWED_HISTORY_TYPES:
-            result.append(
-                HistoryRecordSchema(
-                    id=r.id,
-                    date=r.date,
-                    time=r.time.strftime("%H:%M"),
-                    sugar=r.sugar,
-                    carbs=r.carbs,
-                    breadUnits=r.bread_units,
-                    insulin=r.insulin,
-                    notes=r.notes,
-                    type=cast(HistoryType, r.type),
-                )
-            )
-    return result
-
-
-@api_router.delete("/history/{id}", operation_id="historyIdDelete", tags=["History"])
-async def delete_history(
-    id: str, user: UserContext = Depends(require_tg_user)
-) -> dict[str, str]:
-    def _get(session: Session) -> HistoryRecordDB | None:
-        return session.get(HistoryRecordDB, id)
-
-    record = await run_db(_get)
-    if record is None:
-        raise HTTPException(status_code=404, detail="not found")
-    if record.telegram_id != user["id"]:
-        raise HTTPException(status_code=403, detail="forbidden")
-
-    def _delete(session: Session) -> None:
-        session.delete(record)
-        try:
-            commit(session)
-        except CommitError:
-            raise HTTPException(status_code=500, detail="db commit failed")
-
-    await run_db(_delete)
-    return {"status": "ok"}
-
+api_router.include_router(profile_router)
+api_router.include_router(timezones_router)
+api_router.include_router(health_router)
+api_router.include_router(users_router)
+api_router.include_router(history_router)
 
 # ────────── include router ──────────
 app.include_router(internal_reminders_router)
 app.include_router(metrics.router)
 app.include_router(onboarding_router)
 app.include_router(api_router, prefix="/api")
+app.include_router(webapp_router)
 
 # ────────── run (for local testing) ──────────
 if __name__ == "__main__":  # pragma: no cover

--- a/services/api/app/routers/health.py
+++ b/services/api/app/routers/health.py
@@ -1,0 +1,20 @@
+"""Health check endpoints."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    """Return service health status."""
+
+    return {"status": "ok"}
+

--- a/services/api/app/routers/history.py
+++ b/services/api/app/routers/history.py
@@ -1,0 +1,128 @@
+"""History CRUD endpoints."""
+
+from __future__ import annotations
+
+import logging
+from datetime import time as dt_time
+from typing import cast
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from ..diabetes.services.db import HistoryRecord as HistoryRecordDB, run_db
+from ..diabetes.services.repository import CommitError, commit
+from ..schemas.history import (
+    ALLOWED_HISTORY_TYPES,
+    HistoryRecordSchema,
+    HistoryType,
+)
+from ..schemas.user import UserContext
+from ..telegram_auth import require_tg_user
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _validate_history_type(value: str, status_code: int = 400) -> HistoryType:
+    if value not in ALLOWED_HISTORY_TYPES:
+        raise HTTPException(status_code=status_code, detail="invalid history type")
+    return cast(HistoryType, value)
+
+
+@router.post("/history", operation_id="historyPost", tags=["History"])
+async def post_history(
+    data: HistoryRecordSchema, user: UserContext = Depends(require_tg_user)
+) -> dict[str, str]:
+    """Create or update a history record."""
+
+    validated_type = _validate_history_type(data.type)
+
+    def _save(session: Session) -> None:
+        obj = session.get(HistoryRecordDB, data.id)
+        if obj and obj.telegram_id != user["id"]:
+            raise HTTPException(status_code=403, detail="forbidden")
+        if obj is None:
+            obj = HistoryRecordDB(id=data.id, telegram_id=user["id"])
+            session.add(obj)
+        obj.date = data.date
+        obj.time = dt_time.fromisoformat(data.time)
+        obj.sugar = data.sugar
+        obj.carbs = data.carbs
+        obj.bread_units = data.breadUnits
+        obj.insulin = data.insulin
+        obj.notes = data.notes
+        obj.type = validated_type
+        try:
+            commit(session)
+        except CommitError:  # pragma: no cover - db error
+            raise HTTPException(status_code=500, detail="db commit failed")
+
+    await run_db(_save)
+    return {"status": "ok"}
+
+
+@router.get("/history", operation_id="historyGet", tags=["History"])
+async def get_history(
+    limit: int | None = Query(None, ge=1),
+    user: UserContext = Depends(require_tg_user),
+) -> list[HistoryRecordSchema]:
+    """Return list of history records."""
+
+    def _query(session: Session) -> list[HistoryRecordDB]:
+        query = (
+            session.query(HistoryRecordDB)
+            .filter(HistoryRecordDB.telegram_id == user["id"])
+            .order_by(HistoryRecordDB.date.desc(), HistoryRecordDB.time.desc())
+        )
+        if limit is not None:
+            query = query.limit(limit)
+        return query.all()
+
+    records = await run_db(_query)
+
+    result: list[HistoryRecordSchema] = []
+    for r in records:
+        if r.type in ALLOWED_HISTORY_TYPES:
+            result.append(
+                HistoryRecordSchema(
+                    id=r.id,
+                    date=r.date,
+                    time=r.time.strftime("%H:%M"),
+                    sugar=r.sugar,
+                    carbs=r.carbs,
+                    breadUnits=r.bread_units,
+                    insulin=r.insulin,
+                    notes=r.notes,
+                    type=cast(HistoryType, r.type),
+                )
+            )
+    return result
+
+
+@router.delete("/history/{id}", operation_id="historyIdDelete", tags=["History"])
+async def delete_history(
+    id: str, user: UserContext = Depends(require_tg_user)
+) -> dict[str, str]:
+    """Delete history record by id."""
+
+    def _get(session: Session) -> HistoryRecordDB | None:
+        return session.get(HistoryRecordDB, id)
+
+    record = await run_db(_get)
+    if record is None:
+        raise HTTPException(status_code=404, detail="not found")
+    if record.telegram_id != user["id"]:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    def _delete(session: Session) -> None:
+        session.delete(record)
+        try:
+            commit(session)
+        except CommitError:  # pragma: no cover - db error
+            raise HTTPException(status_code=500, detail="db commit failed")
+
+    await run_db(_delete)
+    return {"status": "ok"}
+

--- a/services/api/app/routers/profile.py
+++ b/services/api/app/routers/profile.py
@@ -1,0 +1,36 @@
+"""Profile related endpoints."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Query
+
+from ..diabetes.schemas.profile import ProfileSettingsIn, ProfileSettingsOut
+from ..schemas.user import UserContext
+from ..services.profile import patch_user_settings
+from ..telegram_auth import require_tg_user
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/profile/self")
+async def profile_self(user: UserContext = Depends(require_tg_user)) -> UserContext:
+    """Return current user context."""
+
+    return user
+
+
+@router.patch("/profile", response_model=ProfileSettingsOut)
+async def profile_patch(
+    data: ProfileSettingsIn,
+    device_tz: str | None = Query(None, alias="deviceTz"),
+    user: UserContext = Depends(require_tg_user),
+) -> ProfileSettingsOut:
+    """Update profile settings."""
+
+    return await patch_user_settings(user["id"], data, device_tz)
+

--- a/services/api/app/routers/timezones.py
+++ b/services/api/app/routers/timezones.py
@@ -1,0 +1,77 @@
+"""Timezone related endpoints."""
+
+from __future__ import annotations
+
+import logging
+import zoneinfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..diabetes.services.db import Timezone as TimezoneDB, run_db
+from ..diabetes.services.repository import CommitError, commit
+from ..schemas.user import UserContext
+from ..telegram_auth import require_tg_user
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class Timezone(BaseModel):
+    tz: str
+
+
+@router.get("/timezones")
+async def get_timezones() -> list[str]:
+    """Return sorted list of all available timezones."""
+
+    return sorted(zoneinfo.available_timezones())
+
+
+@router.get("/timezone")
+async def get_timezone(_: UserContext = Depends(require_tg_user)) -> dict[str, str]:
+    """Return stored timezone value."""
+
+    def _get_timezone(session: Session) -> TimezoneDB | None:
+        return session.get(TimezoneDB, 1)
+
+    tz_row = await run_db(_get_timezone)
+    if not tz_row:
+        raise HTTPException(status_code=404, detail="timezone not set")
+    try:
+        ZoneInfo(tz_row.tz)
+    except ZoneInfoNotFoundError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail="invalid timezone entry") from exc
+    return {"tz": tz_row.tz}
+
+
+@router.put("/timezone")
+async def put_timezone(
+    data: Timezone, _: UserContext = Depends(require_tg_user)
+) -> dict[str, str]:
+    """Store provided timezone."""
+
+    try:
+        ZoneInfo(data.tz)
+    except ZoneInfoNotFoundError as exc:
+        raise HTTPException(status_code=400, detail="invalid timezone") from exc
+
+    def _save_timezone(session: Session) -> None:
+        obj = session.get(TimezoneDB, 1)
+        if obj is None:
+            obj = TimezoneDB(id=1, tz=data.tz)
+            session.add(obj)
+        else:
+            obj.tz = data.tz
+        try:
+            commit(session)
+        except CommitError:  # pragma: no cover - db error
+            raise HTTPException(status_code=500, detail="db commit failed")
+
+    await run_db(_save_timezone)
+    return {"status": "ok"}
+

--- a/services/api/app/routers/users.py
+++ b/services/api/app/routers/users.py
@@ -1,0 +1,66 @@
+"""User management endpoints."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import AliasChoices, BaseModel, Field
+from sqlalchemy.orm import Session
+
+from ..diabetes.services.db import User as UserDB, run_db
+from ..diabetes.services.repository import CommitError, commit
+from ..schemas.role import RoleSchema
+from ..schemas.user import UserContext
+from ..services.user_roles import get_user_role, set_user_role
+from ..telegram_auth import require_tg_user
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class WebUser(BaseModel):
+    telegramId: int = Field(
+        alias="telegramId", validation_alias=AliasChoices("telegramId", "telegram_id")
+    )
+
+
+@router.post("/user")
+async def create_user(
+    data: WebUser, user: UserContext = Depends(require_tg_user)
+) -> dict[str, str]:
+    """Create a user record if it does not exist."""
+
+    if data.telegramId != user["id"]:
+        raise HTTPException(status_code=403, detail="telegram id mismatch")
+
+    def _create_user(session: Session) -> None:
+        db_user = session.get(UserDB, data.telegramId)
+        if db_user is None:
+            session.add(UserDB(telegram_id=data.telegramId, thread_id="webapp"))
+        try:
+            commit(session)
+        except CommitError:  # pragma: no cover - db error
+            raise HTTPException(status_code=500, detail="db commit failed")
+
+    await run_db(_create_user)
+    return {"status": "ok"}
+
+
+@router.get("/user/{user_id}/role")
+async def get_role(user_id: int) -> RoleSchema:
+    """Return user role."""
+
+    role = await get_user_role(user_id)
+    return RoleSchema(role=role or "patient")
+
+
+@router.put("/user/{user_id}/role")
+async def put_role(user_id: int, data: RoleSchema) -> RoleSchema:
+    """Set user role."""
+
+    await set_user_role(user_id, data.role)
+    return RoleSchema(role=data.role)
+

--- a/services/api/app/routers/webapp.py
+++ b/services/api/app/routers/webapp.py
@@ -1,0 +1,51 @@
+"""Routes serving the web application static files."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+
+from .. import config
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+BASE_DIR = Path(__file__).resolve().parents[2] / "webapp"
+DIST_DIR = BASE_DIR / "ui" / "dist"
+UI_DIR = DIST_DIR if (DIST_DIR / "index.html").exists() else BASE_DIR / "ui"
+UI_DIR = UI_DIR.resolve()
+
+
+def get_ui_base_url() -> str:
+    """Return the UI base URL without a trailing slash."""
+
+    return config.get_settings().ui_base_url.rstrip("/")
+
+
+@router.get(f"{get_ui_base_url()}/{{full_path:path}}", include_in_schema=False)
+async def catch_all_ui(full_path: str) -> FileResponse:
+    """Serve UI static files."""
+
+    requested_file = (UI_DIR / full_path).resolve()
+    try:
+        requested_file.relative_to(UI_DIR)
+    except ValueError as exc:  # pragma: no cover - path traversal
+        raise HTTPException(status_code=404) from exc
+    if requested_file.is_file():
+        if requested_file.suffix == ".js":
+            return FileResponse(requested_file, media_type="text/javascript")
+        return FileResponse(requested_file)
+    return FileResponse(UI_DIR / "index.html")
+
+
+@router.get(get_ui_base_url() or "/", include_in_schema=False)
+async def catch_root_ui() -> FileResponse:
+    """Serve root UI entry point."""
+
+    return await catch_all_ui("")
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,7 +173,7 @@ def _reset_init_db() -> Iterator[None]:
 @pytest.fixture(autouse=True, scope="session")
 def _build_ui_assets() -> Iterator[None]:
     """Build webapp UI if static assets are missing."""
-    from services.api.app.main import BASE_DIR, UI_DIR
+    from services.api.app.routers.webapp import BASE_DIR, UI_DIR
 
     repo_root = BASE_DIR.parent
 

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -5,7 +5,8 @@ from collections.abc import Iterator
 import pytest
 from fastapi.testclient import TestClient
 
-from services.api.app.main import UI_DIR, app
+from services.api.app.main import app
+from services.api.app.routers.webapp import UI_DIR
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- move health, timezones, profile, user and history endpoints into dedicated router modules
- serve webapp static files from a separate router
- update main app to include new routers and tests to use new import paths

## Testing
- `pytest -q`
- `pytest tests/test_timezones_api.py tests/test_profile_patch_endpoint.py tests/test_ui_routes.py -q`
- `mypy --strict .`
- `ruff check services/api/app/main.py services/api/app/routers/health.py services/api/app/routers/timezones.py services/api/app/routers/profile.py services/api/app/routers/users.py services/api/app/routers/history.py services/api/app/routers/webapp.py tests/conftest.py tests/test_ui_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb174992ec832aa5bfe82b0f9752fe