### PR TITLE
[ui] allow HelpHint tooltip to open on click

### DIFF
--- a/services/webapp/ui/src/components/HelpHint.tsx
+++ b/services/webapp/ui/src/components/HelpHint.tsx
@@ -39,6 +39,7 @@ const HelpHint = ({
         <TooltipTrigger asChild>
           <button
             type="button"
+            onClick={() => setOpen((prev) => !prev)}
             onKeyDown={handleKeyDown}
             className={cn(
               'flex h-4 w-4 items-center justify-center text-muted-foreground',

--- a/services/webapp/ui/tests/HelpHint.test.tsx
+++ b/services/webapp/ui/tests/HelpHint.test.tsx
@@ -23,6 +23,13 @@ describe('HelpHint', () => {
     expect(screen.queryByRole('tooltip')).toBeNull();
   });
 
+  it('shows tooltip on click', async () => {
+    setup();
+    const button = screen.getByLabelText('ICR');
+    fireEvent.click(button);
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Example');
+  });
+
   it('closes tooltip on Escape key', async () => {
     setup();
     const button = screen.getByLabelText('ICR');


### PR DESCRIPTION
## Summary
- allow tapping HelpHint icon to toggle its tooltip
- test HelpHint opens tooltip on click

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails: Channel closed)*
- `npm test tests/HelpHint.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bb3d93e7e4832a8c502a399193a4bd