### PR TITLE
[learning] add learn_reset command

### DIFF
--- a/services/api/app/diabetes/handlers/learning_onboarding.py
+++ b/services/api/app/diabetes/handlers/learning_onboarding.py
@@ -14,6 +14,8 @@ from telegram.ext import (
     filters,
 )
 
+from ..learning_onboarding import learn_reset
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -41,18 +43,6 @@ async def onboarding_reply(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     user_data.pop("learning_waiting", None)
     user_data["learning_onboarded"] = True
     await message.reply_text("Ответ принят. Отправьте /learn чтобы продолжить.")
-
-
-async def learn_reset(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Reset learning-related state for the user."""
-    logger.debug("learn_reset", extra={"user": update.effective_user})
-    message = update.message
-    user_data = cast(dict[str, object], context.user_data)
-    user_data.pop("learning_onboarded", None)
-    user_data.pop("learning_waiting", None)
-    if message is not None:
-        await message.reply_text("Learning onboarding reset. Отправьте /learn.")
-
 
 def register_handlers(app: App) -> None:
     """Register learning onboarding handlers on the application."""

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import os
 import re
 
 from telegram.ext import (
@@ -137,7 +138,14 @@ def register_handlers(
         gpt_handlers,
         billing_handlers,
     )
-    from services.api.app.config import settings
+    from services.api.app.config import reload_settings, settings
+
+    reload_settings()
+    learning_env = os.getenv("LEARNING_MODE_ENABLED")
+    if learning_env is not None:
+        learning_enabled = learning_env.lower() not in {"0", "false"}
+    else:
+        learning_enabled = settings.learning_mode_enabled
 
     app.add_handler(CommandHandlerT("menu", menu_command))
     app.add_handler(CommandHandlerT("report", reporting_handlers.report_request))
@@ -150,7 +158,7 @@ def register_handlers(
     app.add_handler(sos_handlers.sos_contact_conv)
     app.add_handler(CommandHandlerT("cancel", dose_calc.dose_cancel))
     app.add_handler(CommandHandlerT("help", help_command))
-    if settings.learning_mode_enabled:
+    if learning_enabled:
         from . import learning_handlers, learning_onboarding
 
         app.add_handler(CommandHandlerT("learn", learning_handlers.learn_command))

--- a/services/api/app/diabetes/learning_onboarding.py
+++ b/services/api/app/diabetes/learning_onboarding.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from typing import cast
 
 from telegram import Update
 from telegram.ext import ContextTypes
+
+logger = logging.getLogger(__name__)
 
 
 ONBOARDING_PROMPT = "Перед началом ответьте 'да' чтобы продолжить обучение."
@@ -32,4 +35,21 @@ async def ensure_overrides(
         await message.reply_text(ONBOARDING_PROMPT)
     user_data["learning_waiting"] = True
     return False
+
+
+async def learn_reset(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Reset learning-related state for the user."""
+
+    logger.debug("learn_reset", extra={"user": update.effective_user})
+    user_data = cast(dict[str, object], context.user_data)
+    for key in [
+        "learning_onboarded",
+        "learning_waiting",
+        "learn_profile_overrides",
+        "learn_onboarding_stage",
+    ]:
+        user_data.pop(key, None)
+    message = update.message
+    if message is not None:
+        await message.reply_text("Learning onboarding reset. Отправьте /learn.")
 

--- a/tests/diabetes/test_learning_onboarding.py
+++ b/tests/diabetes/test_learning_onboarding.py
@@ -79,7 +79,11 @@ async def test_learning_onboarding_flow(
 
         message_reset = DummyMessage()
         update_reset = cast(Update, SimpleNamespace(message=message_reset, effective_user=None))
+        context.user_data["learn_profile_overrides"] = {"a": 1}
+        context.user_data["learn_onboarding_stage"] = "stage"
         await learning_onboarding.learn_reset(update_reset, context)
+        assert "learn_profile_overrides" not in context.user_data
+        assert "learn_onboarding_stage" not in context.user_data
 
         message4 = DummyMessage()
         update4 = cast(Update, SimpleNamespace(message=message4, effective_user=None))


### PR DESCRIPTION
## Summary
- add `learn_reset` command handler clearing onboarding overrides
- wire handler into registration with environment check
- test onboarding reset removes override data

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc142fe3fc832aba7757a4a55b8664