### PR TITLE
[diabetes] tighten bot status fetch

### DIFF
--- a/tests/bot/test_start_status.py
+++ b/tests/bot/test_start_status.py
@@ -41,6 +41,7 @@ class DummyResponse:
 class DummySession:
     def __init__(self, data: dict[str, Any]) -> None:
         self._data = data
+        self.timeout: aiohttp.ClientTimeout | None = None
 
     async def __aenter__(self) -> DummySession:
         return self
@@ -48,7 +49,14 @@ class DummySession:
     async def __aexit__(self, exc_type, exc, tb) -> None:
         return None
 
-    def get(self, url: str, headers: dict[str, str] | None = None) -> DummyResponse:
+    def get(
+        self,
+        url: str,
+        headers: dict[str, str] | None = None,
+        *,
+        timeout: aiohttp.ClientTimeout | None = None,
+    ) -> DummyResponse:
+        self.timeout = timeout
         return DummyResponse(self._data)
 
 


### PR DESCRIPTION
## Summary
- log and distinguish timeout vs client errors when fetching onboarding status
- bound aiohttp client with `ClientTimeout`
- cover status handler error paths and timeout propagation

## Testing
- `pytest -q`
- `mypy --strict services/api/app/diabetes/bot_status_handlers.py tests/test_bot_status_handler.py tests/bot/test_start_status.py`
- `ruff check services/api/app/diabetes/bot_status_handlers.py tests/test_bot_status_handler.py tests/bot/test_start_status.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbd098860c832a9c6d15e4af6a6cbe