### PR TITLE
[handlers] add learn_reset command

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -36,7 +36,9 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     CommandHandlerT: TypeAlias = CommandHandler[ContextTypes.DEFAULT_TYPE, object]
     MessageHandlerT: TypeAlias = MessageHandler[ContextTypes.DEFAULT_TYPE, object]
-    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, object]
+    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[
+        ContextTypes.DEFAULT_TYPE, object
+    ]
 else:
     CommandHandlerT = CommandHandler
     MessageHandlerT = MessageHandler
@@ -59,9 +61,17 @@ def register_profile_handlers(
 
     app.add_handler(profile.profile_conv)
     app.add_handler(profile.profile_webapp_handler)
-    app.add_handler(MessageHandlerT(filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view))
-    app.add_handler(CallbackQueryHandlerT(profile.profile_security, pattern="^profile_security"))
-    app.add_handler(CallbackQueryHandlerT(profile.profile_back, pattern="^profile_back$"))
+    app.add_handler(
+        MessageHandlerT(
+            filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view
+        )
+    )
+    app.add_handler(
+        CallbackQueryHandlerT(profile.profile_security, pattern="^profile_security")
+    )
+    app.add_handler(
+        CallbackQueryHandlerT(profile.profile_back, pattern="^profile_back$")
+    )
 
 
 def register_reminder_handlers(
@@ -89,7 +99,9 @@ def register_reminder_handlers(
             reminder_handlers.reminders_list,
         )
     )
-    app.add_handler(CallbackQueryHandlerT(reminder_handlers.reminder_callback, pattern="^remind_"))
+    app.add_handler(
+        CallbackQueryHandlerT(reminder_handlers.reminder_callback, pattern="^remind_")
+    )
 
     # --- DEBUG HANDLERS ---
     try:
@@ -137,6 +149,7 @@ def register_handlers(
         gpt_handlers,
         billing_handlers,
     )
+    from os import getenv
     from services.api.app.config import settings
 
     app.add_handler(CommandHandlerT("menu", menu_command))
@@ -150,18 +163,23 @@ def register_handlers(
     app.add_handler(sos_handlers.sos_contact_conv)
     app.add_handler(CommandHandlerT("cancel", dose_calc.dose_cancel))
     app.add_handler(CommandHandlerT("help", help_command))
-    if settings.learning_mode_enabled:
+    learning_env = getenv("LEARNING_MODE_ENABLED", "1").lower() not in {"0", "false"}
+    if settings.learning_mode_enabled and learning_env:
         from . import learning_handlers
+        from ..learning_onboarding import learn_reset
 
         app.add_handler(CommandHandlerT("learn", learning_handlers.learn_command))
         app.add_handler(CommandHandlerT("lesson", learning_handlers.lesson_command))
         app.add_handler(CommandHandlerT("quiz", learning_handlers.quiz_command))
         app.add_handler(CommandHandlerT("progress", learning_handlers.progress_command))
         app.add_handler(CommandHandlerT("exit", learning_handlers.exit_command))
+        app.add_handler(CommandHandlerT("learn_reset", learn_reset))
     app.add_handler(CommandHandlerT("gpt", gpt_handlers.chat_with_gpt))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))
-    app.add_handler(CallbackQueryHandlerT(billing_handlers.trial_command, pattern="^trial$"))
+    app.add_handler(
+        CallbackQueryHandlerT(billing_handlers.trial_command, pattern="^trial$")
+    )
     register_reminder_handlers(app)
     app.add_handler(CommandHandlerT("alertstats", alert_handlers.alert_stats))
     app.add_handler(CommandHandlerT("hypoalert", security_handlers.hypo_alert_faq))
@@ -177,9 +195,19 @@ def register_handlers(
             reporting_handlers.history_view,
         )
     )
-    app.add_handler(MessageHandlerT(filters.Regex(re.escape(PHOTO_BUTTON_TEXT)), photo_handlers.photo_prompt))
-    app.add_handler(MessageHandlerT(filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help))
-    app.add_handler(MessageHandlerT(filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command))
+    app.add_handler(
+        MessageHandlerT(
+            filters.Regex(re.escape(PHOTO_BUTTON_TEXT)), photo_handlers.photo_prompt
+        )
+    )
+    app.add_handler(
+        MessageHandlerT(
+            filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help
+        )
+    )
+    app.add_handler(
+        MessageHandlerT(filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command)
+    )
     app.add_handler(
         MessageHandlerT(
             filters.Regex(re.escape(SUBSCRIPTION_BUTTON_TEXT)),
@@ -192,11 +220,21 @@ def register_handlers(
             sos_handlers.sos_contact_start,
         )
     )
-    app.add_handler(MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler))
+    app.add_handler(
+        MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler)
+    )
     app.add_handler(MessageHandlerT(filters.PHOTO, photo_handlers.photo_handler))
     app.add_handler(MessageHandlerT(filters.Document.IMAGE, photo_handlers.doc_handler))
-    app.add_handler(CallbackQueryHandlerT(reporting_handlers.report_period_callback, pattern="^report_back$"))
-    app.add_handler(CallbackQueryHandlerT(reporting_handlers.report_period_callback, pattern="^report_period:"))
+    app.add_handler(
+        CallbackQueryHandlerT(
+            reporting_handlers.report_period_callback, pattern="^report_back$"
+        )
+    )
+    app.add_handler(
+        CallbackQueryHandlerT(
+            reporting_handlers.report_period_callback, pattern="^report_period:"
+        )
+    )
     app.add_handler(CallbackQueryHandlerT(callback_router))
 
     async def _clear_waiting_flags(context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/services/api/app/diabetes/learning_onboarding.py
+++ b/services/api/app/diabetes/learning_onboarding.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from telegram import Update
 from telegram.ext import ContextTypes
 
 
-async def ensure_overrides(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> bool:
+async def ensure_overrides(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
     """Ensure learning mode is allowed for the user.
 
     This is a stub implementation that always allows learning mode.
@@ -16,3 +16,17 @@ async def ensure_overrides(
 
     return True
 
+
+async def learn_reset(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    """Clear learning onboarding data from the user context."""
+
+    message = update.effective_message
+    if message is None:
+        return
+    user_data = cast(dict[str, object], ctx.user_data)
+    user_data.pop("learn_profile_overrides", None)
+    user_data.pop("learn_onboarding_stage", None)
+    await message.reply_text("Учебный онбординг сброшен.")
+
+
+__all__ = ["ensure_overrides", "learn_reset"]

--- a/tests/test_learn_reset.py
+++ b/tests/test_learn_reset.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.diabetes.learning_onboarding import learn_reset
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str) -> None:
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_learn_reset_clears_user_data() -> None:
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message, effective_message=message))
+    user_data = {
+        "learn_profile_overrides": {"foo": "bar"},
+        "learn_onboarding_stage": 1,
+        "keep": 2,
+    }
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data=user_data),
+    )
+
+    await learn_reset(update, context)
+
+    assert user_data == {"keep": 2}
+    assert message.replies == ["Учебный онбординг сброшен."]

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -20,18 +20,19 @@ from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import (
     CallbackQueryNoWarnHandler,
 )
 
+from services.api.app.diabetes import learning_onboarding
+from services.api.app.diabetes.handlers import (
+    billing_handlers,
+    learning_handlers,
+    reminder_handlers as rh,
+    security_handlers,
+)
 from services.api.app.diabetes.handlers.registration import (
     register_handlers,
     register_profile_handlers,
     register_reminder_handlers,
 )
 from services.api.app.diabetes.handlers.router import callback_router
-from services.api.app.diabetes.handlers import (
-    security_handlers,
-    reminder_handlers as rh,
-    billing_handlers,
-    learning_handlers,
-)
 from services.api.app.config import reload_settings
 
 
@@ -69,7 +70,9 @@ def test_register_handlers_attaches_expected_handlers(
     assert reporting_handlers.report_request in callbacks
     assert reporting_handlers.history_view in callbacks
     assert any(
-        isinstance(h, CommandHandler) and h.callback is reporting_handlers.history_view and "history" in h.commands
+        isinstance(h, CommandHandler)
+        and h.callback is reporting_handlers.history_view
+        and "history" in h.commands
         for h in handlers
     )
     assert gpt_handlers.chat_with_gpt in callbacks
@@ -78,31 +81,57 @@ def test_register_handlers_attaches_expected_handlers(
     assert billing_handlers.upgrade_command in callbacks
     assert billing_handlers.subscription_button in callbacks
     assert any(
-        isinstance(h, CommandHandler) and h.callback is learning_handlers.lesson_command and "lesson" in h.commands
+        isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.lesson_command
+        and "lesson" in h.commands
         for h in handlers
     )
     assert any(
-        isinstance(h, CommandHandler) and h.callback is learning_handlers.quiz_command and "quiz" in h.commands
+        isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.quiz_command
+        and "quiz" in h.commands
         for h in handlers
     )
     assert any(
-        isinstance(h, CommandHandler) and h.callback is learning_handlers.progress_command and "progress" in h.commands
+        isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.progress_command
+        and "progress" in h.commands
         for h in handlers
     )
     assert any(
-        isinstance(h, CommandHandler) and h.callback is learning_handlers.exit_command and "exit" in h.commands
+        isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.exit_command
+        and "exit" in h.commands
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CommandHandler)
+        and h.callback is learning_onboarding.learn_reset
+        and "learn_reset" in h.commands
         for h in handlers
     )
     # Reminder handlers should be registered
-    assert any(isinstance(h, CallbackQueryHandler) and h.callback is rh.reminder_action_cb for h in handlers)
-    assert any(isinstance(h, MessageHandler) and h.callback is rh.reminder_webapp_save for h in handlers)
-    assert any(isinstance(h, CommandHandler) and h.callback is rh.add_reminder for h in handlers)
+    assert any(
+        isinstance(h, CallbackQueryHandler) and h.callback is rh.reminder_action_cb
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, MessageHandler) and h.callback is rh.reminder_webapp_save
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CommandHandler) and h.callback is rh.add_reminder
+        for h in handlers
+    )
 
     onb_conv = [
         h
         for h in handlers
         if isinstance(h, ConversationHandler)
-        and any(isinstance(ep, CommandHandler) and "start" in ep.commands for ep in h.entry_points)
+        and any(
+            isinstance(ep, CommandHandler) and "start" in ep.commands
+            for ep in h.entry_points
+        )
     ]
     assert onb_conv == []
 
@@ -110,9 +139,15 @@ def test_register_handlers_attaches_expected_handlers(
     assert dose_calc.dose_conv in conv_handlers
     assert sugar_handlers.sugar_conv in conv_handlers
     assert profile_handlers.profile_conv in conv_handlers
-    conv_cmds = [ep for ep in dose_calc.dose_conv.entry_points if isinstance(ep, CommandHandler)]
+    conv_cmds = [
+        ep for ep in dose_calc.dose_conv.entry_points if isinstance(ep, CommandHandler)
+    ]
     assert conv_cmds and "dose" in conv_cmds[0].commands
-    sugar_conv_cmds = [ep for ep in sugar_handlers.sugar_conv.entry_points if isinstance(ep, CommandHandler)]
+    sugar_conv_cmds = [
+        ep
+        for ep in sugar_handlers.sugar_conv.entry_points
+        if isinstance(ep, CommandHandler)
+    ]
     assert sugar_conv_cmds and "sugar" in sugar_conv_cmds[0].commands
     profile_conv_cmd = [
         ep
@@ -131,67 +166,111 @@ def test_register_handlers_attaches_expected_handlers(
     assert profile_conv_cb
 
     text_handlers = [
-        h for h in handlers if isinstance(h, MessageHandler) and h.callback is gpt_handlers.freeform_handler
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is gpt_handlers.freeform_handler
     ]
     assert text_handlers
 
     photo_handler_msgs = [
-        h for h in handlers if isinstance(h, MessageHandler) and h.callback is photo_handlers.photo_handler
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is photo_handlers.photo_handler
     ]
     assert photo_handler_msgs
 
-    doc_handlers = [h for h in handlers if isinstance(h, MessageHandler) and h.callback is photo_handlers.doc_handler]
+    doc_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is photo_handlers.doc_handler
+    ]
     assert doc_handlers
 
     photo_prompt_handlers = [
-        h for h in handlers if isinstance(h, MessageHandler) and h.callback is photo_handlers.photo_prompt
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is photo_handlers.photo_prompt
     ]
     assert photo_prompt_handlers
 
-    sugar_cmd = [h for h in handlers if isinstance(h, CommandHandler) and h.callback is sugar_handlers.sugar_start]
+    sugar_cmd = [
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is sugar_handlers.sugar_start
+    ]
     assert not sugar_cmd
 
-    cancel_cmd = [h for h in handlers if isinstance(h, CommandHandler) and h.callback is dose_calc.dose_cancel]
+    cancel_cmd = [
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is dose_calc.dose_cancel
+    ]
     assert cancel_cmd and "cancel" in cancel_cmd[0].commands
 
     profile_view_handlers = [
-        h for h in handlers if isinstance(h, MessageHandler) and h.callback is profile_handlers.profile_view
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is profile_handlers.profile_view
     ]
     assert profile_view_handlers
 
     report_handlers = [
-        h for h in handlers if isinstance(h, MessageHandler) and h.callback is reporting_handlers.report_request
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler)
+        and h.callback is reporting_handlers.report_request
     ]
     assert report_handlers
 
     report_cmd = [
-        h for h in handlers if isinstance(h, CommandHandler) and h.callback is reporting_handlers.report_request
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler)
+        and h.callback is reporting_handlers.report_request
     ]
     assert report_cmd and "report" in report_cmd[0].commands
 
-    gpt_cmd = [h for h in handlers if isinstance(h, CommandHandler) and h.callback is gpt_handlers.chat_with_gpt]
+    gpt_cmd = [
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is gpt_handlers.chat_with_gpt
+    ]
     assert gpt_cmd and "gpt" in gpt_cmd[0].commands
 
     history_cmd = [
-        h for h in handlers if isinstance(h, CommandHandler) and h.callback is reporting_handlers.history_view
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler)
+        and h.callback is reporting_handlers.history_view
     ]
     assert history_cmd and "history" in history_cmd[0].commands
 
     history_handlers = [
-        h for h in handlers if isinstance(h, MessageHandler) and h.callback is reporting_handlers.history_view
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler)
+        and h.callback is reporting_handlers.history_view
     ]
     assert history_handlers
 
-    cb_handlers = [h for h in handlers if isinstance(h, CallbackQueryHandler) and h.callback is callback_router]
+    cb_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, CallbackQueryHandler) and h.callback is callback_router
+    ]
     assert cb_handlers
     report_cb_handlers = [
         h
         for h in handlers
-        if isinstance(h, CallbackQueryHandler) and h.callback is reporting_handlers.report_period_callback
+        if isinstance(h, CallbackQueryHandler)
+        and h.callback is reporting_handlers.report_period_callback
     ]
     assert report_cb_handlers
     profile_back_handlers = [
-        h for h in handlers if isinstance(h, CallbackQueryHandler) and h.callback is profile_handlers.profile_back
+        h
+        for h in handlers
+        if isinstance(h, CallbackQueryHandler)
+        and h.callback is profile_handlers.profile_back
     ]
     assert profile_back_handlers
 
@@ -199,6 +278,7 @@ def test_register_handlers_attaches_expected_handlers(
 def test_register_handlers_skips_learning_handlers_when_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.delenv("LEARNING_ENABLED", raising=False)
     monkeypatch.setenv("LEARNING_MODE_ENABLED", "0")
     reload_settings()
 
@@ -206,8 +286,10 @@ def test_register_handlers_skips_learning_handlers_when_disabled(
     register_handlers(app)
 
     handlers = app.handlers[0]
-    commands = [cmd for h in handlers if isinstance(h, CommandHandler) for cmd in h.commands]
-    for name in ["learn", "lesson", "quiz", "progress", "exit"]:
+    commands = [
+        cmd for h in handlers if isinstance(h, CommandHandler) for cmd in h.commands
+    ]
+    for name in ["learn", "lesson", "quiz", "progress", "exit", "learn_reset"]:
         assert name not in commands
     monkeypatch.setenv("LEARNING_MODE_ENABLED", "1")
     reload_settings()
@@ -226,11 +308,20 @@ def test_register_profile_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert profile_handlers.profile_conv in handlers
     assert profile_handlers.profile_webapp_handler in handlers
-    assert any(isinstance(h, MessageHandler) and h.callback is profile_handlers.profile_view for h in handlers)
     assert any(
-        isinstance(h, CallbackQueryHandler) and h.callback is profile_handlers.profile_security for h in handlers
+        isinstance(h, MessageHandler) and h.callback is profile_handlers.profile_view
+        for h in handlers
     )
-    assert any(isinstance(h, CallbackQueryHandler) and h.callback is profile_handlers.profile_back for h in handlers)
+    assert any(
+        isinstance(h, CallbackQueryHandler)
+        and h.callback is profile_handlers.profile_security
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CallbackQueryHandler)
+        and h.callback is profile_handlers.profile_back
+        for h in handlers
+    )
 
 
 def test_register_reminder_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -253,13 +344,28 @@ def test_register_reminder_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
     assert called
     handlers = app.handlers[0]
 
-    assert any(isinstance(h, CommandHandler) and h.callback is rh.reminders_list for h in handlers)
-    assert any(isinstance(h, CommandHandler) and h.callback is rh.add_reminder for h in handlers)
+    assert any(
+        isinstance(h, CommandHandler) and h.callback is rh.reminders_list
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CommandHandler) and h.callback is rh.add_reminder
+        for h in handlers
+    )
     assert rh.reminder_action_handler in handlers
     assert rh.reminder_webapp_handler in handlers
-    assert any(isinstance(h, CommandHandler) and h.callback is rh.delete_reminder for h in handlers)
-    assert any(isinstance(h, MessageHandler) and h.callback is rh.reminders_list for h in handlers)
-    assert any(isinstance(h, CallbackQueryHandler) and h.callback is rh.reminder_callback for h in handlers)
+    assert any(
+        isinstance(h, CommandHandler) and h.callback is rh.delete_reminder
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, MessageHandler) and h.callback is rh.reminders_list
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CallbackQueryHandler) and h.callback is rh.reminder_callback
+        for h in handlers
+    )
 
 
 def test_register_reminder_handlers_missing_debug_module(
@@ -289,7 +395,11 @@ async def test_reminders_command_renders_list(
 ) -> None:
     app = ApplicationBuilder().token("TESTTOKEN").build()
     register_reminder_handlers(app)
-    handler = next(h for h in app.handlers[0] if isinstance(h, CommandHandler) and "reminders" in h.commands)
+    handler = next(
+        h
+        for h in app.handlers[0]
+        if isinstance(h, CommandHandler) and "reminders" in h.commands
+    )
 
     monkeypatch.setattr(rh, "run_db", None)
 
@@ -306,7 +416,9 @@ async def test_reminders_command_renders_list(
 
     keyboard = InlineKeyboardMarkup([[InlineKeyboardButton("btn", callback_data="1")]])
 
-    def fake_render(session: Session, user_id: int) -> tuple[str, InlineKeyboardMarkup | None]:
+    def fake_render(
+        session: Session, user_id: int
+    ) -> tuple[str, InlineKeyboardMarkup | None]:
         assert session is session_obj
         assert user_id == 1
         return "rendered", keyboard


### PR DESCRIPTION
## Summary
- reset learning onboarding state via /learn_reset command
- guard learning handler registration by LEARNING_MODE_ENABLED
- test learn_reset handler and registration logic

## Testing
- `pytest -q --cov`
- `mypy --strict services/api/app/diabetes/learning_onboarding.py services/api/app/diabetes/handlers/registration.py tests/test_learn_reset.py tests/test_register_handlers.py`
- `ruff check services/api/app/diabetes/learning_onboarding.py services/api/app/diabetes/handlers/registration.py tests/test_learn_reset.py tests/test_register_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc0e6121cc832a8d03d86481e20d7a