### PR TITLE
[tests] Accept group in DummyApp.add_handler

### DIFF
--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -66,7 +66,9 @@ def test_log_level_debug(monkeypatch: pytest.MonkeyPatch) -> None:
         ) -> None:
             return None
 
-        def add_handler(self, _: object) -> None:
+        def add_handler(
+            self, handler: object, *, group: int | None = None
+        ) -> None:  # pragma: no cover - compatibility
             return None
 
         def run_polling(self) -> None:

--- a/tests/test_bot_single_test_reminder.py
+++ b/tests/test_bot_single_test_reminder.py
@@ -68,7 +68,7 @@ def test_single_test_reminder(monkeypatch: pytest.MonkeyPatch) -> None:
             return None
 
         def add_handler(
-            self, handler: object
+            self, handler: object, *, group: int | None = None
         ) -> None:  # pragma: no cover - compatibility
             return None
 


### PR DESCRIPTION
## Summary
- allow DummyApp.add_handler in tests to accept group keyword

## Testing
- `pytest -q --override-ini='addopts=' tests/test_bot_debug_logging.py tests/test_bot_single_test_reminder.py`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bb2b066ce8832a8d320ceef2523ac1