### PR TITLE
fix(subscription): use billing status endpoint

### DIFF
--- a/services/webapp/ui/src/api/billing.ts
+++ b/services/webapp/ui/src/api/billing.ts
@@ -19,8 +19,10 @@ export interface BillingStatus {
   subscription: SubscriptionInfo | null;
 }
 
-export const getBillingStatus = (userId: string) =>
-  api.get<BillingStatus>(`/billing/status?user_id=${userId}`);
+export const getBillingStatus = (userId: string) => {
+  const params = new URLSearchParams({ user_id: userId });
+  return api.get<BillingStatus>(`/billing/status?${params.toString()}`);
+};
 
 export const startTrial = (userId: string) =>
   api.post<SubscriptionInfo>(`/billing/trial?user_id=${userId}`, {});

--- a/services/webapp/ui/src/pages/Subscription.test.tsx
+++ b/services/webapp/ui/src/pages/Subscription.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, it, vi, beforeEach, expect } from 'vitest';
+import { describe, it, vi, beforeEach, expect, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
 import Subscription from './Subscription';
 import { getBillingStatus } from '@/api/billing';
 
@@ -35,6 +36,10 @@ describe('Subscription states', () => {
     mockedInitData.mockReturnValue(null);
   });
 
+  afterEach(() => {
+    cleanup();
+  });
+
   const renderPage = async (status: unknown) => {
     mockedStatus.mockResolvedValue(status);
     render(
@@ -44,6 +49,15 @@ describe('Subscription states', () => {
     );
     await screen.findByTestId('status-card');
   };
+
+  it('requests billing status on mount', async () => {
+    await renderPage({
+      featureFlags: { billingEnabled: false, paywallMode: 'soft', testMode: true },
+      subscription: null,
+    });
+    expect(mockedStatus).toHaveBeenCalledTimes(1);
+    expect(mockedStatus).toHaveBeenCalledWith('123');
+  });
 
   it('renders no subscription', async () => {
     await renderPage({


### PR DESCRIPTION
## Summary
- query billing status via `/billing/status` with encoded `user_id`
- test fetching billing status on Subscription page
- ensure trial status returns 200 from billing status API

## Testing
- `pytest tests/test_billing_status.py -q` *(fails: Coverage failure: total of 23 is less than fail-under=85)*
- `python -m mypy --strict services/api/app/routers/billing.py tests/test_billing_status.py`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test src/pages/Subscription.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bc095727b8832aae89a7b131315614