### PR TITLE
[profile] Allow timezone save without existing profile

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -459,9 +459,6 @@ async def profile_timezone_save(
             existed, ok = db_set_timezone(session)
     else:
         existed, ok = await run_db(db_set_timezone, sessionmaker=SessionLocal)
-    if not existed:
-        await message.reply_text("Профиль не найден.", reply_markup=menu_keyboard())
-        return END
     if not ok:
         await message.reply_text(
             "⚠️ Не удалось обновить часовой пояс.",
@@ -498,8 +495,11 @@ async def profile_timezone_save(
             len(reminders),
             user_id,
         )
+    text = "✅ Часовой пояс обновлён."
+    if not existed:
+        text = "✅ Профиль создан. Часовой пояс сохранён."
 
-    await message.reply_text("✅ Часовой пояс обновлён.", reply_markup=menu_keyboard())
+    await message.reply_text(text, reply_markup=menu_keyboard())
     return END
 
 

--- a/tests/test_profile_conversation.py
+++ b/tests/test_profile_conversation.py
@@ -120,7 +120,7 @@ async def test_profile_timezone_save_profile_missing(
     )
     state = await handlers.profile_timezone_save(update, context)
     assert state == handlers.END
-    assert any("Профиль не найден" in r for r in message.replies)
+    assert message.replies == ["✅ Профиль создан. Часовой пояс сохранён."]
     run_db_mock.assert_awaited_once()
 
 

--- a/tests/test_profile_timezone_save.py
+++ b/tests/test_profile_timezone_save.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+handlers = importlib.import_module(
+    "services.api.app.diabetes.handlers.profile.conversation"
+)
+
+
+class DummyMessage:
+    def __init__(self, text: str) -> None:
+        self.text: str = text
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_timezone_save_creates_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def run_db(func, sessionmaker):
+        if func.__name__ == "db_set_timezone":
+            return False, True
+        if func.__name__ == "db_get_reminders":
+            return []
+        raise AssertionError(func)
+
+    monkeypatch.setattr(handlers, "run_db", run_db)
+
+    msg = DummyMessage("Europe/Moscow")
+    update = cast(
+        Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(job_queue=SimpleNamespace()),
+    )
+
+    await handlers.profile_timezone_save(update, context)
+    assert msg.replies == ["✅ Профиль создан. Часовой пояс сохранён."]


### PR DESCRIPTION
## Summary
- Avoid error when setting timezone creates a profile
- Test timezone save flow without existing profile

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bbca874b68832aa7f6ee58cde42e64