### PR TITLE
[learning] add command to reset learning onboarding

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -152,12 +152,14 @@ def register_handlers(
     app.add_handler(CommandHandlerT("help", help_command))
     if settings.learning_mode_enabled:
         from . import learning_handlers
+        from .. import learning_onboarding
 
         app.add_handler(CommandHandlerT("learn", learning_handlers.learn_command))
         app.add_handler(CommandHandlerT("lesson", learning_handlers.lesson_command))
         app.add_handler(CommandHandlerT("quiz", learning_handlers.quiz_command))
         app.add_handler(CommandHandlerT("progress", learning_handlers.progress_command))
         app.add_handler(CommandHandlerT("exit", learning_handlers.exit_command))
+        app.add_handler(CommandHandlerT("learn_reset", learning_onboarding.learn_reset))
     app.add_handler(CommandHandlerT("gpt", gpt_handlers.chat_with_gpt))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))

--- a/services/api/app/diabetes/learning_onboarding.py
+++ b/services/api/app/diabetes/learning_onboarding.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import MutableMapping, cast
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+
+async def learn_reset(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Reset learning onboarding progress stored in ``user_data``."""
+
+    message = update.effective_message
+    if message is None:
+        return
+    user_data = cast(MutableMapping[str, object], context.user_data)
+    user_data.pop("learn_profile_overrides", None)
+    user_data.pop("learn_onboarding_stage", None)
+    await message.reply_text("Учебный онбординг сброшен.")
+
+
+__all__ = ["learn_reset"]

--- a/tests/test_learn_reset.py
+++ b/tests/test_learn_reset.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.diabetes import learning_onboarding
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_learn_reset_clears_user_data() -> None:
+    user_data: dict[str, Any] = {
+        "learn_profile_overrides": {"foo": "bar"},
+        "learn_onboarding_stage": "stage",
+    }
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(effective_message=message, message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data=user_data),
+    )
+
+    await learning_onboarding.learn_reset(update, context)
+
+    assert user_data == {}
+    assert message.replies == ["Учебный онбординг сброшен."]


### PR DESCRIPTION
## Summary
- allow users to reset learning onboarding state via /learn_reset
- register learn_reset command when learning mode is enabled
- test that learn_reset clears onboarding-related user data

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc0c492160832aae6d41a0bd1b4fb7