### PR TITLE
[services] Allow partial profile updates

### DIFF
--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -69,16 +69,8 @@ def test_validate_profile_rejects_invalid_values(
     assert str(exc.value) == message
 
 
-@pytest.mark.parametrize(
-    "field,message",
-    [
-        ("icr", "icr is required"),
-        ("cf", "cf is required"),
-        ("low", "target is required"),
-        ("high", "target is required"),
-    ],
-)
-def test_validate_profile_rejects_missing_fields(field: str, message: str) -> None:
+@pytest.mark.parametrize("field", ["icr", "cf", "low", "high"])
+def test_validate_profile_allows_missing_fields(field: str) -> None:
     kwargs = {
         "telegramId": 1,
         "icr": 1.0,
@@ -89,9 +81,7 @@ def test_validate_profile_rejects_missing_fields(field: str, message: str) -> No
     }
     kwargs.pop(field)
     data = ProfileSchema(**kwargs)
-    with pytest.raises(ValueError) as exc:
-        _validate_profile(data)
-    assert str(exc.value) == message
+    _validate_profile(data)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- update profile saving to merge with existing records
- support partial profile validation
- test partial profile update flow

## Testing
- `ruff check tests/test_profile_validation.py tests/test_profile_webapp_save_flow.py services/api/app/services/profile.py`
- `mypy --strict services/api/app/services/profile.py tests/test_profile_webapp_save_flow.py tests/test_profile_validation.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbee551ef0832ab07de0be51564b9c