### PR TITLE
[build] ensure venv for migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,14 @@ DB_URL?=postgresql://postgres@localhost/$(DB_NAME)
 RUN_AS_POSTGRES?=sudo -u postgres
 PYTHONPATH?=PYTHONPATH=/opt/saharlight-ux
 
+# === VENV ===
+
+venv:
+	python3.12 -m venv venv && venv/bin/pip install -r requirements.txt
+
 # === MIGRATIONS ===
 
-migrate:
+migrate: venv
 	$(PYTHONPATH) $(ALEMBIC) upgrade head
 
 step-up:

--- a/README.md
+++ b/README.md
@@ -33,8 +33,19 @@ cp infra/env/.env.example .env
 ```
 Заполните `.env` своими значениями.
 
+## Миграции
+
+Перед запуском миграций создайте и активируйте виртуальное окружение:
+
+```bash
+python3.12 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+make migrate
+```
+
 ### Установка `diabetes_sdk`
-Для доступа к внешнему API нужен приватный пакет `diabetes_sdk`. 
+Для доступа к внешнему API нужен приватный пакет `diabetes_sdk`.
 Получите доступ у мейнтейнеров и установите его вручную, например:
 
 ```bash


### PR DESCRIPTION
## Summary
- add Makefile target to create venv and install requirements
- document virtual environment requirement before running migrations

## Testing
- `pytest -q` *(fails: unrecognized arguments: --cov=...)*
- `mypy --strict .` *(interrupted: operation timed out)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68bc008c8628832aa5122317aa30dd33