### PR TITLE
[ui] Handle missing profile gracefully

### DIFF
--- a/services/webapp/ui/src/features/profile/hooks.ts
+++ b/services/webapp/ui/src/features/profile/hooks.ts
@@ -1,36 +1,28 @@
 import { useEffect, useState } from "react";
-import { useToast } from "@/hooks/use-toast";
-import { useTranslation } from "@/i18n";
 import { getProfile } from "./api";
+
+const DEFAULT_AFTER_MEAL_MINUTES = 120;
 
 export function useDefaultAfterMealMinutes(
   telegramId: number | null | undefined,
 ) {
-  const [value, setValue] = useState<number | null>(null);
-  const { toast } = useToast();
-  const { t } = useTranslation("profile");
+  const [value, setValue] = useState<number>(DEFAULT_AFTER_MEAL_MINUTES);
 
   useEffect(() => {
     if (!telegramId) return;
     getProfile(telegramId)
       .then((profile) => {
-        if (!profile) {
-          toast({
-            title: t("error"),
-            description: t("notFound"),
-            variant: "destructive",
-          });
-          return;
-        }
-        const minutes = profile.afterMealMinutes;
-        if (typeof minutes === "number") {
-          setValue(minutes);
-        }
+        const minutes = profile?.afterMealMinutes;
+        setValue(
+          typeof minutes === "number"
+            ? minutes
+            : DEFAULT_AFTER_MEAL_MINUTES,
+        );
       })
-      .catch((err) => {
-        console.warn("Failed to load profile:", err);
+      .catch(() => {
+        setValue(DEFAULT_AFTER_MEAL_MINUTES);
       });
-  }, [telegramId, toast, t]);
+  }, [telegramId]);
 
   return value;
 }

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -296,11 +296,6 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
       .then((data) => {
         if (cancelled) return;
         if (!data) {
-          toast({
-            title: t('profile.error'),
-            description: t('profile.notFound'),
-            variant: 'destructive',
-          });
           return;
         }
 

--- a/services/webapp/ui/tests/profile.onboarding.test.tsx
+++ b/services/webapp/ui/tests/profile.onboarding.test.tsx
@@ -37,6 +37,7 @@ vi.mock('../src/features/profile/api', async () => {
     ...actual,
     saveProfile: vi.fn(),
     patchProfile: vi.fn(),
+    getProfile: vi.fn().mockResolvedValue(null),
   };
 });
 
@@ -73,23 +74,12 @@ describe('Profile onboarding', () => {
   });
 
   it('renders empty form when profile is missing (404)', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify({ detail: 'not found' }), {
-          status: 404,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-      );
-    vi.stubGlobal('fetch', fetchMock);
-
     const { getByPlaceholderText } = render(<Profile />);
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     expect((getByPlaceholderText('6.0') as HTMLInputElement).value).toBe('');
-    expect(toast).not.toHaveBeenCalled();
   });
 });

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -756,22 +756,16 @@ describe('Profile page', () => {
     expect(patchProfile).not.toHaveBeenCalled();
   });
 
-  it('shows toast when profile is missing', async () => {
+  it('renders empty form when profile is missing', async () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
     (getProfile as vi.Mock).mockResolvedValue(null);
 
-    render(<Profile />);
+    const { getByPlaceholderText } = render(<Profile />);
     await waitFor(() => {
       expect(getProfile).toHaveBeenCalledWith(123);
     });
-    const { t } = useTranslation();
-    expect(toast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: t('profile.error'),
-        description: t('profile.notFound'),
-        variant: 'destructive',
-      }),
-    );
+    expect(toast).not.toHaveBeenCalled();
+    expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('');
   });
 
   it('shows warning modal and blocks save until confirmation', async () => {

--- a/services/webapp/ui/tests/useDefaultAfterMealMinutes.test.ts
+++ b/services/webapp/ui/tests/useDefaultAfterMealMinutes.test.ts
@@ -5,14 +5,8 @@ vi.mock('../src/features/profile/api', () => ({
   getProfile: vi.fn(),
 }));
 
-const toast = vi.fn();
-vi.mock('../src/hooks/use-toast', () => ({
-  useToast: () => ({ toast }),
-}));
-
 import { useDefaultAfterMealMinutes } from '../src/features/profile/hooks';
 import { getProfile } from '../src/features/profile/api';
-import { useTranslation } from '../src/i18n';
 
 describe('useDefaultAfterMealMinutes', () => {
   afterEach(() => {
@@ -27,28 +21,21 @@ describe('useDefaultAfterMealMinutes', () => {
     });
   });
 
-  it('returns null when afterMealMinutes is missing', async () => {
+  it('returns default when afterMealMinutes is missing', async () => {
     (getProfile as vi.Mock).mockResolvedValue({});
     const { result } = renderHook(() => useDefaultAfterMealMinutes(1));
     await waitFor(() => {
-      expect(result.current).toBeNull();
+      expect(result.current).toBe(120);
     });
   });
 
-  it('shows toast when profile is null', async () => {
+  it('returns default when profile is null', async () => {
     (getProfile as vi.Mock).mockResolvedValue(null);
-    const { t } = useTranslation('profile');
-    renderHook(() => useDefaultAfterMealMinutes(1));
+    const { result } = renderHook(() => useDefaultAfterMealMinutes(1));
     await waitFor(() => {
       expect(getProfile).toHaveBeenCalled();
+      expect(result.current).toBe(120);
     });
-    expect(toast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: t('error'),
-        description: t('notFound'),
-        variant: 'destructive',
-      }),
-    );
   });
 });
 


### PR DESCRIPTION
## Summary
- avoid error toast when user profile is absent
- provide default after-meal minutes instead of warning
- test empty profile rendering on 404

## Testing
- `npm test` *(fails: tests/ProfileHelpSheet.test.tsx, src/pages/Subscription.test.tsx, tests/reminders.default.test.tsx)*
- `npm run lint` *(fails: eslint errors)*
- `npm run typecheck`
- `pytest -q` *(fails: pytest hung after invocation)*
- `mypy --strict .` *(fails: interrupted)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68bb390edefc832aab7fc8740ad438c8