### PR TITLE
[handlers] Guard learning handlers behind flag

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -137,7 +137,7 @@ def register_handlers(
         gpt_handlers,
         billing_handlers,
     )
-    from . import learning_handlers
+    from services.api.app.config import settings
 
     app.add_handler(CommandHandlerT("menu", menu_command))
     app.add_handler(CommandHandlerT("report", reporting_handlers.report_request))
@@ -150,11 +150,14 @@ def register_handlers(
     app.add_handler(sos_handlers.sos_contact_conv)
     app.add_handler(CommandHandlerT("cancel", dose_calc.dose_cancel))
     app.add_handler(CommandHandlerT("help", help_command))
-    app.add_handler(CommandHandlerT("learn", learning_handlers.learn_command))
-    app.add_handler(CommandHandlerT("lesson", learning_handlers.lesson_command))
-    app.add_handler(CommandHandlerT("quiz", learning_handlers.quiz_command))
-    app.add_handler(CommandHandlerT("progress", learning_handlers.progress_command))
-    app.add_handler(CommandHandlerT("exit", learning_handlers.exit_command))
+    if settings.learning_mode_enabled:
+        from . import learning_handlers
+
+        app.add_handler(CommandHandlerT("learn", learning_handlers.learn_command))
+        app.add_handler(CommandHandlerT("lesson", learning_handlers.lesson_command))
+        app.add_handler(CommandHandlerT("quiz", learning_handlers.quiz_command))
+        app.add_handler(CommandHandlerT("progress", learning_handlers.progress_command))
+        app.add_handler(CommandHandlerT("exit", learning_handlers.exit_command))
     app.add_handler(CommandHandlerT("gpt", gpt_handlers.chat_with_gpt))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -121,6 +121,10 @@ def main() -> None:  # pragma: no cover
 
     # ---- Register handlers (they may schedule reminders)
     register_handlers(application)
+    if settings.learning_mode_enabled:
+        logger.info("📚 Учебный режим включён")
+    else:
+        logger.info("📚 Учебный режим выключен")
     register_billing_handlers(application)
 
     # ---- Schedule test job on startup


### PR DESCRIPTION
## Summary
- register learning commands only when `settings.learning_mode_enabled`
- log learning mode status at startup
- test that learning handlers aren't registered when learning mode disabled

## Testing
- `ruff check .`
- `mypy --strict services/api/app/diabetes/handlers/registration.py services/bot/main.py tests/test_register_handlers.py`
- `pytest -q --maxfail=1` *(fails: async def functions are not natively supported)*
- `pytest tests/test_register_handlers.py::test_register_handlers_attaches_expected_handlers tests/test_register_handlers.py::test_register_handlers_skips_learning_handlers_when_disabled -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68bbfb3e3898832aa4e335d1402bf25f