### PR TITLE
[services] Handle profile DB availability errors

### DIFF
--- a/tests/test_profile_errors.py
+++ b/tests/test_profile_errors.py
@@ -1,0 +1,37 @@
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.exc import OperationalError
+
+from services.api.app.diabetes.services.db import Profile
+from services.api.app.services import profile as profile_service
+
+
+@pytest.mark.asyncio
+async def test_get_profile_operational_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run_db(*args: object, **kwargs: object) -> Profile | None:
+        raise OperationalError("stmt", {}, Exception("db down"))
+
+    monkeypatch.setattr(profile_service.db, "run_db", _run_db)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await profile_service.get_profile(1)
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail == "database temporarily unavailable"
+
+
+@pytest.mark.asyncio
+async def test_get_profile_unexpected_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run_db(*args: object, **kwargs: object) -> Profile | None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(profile_service.db, "run_db", _run_db)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await profile_service.get_profile(1)
+
+    assert excinfo.value.status_code == 500


### PR DESCRIPTION
## Summary
- return 503 on database connection issues when fetching profiles
- test profile lookup resilience to database failures

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/test_profile_errors.py -q` *(fails: Coverage failure: total of 24 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68bb18667f20832ab6664ae203c798e7