### PR TITLE
[services] Ensure SessionLocal bind compatibility

### DIFF
--- a/tests/test_webapp_timezone.py
+++ b/tests/test_webapp_timezone.py
@@ -46,6 +46,9 @@ def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
     SessionLocal = sessionmaker(bind=engine, class_=Session)
     db.Base.metadata.create_all(bind=engine)
 
+    # Ensure application code uses the in-memory sessionmaker
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal)
+
     async def run_db_wrapper(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         return await db.run_db(fn, *args, sessionmaker=SessionLocal, **kwargs)
 

--- a/tests/test_webapp_user.py
+++ b/tests/test_webapp_user.py
@@ -26,6 +26,9 @@ def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
     SessionLocal = sessionmaker(bind=engine, class_=Session)
     db.Base.metadata.create_all(bind=engine)
 
+    # Ensure application code uses the in-memory sessionmaker
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal)
+
     async def run_db_wrapper(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         return await db.run_db(fn, *args, sessionmaker=SessionLocal, **kwargs)
 


### PR DESCRIPTION
## Summary
- update DB engine checks to use SQLAlchemy 2 session binding
- reset sessionmaker bind when disposing engine
- stabilize tests by overriding SessionLocal in webapp helpers

## Testing
- `pytest -q --no-cov tests/test_config.py tests/test_db_reinit.py tests/test_webapp_timezone.py tests/test_webapp_user.py`
- `mypy --strict services/api/app/diabetes/services/db.py tests/test_config.py tests/test_db_reinit.py tests/test_webapp_timezone.py tests/test_webapp_user.py`
- `ruff check services/api/app/diabetes/services/db.py tests/test_config.py tests/test_db_reinit.py tests/test_webapp_timezone.py tests/test_webapp_user.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb2b065830832aa1933033527aeb39