### PR TITLE
[webapp] Prevent state update after unmount in profile hook

### DIFF
--- a/services/webapp/ui/src/features/profile/hooks.ts
+++ b/services/webapp/ui/src/features/profile/hooks.ts
@@ -10,8 +10,10 @@ export function useDefaultAfterMealMinutes(
 
   useEffect(() => {
     if (!telegramId) return;
+    let cancelled = false;
     getProfile(telegramId)
       .then((profile) => {
+        if (cancelled) return;
         const minutes = profile?.afterMealMinutes;
         setValue(
           typeof minutes === "number"
@@ -20,8 +22,12 @@ export function useDefaultAfterMealMinutes(
         );
       })
       .catch(() => {
+        if (cancelled) return;
         setValue(DEFAULT_AFTER_MEAL_MINUTES);
       });
+    return () => {
+      cancelled = true;
+    };
   }, [telegramId]);
 
   return value;


### PR DESCRIPTION
## Summary
- avoid state updates after unmount in profile hook

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: ESLint found errors in unrelated files)*
- `pnpm --filter ./services/webapp/ui exec eslint src/features/profile/hooks.ts`
- `pnpm --filter ./services/webapp/ui test`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pytest -q --cov` *(fails: async tests not supported)*
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68bbb0424798832abf5530ed8f161be6