### PR TITLE
[learn] init db before loading fixtures

### DIFF
--- a/docs/learn_mode.md
+++ b/docs/learn_mode.md
@@ -18,10 +18,13 @@ LEARNING_MODE_ENABLED=true
 ## Подготовка базы данных
 
 ```bash
-alembic upgrade head
+make migrate
 ```
 
 ## Как загрузить уроки
+
+Команду можно запускать сразу после миграции, вручную вызывать `init_db` не
+нужно:
 
 ```bash
 make load-lessons

--- a/services/api/app/diabetes/learning_fixtures.py
+++ b/services/api/app/diabetes/learning_fixtures.py
@@ -49,7 +49,9 @@ class LessonModel(BaseModel):
 LESSON_LIST = TypeAdapter(list[LessonModel])
 
 
-DEFAULT_CONTENT_FILE = Path(__file__).resolve().parents[4] / "content" / "lessons_v0.json"
+DEFAULT_CONTENT_FILE = (
+    Path(__file__).resolve().parents[4] / "content" / "lessons_v0.json"
+)
 
 
 async def load_lessons(
@@ -65,7 +67,9 @@ async def load_lessons(
 
     def _load(session: Session) -> None:
         for item in lessons:
-            slug = item.slug or re.sub(r"[^a-z0-9]+", "-", item.title.lower()).strip("-")
+            slug = item.slug or re.sub(r"[^a-z0-9]+", "-", item.title.lower()).strip(
+                "-"
+            )
             lesson = Lesson(
                 slug=slug,
                 title=item.title,
@@ -119,8 +123,8 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 async def main(argv: list[str] | None = None) -> None:
-    init_db()
     args = _build_parser().parse_args(argv)
+    init_db()
     if args.reset:
         await reset_lessons()
     await load_lessons(args.path)

--- a/tests/learning/test_load_lessons.py
+++ b/tests/learning/test_load_lessons.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine
@@ -38,3 +39,29 @@ async def test_load_lessons_v0() -> None:
     finally:
         db.dispose_engine(engine)
         db.SessionLocal.configure(bind=None)
+
+
+@pytest.mark.asyncio()
+async def test_main_loads_lessons() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    def fake_init_db() -> None:
+        db.SessionLocal.configure(bind=engine)
+        db.Base.metadata.create_all(bind=engine)
+
+    path = Path(__file__).resolve().parents[2] / "content/lessons_v0.json"
+    with patch(
+        "services.api.app.diabetes.learning_fixtures.init_db", side_effect=fake_init_db
+    ) as init_db_mock:
+        await learning_fixtures.main([str(path)])
+        init_db_mock.assert_called_once()
+        with db.SessionLocal() as session:
+            lessons = session.query(Lesson).all()
+            assert len(lessons) > 0
+
+    db.dispose_engine(engine)
+    db.SessionLocal.configure(bind=None)


### PR DESCRIPTION
## Summary
- ensure learning fixtures initialize the database before seeding
- document migration step before `make load-lessons`
- add test covering CLI lesson loader

## Testing
- `DATABASE_URL=sqlite:////tmp/learning.db make load-lessons`
- `sqlite3 /tmp/learning.db "select count(*) from lessons;"` -> `4`
- `pytest tests/learning/test_load_lessons.py -q --cov-fail-under=0`
- `mypy --strict .` *(fails: incompatible return value type)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bbd5c7bd60832aa74562f36f9abb18