### PR TITLE
[db] validate engine during init

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -469,9 +469,6 @@ class HistoryRecord(Base):
 def init_db() -> None:
     """Создать таблицы, если их ещё нет (для локального запуска)."""
 
-    if SessionLocal.bind is not None:
-        return
-
     url = sa.engine.make_url(settings.database_url)
     if url.drivername.startswith("sqlite"):
         database_url = url
@@ -495,5 +492,9 @@ def init_db() -> None:
                 engine.dispose()
             engine = create_engine(database_url)
             SessionLocal.configure(bind=engine)
+        current_engine = engine
 
-    Base.metadata.create_all(bind=engine)
+    if current_engine is None:
+        raise RuntimeError("Database engine is not configured. Call init_db() to configure it.")
+
+    Base.metadata.create_all(bind=current_engine)

--- a/tests/test_db_init_no_engine.py
+++ b/tests/test_db_init_no_engine.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+from types import ModuleType
+from typing import Any, cast
+
+import pytest
+
+
+def _reload(module: str) -> ModuleType:
+    if module in sys.modules:
+        del sys.modules[module]
+    return importlib.import_module(module)
+
+
+def test_init_db_raises_when_engine_not_created(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DB_PASSWORD", "pwd")
+    _reload("services.api.app.config")
+    db = cast(Any, _reload("services.api.app.diabetes.services.db"))
+
+    monkeypatch.setattr(db, "create_engine", lambda url: None)
+
+    with pytest.raises(RuntimeError):
+        db.init_db()
+    db.init_db = lambda: None


### PR DESCRIPTION
## Summary
- validate and reuse database engine during `init_db`
- add test covering engine creation failure

## Testing
- `pytest -q` *(fails: TypeError in DummyApp.add_handler, missing SQLite tables)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bb284129a4832a961959af2b073fa4