### PR TITLE
[profile] Disable timezone auto after manual set

### DIFF
--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -257,13 +257,19 @@ def save_profile(
     return True
 
 
-def set_timezone(session: Session, user_id: int, tz: str) -> tuple[bool, bool]:
+def set_timezone(
+    session: Session, user_id: int, tz: str, *, auto: bool
+) -> tuple[bool, bool]:
     """Update user timezone in the database.
 
     Returns ``(existed, ok)`` where ``existed`` shows whether the profile was
     present before the update and ``ok`` indicates commit success.
     """
-    return patch_user_settings(session, user_id, ProfileSettingsIn(timezone=tz))
+    return patch_user_settings(
+        session,
+        user_id,
+        ProfileSettingsIn(timezone=tz, timezoneAuto=auto),
+    )
 
 
 def get_profile_settings(session: Session, user_id: int) -> LocalProfileSettings | None:

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -452,7 +452,7 @@ async def profile_timezone_save(
     user_id = user.id
 
     def db_set_timezone(session: Session) -> tuple[bool, bool]:
-        return set_timezone(session, user_id, raw)
+        return set_timezone(session, user_id, raw, auto=False)
 
     if run_db is None:
         with SessionLocal() as session:

--- a/tests/test_profile_timezone_auto_off.py
+++ b/tests/test_profile_timezone_auto_off.py
@@ -1,0 +1,42 @@
+import pytest
+from collections.abc import Generator
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+import importlib
+from services.api.app.diabetes.services.db import Base, User, Profile
+
+profile_api = importlib.import_module(
+    "services.api.app.diabetes.handlers.profile.api"
+)
+
+
+@pytest.fixture()
+def session_factory() -> Generator[sessionmaker[Session], None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestSession: sessionmaker[Session] = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False
+    )
+    try:
+        yield TestSession
+    finally:
+        engine.dispose()
+
+
+def test_profile_timezone_auto_off(session_factory: sessionmaker[Session]) -> None:
+    with session_factory() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.add(Profile(telegram_id=1, timezone="UTC", timezone_auto=True))
+        session.commit()
+        profile_api.set_timezone(session, 1, "Europe/Moscow", auto=False)
+
+    with session_factory() as session:
+        profile = session.get(Profile, 1)
+        assert profile is not None
+        assert profile.timezone == "Europe/Moscow"
+        assert profile.timezone_auto is False


### PR DESCRIPTION
## Summary
- disable timezone auto flag when user sets timezone manually
- update profile flow to use new API
- add regression tests for timezone_auto flag

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bbca843adc832a8f480165800333f0