### PR TITLE
[handlers] Improve debug reminder handler error handling

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -109,11 +109,10 @@ def register_reminder_handlers(
         )
 
         register_debug_reminder_handlers(app)
-    except ImportError as e:
-        logger.warning("⚠️ Could not load debug reminder handlers: %s", e)
-    except Exception:
-        logger.exception("Failed to load debug reminder handlers")
-        raise
+    except (RuntimeError, ImportError) as exc:
+        handler_name = "register_debug_reminder_handlers"
+        logger.error("Failed to load %s: %s", handler_name, exc)
+        raise RuntimeError(f"{handler_name} failed") from exc
 
     # --- Schedule reminders ---
     job_queue = app.job_queue

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -356,10 +356,11 @@ def test_register_reminder_handlers_missing_debug_module(
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
 
-    with caplog.at_level(logging.WARNING):
-        register_reminder_handlers(app)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError, match="register_debug_reminder_handlers"):
+            register_reminder_handlers(app)
 
-    assert "Could not load debug reminder handlers" in caplog.text
+    assert "Failed to load register_debug_reminder_handlers" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- improve debug reminder handler registration error handling
- update registration tests accordingly

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/test_register_handlers.py::test_register_reminder_handlers_missing_debug_module -q` *(fails: coverage < 85%)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd09c083c832a96d5fd7c9567bed9