### PR TITLE
[tests] add in-memory db fixture

### DIFF
--- a/tests/test_profile_non_insulin.py
+++ b/tests/test_profile_non_insulin.py
@@ -1,9 +1,7 @@
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
-import services.api.app.diabetes.services.db as db
-from services.api.app.diabetes.services.db import Base, User
+from services.api.app.diabetes.services.db import User
 from services.api.app.schemas.profile import ProfileSchema
 from services.api.app.services import profile as profile_service
 
@@ -11,13 +9,9 @@ from services.api.app.services import profile as profile_service
 @pytest.mark.asyncio
 @pytest.mark.parametrize("therapy_type", ["tablets", "none"])
 async def test_save_profile_allows_non_insulin(
-    therapy_type: str, monkeypatch: pytest.MonkeyPatch
+    therapy_type: str, in_memory_db: sessionmaker[Session]
 ) -> None:
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
-    TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
-    monkeypatch.setattr(db, "SessionLocal", TestSession)
-    with TestSession() as session:
+    with in_memory_db() as session:
         session.add(User(telegram_id=1, thread_id="t"))
         session.commit()
 
@@ -33,4 +27,3 @@ async def test_save_profile_allows_non_insulin(
     prof = await profile_service.get_profile(1)
     assert prof.icr is None
     assert prof.cf is None
-    engine.dispose()


### PR DESCRIPTION
## Summary
- provide `in_memory_db` fixture for tests using an in-memory SQLite database
- reuse the fixture in profile tests

## Testing
- `pytest tests/test_profile_non_insulin.py -q --cov --cov-fail-under=0`
- `ruff check tests/conftest.py tests/test_profile_non_insulin.py`
- `mypy --strict tests/test_profile_non_insulin.py tests/conftest.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb18677178832aa6fad18652df3c24