### PR TITLE
[profile] Preserve user timezone when auto detection is enabled

### DIFF
--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -335,7 +335,12 @@ def patch_user_settings(
         profile.prebolus_min = data.preBolus
     if data.afterMealMinutes is not None:
         profile.postmeal_check_min = data.afterMealMinutes
-    if profile.timezone_auto and device_tz and profile.timezone != device_tz:
+    if (
+        profile.timezone_auto
+        and device_tz
+        and data.timezone is None
+        and profile.timezone != device_tz
+    ):
         profile.timezone = device_tz
     try:
         commit(session)

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -104,7 +104,12 @@ async def patch_user_settings(
         if data.afterMealMinutes is not None:
             profile.postmeal_check_min = data.afterMealMinutes
 
-        if profile.timezone_auto and device_tz and profile.timezone != device_tz:
+        if (
+            profile.timezone_auto
+            and device_tz
+            and data.timezone is None
+            and profile.timezone != device_tz
+        ):
             profile.timezone = device_tz
 
         try:


### PR DESCRIPTION
## Summary
- apply device timezone only when user hasn't set timezone explicitly
- ensure patch user settings keeps user timezone even with auto detection
- test timezone with deviceTz param retains user choice

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bbe0758894832a960860511e9b1453