### PR TITLE
[billing] align subscription status names

### DIFF
--- a/services/api/app/billing/jobs.py
+++ b/services/api/app/billing/jobs.py
@@ -13,7 +13,7 @@ from telegram.ext import ContextTypes
 from services.api.app.diabetes.handlers.reminder_jobs import DefaultJobQueue
 from services.api.app.diabetes.services.db import (
     Subscription,
-    SubscriptionStatus,
+    SubStatus,
     run_db,
 )
 from services.api.app.diabetes.services.repository import commit
@@ -51,14 +51,14 @@ async def expire_subscriptions(_context: ContextTypes.DEFAULT_TYPE) -> None:
         now = _utcnow()
         subs = session.scalars(
             sa.select(Subscription).where(
-                Subscription.status.in_([SubscriptionStatus.TRIAL.value, SubscriptionStatus.ACTIVE.value]),
+                Subscription.status.in_([SubStatus.trial.value, SubStatus.active.value]),
                 Subscription.end_date != None,  # noqa: E711
                 Subscription.end_date < now,
             )
         ).all()
         for sub in subs:
-            if sub.status == SubscriptionStatus.ACTIVE.value:
-                sub.status = cast(SubscriptionStatus, SubscriptionStatus.EXPIRED.value)
+            if sub.status == SubStatus.active.value:
+                sub.status = cast(SubStatus, SubStatus.expired.value)
             log_billing_event(
                 session,
                 sub.user_id,

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -397,11 +397,11 @@ class Timezone(Base):
     tz: Mapped[str] = mapped_column(String, nullable=False)
 
 
-class SubscriptionStatus(str, Enum):
-    TRIAL = "trial"
-    ACTIVE = "active"
-    CANCELED = "canceled"
-    EXPIRED = "expired"
+class SubStatus(str, Enum):
+    trial = "trial"
+    active = "active"
+    canceled = "canceled"
+    expired = "expired"
 
 
 class Subscription(Base):
@@ -426,9 +426,9 @@ class Subscription(Base):
         ),
         nullable=False,
     )
-    status: Mapped[SubscriptionStatus] = mapped_column(
+    status: Mapped[SubStatus] = mapped_column(
         sa.Enum(
-            SubscriptionStatus,
+            SubStatus,
             name="subscription_status",
             create_type=False,
             values_callable=lambda enum: [e.value for e in enum],

--- a/services/api/app/schemas/billing.py
+++ b/services/api/app/schemas/billing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
-from services.api.app.diabetes.services.db import SubscriptionPlan, SubscriptionStatus
+from services.api.app.diabetes.services.db import SubscriptionPlan, SubStatus
 
 
 class FeatureFlags(BaseModel):
@@ -38,7 +38,7 @@ class SubscriptionSchema(BaseModel):
     """Information about a user subscription."""
 
     plan: SubscriptionPlan
-    status: SubscriptionStatus
+    status: SubStatus
     provider: str
     startDate: datetime = Field(
         alias="startDate", validation_alias=AliasChoices("startDate", "start_date")

--- a/tests/billing/test_admin_mock_webhook.py
+++ b/tests/billing/test_admin_mock_webhook.py
@@ -13,7 +13,7 @@ from services.api.app.diabetes.services.db import (
     Base,
     Subscription,
     SubscriptionPlan,
-    SubscriptionStatus,
+    SubStatus,
 )
 from services.api.app.billing.log import BillingLog
 from services.api.app.main import app
@@ -68,7 +68,7 @@ def test_admin_mock_webhook(monkeypatch: pytest.MonkeyPatch) -> None:
             Subscription(
                 user_id=1,
                 plan=SubscriptionPlan.PRO,
-                status=SubscriptionStatus.CANCELED,
+                status=SubStatus.canceled,
                 provider="dummy",
                 transaction_id="tx1",
                 start_date=datetime.now(timezone.utc),
@@ -88,7 +88,7 @@ def test_admin_mock_webhook(monkeypatch: pytest.MonkeyPatch) -> None:
     with session_local() as session:
         sub = session.scalar(select(Subscription).where(Subscription.transaction_id == "tx1"))
         assert sub is not None
-        assert sub.status == SubscriptionStatus.ACTIVE
+        assert sub.status == SubStatus.active
 
 
 def test_admin_mock_webhook_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/billing/test_billing_subscribe.py
+++ b/tests/billing/test_billing_subscribe.py
@@ -14,7 +14,7 @@ from services.api.app.diabetes.services.db import (
     Base,
     Subscription,
     SubscriptionPlan,
-    SubscriptionStatus,
+    SubStatus,
 )
 from services.api.app.billing.log import BillingLog
 from services.api.app.routers import billing
@@ -85,7 +85,7 @@ def test_subscribe_dummy_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     with session_local() as session:
         sub = session.scalar(select(Subscription).where(Subscription.transaction_id == data["id"]))
         assert sub is not None
-        assert sub.status == SubscriptionStatus.ACTIVE
+        assert sub.status == SubStatus.active
         assert sub.plan == SubscriptionPlan.PRO
 
 
@@ -143,7 +143,7 @@ def test_subscribe_conflict_with_existing_active(
             Subscription(
                 user_id=1,
                 plan=SubscriptionPlan.PRO,
-                status=SubscriptionStatus.ACTIVE,
+                status=SubStatus.active,
                 provider="dummy",
                 transaction_id="existing",
                 start_date=datetime.now(timezone.utc),

--- a/tests/billing/test_billing_webhook.py
+++ b/tests/billing/test_billing_webhook.py
@@ -14,7 +14,7 @@ from services.api.app.diabetes.services.db import (
     Base,
     Subscription,
     SubscriptionPlan,
-    SubscriptionStatus,
+    SubStatus,
 )
 from services.api.app.billing.log import BillingEvent, BillingLog
 from services.api.app.routers import billing
@@ -87,7 +87,7 @@ def test_webhook_activates_subscription(monkeypatch: pytest.MonkeyPatch, caplog:
     with session_local() as session:
         sub = session.scalar(select(Subscription).where(Subscription.transaction_id == checkout_id))
         assert sub is not None
-        assert sub.status == SubscriptionStatus.ACTIVE
+        assert sub.status == SubStatus.active
         assert sub.plan == SubscriptionPlan.PRO
         assert sub.end_date is not None
         log = session.scalar(
@@ -150,7 +150,7 @@ def test_webhook_invalid_signature(monkeypatch: pytest.MonkeyPatch) -> None:
     with session_local() as session:
         sub = session.scalar(select(Subscription).where(Subscription.transaction_id == checkout_id))
         assert sub is not None
-        assert sub.status == SubscriptionStatus.ACTIVE
+        assert sub.status == SubStatus.active
         assert sub.end_date is None
 
 
@@ -173,7 +173,7 @@ def test_webhook_signature_header_mismatch(monkeypatch: pytest.MonkeyPatch) -> N
     with session_local() as session:
         sub = session.scalar(select(Subscription).where(Subscription.transaction_id == checkout_id))
         assert sub is not None
-        assert sub.status == SubscriptionStatus.ACTIVE
+        assert sub.status == SubStatus.active
         assert sub.end_date is None
 
 

--- a/tests/billing/test_expire_job.py
+++ b/tests/billing/test_expire_job.py
@@ -13,7 +13,7 @@ from services.api.app.diabetes.services.db import (
     Base,
     Subscription,
     SubscriptionPlan,
-    SubscriptionStatus,
+    SubStatus,
 )
 from services.api.app.billing.log import BillingEvent, BillingLog
 from services.api.app.billing import jobs
@@ -38,7 +38,7 @@ async def test_expire_subscriptions_logs_event(
         sub = Subscription(
             user_id=1,
             plan=SubscriptionPlan.PRO,
-            status=SubscriptionStatus.TRIAL,
+            status=SubStatus.trial,
             provider="dummy",
             transaction_id="tx1",
             end_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
@@ -59,7 +59,7 @@ async def test_expire_subscriptions_logs_event(
     with session_local() as session:
         sub = session.scalar(select(Subscription))
         assert sub is not None
-        assert sub.status == SubscriptionStatus.TRIAL
+        assert sub.status == SubStatus.trial
         log = session.scalar(
             select(BillingLog).where(
                 BillingLog.user_id == 1,

--- a/tests/billing/test_subscription_atomicity.py
+++ b/tests/billing/test_subscription_atomicity.py
@@ -10,7 +10,7 @@ from services.api.app.diabetes.services.db import (
     Base,
     Subscription,
     SubscriptionPlan,
-    SubscriptionStatus,
+    SubStatus,
     run_db,
 )
 
@@ -36,7 +36,7 @@ async def test_subscription_creation_atomicity() -> None:
             draft = Subscription(
                 user_id=1,
                 plan=SubscriptionPlan.PRO,
-                status=SubscriptionStatus.ACTIVE,
+                status=SubStatus.active,
                 provider="dummy",
                 transaction_id="tx",
             )

--- a/tests/test_billing_status.py
+++ b/tests/test_billing_status.py
@@ -14,7 +14,7 @@ from services.api.app.diabetes.services.db import (
     Base,
     Subscription,
     SubscriptionPlan,
-    SubscriptionStatus,
+    SubStatus,
 )
 
 
@@ -77,7 +77,7 @@ def test_status_with_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
             Subscription(
                 user_id=1,
                 plan=SubscriptionPlan.PRO,
-                status=SubscriptionStatus.ACTIVE,
+                status=SubStatus.active,
                 provider="dummy",
                 transaction_id="t1",
                 start_date=datetime(2024, 1, 1),
@@ -97,7 +97,7 @@ def test_status_with_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
         "testMode": True,
     }
     assert data["subscription"]["plan"] == "pro"
-    assert data["subscription"]["status"] == "active"
+    assert data["subscription"]["status"] == SubStatus.active.value
     assert data["subscription"]["provider"] == "dummy"
     assert data["subscription"]["startDate"].startswith("2024-01-01")
     assert data["subscription"]["endDate"] is None
@@ -113,7 +113,7 @@ def test_status_with_multiple_subscriptions(
                 Subscription(
                     user_id=1,
                     plan=SubscriptionPlan.PRO,
-                    status=SubscriptionStatus.CANCELED,
+                    status=SubStatus.canceled,
                     provider="dummy",
                     transaction_id="t1",
                     start_date=datetime(2024, 1, 1),
@@ -122,7 +122,7 @@ def test_status_with_multiple_subscriptions(
                 Subscription(
                     user_id=1,
                     plan=SubscriptionPlan.FAMILY,
-                    status=SubscriptionStatus.ACTIVE,
+                    status=SubStatus.active,
                     provider="dummy",
                     transaction_id="t2",
                     start_date=datetime(2024, 3, 1),
@@ -143,7 +143,7 @@ def test_status_with_multiple_subscriptions(
         "testMode": True,
     }
     assert data["subscription"]["plan"] == "family"
-    assert data["subscription"]["status"] == "active"
+    assert data["subscription"]["status"] == SubStatus.active.value
     assert data["subscription"]["startDate"].startswith("2024-03-01")
 
 
@@ -157,7 +157,7 @@ def test_status_with_active_and_trial_subscriptions(
                 Subscription(
                     user_id=1,
                     plan=SubscriptionPlan.PRO,
-                    status=SubscriptionStatus.ACTIVE,
+                    status=SubStatus.active,
                     provider="dummy",
                     transaction_id="t1",
                     start_date=datetime(2024, 1, 1),
@@ -166,7 +166,7 @@ def test_status_with_active_and_trial_subscriptions(
                 Subscription(
                     user_id=1,
                     plan=SubscriptionPlan.FAMILY,
-                    status=SubscriptionStatus.TRIAL,
+                    status=SubStatus.trial,
                     provider="dummy",
                     transaction_id="t2",
                     start_date=datetime(2024, 4, 1),
@@ -181,7 +181,7 @@ def test_status_with_active_and_trial_subscriptions(
         resp = client.get("/api/billing/status", params={"user_id": 1})
     assert resp.status_code == 200
     data = resp.json()
-    assert data["subscription"]["status"] == "active"
+    assert data["subscription"]["status"] == SubStatus.active.value
     assert data["subscription"]["plan"] == "pro"
     assert data["subscription"]["startDate"].startswith("2024-01-01")
 
@@ -193,7 +193,7 @@ def test_duplicate_status_per_user() -> None:
             Subscription(
                 user_id=1,
                 plan=SubscriptionPlan.PRO,
-                status=SubscriptionStatus.ACTIVE,
+                status=SubStatus.active,
                 provider="dummy",
                 transaction_id="t1",
                 start_date=datetime(2024, 1, 1),
@@ -204,7 +204,7 @@ def test_duplicate_status_per_user() -> None:
             Subscription(
                 user_id=1,
                 plan=SubscriptionPlan.FAMILY,
-                status=SubscriptionStatus.ACTIVE,
+                status=SubStatus.active,
                 provider="dummy",
                 transaction_id="t2",
                 start_date=datetime(2024, 2, 1),


### PR DESCRIPTION
## Summary
- introduce `SubStatus` enum with lowercase billing status values
- use `SubStatus` across billing router, jobs and schemas
- update tests for new enum

## Testing
- `pytest -q` *(fails: TypeError, AttributeError in reminder handlers)*
- `mypy --strict services/api/app/routers/billing.py services/api/app/diabetes/services/db.py services/api/app/billing/jobs.py services/api/app/schemas/billing.py tests/test_billing_trial.py tests/test_billing_status.py tests/billing/test_subscription_atomicity.py tests/billing/test_expire_job.py tests/billing/test_admin_mock_webhook.py tests/billing/test_billing_webhook.py tests/billing/test_billing_subscribe.py` *(fails: return value type errors in unrelated modules)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68bbd3204104832a9c19332b2697df66