### PR TITLE
[services] Fix SessionLocal bind check

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -468,11 +468,11 @@ class HistoryRecord(Base):
 # ────────────────────── инициализация ────────────────────────
 def init_db() -> None:
     """Создать таблицы, если их ещё нет (для локального запуска)."""
-
-    if SessionLocal.bind is not None:
-        return
+    global engine
 
     url = sa.engine.make_url(settings.database_url)
+    if SessionLocal.kw.get("bind") is not None and engine is not None and engine.url == url:
+        return
     if url.drivername.startswith("sqlite"):
         database_url = url
     else:
@@ -488,7 +488,6 @@ def init_db() -> None:
             database=settings.db_name,
         )
 
-    global engine
     with engine_lock:
         if engine is None or engine.url != database_url:
             if engine is not None:


### PR DESCRIPTION
## Summary
- avoid AttributeError in init_db by checking SessionLocal.kw['bind'] and existing engine URL before returning
- ensure dispose_engine updates global engine correctly

## Testing
- `python - <<'PY'
import os
os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
from services.api.app.diabetes.services import db
from sqlalchemy import inspect

db.engine = None
if 'bind' in db.SessionLocal.kw: del db.SessionLocal.kw['bind']

db.init_db()
print('Engine configured:', db.engine is not None)
print('Session bind is engine:', db.SessionLocal.kw.get('bind') is db.engine)
insp = inspect(db.engine)
print('Tables count:', len(insp.get_table_names()))
PY`
- `pytest tests/test_run_db.py -q --no-cov`
- `pytest tests/test_db_reinit.py -q --no-cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bb27a0c748832a93b702ae881d522e