### PR TITLE
[profile] Localize SOS toggle button

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -659,7 +659,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             ],
             [
                 InlineKeyboardButton(
-                    f"SOS-уведомления: {'off' if result['sos_enabled'] else 'on'}",
+                    f"SOS-уведомления: {'Выкл' if result['sos_enabled'] else 'Вкл'}",
                     callback_data="profile_security:toggle_sos",
                 )
             ],


### PR DESCRIPTION
## Summary
- Replace SOS alerts toggle text with Russian "Выкл"/"Вкл" to reflect next action
- Test button label for both enabled and disabled states

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68bbca8cc6b8832ab7d70f7164fec28b