### PR TITLE
[webapp] preserve profile fields when saving

### DIFF
--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -29,6 +29,13 @@ export async function saveProfile({
   target,
   low,
   high,
+  quietStart,
+  quietEnd,
+  timezone,
+  timezoneAuto,
+  sosContact,
+  sosAlertsEnabled,
+  therapyType,
 }: {
   telegramId: number;
   target: number;
@@ -36,6 +43,13 @@ export async function saveProfile({
   high: number;
   icr?: number;
   cf?: number;
+  quietStart?: string;
+  quietEnd?: string;
+  timezone?: string;
+  timezoneAuto?: boolean;
+  sosContact?: string | null;
+  sosAlertsEnabled?: boolean;
+  therapyType?: string | null;
 }) {
   try {
     const body: Record<string, unknown> = {
@@ -51,6 +65,34 @@ export async function saveProfile({
 
     if (cf !== undefined) {
       body.cf = cf;
+    }
+
+    if (quietStart !== undefined) {
+      body.quietStart = quietStart;
+    }
+
+    if (quietEnd !== undefined) {
+      body.quietEnd = quietEnd;
+    }
+
+    if (timezone !== undefined) {
+      body.timezone = timezone;
+    }
+
+    if (timezoneAuto !== undefined) {
+      body.timezoneAuto = timezoneAuto;
+    }
+
+    if (sosContact !== undefined) {
+      body.sosContact = sosContact;
+    }
+
+    if (sosAlertsEnabled !== undefined) {
+      body.sosAlertsEnabled = sosAlertsEnabled;
+    }
+
+    if (therapyType !== undefined) {
+      body.therapyType = therapyType;
     }
 
     return await tgFetch<ProfileSchema>('/profiles', {

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -44,6 +44,10 @@ type ProfileForm = {
   rapidInsulinType: RapidInsulin;
   maxBolus: string;
   afterMealMinutes: string;
+  quietStart: string;
+  quietEnd: string;
+  sosContact: string | null;
+  sosAlertsEnabled: boolean;
 };
 
 type ParsedProfile = {
@@ -249,6 +253,10 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     rapidInsulinType: 'aspart',
     maxBolus: "",
     afterMealMinutes: "",
+    quietStart: '23:00',
+    quietEnd: '07:00',
+    sosContact: null,
+    sosAlertsEnabled: true,
   });
   const [original, setOriginal] = useState<ProfileForm | null>(null);
   const [timezones, setTimezones] = useState<string[]>([]);
@@ -387,6 +395,10 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
           rapidInsulinType,
           maxBolus,
           afterMealMinutes,
+          quietStart: data.quietStart ?? '23:00',
+          quietEnd: data.quietEnd ?? '07:00',
+          sosContact: data.sosContact ?? null,
+          sosAlertsEnabled: data.sosAlertsEnabled ?? true,
         };
 
         setProfile(loadedProfile);
@@ -516,11 +528,25 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
         high: number;
         icr?: number;
         cf?: number;
+        quietStart: string;
+        quietEnd: string;
+        timezone: string;
+        timezoneAuto: boolean;
+        sosContact: string | null;
+        sosAlertsEnabled: boolean;
+        therapyType: TherapyType;
       } = {
         telegramId: data.telegramId,
         target: data.target!,
         low: data.low!,
         high: data.high!,
+        quietStart: profile.quietStart,
+        quietEnd: profile.quietEnd,
+        timezone: profile.timezone,
+        timezoneAuto: profile.timezoneAuto,
+        sosContact: profile.sosContact,
+        sosAlertsEnabled: profile.sosAlertsEnabled,
+        therapyType: data.therapyType ?? originalTherapyType,
       };
 
       if (data.therapyType !== 'tablets' && data.therapyType !== 'none') {

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -104,13 +104,37 @@ describe('profile api', () => {
       );
     vi.stubGlobal('fetch', mockFetch);
 
-    await saveProfile({ telegramId: 1, target: 5, low: 4, high: 10 });
+    await saveProfile({
+      telegramId: 1,
+      target: 5,
+      low: 4,
+      high: 10,
+      timezone: 'UTC',
+      timezoneAuto: false,
+      quietStart: '23:00',
+      quietEnd: '07:00',
+      sosAlertsEnabled: true,
+      sosContact: null,
+      therapyType: 'none',
+    });
 
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/profiles',
       expect.objectContaining({
         method: 'POST',
-        body: JSON.stringify({ telegramId: 1, target: 5, low: 4, high: 10 }),
+        body: JSON.stringify({
+          telegramId: 1,
+          target: 5,
+          low: 4,
+          high: 10,
+          timezone: 'UTC',
+          timezoneAuto: false,
+          quietStart: '23:00',
+          quietEnd: '07:00',
+          sosAlertsEnabled: true,
+          sosContact: null,
+          therapyType: 'none',
+        }),
       }),
     );
   });

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -70,6 +70,8 @@ describe('Profile page', () => {
       sosAlertsEnabled: true,
       sosContact: null,
       glucoseUnits: 'mmol/L',
+      quietStart: '23:00',
+      quietEnd: '07:00',
     });
     const realDTF = Intl.DateTimeFormat;
     const realResolved = realDTF.prototype.resolvedOptions;
@@ -274,11 +276,52 @@ describe('Profile page', () => {
         target: 5.5,
         low: 4,
         high: 10,
+        timezone: 'Europe/Moscow',
+        timezoneAuto: false,
+        quietStart: '23:00',
+        quietEnd: '07:00',
+        sosAlertsEnabled: true,
+        sosContact: null,
+        therapyType: 'insulin',
       });
       expect(patchProfile).not.toHaveBeenCalled();
       expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({ title: 'Профиль сохранен' }),
       );
+    });
+  });
+
+  it('preserves settings when updating ICR only', async () => {
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
+    (saveProfile as vi.Mock).mockResolvedValue(undefined);
+    const { getByText, getByPlaceholderText } = render(<Profile />);
+
+    await waitFor(() => {
+      expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('12');
+    });
+
+    const icrInput = getByPlaceholderText('12') as HTMLInputElement;
+    fireEvent.change(icrInput, { target: { value: '13' } });
+
+    fireEvent.click(getByText('Сохранить настройки'));
+
+    await waitFor(() => {
+      expect(saveProfile).toHaveBeenCalledWith({
+        telegramId: 123,
+        icr: 13,
+        cf: 2.5,
+        target: 6,
+        low: 4,
+        high: 10,
+        timezone: 'Europe/Moscow',
+        timezoneAuto: false,
+        quietStart: '23:00',
+        quietEnd: '07:00',
+        sosAlertsEnabled: true,
+        sosContact: null,
+        therapyType: 'insulin',
+      });
+      expect(patchProfile).not.toHaveBeenCalled();
     });
   });
 
@@ -306,6 +349,10 @@ describe('Profile page', () => {
         timezone: 'Europe/Moscow',
         timezoneAuto: false,
         therapyType: therapy,
+        quietStart: '23:00',
+        quietEnd: '07:00',
+        sosAlertsEnabled: true,
+        sosContact: null,
       });
       const { queryByLabelText } = render(<Profile therapyType={therapy} />);
       await waitFor(() => {
@@ -336,6 +383,10 @@ describe('Profile page', () => {
         timezone: 'Europe/Moscow',
         timezoneAuto: false,
         therapyType: therapy,
+        quietStart: '23:00',
+        quietEnd: '07:00',
+        sosAlertsEnabled: true,
+        sosContact: null,
       });
       render(<Profile therapyType={therapy} />);
       await waitFor(() => {
@@ -360,6 +411,10 @@ describe('Profile page', () => {
         timezone: 'Europe/Moscow',
         timezoneAuto: false,
         therapyType: therapy,
+        quietStart: '23:00',
+        quietEnd: '07:00',
+        sosAlertsEnabled: true,
+        sosContact: null,
       });
       render(<Profile therapyType={therapy} />);
       await waitFor(() => {
@@ -377,25 +432,29 @@ describe('Profile page', () => {
 
   it('allows zero pre-bolus and after-meal delay for insulin therapy', async () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
-    (getProfile as vi.Mock).mockResolvedValueOnce({
-      telegramId: 123,
-      icr: 12,
-      cf: 2.5,
-      target: 6,
-      low: 4,
-      high: 10,
-      dia: 4,
-      preBolus: 0,
-      roundStep: 0.5,
-      carbUnits: 'g',
-      gramsPerXe: 12,
-      rapidInsulinType: 'aspart' as RapidInsulin,
-      maxBolus: 10,
-      afterMealMinutes: 0,
-      timezone: 'Europe/Moscow',
-      timezoneAuto: false,
-      therapyType: 'insulin',
-    });
+      (getProfile as vi.Mock).mockResolvedValueOnce({
+        telegramId: 123,
+        icr: 12,
+        cf: 2.5,
+        target: 6,
+        low: 4,
+        high: 10,
+        dia: 4,
+        preBolus: 0,
+        roundStep: 0.5,
+        carbUnits: 'g',
+        gramsPerXe: 12,
+        rapidInsulinType: 'aspart' as RapidInsulin,
+        maxBolus: 10,
+        afterMealMinutes: 0,
+        timezone: 'Europe/Moscow',
+        timezoneAuto: false,
+        therapyType: 'insulin',
+        quietStart: '23:00',
+        quietEnd: '07:00',
+        sosAlertsEnabled: true,
+        sosContact: null,
+      });
 
     render(<Profile />);
     await waitFor(() => {
@@ -420,6 +479,10 @@ describe('Profile page', () => {
         timezone: 'Europe/Moscow',
         timezoneAuto: false,
         therapyType: therapy,
+        quietStart: '23:00',
+        quietEnd: '07:00',
+        sosAlertsEnabled: true,
+        sosContact: null,
       });
       render(<Profile therapyType={therapy} />);
       await waitFor(() => {
@@ -824,6 +887,13 @@ describe('Profile page', () => {
         target: 6,
         low: 4,
         high: 10,
+        timezone: 'Europe/Moscow',
+        timezoneAuto: false,
+        quietStart: '23:00',
+        quietEnd: '07:00',
+        sosAlertsEnabled: true,
+        sosContact: null,
+        therapyType: 'insulin',
       });
       expect(patchProfile).not.toHaveBeenCalled();
       expect(toast).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- include quiet hours, timezone, SOS and therapy settings in profile save payload
- keep existing profile values when updating ICR and CF
- test profile form to ensure ICR updates don't reset other settings

## Testing
- `pnpm test` *(some UI tests output truncated)*
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bbf4fabcc0832abc709637d955aea4