### PR TITLE
[migrations] Guard billing_event drop for SQLite

### DIFF
--- a/services/api/alembic/versions/20250904_billing_log.py
+++ b/services/api/alembic/versions/20250904_billing_log.py
@@ -37,4 +37,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index("ix_billing_logs_user_id", table_name="billing_logs")
     op.drop_table("billing_logs")
-    op.execute("DROP TYPE billing_event")
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("DROP TYPE billing_event")


### PR DESCRIPTION
## Summary
- guard billing_event enum drop so SQLite migrations succeed

## Testing
- `ruff check .`
- `mypy --strict --follow-imports=skip services/api/alembic/versions/20250904_billing_log.py tests/migrations/test_upgrade.py`
- `pytest tests/migrations/test_upgrade.py -q --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68bb21a867d0832aaf5c7c08219d0e29