### PR TITLE
[webapp] deduplicate profile query setup

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Save } from "lucide-react";
+
 import { MedicalHeader } from "@/components/MedicalHeader";
 import { useToast } from "@/hooks/use-toast";
 import MedicalButton from "@/components/MedicalButton";
@@ -13,7 +14,6 @@ import ProfileHelpSheet from "@/components/ProfileHelpSheet";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useTranslation } from "@/i18n";
 import { saveProfile, getProfile, patchProfile } from "@/features/profile/api";
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { PatchProfileDto, RapidInsulin } from "@/features/profile/types";
 import { getTimezones } from "@/api/timezones";
 import { useTelegram } from "@/hooks/useTelegram";
@@ -294,13 +294,6 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     ) | null
   >(null);
   const [loaded, setLoaded] = useState(false);
-
-  const queryClient = useQueryClient();
-  const patchProfileMutation = useMutation({
-    mutationFn: patchProfile,
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ['profile'] }),
-  });
 
   useEffect(() => {
     if (isOnboardingFlow) {


### PR DESCRIPTION
## Summary
- remove duplicate react-query import
- drop extra queryClient and mutation declarations in Profile page

## Testing
- `pnpm run build`
- `pnpm lint` *(fails: Unexpected any in tests)*
- `pnpm test` *(fails: profile api > does not send insulin fields for non-insulin profiles)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc0e2e340c832ab9a1b8885be9e8cd