### PR TITLE
[profile] add helper for numeric parsing

### DIFF
--- a/services/api/app/diabetes/handlers/profile/__init__.py
+++ b/services/api/app/diabetes/handlers/profile/__init__.py
@@ -22,12 +22,13 @@ from .conversation import (
     profile_webapp_handler,
     profile_webapp_save,
 )
-from .validation import parse_profile_args
+from .validation import parse_profile_args, parse_profile_values
 from services.api.app.diabetes.utils.ui import back_keyboard
 
 
 def get_api() -> tuple[object, type[Exception], type]:
     return _api.get_api(_conversation.SessionLocal)
+
 
 __all__ = [
     "profile_command",
@@ -55,6 +56,7 @@ __all__ = [
     "fetch_profile",
     "post_profile",
     "parse_profile_args",
+    "parse_profile_values",
 ]
 
 # Attach helper functions to the conversation module so tests and other modules
@@ -66,6 +68,7 @@ for _attr in (
     "fetch_profile",
     "post_profile",
     "parse_profile_args",
+    "parse_profile_values",
     "back_keyboard",
 ):
     setattr(_conversation, _attr, globals()[_attr])
@@ -77,4 +80,3 @@ _conversation.__all__ = __all__
 import sys as _sys  # noqa: E402
 
 _sys.modules[__name__] = _conversation
-

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -79,6 +79,7 @@ from .validation import (  # noqa: E402
     MSG_TARGET_GT0,
     MSG_TARGET_RANGE,  # noqa: F401 - re-exported for tests
     parse_profile_args,
+    parse_profile_values,
     validate_profile_numbers,
 )
 
@@ -158,19 +159,13 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         return END
 
     try:
-        icr = float(values["icr"].replace(",", "."))
-        cf = float(values["cf"].replace(",", "."))
-        target = float(values["target"].replace(",", "."))
-        low = float(values["low"].replace(",", "."))
-        high = float(values["high"].replace(",", "."))
-    except ValueError:
+        icr, cf, target, low, high = parse_profile_values(values)
+    except ValueError as exc:
         await message.reply_text(
-            "❗ Пожалуйста, введите корректные числа. Справка: /profile help"
+            exc.args[0]
+            if exc.args
+            else "❗ Пожалуйста, введите корректные числа. Справка: /profile help"
         )
-        return END
-    error = validate_profile_numbers(icr, cf, target, low, high)
-    if error:
-        await message.reply_text(error)
         return END
 
     warning_msg = ""
@@ -375,17 +370,11 @@ async def profile_webapp_save(
         await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
         return
     try:
-        icr = float(str(data["icr"]).replace(",", "."))
-        cf = float(str(data["cf"]).replace(",", "."))
-        target = float(str(data["target"]).replace(",", "."))
-        low = float(str(data["low"]).replace(",", "."))
-        high = float(str(data["high"]).replace(",", "."))
-    except ValueError:
-        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
-        return
-    error = validate_profile_numbers(icr, cf, target, low, high)
-    if error:
-        await eff_msg.reply_text(error, reply_markup=menu_keyboard())
+        icr, cf, target, low, high = parse_profile_values(data)
+    except ValueError as exc:
+        await eff_msg.reply_text(
+            exc.args[0] if exc.args else error_msg, reply_markup=menu_keyboard()
+        )
         return
     user = update.effective_user
     if user is None:
@@ -1054,6 +1043,7 @@ __all__ = [
     "fetch_profile",
     "post_profile",
     "parse_profile_args",
+    "parse_profile_values",
     "profile_command",
     "profile_view",
     "profile_cancel",

--- a/services/api/app/diabetes/handlers/profile/validation.py
+++ b/services/api/app/diabetes/handlers/profile/validation.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 """Utilities for parsing and validating user input for profile handlers."""
 
+from collections.abc import Mapping
+from typing import Any
+
 
 # User-facing validation messages reused across conversation flows.
 MSG_ICR_GT0 = "ИКХ должен быть больше 0."
@@ -63,3 +66,28 @@ def validate_profile_numbers(
     if not (low < target < high):
         return MSG_TARGET_RANGE
     return None
+
+
+def parse_profile_values(
+    values: Mapping[str, Any],
+) -> tuple[float, float, float, float, float]:
+    """Convert mapping of strings to floats and validate profile numbers.
+
+    Raises :class:`ValueError` if conversion fails or if the numbers fail
+    :func:`validate_profile_numbers` checks.  When validation fails the error
+    message from :func:`validate_profile_numbers` is attached to the exception.
+    """
+
+    try:
+        icr = float(str(values["icr"]).replace(",", "."))
+        cf = float(str(values["cf"]).replace(",", "."))
+        target = float(str(values["target"]).replace(",", "."))
+        low = float(str(values["low"]).replace(",", "."))
+        high = float(str(values["high"]).replace(",", "."))
+    except (KeyError, ValueError) as exc:  # pragma: no cover - exact message unused
+        raise ValueError from exc
+
+    error = validate_profile_numbers(icr, cf, target, low, high)
+    if error:
+        raise ValueError(error)
+    return icr, cf, target, low, high

--- a/tests/test_handlers_profile_webapp.py
+++ b/tests/test_handlers_profile_webapp.py
@@ -215,3 +215,18 @@ async def test_webapp_save_db_error(monkeypatch: pytest.MonkeyPatch) -> None:
     assert post_mock.call_count == 1
     save_mock.assert_called_once()
     assert msg.texts == ["⚠️ Не удалось сохранить профиль."]
+
+
+def test_parse_profile_values_success() -> None:
+    result = handlers.parse_profile_values(
+        {"icr": "8", "cf": "3", "target": "6", "low": "4", "high": "9"}
+    )
+    assert result == (8.0, 3.0, 6.0, 4.0, 9.0)
+
+
+def test_parse_profile_values_error() -> None:
+    with pytest.raises(ValueError) as exc:
+        handlers.parse_profile_values(
+            {"icr": "0", "cf": "3", "target": "6", "low": "4", "high": "9"}
+        )
+    assert str(exc.value) == handlers.MSG_ICR_GT0

--- a/tests/test_profile_webapp_save_flow.py
+++ b/tests/test_profile_webapp_save_flow.py
@@ -104,3 +104,17 @@ async def test_webapp_save_comma_decimal(monkeypatch: pytest.MonkeyPatch) -> Non
     text = msg.texts[0]
     assert "ИКХ: 8.5" in text
     assert "Низкий порог: 4.2" in text
+
+
+def test_parse_profile_values_comma() -> None:
+    result = handlers.parse_profile_values(
+        {"icr": "8,5", "cf": "3", "target": "6", "low": "4,2", "high": "9"}
+    )
+    assert result == (8.5, 3.0, 6.0, 4.2, 9.0)
+
+
+def test_parse_profile_values_invalid_number() -> None:
+    with pytest.raises(ValueError):
+        handlers.parse_profile_values(
+            {"icr": "x", "cf": "3", "target": "6", "low": "4", "high": "9"}
+        )


### PR DESCRIPTION
## Summary
- add `parse_profile_values` to centralize parsing and validation of profile numbers
- use helper in `/profile` command and webapp save handler
- extend webapp tests to cover new helper

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bbb056d734832a8c2a37e09249820d