### PR TITLE
[ui] Pass telegramId to profile fetch

### DIFF
--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -2,9 +2,11 @@ import type { ProfileSchema } from '@sdk';
 import { tgFetch, FetchError } from '@/lib/tgFetch';
 import type { Profile, PatchProfileDto, RapidInsulin } from './types';
 
-export async function getProfile(): Promise<Profile | null> {
+export async function getProfile(telegramId: number): Promise<Profile | null> {
   try {
-    return await tgFetch<Profile>(`/profile/self`);
+    return await tgFetch<Profile>(
+      `/profiles?telegramId=${telegramId}`,
+    );
   } catch (error) {
     if (error instanceof FetchError) {
       if (error.status === 404) {

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -293,7 +293,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
 
     let cancelled = false;
 
-    getProfile()
+    getProfile(telegramId)
       .then((data) => {
         if (cancelled) return;
         if (!data) {

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -22,8 +22,13 @@ describe('profile api', () => {
       );
     vi.stubGlobal('fetch', mockFetch);
 
-    await expect(getProfile()).rejects.toThrow('Не удалось получить профиль: boom');
-    expect(mockFetch).toHaveBeenCalledWith('/api/profile/self', expect.any(Object));
+    await expect(getProfile(1)).rejects.toThrow(
+      'Не удалось получить профиль: boom',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/profiles?telegramId=1',
+      expect.any(Object),
+    );
   });
 
   it('returns null when profile not found', async () => {
@@ -37,9 +42,12 @@ describe('profile api', () => {
       );
     vi.stubGlobal('fetch', mockFetch);
 
-    const result = await getProfile();
+    const result = await getProfile(1);
     expect(result).toBeNull();
-    expect(mockFetch).toHaveBeenCalledWith('/api/profile/self', expect.any(Object));
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/profiles?telegramId=1',
+      expect.any(Object),
+    );
   });
 
   it('throws error when getProfile returns invalid JSON', async () => {
@@ -53,10 +61,13 @@ describe('profile api', () => {
       );
     vi.stubGlobal('fetch', mockFetch);
 
-    await expect(getProfile()).rejects.toThrow(
+    await expect(getProfile(1)).rejects.toThrow(
       'Не удалось получить профиль: Некорректный ответ сервера',
     );
-    expect(mockFetch).toHaveBeenCalledWith('/api/profile/self', expect.any(Object));
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/profiles?telegramId=1',
+      expect.any(Object),
+    );
   });
 
   it('throws error when saveProfile request fails', async () => {

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -159,7 +159,7 @@ describe('Profile page', () => {
     const { getByLabelText } = render(<Profile />);
 
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalled();
+      expect(getProfile).toHaveBeenCalledWith(123);
     });
 
     const options = Array.from(
@@ -204,7 +204,7 @@ describe('Profile page', () => {
     const { queryByLabelText, getByDisplayValue } = render(<Profile />);
 
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalled();
+      expect(getProfile).toHaveBeenCalledWith(123);
     });
 
     expect(queryByLabelText('Граммов на 1 ХЕ')).toBeNull();
@@ -309,7 +309,7 @@ describe('Profile page', () => {
       });
       const { queryByLabelText } = render(<Profile therapyType={therapy} />);
       await waitFor(() => {
-        expect(getProfile).toHaveBeenCalled();
+        expect(getProfile).toHaveBeenCalledWith(123);
       });
       expect(queryByLabelText(/ICR/)).toBeNull();
       expect(queryByLabelText(/Коэффициент коррекции/)).toBeNull();
@@ -339,7 +339,7 @@ describe('Profile page', () => {
       });
       render(<Profile therapyType={therapy} />);
       await waitFor(() => {
-        expect(getProfile).toHaveBeenCalled();
+        expect(getProfile).toHaveBeenCalledWith(123);
       });
       expect(toast).not.toHaveBeenCalled();
     },
@@ -363,7 +363,7 @@ describe('Profile page', () => {
       });
       render(<Profile therapyType={therapy} />);
       await waitFor(() => {
-        expect(getProfile).toHaveBeenCalled();
+        expect(getProfile).toHaveBeenCalledWith(123);
       });
       expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -399,7 +399,7 @@ describe('Profile page', () => {
 
     render(<Profile />);
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalled();
+      expect(getProfile).toHaveBeenCalledWith(123);
     });
     expect(toast).not.toHaveBeenCalled();
   });
@@ -423,7 +423,7 @@ describe('Profile page', () => {
       });
       render(<Profile therapyType={therapy} />);
       await waitFor(() => {
-        expect(getProfile).toHaveBeenCalled();
+        expect(getProfile).toHaveBeenCalledWith(123);
       });
       expect(toast).not.toHaveBeenCalled();
     },
@@ -617,7 +617,7 @@ describe('Profile page', () => {
 
     const { getByPlaceholderText } = render(<Profile />);
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalled();
+      expect(getProfile).toHaveBeenCalledWith(123);
     });
     expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('15');
     expect((getByPlaceholderText('2.5') as HTMLInputElement).value).toBe('3');
@@ -642,7 +642,7 @@ describe('Profile page', () => {
 
     const { getByPlaceholderText } = render(<Profile />);
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalled();
+      expect(getProfile).toHaveBeenCalledWith(123);
     });
     expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('15');
     expect((getByPlaceholderText('2.5') as HTMLInputElement).value).toBe('3');
@@ -674,7 +674,7 @@ describe('Profile page', () => {
 
     const { getByPlaceholderText } = render(<Profile />);
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalled();
+      expect(getProfile).toHaveBeenCalledWith(123);
     });
 
     expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('15');
@@ -728,7 +728,7 @@ describe('Profile page', () => {
 
       render(<Profile />);
       await waitFor(() => {
-        expect(getProfile).toHaveBeenCalled();
+        expect(getProfile).toHaveBeenCalledWith(123);
       });
 
       if (shouldToast) {
@@ -751,7 +751,7 @@ describe('Profile page', () => {
 
     const { getByPlaceholderText } = render(<Profile />);
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalled();
+      expect(getProfile).toHaveBeenCalledWith(123);
     });
     expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -770,7 +770,7 @@ describe('Profile page', () => {
 
     const { getByPlaceholderText } = render(<Profile />);
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalled();
+      expect(getProfile).toHaveBeenCalledWith(123);
     });
     expect(toast).not.toHaveBeenCalled();
     expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('');

--- a/services/webapp/ui/tests/useDefaultAfterMealMinutes.test.ts
+++ b/services/webapp/ui/tests/useDefaultAfterMealMinutes.test.ts
@@ -33,7 +33,7 @@ describe('useDefaultAfterMealMinutes', () => {
     (getProfile as vi.Mock).mockResolvedValue(null);
     const { result } = renderHook(() => useDefaultAfterMealMinutes(1));
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalled();
+      expect(getProfile).toHaveBeenCalledWith(1);
       expect(result.current).toBe(120);
     });
   });


### PR DESCRIPTION
## Summary
- Fetch profiles by telegram ID instead of `/profile/self`
- Propagate telegramId when requesting profile in Profile page
- Update profile-related tests for new API signature

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported; coverage 56.50%)*
- `mypy --strict .` *(fails: incompatible return value type in reminders and history modules)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bbd5f2aa20832ab0ce153b4c984857