### PR TITLE
[handlers] check overrides before listing lessons

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -17,6 +17,7 @@ from services.api.app.diabetes.models_learning import Lesson, LessonProgress
 from services.api.app.diabetes.services.db import SessionLocal, run_db
 from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.ui import menu_keyboard
+from ..learning_onboarding import ensure_overrides
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,8 @@ async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     """Reply with learning mode status or greeting."""
     message = update.message
     if message is None:
+        return
+    if not await ensure_overrides(update, context):
         return
     if not settings.learning_mode_enabled:
         await message.reply_text("🚫 Обучение недоступно.")

--- a/services/api/app/diabetes/learning_onboarding.py
+++ b/services/api/app/diabetes/learning_onboarding.py
@@ -1,0 +1,18 @@
+"""Learning mode onboarding utilities."""
+
+from __future__ import annotations
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+
+async def ensure_overrides(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> bool:
+    """Ensure learning mode is allowed for the user.
+
+    This is a stub implementation that always allows learning mode.
+    """
+
+    return True
+


### PR DESCRIPTION
## Summary
- ensure onboarding overrides are satisfied before showing lessons
- stub learning onboarding helper

## Testing
- `pytest tests -q --cov --cov-fail-under=85` *(fails: KeyboardInterrupt / config warnings)*
- `mypy --strict .` *(fails: Interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc0c4672f4832a9c9fe526a72c1160