### PR TITLE
[webapp] fetch profile via new settings endpoint

### DIFF
--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -2,11 +2,9 @@ import type { ProfileSchema } from '@sdk';
 import { tgFetch, FetchError } from '@/lib/tgFetch';
 import type { Profile, PatchProfileDto, RapidInsulin } from './types';
 
-export async function getProfile(
-  telegramId: number,
-): Promise<Profile | null> {
+export async function getProfile(): Promise<Profile | null> {
   try {
-    return await tgFetch<Profile>(`/profiles?telegramId=${telegramId}`);
+    return await tgFetch<Profile>(`/profile`);
   } catch (error) {
     if (error instanceof FetchError) {
       if (error.status === 404) {

--- a/services/webapp/ui/src/features/profile/types.ts
+++ b/services/webapp/ui/src/features/profile/types.ts
@@ -1,18 +1,12 @@
-import type { ProfileSchema, ProfileSettingsIn } from "@sdk";
+import type {
+  ProfileSchema,
+  ProfileSettingsIn,
+  ProfileSettingsOut,
+} from "@sdk";
 
 export type RapidInsulin = "aspart" | "lispro" | "glulisine" | "regular";
 
-export interface Profile extends ProfileSchema {
-  dia?: number | null;
-  preBolus?: number | null;
-  roundStep?: number | null;
-  carbUnits?: "g" | "xe" | null;
-  gramsPerXe?: number | null;
-  rapidInsulinType?: RapidInsulin | null;
-  maxBolus?: number | null;
-  afterMealMinutes?: number | null;
-  therapyType?: "insulin" | "tablets" | "none" | "mixed" | null;
-}
+export type Profile = ProfileSchema & ProfileSettingsOut;
 
 export type PatchProfileDto = Partial<
   Pick<

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -293,7 +293,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
 
     let cancelled = false;
 
-    getProfile(telegramId)
+    getProfile()
       .then((data) => {
         if (cancelled) return;
         if (!data) {

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -22,11 +22,8 @@ describe('profile api', () => {
       );
     vi.stubGlobal('fetch', mockFetch);
 
-    await expect(getProfile(1)).rejects.toThrow('Не удалось получить профиль: boom');
-    expect(mockFetch).toHaveBeenCalledWith(
-      '/api/profiles?telegramId=1',
-      expect.any(Object),
-    );
+    await expect(getProfile()).rejects.toThrow('Не удалось получить профиль: boom');
+    expect(mockFetch).toHaveBeenCalledWith('/api/profile', expect.any(Object));
   });
 
   it('returns null when profile not found', async () => {
@@ -40,12 +37,9 @@ describe('profile api', () => {
       );
     vi.stubGlobal('fetch', mockFetch);
 
-    const result = await getProfile(1);
+    const result = await getProfile();
     expect(result).toBeNull();
-    expect(mockFetch).toHaveBeenCalledWith(
-      '/api/profiles?telegramId=1',
-      expect.any(Object),
-    );
+    expect(mockFetch).toHaveBeenCalledWith('/api/profile', expect.any(Object));
   });
 
   it('throws error when getProfile returns invalid JSON', async () => {
@@ -59,13 +53,10 @@ describe('profile api', () => {
       );
     vi.stubGlobal('fetch', mockFetch);
 
-    await expect(getProfile(1)).rejects.toThrow(
+    await expect(getProfile()).rejects.toThrow(
       'Не удалось получить профиль: Некорректный ответ сервера',
     );
-    expect(mockFetch).toHaveBeenCalledWith(
-      '/api/profiles?telegramId=1',
-      expect.any(Object),
-    );
+    expect(mockFetch).toHaveBeenCalledWith('/api/profile', expect.any(Object));
   });
 
   it('throws error when saveProfile request fails', async () => {


### PR DESCRIPTION
## Summary
- switch profile fetch to `/profile` endpoint returning `ProfileSettingsOut`
- align profile types with `ProfileSettingsOut`
- update profile page and tests for new endpoint and fields

## Testing
- `pnpm exec eslint src/features/profile/api.ts src/features/profile/types.ts src/pages/Profile.tsx tests/profile.api.test.ts tests/profile.test.tsx`
- `pnpm test tests/profile.api.test.ts`
- `pnpm test -- tests/profile.test.tsx -t "displays carbUnits options"`


------
https://chatgpt.com/codex/tasks/task_e_68bbc729a99c832a8836deb37ba940b7