### PR TITLE
[ui] support mobile tooltip

### DIFF
--- a/services/webapp/ui/src/components/HelpHint.tsx
+++ b/services/webapp/ui/src/components/HelpHint.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { useTranslation } from '@/i18n';
+import { useMediaQuery } from '@/hooks/use-media-query';
 
 interface HelpHintProps {
   label?: string;
@@ -25,6 +26,7 @@ const HelpHint = ({
 }: HelpHintProps) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const isSmallScreen = useMediaQuery('(max-width: 640px)');
 
   const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
     if (event.key === 'Escape') {
@@ -50,7 +52,9 @@ const HelpHint = ({
             <HelpCircle className="h-4 w-4" aria-hidden="true" />
           </button>
         </TooltipTrigger>
-        <TooltipContent side={side}>{children}</TooltipContent>
+        <TooltipContent mobile={isSmallScreen} side={isSmallScreen ? 'bottom' : side}>
+          {children}
+        </TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );

--- a/services/webapp/ui/src/components/ui/tooltip.tsx
+++ b/services/webapp/ui/src/components/ui/tooltip.tsx
@@ -9,15 +9,22 @@ const Tooltip = TooltipPrimitive.Root
 
 const TooltipTrigger = TooltipPrimitive.Trigger
 
+interface TooltipContentProps
+  extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> {
+  mobile?: boolean
+}
+
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+  TooltipContentProps
+>(({ className, sideOffset = 4, mobile = false, collisionPadding, ...props }, ref) => (
   <TooltipPrimitive.Content
     ref={ref}
     sideOffset={sideOffset}
+    collisionPadding={mobile ? 16 : collisionPadding}
     className={cn(
       "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      mobile && "max-w-[calc(100vw-2rem)]",
       className
     )}
     {...props}

--- a/services/webapp/ui/src/hooks/use-media-query.ts
+++ b/services/webapp/ui/src/hooks/use-media-query.ts
@@ -1,0 +1,35 @@
+import * as React from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window.matchMedia !== 'function') {
+      return;
+    }
+    const mql = window.matchMedia(query);
+    const onChange = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+    const useEventListener = typeof mql.addEventListener === 'function';
+    if (useEventListener) {
+      mql.addEventListener('change', onChange);
+    } else {
+      // @ts-expect-error -- older browsers
+      mql.addListener(onChange);
+    }
+    setMatches(mql.matches);
+    return () => {
+      if (useEventListener) {
+        mql.removeEventListener('change', onChange);
+      } else {
+        // @ts-expect-error -- older browsers
+        mql.removeListener(onChange);
+      }
+    };
+  }, [query]);
+
+  return matches;
+}
+
+export default useMediaQuery;


### PR DESCRIPTION
## Summary
- Adjust HelpHint to render mobile-friendly tooltip on small screens
- Add generic useMediaQuery hook for screen width checks
- Extend TooltipContent with mobile-specific styling

## Testing
- `npm test tests/HelpHint.test.tsx`
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict services/api` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bbb087034c832a8cda1207cd0984c8