### PR TITLE
[profile] align profile fetch endpoint

### DIFF
--- a/services/api/app/routers/profile.py
+++ b/services/api/app/routers/profile.py
@@ -24,6 +24,13 @@ async def profile_self(user: UserContext = Depends(require_tg_user)) -> UserCont
     return user
 
 
+@router.get("/profile")
+async def profile(user: UserContext = Depends(require_tg_user)) -> UserContext:
+    """Backward-compatible alias for :func:`profile_self`."""
+
+    return await profile_self(user)
+
+
 @router.patch("/profile", response_model=ProfileSettingsOut)
 async def profile_patch(
     data: ProfileSettingsIn,

--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -4,7 +4,7 @@ import type { Profile, PatchProfileDto, RapidInsulin } from './types';
 
 export async function getProfile(): Promise<Profile | null> {
   try {
-    return await tgFetch<Profile>(`/profile`);
+    return await tgFetch<Profile>(`/profile/self`);
   } catch (error) {
     if (error instanceof FetchError) {
       if (error.status === 404) {

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -23,7 +23,7 @@ describe('profile api', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     await expect(getProfile()).rejects.toThrow('Не удалось получить профиль: boom');
-    expect(mockFetch).toHaveBeenCalledWith('/api/profile', expect.any(Object));
+    expect(mockFetch).toHaveBeenCalledWith('/api/profile/self', expect.any(Object));
   });
 
   it('returns null when profile not found', async () => {
@@ -39,7 +39,7 @@ describe('profile api', () => {
 
     const result = await getProfile();
     expect(result).toBeNull();
-    expect(mockFetch).toHaveBeenCalledWith('/api/profile', expect.any(Object));
+    expect(mockFetch).toHaveBeenCalledWith('/api/profile/self', expect.any(Object));
   });
 
   it('throws error when getProfile returns invalid JSON', async () => {
@@ -56,7 +56,7 @@ describe('profile api', () => {
     await expect(getProfile()).rejects.toThrow(
       'Не удалось получить профиль: Некорректный ответ сервера',
     );
-    expect(mockFetch).toHaveBeenCalledWith('/api/profile', expect.any(Object));
+    expect(mockFetch).toHaveBeenCalledWith('/api/profile/self', expect.any(Object));
   });
 
   it('throws error when saveProfile request fails', async () => {


### PR DESCRIPTION
## Summary
- add /profile GET alias for backwards compatibility
- fetch profile from /profile/self on webapp
- update profile API tests for new route

## Testing
- `pytest tests/billing/test_service.py::test_create_payment_unknown_provider -q` *(fails: async plugin missing, coverage <85)*
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test`


------
https://chatgpt.com/codex/tasks/task_e_68bbd0b51754832aa9fa14332ca2f460