### PR TITLE
[profiles] Add profile overrides

### DIFF
--- a/services/api/app/profiles.py
+++ b/services/api/app/profiles.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import cast
+
+from telegram.ext import ContextTypes
+
+from ..rest_client import get_json
+
+
+async def get_profile_for_user(
+    _: int, ctx: ContextTypes.DEFAULT_TYPE
+) -> dict[str, object]:
+    base = await get_json("/profile/self")
+    user_data = ctx.user_data or {}
+    overrides = cast(
+        dict[str, object], user_data.get("learn_profile_overrides", {})
+    )
+    profile = {**base, **overrides}
+    profile.setdefault("age_group", "adult")
+    profile.setdefault("diabetes_type", "unknown")
+    profile.setdefault("learning_level", "novice")
+    return profile

--- a/services/api/rest_client.py
+++ b/services/api/rest_client.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import cast
+
+import httpx
+
+from .app.config import get_settings
+
+
+async def get_json(path: str) -> dict[str, object]:
+    base = get_settings().api_url
+    if not base:
+        raise RuntimeError("API_URL not configured")
+    url = f"{base.rstrip('/')}{path}"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        return cast(dict[str, object], resp.json())

--- a/tests/test_profiles_overrides.py
+++ b/tests/test_profiles_overrides.py
@@ -1,0 +1,32 @@
+import pytest
+import services.api.app.profiles as profiles
+
+
+class DummyCtx:
+    def __init__(self, user_data: dict[str, object]) -> None:
+        self.user_data = user_data
+
+
+@pytest.mark.asyncio
+async def test_get_profile_for_user_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_json(path: str) -> dict[str, object]:
+        assert path == "/profile/self"
+        return {
+            "therapyType": "bolus",
+            "rapidInsulinType": "aspart",
+            "carbUnits": "grams",
+        }
+
+    monkeypatch.setattr(profiles, "get_json", fake_get_json)
+    ctx = DummyCtx(
+        {"learn_profile_overrides": {"carbUnits": "units", "learning_level": "expert"}}
+    )
+    result = await profiles.get_profile_for_user(123, ctx)
+    assert result == {
+        "therapyType": "bolus",
+        "rapidInsulinType": "aspart",
+        "carbUnits": "units",
+        "age_group": "adult",
+        "diabetes_type": "unknown",
+        "learning_level": "expert",
+    }


### PR DESCRIPTION
## Summary
- add REST helper to fetch profile and merge learning overrides
- provide rest_client for API calls
- cover profile override logic with tests

## Testing
- `pytest -q` *(fails: test_register_handlers_skips_learning_handlers_when_disabled)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc12009d04832a8ca0719f58595cd4