### PR TITLE
[profile] extract profile view formatter

### DIFF
--- a/services/api/app/diabetes/handlers/profile/__init__.py
+++ b/services/api/app/diabetes/handlers/profile/__init__.py
@@ -33,6 +33,7 @@ def get_api() -> tuple[object, type[Exception], type]:
 __all__ = [
     "profile_command",
     "profile_view",
+    "profile_view_formatter",
     "profile_cancel",
     "profile_back",
     "profile_security",

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -83,6 +83,8 @@ from .validation import (  # noqa: E402
     validate_profile_numbers,
 )
 
+from .formatters import profile_view_formatter  # noqa: E402
+
 back_keyboard: ReplyKeyboardMarkup = _back_keyboard
 
 from .. import UserData  # noqa: E402
@@ -254,115 +256,19 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             )
         ]
 
-    if not profile:
-        text = (
-            "Ваш профиль пока не настроен.\n\nНастройки профиля доступны в приложении."
-        )
-        if webapp_button is not None:
-            text += " Нажмите кнопку ниже, чтобы открыть и обновить данные."
-            keyboard = InlineKeyboardMarkup([webapp_button])
-            await message.reply_text(text, parse_mode="Markdown", reply_markup=keyboard)
-        else:
-            await message.reply_text(text, parse_mode="Markdown")
-        return
+    if profile is not None:
+        quiet_start = getattr(profile, "quiet_start", None)
+        quiet_end = getattr(profile, "quiet_end", None)
+        if isinstance(quiet_start, dict):
+            setattr(profile, "quiet_start", dt_time(**quiet_start))
+        if isinstance(quiet_end, dict):
+            setattr(profile, "quiet_end", dt_time(**quiet_end))
 
-    icr = getattr(profile, "icr", None)
-    cf = getattr(profile, "cf", None)
-    target = getattr(profile, "target", None)
-    low = getattr(profile, "low", None)
-    high = getattr(profile, "high", None)
-    dia = getattr(profile, "dia", None)
-    round_step = getattr(profile, "round_step", None)
-    carb_units = getattr(profile, "carb_units", None)
-    grams_per_xe = getattr(profile, "grams_per_xe", None)
-    therapy_type = getattr(profile, "therapy_type", None)
-    rapid_insulin_type = getattr(profile, "rapid_insulin_type", None)
-    if rapid_insulin_type is None:
-        rapid_insulin_type = getattr(profile, "insulin_type", None)
-    prebolus_min = getattr(profile, "prebolus_min", None)
-    max_bolus = getattr(profile, "max_bolus", None)
-    postmeal_check_min = getattr(profile, "postmeal_check_min", None)
-    quiet_start = getattr(profile, "quiet_start", None)
-    quiet_end = getattr(profile, "quiet_end", None)
-    if isinstance(quiet_start, dict):
-        quiet_start = dt_time(**quiet_start)
-    if isinstance(quiet_end, dict):
-        quiet_end = dt_time(**quiet_end)
-    timezone = getattr(profile, "timezone", None)
-    sos_contact = getattr(profile, "sos_contact", None)
-    sos_alerts_enabled = getattr(profile, "sos_alerts_enabled", None)
-
-    bolus_lines = []
-    if icr is not None:
-        bolus_lines.append(f"• ИКХ: {icr} г/ед.")
-    if cf is not None:
-        bolus_lines.append(f"• КЧ: {cf} ммоль/л")
-    if target is not None:
-        bolus_lines.append(f"• Целевой сахар: {target} ммоль/л")
-    if low is not None:
-        bolus_lines.append(f"• Низкий порог: {low} ммоль/л")
-    if high is not None:
-        bolus_lines.append(f"• Высокий порог: {high} ммоль/л")
-    if dia is not None:
-        bolus_lines.append(f"• ДиА: {dia} ч")
-    if round_step is not None:
-        bolus_lines.append(f"• Округление: {round_step} ед.")
-    if therapy_type is not None:
-        bolus_lines.append(f"• Терапия: {therapy_type}")
-    if rapid_insulin_type is not None:
-        bolus_lines.append(f"• Инсулин: {rapid_insulin_type}")
-    if prebolus_min is not None:
-        bolus_lines.append(f"• Преболюс: {prebolus_min} мин")
-    if max_bolus is not None:
-        bolus_lines.append(f"• Макс. болюс: {max_bolus}")
-    if postmeal_check_min is not None:
-        bolus_lines.append(f"• Проверка после еды: {postmeal_check_min} мин")
-
-    carb_lines: list[str] = []
-    if carb_units is not None:
-        carb_lines.append(f"• Ед. углеводов: {carb_units}")
-    if grams_per_xe is not None:
-        carb_lines.append(f"• Грамм/ХЕ: {grams_per_xe}")
-
-    safety_lines: list[str] = []
-    if quiet_start and quiet_end:
-        qs = (
-            quiet_start.strftime("%H:%M")
-            if hasattr(quiet_start, "strftime")
-            else str(quiet_start)
-        )
-        qe = (
-            quiet_end.strftime("%H:%M")
-            if hasattr(quiet_end, "strftime")
-            else str(quiet_end)
-        )
-        safety_lines.append(f"• Тихий режим: {qs}-{qe}")
-    if timezone is not None:
-        safety_lines.append(f"• Часовой пояс: {timezone}")
-    if sos_contact is not None:
-        safety_lines.append(f"• SOS контакт: {sos_contact}")
-    if sos_alerts_enabled is not None:
-        state = "вкл" if sos_alerts_enabled else "выкл"
-        safety_lines.append(f"• SOS оповещения: {state}")
-
-    sections: list[str] = []
-    if bolus_lines:
-        sections.append("💉 *Болус*\n" + "\n".join(bolus_lines))
-    if carb_lines:
-        sections.append("🍽 *Углеводы*\n" + "\n".join(carb_lines))
-    if safety_lines:
-        sections.append("🛡 *Безопасность*\n" + "\n".join(safety_lines))
-
-    msg = "📄 Ваш профиль:\n\n" + "\n\n".join(sections)
-    rows = [
-        [InlineKeyboardButton("✏️ Изменить", callback_data="profile_edit")],
-        [InlineKeyboardButton("🔔 Безопасность", callback_data="profile_security")],
-        [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
-    ]
-    if webapp_button is not None:
-        rows.insert(1, webapp_button)
-    keyboard = InlineKeyboardMarkup(rows)
-    await message.reply_text(msg, reply_markup=keyboard, parse_mode="Markdown")
+    text, keyboard = profile_view_formatter(profile, webapp_button)
+    if keyboard is not None:
+        await message.reply_text(text, parse_mode="Markdown", reply_markup=keyboard)
+    else:
+        await message.reply_text(text, parse_mode="Markdown")
 
 
 async def profile_webapp_save(
@@ -1071,6 +977,7 @@ __all__ = [
     "parse_profile_values",
     "profile_command",
     "profile_view",
+    "profile_view_formatter",
     "profile_cancel",
     "profile_back",
     "profile_security",

--- a/services/api/app/diabetes/handlers/profile/formatters.py
+++ b/services/api/app/diabetes/handlers/profile/formatters.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+
+def profile_view_formatter(
+    profile: object | None,
+    webapp_button: list[InlineKeyboardButton] | None,
+) -> tuple[str, InlineKeyboardMarkup | None]:
+    """Build message text and keyboard for profile view."""
+    if profile is None:
+        text = (
+            "Ваш профиль пока не настроен.\n\n"
+            "Настройки профиля доступны в приложении."
+        )
+        if webapp_button is not None:
+            text += " Нажмите кнопку ниже, чтобы открыть и обновить данные."
+            return text, InlineKeyboardMarkup([webapp_button])
+        return text, None
+
+    icr = getattr(profile, "icr", None)
+    cf = getattr(profile, "cf", None)
+    target = getattr(profile, "target", None)
+    low = getattr(profile, "low", None)
+    high = getattr(profile, "high", None)
+    dia = getattr(profile, "dia", None)
+    round_step = getattr(profile, "round_step", None)
+    carb_units = getattr(profile, "carb_units", None)
+    grams_per_xe = getattr(profile, "grams_per_xe", None)
+    therapy_type = getattr(profile, "therapy_type", None)
+    rapid_insulin_type = getattr(profile, "rapid_insulin_type", None)
+    if rapid_insulin_type is None:
+        rapid_insulin_type = getattr(profile, "insulin_type", None)
+    prebolus_min = getattr(profile, "prebolus_min", None)
+    max_bolus = getattr(profile, "max_bolus", None)
+    postmeal_check_min = getattr(profile, "postmeal_check_min", None)
+    quiet_start = getattr(profile, "quiet_start", None)
+    quiet_end = getattr(profile, "quiet_end", None)
+    timezone = getattr(profile, "timezone", None)
+    sos_contact = getattr(profile, "sos_contact", None)
+    sos_alerts_enabled = getattr(profile, "sos_alerts_enabled", None)
+
+    bolus_lines: list[str] = []
+    if icr is not None:
+        bolus_lines.append(f"• ИКХ: {icr} г/ед.")
+    if cf is not None:
+        bolus_lines.append(f"• КЧ: {cf} ммоль/л")
+    if target is not None:
+        bolus_lines.append(f"• Целевой сахар: {target} ммоль/л")
+    if low is not None:
+        bolus_lines.append(f"• Низкий порог: {low} ммоль/л")
+    if high is not None:
+        bolus_lines.append(f"• Высокий порог: {high} ммоль/л")
+    if dia is not None:
+        bolus_lines.append(f"• ДиА: {dia} ч")
+    if round_step is not None:
+        bolus_lines.append(f"• Округление: {round_step} ед.")
+    if therapy_type is not None:
+        bolus_lines.append(f"• Терапия: {therapy_type}")
+    if rapid_insulin_type is not None:
+        bolus_lines.append(f"• Инсулин: {rapid_insulin_type}")
+    if prebolus_min is not None:
+        bolus_lines.append(f"• Преболюс: {prebolus_min} мин")
+    if max_bolus is not None:
+        bolus_lines.append(f"• Макс. болюс: {max_bolus}")
+    if postmeal_check_min is not None:
+        bolus_lines.append(f"• Проверка после еды: {postmeal_check_min} мин")
+
+    carb_lines: list[str] = []
+    if carb_units is not None:
+        carb_lines.append(f"• Ед. углеводов: {carb_units}")
+    if grams_per_xe is not None:
+        carb_lines.append(f"• Грамм/ХЕ: {grams_per_xe}")
+
+    safety_lines: list[str] = []
+    if quiet_start and quiet_end:
+        qs = quiet_start.strftime("%H:%M") if hasattr(quiet_start, "strftime") else str(quiet_start)
+        qe = quiet_end.strftime("%H:%M") if hasattr(quiet_end, "strftime") else str(quiet_end)
+        safety_lines.append(f"• Тихий режим: {qs}-{qe}")
+    if timezone is not None:
+        safety_lines.append(f"• Часовой пояс: {timezone}")
+    if sos_contact is not None:
+        safety_lines.append(f"• SOS контакт: {sos_contact}")
+    if sos_alerts_enabled is not None:
+        state = "вкл" if sos_alerts_enabled else "выкл"
+        safety_lines.append(f"• SOS оповещения: {state}")
+
+    sections: list[str] = []
+    if bolus_lines:
+        sections.append("💉 *Болус*\n" + "\n".join(bolus_lines))
+    if carb_lines:
+        sections.append("🍽 *Углеводы*\n" + "\n".join(carb_lines))
+    if safety_lines:
+        sections.append("🛡 *Безопасность*\n" + "\n".join(safety_lines))
+
+    msg = "📄 Ваш профиль:\n\n" + "\n\n".join(sections)
+    rows = [
+        [InlineKeyboardButton("✏️ Изменить", callback_data="profile_edit")],
+        [InlineKeyboardButton("🔔 Безопасность", callback_data="profile_security")],
+        [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
+    ]
+    if webapp_button is not None:
+        rows.insert(1, webapp_button)
+    return msg, InlineKeyboardMarkup(rows)

--- a/tests/test_profile_view_formatter.py
+++ b/tests/test_profile_view_formatter.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+from services.api.app.diabetes.handlers.profile.formatters import profile_view_formatter
+
+
+def test_profile_view_formatter_existing_profile() -> None:
+    profile = SimpleNamespace(
+        icr=8.0,
+        cf=3.0,
+        target=6.0,
+        low=4.0,
+        high=9.0,
+        sos_contact="+123",
+        sos_alerts_enabled=True,
+    )
+    text, markup = profile_view_formatter(profile, None)
+    assert "📄 Ваш профиль" in text
+    assert "• ИКХ: 8.0 г/ед." in text
+    assert isinstance(markup, InlineKeyboardMarkup)
+    buttons = [b.text for row in markup.inline_keyboard for b in row]
+    assert "✏️ Изменить" in buttons
+    assert "🔙 Назад" in buttons
+
+
+def test_profile_view_formatter_no_profile_button() -> None:
+    button = InlineKeyboardButton("open", url="https://example.com")
+    text, markup = profile_view_formatter(None, [button])
+    assert "Ваш профиль пока не настроен" in text
+    assert isinstance(markup, InlineKeyboardMarkup)
+    assert markup.inline_keyboard[0][0].text == "open"


### PR DESCRIPTION
## Summary
- refactor profile_view to delegate message formatting to new profile_view_formatter
- expose formatter and add direct unit tests

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict services/api/app/diabetes/handlers/profile/formatters.py services/api/app/diabetes/handlers/profile/conversation.py tests/test_profile_view_formatter.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bbb27031b0832abcc8acc400b8483c