### PR TITLE
[billing] use enum value for trial status

### DIFF
--- a/tests/test_billing_trial_response.py
+++ b/tests/test_billing_trial_response.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+import pytest
+
+from services.api.app.diabetes.services.db import SubStatus
+from tests.test_billing_trial import make_client, setup_db
+
+
+def test_trial_response_contains_end_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.post("/api/billing/trial", params={"user_id": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["plan"] == "pro"
+    assert data["status"] == SubStatus.trial.value
+    assert "endDate" in data and data["endDate"]
+    # ensure endDate is valid ISO format
+    datetime.fromisoformat(data["endDate"])


### PR DESCRIPTION
## Summary
- use `SubStatus.trial.value` instead of literal status when locating or creating trial subscriptions
- add regression test ensuring the trial endpoint responds with plan, status, and end date

## Testing
- `pytest -q --cov` *(fails: Required test coverage of 85% not reached. Total coverage: 56.25%)*
- `pytest tests/test_billing_trial.py::test_trial_creation tests/test_billing_trial_response.py::test_trial_response_contains_end_date -q` *(fails: Coverage failure: total of 23 is less than fail-under=85)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bbe0bd4a88832aa9c4eb2c26567e62