### PR TITLE
[webapp] Skip undefined profile values

### DIFF
--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -70,6 +70,18 @@ describe("parseProfile", () => {
     expect(result.errors.gramsPerXe).toBe("required");
   });
 
+  it("does not set zero for empty optional numbers", () => {
+    const result = parseProfile(makeProfile({ gramsPerXe: "" }));
+    expect(result.errors).toEqual({});
+    expect(result.data.gramsPerXe).toBeUndefined();
+  });
+
+  it("leaves empty required numbers undefined", () => {
+    const result = parseProfile(makeProfile({ icr: "" }));
+    expect(result.errors.icr).toBe("required");
+    expect(result.data.icr).toBeUndefined();
+  });
+
   it("validates target range", () => {
     const result = parseProfile(makeProfile({ target: "12" }));
     expect(result.errors.target).toBe("out_of_range");


### PR DESCRIPTION
## Summary
- return `undefined` for empty numeric profile fields
- avoid including `undefined` values in profile updates
- add tests to ensure empty inputs don't send zeros

## Testing
- `pnpm --filter ./services/webapp/ui test tests/parseProfile.test.ts`
- `pytest tests/diabetes/test_commands.py::test_help_mentions_webapp -q` (fails: async def functions are not natively supported)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bbee6282e0832a850b35aa79f6dcf4