### PR TITLE
[bot] Replace /start onboarding with WebApp CTA

### DIFF
--- a/services/bot/handlers/__init__.py
+++ b/services/bot/handlers/__init__.py
@@ -1,0 +1,3 @@
+"""Bot-specific handlers package."""
+
+__all__: list[str] = []

--- a/services/bot/handlers/start_webapp.py
+++ b/services/bot/handlers/start_webapp.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+from typing import TypeAlias
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, WebAppInfo
+from telegram.ext import CommandHandler, ContextTypes
+
+logger = logging.getLogger(__name__)
+
+CommandHandlerT: TypeAlias = CommandHandler[ContextTypes.DEFAULT_TYPE, object]
+
+
+def build_start_handler(ui_base_url: str) -> CommandHandlerT:
+    """Return a ``/start`` handler that links to the WebApp onboarding."""
+
+    async def _start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        profile_url = f"{ui_base_url.rstrip('/')}/profile?flow=onboarding&step=profile"
+        reminders_url = f"{ui_base_url.rstrip('/')}/reminders?flow=onboarding&step=reminders"
+
+        kb = InlineKeyboardMarkup(
+            [
+                [InlineKeyboardButton("🧾 Открыть профиль", web_app=WebAppInfo(profile_url))],
+                [
+                    InlineKeyboardButton(
+                        "⏰ Открыть напоминания", web_app=WebAppInfo(reminders_url)
+                    )
+                ],
+            ]
+        )
+
+        if update.message:
+            await update.message.reply_text(
+                "👋 Добро пожаловать! Быстрая настройка в приложении:",
+                reply_markup=kb,
+            )
+
+    return CommandHandlerT("start", _start)
+
+
+__all__ = ["build_start_handler"]

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -16,6 +16,7 @@ from services.api.app.config import settings
 from services.api.app.diabetes.handlers.registration import register_handlers
 from services.api.app.diabetes.services.db import init_db
 from services.api.app.menu_button import post_init as menu_button_post_init
+from services.bot.handlers.start_webapp import build_start_handler
 from services.bot.ptb_patches import apply_jobqueue_stop_workaround  # 👈 добавили
 from services.bot.telegram_payments import register_billing_handlers
 
@@ -95,6 +96,9 @@ def main() -> None:  # pragma: no cover
         dict[str, object],
         DefaultJobQueue,
     ] = Application.builder().token(BOT_TOKEN).post_init(post_init).build()
+
+    application.add_handler(build_start_handler(settings.ui_base_url), group=0)
+    logger.info("✅ /start → WebApp CTA mode enabled")
 
     # ---- Configure APScheduler timezone BEFORE any scheduling
     tz_msk = ZoneInfo("Europe/Moscow")

--- a/tests/bot/test_start_webapp.py
+++ b/tests/bot/test_start_webapp.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.bot.handlers.start_webapp import build_start_handler
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_start_webapp_buttons() -> None:
+    handler = build_start_handler("https://ui.example")
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]], SimpleNamespace()
+    )
+
+    await handler.callback(update, context)
+
+    assert message.replies == ["👋 Добро пожаловать! Быстрая настройка в приложении:"]
+    buttons = message.kwargs[0]["reply_markup"].inline_keyboard
+    assert buttons[0][0].web_app.url.endswith(
+        "/profile?flow=onboarding&step=profile"
+    )
+    assert buttons[1][0].web_app.url.endswith(
+        "/reminders?flow=onboarding&step=reminders"
+    )


### PR DESCRIPTION
## Summary
- add WebApp-based /start handler
- register WebApp onboarding in bot service and log enablement
- cover WebApp start handler with unit test

## Testing
- `pytest tests/bot/test_start_webapp.py -q -o addopts='--cov=services.bot.handlers.start_webapp --cov-report=term-missing --cov-fail-under=0'`
- `ruff check .`
- `mypy --strict .`


------
https://chatgpt.com/codex/tasks/task_e_68bb23f034e4832aa00bb266c35ed21a