### PR TITLE
profile/ui: unblock input before profile load, fix CF pattern

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -306,6 +306,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     const telegramId = resolveTelegramId(user, initData);
 
     if (typeof telegramId !== "number") {
+      setLoaded(true);
       return;
     }
 
@@ -448,7 +449,6 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
   }, [user, initData, toast, t]);
 
   const handleInputChange = (field: keyof ProfileForm, value: string) => {
-    if (!loaded) return;
     setFieldErrors((prev) => ({ ...prev, [field]: undefined }));
     if (field === "timezone") {
       setProfile((prev) => ({ ...prev, timezone: value }));
@@ -747,7 +747,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
                       id="cf"
                       type="text"
                       inputMode="decimal"
-                      pattern="^\\d*(?:[.,]\\д*)?$"
+                      pattern="^\\d*(?:[.,]\\d*)?$"
                       value={profile.cf}
                       onChange={(e) => handleInputChange("cf", e.target.value)}
                       className={`medical-input ${fieldErrors.cf ? 'border-destructive' : ''}`}


### PR DESCRIPTION
## Summary
- allow editing profile fields before data load and mark profile loaded when Telegram ID is missing
- correct CF field pattern to accept decimal values

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: react-refresh/only-export-components, no-empty-object-type, etc.)*
- `pnpm --filter ./services/webapp/ui test` *(fails: JavaScript heap out of memory)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bbfcf92a20832a82409123a1398e83