### PR TITLE
[handlers] Register onboarding conversation

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -140,6 +140,7 @@ def register_handlers(
     # (for example OpenAI client initialization).
     from . import (
         dose_calc,
+        onboarding_handlers,
         reporting_handlers,
         alert_handlers,
         sos_handlers,
@@ -150,10 +151,14 @@ def register_handlers(
         billing_handlers,
     )
     from . import learning_handlers
+
     app.add_handler(CommandHandlerT("menu", menu_command))
     app.add_handler(CommandHandlerT("report", reporting_handlers.report_request))
     app.add_handler(CommandHandlerT("history", reporting_handlers.history_view))
     app.add_handler(dose_calc.dose_conv)
+    # Register onboarding before profile and sugar conversations to ensure
+    # proper routing of the /start command and initial inputs
+    app.add_handler(onboarding_handlers.onboarding_conv)
     # Register profile conversation before sugar conversation so that numeric
     # inputs for profile aren't captured by sugar logging
     register_profile_handlers(app)


### PR DESCRIPTION
## Summary
- Register onboarding conversation to ensure /start flows before profile and sugar conversations

## Testing
- `ruff check services/api/app/diabetes/handlers/registration.py`
- `mypy --strict services/api/app/diabetes/handlers/registration.py`
- `pytest -q -o addopts="" tests/test_register_handlers.py::test_register_handlers_attaches_expected_handlers --cov=services.api.app.diabetes.handlers.registration --cov-fail-under=85`

------
https://chatgpt.com/codex/tasks/task_e_68bb30727b58832a91ddd253fbfb3102