### PR TITLE
[bot] Switch /start to WebApp onboarding

### DIFF
--- a/services/bot/handlers/start_webapp.py
+++ b/services/bot/handlers/start_webapp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import TypeAlias
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, WebAppInfo
@@ -11,8 +12,13 @@ logger = logging.getLogger(__name__)
 CommandHandlerT: TypeAlias = CommandHandler[ContextTypes.DEFAULT_TYPE, object]
 
 
-def build_start_handler(ui_base_url: str) -> CommandHandlerT:
+def build_start_handler() -> CommandHandlerT:
     """Return a ``/start`` handler that links to the WebApp onboarding."""
+
+    ui_base_url = os.getenv("UI_BASE_URL", "/ui")
+    if ui_base_url.startswith("/"):
+        public_origin = os.getenv("PUBLIC_ORIGIN", "")
+        ui_base_url = f"{public_origin.rstrip('/')}{ui_base_url}"
 
     async def _start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         profile_url = f"{ui_base_url.rstrip('/')}/profile?flow=onboarding&step=profile"

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -97,7 +97,7 @@ def main() -> None:  # pragma: no cover
         DefaultJobQueue,
     ] = Application.builder().token(BOT_TOKEN).post_init(post_init).build()
 
-    application.add_handler(build_start_handler(settings.ui_base_url), group=0)
+    application.add_handler(build_start_handler(), group=0)
     logger.info("✅ /start → WebApp CTA mode enabled")
 
     # ---- Configure APScheduler timezone BEFORE any scheduling


### PR DESCRIPTION
## Summary
- use environment-based WebApp links for /start
- register new WebApp start handler first in bot startup
- drop onboarding conversation from handler registration tests

## Testing
- `pytest tests/bot/test_start_webapp.py tests/test_register_handlers.py -q` *(fails: Coverage failure: total of 27 is less than fail-under=85)*
- `ruff check .`
- `mypy --strict .`


------
https://chatgpt.com/codex/tasks/task_e_68bb2edbc8bc832aa7f0f2d57b2b47b5