### PR TITLE
[services] Replace session.query with select

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable
 from typing import cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+import sqlalchemy as sa
 from sqlalchemy.orm import Session, selectinload
 from telegram import (
     InlineKeyboardButton,
@@ -90,9 +91,7 @@ back_keyboard: ReplyKeyboardMarkup = _back_keyboard
 from .. import UserData  # noqa: E402
 
 
-PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(
-    6
-)
+PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(6)
 END: int = ConversationHandler.END
 
 
@@ -121,21 +120,9 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         if callable(end_conv):
             end_conv(update, context, END)
         else:
-            chat_id = (
-                getattr(update.effective_chat, "id", None)
-                if sugar_conv.per_chat
-                else None
-            )
-            user_id = (
-                getattr(update.effective_user, "id", None)
-                if sugar_conv.per_user
-                else None
-            )
-            msg_id = (
-                getattr(update.effective_message, "message_id", None)
-                if sugar_conv.per_message
-                else None
-            )
+            chat_id = getattr(update.effective_chat, "id", None) if sugar_conv.per_chat else None
+            user_id = getattr(update.effective_user, "id", None) if sugar_conv.per_user else None
+            msg_id = getattr(update.effective_message, "message_id", None) if sugar_conv.per_message else None
             key = cast(
                 tuple[int | str, ...],
                 tuple(i for i in (chat_id, user_id, msg_id) if i is not None),
@@ -145,7 +132,9 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             else:
                 logger.warning("sugar_conv lacks _update_state method")
 
-    help_text = "Настройки профиля доступны в приложении. Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
+    help_text = (
+        "Настройки профиля доступны в приложении. Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
+    )
 
     if len(args) == 1 and args[0].lower() == "help":
         await message.reply_text(help_text, parse_mode="Markdown")
@@ -164,9 +153,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         icr, cf, target, low, high = parse_profile_values(values)
     except ValueError as exc:
         await message.reply_text(
-            exc.args[0]
-            if exc.args
-            else "❗ Пожалуйста, введите корректные числа. Справка: /profile help"
+            exc.args[0] if exc.args else "❗ Пожалуйста, введите корректные числа. Справка: /profile help"
         )
         return END
 
@@ -303,9 +290,7 @@ async def profile_webapp_save(
     try:
         icr, cf, target, low, high = parse_profile_values(data)
     except ValueError as exc:
-        await eff_msg.reply_text(
-            exc.args[0] if exc.args else error_msg, reply_markup=menu_keyboard()
-        )
+        await eff_msg.reply_text(exc.args[0] if exc.args else error_msg, reply_markup=menu_keyboard())
         return
     user = update.effective_user
     if user is None:
@@ -399,9 +384,7 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     button = build_timezone_webapp_button()
     if button:
         keyboard = InlineKeyboardMarkup([[button]])
-        await message.reply_text(
-            "Можно определить автоматически:", reply_markup=keyboard
-        )
+        await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
     else:
         await message.reply_text(
             "Автоматическое определение недоступно, укажите часовой пояс вручную.",
@@ -410,9 +393,7 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     return PROFILE_TZ
 
 
-async def profile_timezone_save(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     """Save user timezone from input."""
     message = update.message
     if message is None:
@@ -437,9 +418,7 @@ async def profile_timezone_save(
         button = build_timezone_webapp_button()
         if button:
             keyboard = InlineKeyboardMarkup([[button]])
-            await message.reply_text(
-                "Можно определить автоматически:", reply_markup=keyboard
-            )
+            await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
         else:
             await message.reply_text(
                 "Автоматическое определение недоступно, введите часовой пояс вручную.",
@@ -472,13 +451,12 @@ async def profile_timezone_save(
     else:
 
         def db_get_reminders(session: Session) -> list[Reminder]:
-            return (
-                session.query(Reminder)
+            return session.scalars(
+                sa.select(Reminder)
                 .options(selectinload(Reminder.user))
                 .filter_by(telegram_id=user_id, is_enabled=True)
                 .filter(Reminder.time.is_not(None))
-                .all()
-            )
+            ).all()
 
         if run_db is None:
             with SessionLocal() as session:
@@ -503,9 +481,7 @@ async def profile_timezone_save(
     return END
 
 
-def _security_db(
-    session: Session, user_id: int, action: str | None
-) -> dict[str, object]:
+def _security_db(session: Session, user_id: int, action: str | None) -> dict[str, object]:
     profile = session.get(Profile, user_id)
     user = session.get(User, user_id)
     if not profile:
@@ -542,22 +518,13 @@ def _security_db(
     if changed:
         try:
             commit(session)
-            alert = (
-                session.query(Alert)
-                .filter_by(user_id=user_id)
-                .order_by(Alert.ts.desc())
-                .first()
-            )
+            alert = session.scalars(sa.select(Alert).filter_by(user_id=user_id).order_by(Alert.ts.desc())).first()
             alert_sugar = alert.sugar if alert else None
         except CommitError:
             commit_ok = False
 
-    rems = session.query(Reminder).filter_by(telegram_id=user_id).all()
-    rem_text = (
-        "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems)
-        if rems
-        else "нет"
-    )
+    rems = session.scalars(sa.select(Reminder).filter_by(telegram_id=user_id)).all()
+    rem_text = "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems) if rems else "нет"
     return {
         "found": True,
         "commit_ok": commit_ok,
@@ -642,20 +609,12 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton(
-                    "Низкий -0.5", callback_data="profile_security:low_dec"
-                ),
-                InlineKeyboardButton(
-                    "Низкий +0.5", callback_data="profile_security:low_inc"
-                ),
+                InlineKeyboardButton("Низкий -0.5", callback_data="profile_security:low_dec"),
+                InlineKeyboardButton("Низкий +0.5", callback_data="profile_security:low_inc"),
             ],
             [
-                InlineKeyboardButton(
-                    "Высокий -0.5", callback_data="profile_security:high_dec"
-                ),
-                InlineKeyboardButton(
-                    "Высокий +0.5", callback_data="profile_security:high_inc"
-                ),
+                InlineKeyboardButton("Высокий -0.5", callback_data="profile_security:high_dec"),
+                InlineKeyboardButton("Высокий +0.5", callback_data="profile_security:high_inc"),
             ],
             [
                 InlineKeyboardButton(
@@ -663,15 +622,9 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     callback_data="profile_security:toggle_sos",
                 )
             ],
+            [InlineKeyboardButton("SOS контакт", callback_data="profile_security:sos_contact")],
             [
-                InlineKeyboardButton(
-                    "SOS контакт", callback_data="profile_security:sos_contact"
-                )
-            ],
-            [
-                InlineKeyboardButton(
-                    "➕ Добавить", callback_data="profile_security:add"
-                ),
+                InlineKeyboardButton("➕ Добавить", callback_data="profile_security:add"),
                 InlineKeyboardButton("🗑 Удалить", callback_data="profile_security:del"),
             ],
             [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
@@ -768,9 +721,7 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     try:
         target = float(text)
     except ValueError:
-        await message.reply_text(
-            "Введите целевой сахар числом.", reply_markup=back_keyboard
-        )
+        await message.reply_text("Введите целевой сахар числом.", reply_markup=back_keyboard)
         return PROFILE_TARGET
     if target <= 0:
         await message.reply_text(MSG_TARGET_GT0, reply_markup=back_keyboard)
@@ -800,9 +751,7 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     try:
         low = float(text)
     except ValueError:
-        await message.reply_text(
-            "Введите нижний порог числом.", reply_markup=back_keyboard
-        )
+        await message.reply_text("Введите нижний порог числом.", reply_markup=back_keyboard)
         return PROFILE_LOW
     if low <= 0:
         await message.reply_text(MSG_LOW_GT0, reply_markup=back_keyboard)
@@ -832,18 +781,14 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     try:
         high = float(text)
     except ValueError:
-        await message.reply_text(
-            "Введите верхний порог числом.", reply_markup=back_keyboard
-        )
+        await message.reply_text("Введите верхний порог числом.", reply_markup=back_keyboard)
         return PROFILE_HIGH
     icr = user_data.get("profile_icr")
     cf = user_data.get("profile_cf")
     target = user_data.get("profile_target")
     low = user_data.get("profile_low")
     if None in (icr, cf, target, low):
-        await message.reply_text(
-            "⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново."
-        )
+        await message.reply_text("⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново.")
         return END
     error = validate_profile_numbers(icr, cf, target, low, high)
     if error:
@@ -915,15 +860,11 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return END
 
 
-async def _profile_edit_entry(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def _profile_edit_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     return await profile_edit(update, context)
 
 
-async def _profile_timezone_entry(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def _profile_timezone_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     return await profile_timezone(update, context)
 
 
@@ -931,16 +872,12 @@ profile_conv = ConversationHandler(
     entry_points=[
         CommandHandler("profile", profile_command),
         CallbackQueryNoWarnHandler(_profile_edit_entry, pattern="^profile_edit$"),
-        CallbackQueryNoWarnHandler(
-            _profile_timezone_entry, pattern="^profile_timezone$"
-        ),
+        CallbackQueryNoWarnHandler(_profile_timezone_entry, pattern="^profile_timezone$"),
     ],
     states={
         PROFILE_ICR: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_icr)],
         PROFILE_CF: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_cf)],
-        PROFILE_TARGET: [
-            MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)
-        ],
+        PROFILE_TARGET: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)],
         PROFILE_LOW: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_low)],
         PROFILE_HIGH: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_high)],
         PROFILE_TZ: [
@@ -962,9 +899,7 @@ profile_conv = ConversationHandler(
 )
 
 
-profile_webapp_handler = MessageHandler(
-    filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save
-)
+profile_webapp_handler = MessageHandler(filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save)
 
 
 __all__ = [

--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -5,6 +5,7 @@ import logging
 import re
 from datetime import timedelta
 
+import sqlalchemy as sa
 from sqlalchemy.orm import Session, sessionmaker, selectinload
 from telegram.ext import ContextTypes
 
@@ -34,12 +35,11 @@ async def _reminders_gc(_context: ContextTypes.DEFAULT_TYPE) -> None:
 
     def load_active() -> list[Reminder]:
         with session_factory() as session:
-            return (
-                session.query(Reminder)
+            return session.scalars(
+                sa.select(Reminder)
                 .options(selectinload(Reminder.user).selectinload(User.profile))
-                .filter(Reminder.is_enabled == True)  # noqa: E712
-                .all()
-            )
+                .where(Reminder.is_enabled == True)  # noqa: E712
+            ).all()
 
     reminders = await asyncio.to_thread(load_active)
     active_ids = {rem.id for rem in reminders}


### PR DESCRIPTION
## Summary
- refactor various services to replace `session.query` with `sa.select` and `session.execute`/`session.scalars`
- modernize curriculum engine and related handlers to use `.scalar_one()` and `.scalars().all()`
- update scripts and jobs to new SQLAlchemy style

## Testing
- `ruff check .`
- `mypy --strict services/api/app/diabetes/curriculum_engine.py`
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd0a05288832abc60ffe495e8bfe5