### PR TITLE
[learning] Add prompt builders for tutor

### DIFF
--- a/services/api/app/diabetes/learning_prompts.py
+++ b/services/api/app/diabetes/learning_prompts.py
@@ -2,6 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from textwrap import dedent
+
+
+MAX_PROMPT_LEN = 1_500
+
+
+def _trim(text: str, limit: int = MAX_PROMPT_LEN) -> str:
+    """Ensure *text* does not exceed ``limit`` characters."""
+
+    return text[:limit]
+
 
 def disclaimer() -> str:
     """Return the standard medical warning."""
@@ -48,3 +60,48 @@ def build_feedback(correct: bool, explanation: str) -> str:
     prefix = "Верно." if correct else "Неверно."
     prompt = f"{prefix} {explanation}".strip()
     return _with_disclaimer(prompt)
+
+
+def build_system_prompt(p: Mapping[str, str | None]) -> str:
+    """Build a system prompt tailored to the user *p* profile."""
+
+    tone = {
+        "teen": "простым языком, дружелюбно",
+        "adult": "ясно и по делу",
+        "60+": "очень простыми фразами, поддерживающе",
+    }.get(p.get("age_group") or "", "ясно и просто")
+    prompt = dedent(
+        f"""
+        Ты — персональный тьютор по диабету. Подстраивайся под пользователя.
+        Профиль: тип диабета={p.get('diabetes_type', 'unknown')},
+        терапия={p.get('therapyType', 'unknown')},
+        уровень={p.get('learning_level', 'novice')},
+        углеводы={p.get('carbUnits', 'XE')}. Тон: {tone}.
+        Пиши коротко (2–4 предложения). Каждый шаг заканчивай ОДНИМ
+        вопросом-проверкой.
+        Не назначай лечение/дозировки; при сомнениях — советуй обсудить
+        с врачом.
+        """
+    ).strip()
+    return _trim(prompt)
+
+
+def build_user_prompt_step(
+    topic_slug: str, step_idx: int, prev_summary: str | None
+) -> str:
+    """Build a user-level prompt for a learning step."""
+
+    goals = {
+        "xe_basics": "объяснить, что такое ХЕ (~10–12 г углеводов) на простых примерах",
+        "healthy-eating": "дать 3 базовых правила питания и один применимый совет",
+        "basics-of-diabetes": "кратко: что такое сахар крови, зачем замеры",
+        "insulin-usage": "связь углеводов и короткого инсулина на уровне принципов (без доз)",
+    }
+    goal = goals.get(topic_slug, "дать понятный шаг по теме")
+    summary = (prev_summary or "—")[:400]
+    prompt = (
+        f"Тема: {topic_slug}. Цель шага: {goal}. Номер шага: {step_idx}. "
+        f"Резюме предыдущего: {summary}. "
+        "Сначала объясни, затем задай один вопрос. Ответ не показывай."
+    )
+    return _trim(prompt)

--- a/tests/test_learning_prompts.py
+++ b/tests/test_learning_prompts.py
@@ -9,6 +9,8 @@ from services.api.app.diabetes.learning_prompts import (
     build_explain_step,
     build_feedback,
     build_quiz_check,
+    build_system_prompt,
+    build_user_prompt_step,
     disclaimer,
 )
 
@@ -59,4 +61,22 @@ def test_build_feedback_variants(correct: bool, prefix: str) -> None:
     assert text
     assert text.startswith(prefix)
     assert text.endswith(disclaimer())
+
+
+def test_build_system_prompt_limits_length() -> None:
+    """System prompt should contain warnings and stay within 1.5k chars."""
+
+    prompt = build_system_prompt({"age_group": "adult"})
+    assert "Не назначай" in prompt
+    assert "вопросом-проверкой" in prompt
+    assert len(prompt) <= 1_500
+
+
+def test_build_user_prompt_step_trims_and_ends_with_instruction() -> None:
+    """User prompt builder must trim long text and keep final instruction."""
+
+    long_summary = "x" * 2_000
+    prompt = build_user_prompt_step("xe_basics", 1, long_summary)
+    assert len(prompt) <= 1_500
+    assert prompt.endswith("Ответ не показывай.")
 


### PR DESCRIPTION
## Summary
- add system and user prompt builders with medical disclaimers
- limit generated prompts to 1.5k characters
- cover prompt builders with tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc14822060832ab3edc3fb74a6bee0