### PR TITLE
test: add learning onboarding flow tests

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -41,10 +41,10 @@ async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     message = update.message
     if message is None:
         return
-    if not await ensure_overrides(update, context):
-        return
     if not settings.learning_mode_enabled:
         await message.reply_text("🚫 Обучение недоступно.")
+        return
+    if not await ensure_overrides(update, context):
         return
     model = settings.learning_command_model
 

--- a/services/api/app/diabetes/handlers/learning_onboarding.py
+++ b/services/api/app/diabetes/handlers/learning_onboarding.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias, cast
 
 from telegram import Update
 from telegram.ext import (
@@ -32,11 +32,26 @@ else:
 async def onboarding_reply(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle user replies during learning onboarding."""
     logger.debug("onboarding_reply", extra={"user": update.effective_user})
+    message = update.message
+    if message is None:
+        return
+    user_data = cast(dict[str, object], context.user_data)
+    if not user_data.get("learning_waiting"):
+        return
+    user_data.pop("learning_waiting", None)
+    user_data["learning_onboarded"] = True
+    await message.reply_text("Ответ принят. Отправьте /learn чтобы продолжить.")
 
 
 async def learn_reset(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Reset learning-related state for the user."""
     logger.debug("learn_reset", extra={"user": update.effective_user})
+    message = update.message
+    user_data = cast(dict[str, object], context.user_data)
+    user_data.pop("learning_onboarded", None)
+    user_data.pop("learning_waiting", None)
+    if message is not None:
+        await message.reply_text("Learning onboarding reset. Отправьте /learn.")
 
 
 def register_handlers(app: App) -> None:

--- a/services/api/app/diabetes/learning_onboarding.py
+++ b/services/api/app/diabetes/learning_onboarding.py
@@ -2,17 +2,34 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from telegram import Update
 from telegram.ext import ContextTypes
+
+
+ONBOARDING_PROMPT = "Перед началом ответьте 'да' чтобы продолжить обучение."
 
 
 async def ensure_overrides(
     update: Update, context: ContextTypes.DEFAULT_TYPE
 ) -> bool:
-    """Ensure learning mode is allowed for the user.
+    """Ensure learning mode prerequisites are satisfied.
 
-    This is a stub implementation that always allows learning mode.
+    If the user has not yet answered the onboarding question, send it and
+    return ``False`` so that the calling handler can stop further processing.
+    ``True`` is returned once the onboarding question has been answered.
     """
 
-    return True
+    user_data = cast(dict[str, object] | None, getattr(context, "user_data", None))
+    if user_data is None:
+        user_data = {}
+        setattr(context, "user_data", user_data)
+    if user_data.get("learning_onboarded"):
+        return True
+    message = update.message
+    if message is not None:
+        await message.reply_text(ONBOARDING_PROMPT)
+    user_data["learning_waiting"] = True
+    return False
 

--- a/services/api/tests/test_learning_mode_toggle.py
+++ b/services/api/tests/test_learning_mode_toggle.py
@@ -78,10 +78,10 @@ async def test_learning_mode_enabled_lists_lessons(
     monkeypatch.setattr(learning_handlers, "settings", settings)
 
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message))
+    update = cast(Update, SimpleNamespace(message=message, effective_user=None))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(),
+        SimpleNamespace(user_data={"learning_onboarded": True}),
     )
 
     await learning_handlers.learn_command(update, context)
@@ -103,10 +103,10 @@ async def test_learning_mode_disabled_denies_access(
     monkeypatch.setattr(learning_handlers, "settings", settings)
 
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message))
+    update = cast(Update, SimpleNamespace(message=message, effective_user=None))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(),
+        SimpleNamespace(user_data={"learning_onboarded": True}),
     )
 
     with caplog.at_level(

--- a/tests/diabetes/test_learning_handlers.py
+++ b/tests/diabetes/test_learning_handlers.py
@@ -28,10 +28,10 @@ class DummyMessage:
 async def test_learn_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_mode_enabled", False)
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message))
+    update = cast(Update, SimpleNamespace(message=message, effective_user=None))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(),
+        SimpleNamespace(user_data={}),
     )
     await learning_handlers.learn_command(update, context)
     assert message.replies == ["🚫 Обучение недоступно."]
@@ -67,10 +67,10 @@ async def test_learn_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     await load_lessons(path, sessionmaker=SessionLocal)
     monkeypatch.setattr(learning_handlers, "SessionLocal", SessionLocal)
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message))
+    update = cast(Update, SimpleNamespace(message=message, effective_user=None))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(),
+        SimpleNamespace(user_data={"learning_onboarded": True}),
     )
     await learning_handlers.learn_command(update, context)
     assert "super-model" in message.replies[0]

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -45,10 +45,10 @@ async def test_learn_command_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(handlers, "settings", Settings(LEARNING_MODE_ENABLED="0", _env_file=None))
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message))
+    update = cast(Update, SimpleNamespace(message=message, effective_user=None))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(),
+        SimpleNamespace(user_data={}),
     )
 
     await handlers.learn_command(update, context)
@@ -68,10 +68,10 @@ async def test_learn_command_no_lessons(monkeypatch: pytest.MonkeyPatch) -> None
         Settings(LEARNING_MODE_ENABLED="1", LEARNING_COMMAND_MODEL="m", _env_file=None),
     )
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message))
+    update = cast(Update, SimpleNamespace(message=message, effective_user=None))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(),
+        SimpleNamespace(user_data={"learning_onboarded": True}),
     )
 
     await handlers.learn_command(update, context)
@@ -107,10 +107,10 @@ async def test_learn_command_lists_lessons(monkeypatch: pytest.MonkeyPatch, tmp_
         Settings(LEARNING_MODE_ENABLED="1", LEARNING_COMMAND_MODEL="m", _env_file=None),
     )
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message))
+    update = cast(Update, SimpleNamespace(message=message, effective_user=None))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(),
+        SimpleNamespace(user_data={"learning_onboarded": True}),
     )
 
     await handlers.learn_command(update, context)


### PR DESCRIPTION
## Summary
- add onboarding prompt gating to learning mode
- reset onboarding state via `/learn_reset`
- test learning onboarding and command flow

## Testing
- `ruff check services/api/app/diabetes/learning_onboarding.py services/api/app/diabetes/handlers/learning_onboarding.py services/api/app/diabetes/handlers/learning_handlers.py services/api/tests/test_learning_mode_toggle.py tests/diabetes/test_learning_handlers.py tests/test_learn_command.py tests/diabetes/test_learning_onboarding.py`
- `mypy --strict services/api/app/diabetes/learning_onboarding.py services/api/app/diabetes/handlers/learning_onboarding.py services/api/app/diabetes/handlers/learning_handlers.py services/api/tests/test_learning_mode_toggle.py tests/diabetes/test_learning_handlers.py tests/test_learn_command.py tests/diabetes/test_learning_onboarding.py`
- `pytest services/api/tests/test_learning_mode_toggle.py tests/diabetes/test_learning_handlers.py tests/diabetes/test_learning_onboarding.py -q --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68bc0eaa2204832aafed8395f1c09435