### PR TITLE
[migrations] guard Postgres-specific ops

### DIFF
--- a/services/api/alembic/versions/20250812_add_org_id_to_reminders.py
+++ b/services/api/alembic/versions/20250812_add_org_id_to_reminders.py
@@ -41,4 +41,8 @@ def downgrade() -> None:
 
     columns = [col["name"] for col in inspector.get_columns("reminders")]
     if "org_id" in columns:
-        op.drop_column("reminders", "org_id")
+        if bind.dialect.name == "postgresql":
+            op.drop_column("reminders", "org_id")
+        else:
+            with op.batch_alter_table("reminders") as batch_op:
+                batch_op.drop_column("org_id")

--- a/services/api/alembic/versions/20250813_add_org_id_to_users.py
+++ b/services/api/alembic/versions/20250813_add_org_id_to_users.py
@@ -41,4 +41,8 @@ def downgrade() -> None:
 
     columns = [col["name"] for col in inspector.get_columns("users")]
     if "org_id" in columns:
-        op.drop_column("users", "org_id")
+        if bind.dialect.name == "postgresql":
+            op.drop_column("users", "org_id")
+        else:
+            with op.batch_alter_table("users") as batch_op:
+                batch_op.drop_column("org_id")

--- a/services/api/alembic/versions/20250814_add_org_id_to_profiles.py
+++ b/services/api/alembic/versions/20250814_add_org_id_to_profiles.py
@@ -41,4 +41,8 @@ def downgrade() -> None:
 
     columns = [col["name"] for col in inspector.get_columns("profiles")]
     if "org_id" in columns:
-        op.drop_column("profiles", "org_id")
+        if bind.dialect.name == "postgresql":
+            op.drop_column("profiles", "org_id")
+        else:
+            with op.batch_alter_table("profiles") as batch_op:
+                batch_op.drop_column("org_id")

--- a/services/api/alembic/versions/20250815_add_org_id_to_entries.py
+++ b/services/api/alembic/versions/20250815_add_org_id_to_entries.py
@@ -41,4 +41,8 @@ def downgrade() -> None:
 
     columns = [col["name"] for col in inspector.get_columns("entries")]
     if "org_id" in columns:
-        op.drop_column("entries", "org_id")
+        if bind.dialect.name == "postgresql":
+            op.drop_column("entries", "org_id")
+        else:
+            with op.batch_alter_table("entries") as batch_op:
+                batch_op.drop_column("org_id")

--- a/services/api/alembic/versions/20250816_add_org_id_to_alerts.py
+++ b/services/api/alembic/versions/20250816_add_org_id_to_alerts.py
@@ -41,4 +41,8 @@ def downgrade() -> None:
 
     columns = [col["name"] for col in inspector.get_columns("alerts")]
     if "org_id" in columns:
-        op.drop_column("alerts", "org_id")
+        if bind.dialect.name == "postgresql":
+            op.drop_column("alerts", "org_id")
+        else:
+            with op.batch_alter_table("alerts") as batch_op:
+                batch_op.drop_column("org_id")

--- a/services/api/alembic/versions/20250818_add_name_fields_to_users.py
+++ b/services/api/alembic/versions/20250818_add_name_fields_to_users.py
@@ -29,9 +29,18 @@ def downgrade() -> None:
     inspector = sa.inspect(bind)
 
     columns = [col["name"] for col in inspector.get_columns("users")]
-    if "username" in columns:
-        op.drop_column("users", "username")
-    if "last_name" in columns:
-        op.drop_column("users", "last_name")
-    if "first_name" in columns:
-        op.drop_column("users", "first_name")
+    if bind.dialect.name == "postgresql":
+        if "username" in columns:
+            op.drop_column("users", "username")
+        if "last_name" in columns:
+            op.drop_column("users", "last_name")
+        if "first_name" in columns:
+            op.drop_column("users", "first_name")
+    else:
+        with op.batch_alter_table("users") as batch_op:
+            if "username" in columns:
+                batch_op.drop_column("username")
+            if "last_name" in columns:
+                batch_op.drop_column("last_name")
+            if "first_name" in columns:
+                batch_op.drop_column("first_name")

--- a/services/api/alembic/versions/20250821_add_snooze_minutes_to_reminder_logs.py
+++ b/services/api/alembic/versions/20250821_add_snooze_minutes_to_reminder_logs.py
@@ -27,4 +27,8 @@ def downgrade() -> None:
     inspector = sa.inspect(bind)
     columns = [col["name"] for col in inspector.get_columns("reminder_logs")]
     if "snooze_minutes" in columns:
-        op.drop_column("reminder_logs", "snooze_minutes")
+        if bind.dialect.name == "postgresql":
+            op.drop_column("reminder_logs", "snooze_minutes")
+        else:
+            with op.batch_alter_table("reminder_logs") as batch_op:
+                batch_op.drop_column("snooze_minutes")

--- a/services/api/alembic/versions/20250824_reminders_kind_minutes_days_mask.py
+++ b/services/api/alembic/versions/20250824_reminders_kind_minutes_days_mask.py
@@ -59,13 +59,26 @@ def downgrade() -> None:
         op.drop_index("ix_reminders_owner_enabled", table_name="reminders")
 
     columns = [col["name"] for col in inspector.get_columns("reminders")]
-    if "is_enabled" in columns:
-        op.drop_column("reminders", "is_enabled")
-    if "days_mask" in columns:
-        op.drop_column("reminders", "days_mask")
-    if "minutes_after" in columns:
-        op.drop_column("reminders", "minutes_after")
-    if "interval_minutes" in columns:
-        op.drop_column("reminders", "interval_minutes")
-    if "kind" in columns:
-        op.drop_column("reminders", "kind")
+    if bind.dialect.name == "postgresql":
+        if "is_enabled" in columns:
+            op.drop_column("reminders", "is_enabled")
+        if "days_mask" in columns:
+            op.drop_column("reminders", "days_mask")
+        if "minutes_after" in columns:
+            op.drop_column("reminders", "minutes_after")
+        if "interval_minutes" in columns:
+            op.drop_column("reminders", "interval_minutes")
+        if "kind" in columns:
+            op.drop_column("reminders", "kind")
+    else:
+        with op.batch_alter_table("reminders") as batch_op:
+            if "is_enabled" in columns:
+                batch_op.drop_column("is_enabled")
+            if "days_mask" in columns:
+                batch_op.drop_column("days_mask")
+            if "minutes_after" in columns:
+                batch_op.drop_column("minutes_after")
+            if "interval_minutes" in columns:
+                batch_op.drop_column("interval_minutes")
+            if "kind" in columns:
+                batch_op.drop_column("kind")

--- a/services/api/alembic/versions/20250902_drop_user_timezone.py
+++ b/services/api/alembic/versions/20250902_drop_user_timezone.py
@@ -12,10 +12,15 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    inspector = sa.inspect(op.get_bind())
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
     cols = [c["name"] for c in inspector.get_columns("users")]
     if "timezone" in cols:
-        op.drop_column("users", "timezone")
+        if bind.dialect.name == "postgresql":
+            op.drop_column("users", "timezone")
+        else:
+            with op.batch_alter_table("users") as batch_op:
+                batch_op.drop_column("timezone")
 
 
 def downgrade() -> None:

--- a/services/api/alembic/versions/20250903_add_timezone_auto_to_users.py
+++ b/services/api/alembic/versions/20250903_add_timezone_auto_to_users.py
@@ -25,4 +25,8 @@ def downgrade() -> None:
     inspector = sa.inspect(bind)
     columns = [col["name"] for col in inspector.get_columns("users")]
     if "timezone_auto" in columns:
-        op.drop_column("users", "timezone_auto")
+        if bind.dialect.name == "postgresql":
+            op.drop_column("users", "timezone_auto")
+        else:
+            with op.batch_alter_table("users") as batch_op:
+                batch_op.drop_column("timezone_auto")

--- a/services/api/alembic/versions/20250904_change_description.py
+++ b/services/api/alembic/versions/20250904_change_description.py
@@ -175,7 +175,11 @@ def downgrade() -> None:
         )
     columns = {col['name'] for col in inspector.get_columns('reminder_logs')}
     if 'org_id' in columns:
-        op.drop_column('reminder_logs', 'org_id')
+        if bind.dialect.name == 'postgresql':
+            op.drop_column('reminder_logs', 'org_id')
+        else:
+            with op.batch_alter_table('reminder_logs') as batch_op:
+                batch_op.drop_column('org_id')
     op.create_index('ix_profiles_org_id', 'profiles', ['org_id'], unique=False)
     with op.batch_alter_table('profiles') as batch_op:
         batch_op.alter_column(

--- a/services/api/alembic/versions/20250906_move_user_settings_to_profile.py
+++ b/services/api/alembic/versions/20250906_move_user_settings_to_profile.py
@@ -127,7 +127,11 @@ def upgrade() -> None:
                 WHERE profiles.telegram_id = u.telegram_id
                 """,
             )
-        op.drop_column("users", "timezone_auto")
+        if bind.dialect.name == "postgresql":
+            op.drop_column("users", "timezone_auto")
+        else:
+            with op.batch_alter_table("users") as batch_op:
+                batch_op.drop_column("timezone_auto")
 
     with op.batch_alter_table("profiles") as batch_op:
         batch_op.alter_column(
@@ -204,30 +208,57 @@ def downgrade() -> None:
                 """,
             )
 
-    if "postmeal_check_min" in profile_columns:
-        op.drop_column("profiles", "postmeal_check_min")
-    if "max_bolus" in profile_columns:
-        op.drop_column("profiles", "max_bolus")
-    if "prebolus_min" in profile_columns:
-        op.drop_column("profiles", "prebolus_min")
-    if "insulin_type" in profile_columns:
-        op.drop_column("profiles", "insulin_type")
-    if "glucose_units" in profile_columns:
-        op.drop_column("profiles", "glucose_units")
-    if "therapy_type" in profile_columns:
-        op.drop_column("profiles", "therapy_type")
-    if "grams_per_xe" in profile_columns:
-        op.drop_column("profiles", "grams_per_xe")
-    if "carb_units" in profile_columns:
-        op.drop_column("profiles", "carb_units")
-    if "round_step" in profile_columns:
-        op.drop_column("profiles", "round_step")
-    if "dia" in profile_columns:
-        op.drop_column("profiles", "dia")
-    if "timezone_auto" in profile_columns:
-        op.drop_column("profiles", "timezone_auto")
-    if "timezone" in profile_columns:
-        op.drop_column("profiles", "timezone")
+    if bind.dialect.name == "postgresql":
+        if "postmeal_check_min" in profile_columns:
+            op.drop_column("profiles", "postmeal_check_min")
+        if "max_bolus" in profile_columns:
+            op.drop_column("profiles", "max_bolus")
+        if "prebolus_min" in profile_columns:
+            op.drop_column("profiles", "prebolus_min")
+        if "insulin_type" in profile_columns:
+            op.drop_column("profiles", "insulin_type")
+        if "glucose_units" in profile_columns:
+            op.drop_column("profiles", "glucose_units")
+        if "therapy_type" in profile_columns:
+            op.drop_column("profiles", "therapy_type")
+        if "grams_per_xe" in profile_columns:
+            op.drop_column("profiles", "grams_per_xe")
+        if "carb_units" in profile_columns:
+            op.drop_column("profiles", "carb_units")
+        if "round_step" in profile_columns:
+            op.drop_column("profiles", "round_step")
+        if "dia" in profile_columns:
+            op.drop_column("profiles", "dia")
+        if "timezone_auto" in profile_columns:
+            op.drop_column("profiles", "timezone_auto")
+        if "timezone" in profile_columns:
+            op.drop_column("profiles", "timezone")
+    else:
+        with op.batch_alter_table("profiles") as batch_op:
+            if "postmeal_check_min" in profile_columns:
+                batch_op.drop_column("postmeal_check_min")
+            if "max_bolus" in profile_columns:
+                batch_op.drop_column("max_bolus")
+            if "prebolus_min" in profile_columns:
+                batch_op.drop_column("prebolus_min")
+            if "insulin_type" in profile_columns:
+                batch_op.drop_column("insulin_type")
+            if "glucose_units" in profile_columns:
+                batch_op.drop_column("glucose_units")
+            if "therapy_type" in profile_columns:
+                batch_op.drop_column("therapy_type")
+            if "grams_per_xe" in profile_columns:
+                batch_op.drop_column("grams_per_xe")
+            if "carb_units" in profile_columns:
+                batch_op.drop_column("carb_units")
+            if "round_step" in profile_columns:
+                batch_op.drop_column("round_step")
+            if "dia" in profile_columns:
+                batch_op.drop_column("dia")
+            if "timezone_auto" in profile_columns:
+                batch_op.drop_column("timezone_auto")
+            if "timezone" in profile_columns:
+                batch_op.drop_column("timezone")
 
     if "timezone_auto" in user_columns:
         op.alter_column("users", "timezone_auto", server_default=None)

--- a/services/api/alembic/versions/20250912_add_lesson_steps.py
+++ b/services/api/alembic/versions/20250912_add_lesson_steps.py
@@ -40,4 +40,9 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index("ix_lesson_steps_lesson_id", table_name="lesson_steps")
     op.drop_table("lesson_steps")
-    op.drop_column("lessons", "is_active")
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.drop_column("lessons", "is_active")
+    else:
+        with op.batch_alter_table("lessons") as batch_op:
+            batch_op.drop_column("is_active")

--- a/services/api/alembic/versions/20250914_add_progress_state_fields.py
+++ b/services/api/alembic/versions/20250914_add_progress_state_fields.py
@@ -41,5 +41,11 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column("lesson_progress", "current_question")
-    op.drop_column("lesson_progress", "current_step")
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.drop_column("lesson_progress", "current_question")
+        op.drop_column("lesson_progress", "current_step")
+    else:
+        with op.batch_alter_table("lesson_progress") as batch_op:
+            batch_op.drop_column("current_question")
+            batch_op.drop_column("current_step")

--- a/services/api/alembic/versions/20250918_add_slug_to_lessons.py
+++ b/services/api/alembic/versions/20250918_add_slug_to_lessons.py
@@ -53,4 +53,9 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_index("ix_lessons_slug", table_name="lessons")
-    op.drop_column("lessons", "slug")
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.drop_column("lessons", "slug")
+    else:
+        with op.batch_alter_table("lessons") as batch_op:
+            batch_op.drop_column("slug")

--- a/tests/migrations/test_upgrade.py
+++ b/tests/migrations/test_upgrade.py
@@ -38,6 +38,9 @@ class _DummyBatchOp:
     def alter_column(self, *args: object, **kwargs: object) -> None:
         return None
 
+    def drop_column(self, *args: object, **kwargs: object) -> None:
+        return None
+
 
 class _DummyInspector:
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- make Alembic migrations SQLite-aware by guarding Postgres-only ops
- expand dummy batch op used in migration tests

## Testing
- `pytest -q tests/migrations/test_upgrade.py::test_upgrade --no-cov`
- `pytest -q tests/migrations/test_upgrade.py::test_timezone_auto_upgrade_sql tests/migrations/test_upgrade.py::test_timezone_auto_downgrade_sql --no-cov`
- `mypy --strict .`
- `ruff check .`
- `pytest -q --cov` *(fails: async plugin missing, low coverage)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2b082464832a988aff12b96ada3b