### PR TITLE
[handlers] remove onboarding conv from registration

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -140,7 +140,6 @@ def register_handlers(
     # (for example OpenAI client initialization).
     from . import (
         dose_calc,
-        onboarding_handlers,
         reporting_handlers,
         alert_handlers,
         sos_handlers,
@@ -156,9 +155,6 @@ def register_handlers(
     app.add_handler(CommandHandlerT("report", reporting_handlers.report_request))
     app.add_handler(CommandHandlerT("history", reporting_handlers.history_view))
     app.add_handler(dose_calc.dose_conv)
-    # Register onboarding before profile and sugar conversations to ensure
-    # proper routing of the /start command and initial inputs
-    app.add_handler(onboarding_handlers.onboarding_conv)
     # Register profile conversation before sugar conversation so that numeric
     # inputs for profile aren't captured by sugar logging
     register_profile_handlers(app)


### PR DESCRIPTION
## Summary
- drop onboarding conversation from general handler registration
- keep /start routed via `build_start_handler`

## Testing
- `pytest tests/test_register_handlers.py::test_register_handlers_attaches_expected_handlers -q --no-cov`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bb363ff2ec832aba9577941079c8ce