### PR TITLE
[diabetes] Add dynamic tutor with formatted replies

### DIFF
--- a/services/api/app/diabetes/dynamic_tutor.py
+++ b/services/api/app/diabetes/dynamic_tutor.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from openai.types.chat import ChatCompletionMessageParam
+
+from .llm_router import LLMRouter, LLMTask
+from .learning_prompts import build_system_prompt, build_user_prompt_step
+from .services.gpt_client import create_chat_completion, format_reply
+
+
+async def _chat(model: str, system: str, user: str, *, max_tokens: int = 350) -> str:
+    """Call OpenAI chat completion and format the reply."""
+    messages: list[ChatCompletionMessageParam] = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+    completion = await create_chat_completion(
+        model=model,
+        messages=messages,
+        temperature=0.4,
+        max_tokens=max_tokens,
+    )
+    content = completion.choices[0].message.content or ""
+    return format_reply(content)
+
+
+async def generate_step_text(
+    profile: Mapping[str, str | None],
+    topic_slug: str,
+    step_idx: int,
+    prev_summary: str | None,
+) -> str:
+    """Generate explanation text for a learning step."""
+    model = LLMRouter().choose_model(LLMTask.EXPLAIN_STEP)
+    try:
+        system = build_system_prompt(profile)
+        user = build_user_prompt_step(topic_slug, step_idx, prev_summary)
+        return await _chat(model, system, user)
+    except RuntimeError:
+        return "сервер занят, попробуйте позже"
+
+
+async def check_user_answer(
+    profile: Mapping[str, str | None],
+    topic_slug: str,
+    user_answer: str,
+    last_step_text: str,
+) -> str:
+    """Evaluate user's quiz answer and provide feedback."""
+    model = LLMRouter().choose_model(LLMTask.QUIZ_CHECK)
+    system = build_system_prompt(profile)
+    user = (
+        f"Тема: {topic_slug}. Текст предыдущего шага:\n{last_step_text}\n\n"
+        f"Ответ пользователя: «{user_answer}». Оцени кратко (верно/почти/неверно), "
+        "объясни в 1–2 предложениях и дай мягкий совет, что повторить."
+    )
+    try:
+        return await _chat(model, system, user, max_tokens=250)
+    except RuntimeError:
+        return "сервер занят, попробуйте позже"
+
+
+__all__ = ["generate_step_text", "check_user_answer"]

--- a/tests/test_dynamic_tutor.py
+++ b/tests/test_dynamic_tutor.py
@@ -1,0 +1,76 @@
+import types
+
+import pytest
+
+from services.api.app.diabetes import dynamic_tutor
+
+
+class _FakeCompletion:
+    def __init__(self, content: str) -> None:
+        self.choices = [
+            types.SimpleNamespace(message=types.SimpleNamespace(content=content))
+        ]
+
+
+@pytest.mark.asyncio
+async def test_generate_step_text_formats_reply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_create_chat_completion(**kwargs: object) -> _FakeCompletion:
+        return _FakeCompletion("a" * 900 + "\n\n" + "b" * 900)
+
+    monkeypatch.setattr(
+        dynamic_tutor, "create_chat_completion", fake_create_chat_completion
+    )
+    monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
+
+    result = await dynamic_tutor.generate_step_text({}, "t", 1, None)
+
+    assert result == "a" * 800 + "\n\n" + "b" * 800
+
+
+@pytest.mark.asyncio
+async def test_generate_step_text_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def raise_error(**kwargs: object) -> _FakeCompletion:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(dynamic_tutor, "create_chat_completion", raise_error)
+    monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
+
+    result = await dynamic_tutor.generate_step_text({}, "t", 1, None)
+
+    assert result == "сервер занят, попробуйте позже"
+
+
+@pytest.mark.asyncio
+async def test_check_user_answer_uses_max_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_create_chat_completion(**kwargs: object) -> _FakeCompletion:
+        captured.update(kwargs)
+        return _FakeCompletion("ok")
+
+    monkeypatch.setattr(
+        dynamic_tutor, "create_chat_completion", fake_create_chat_completion
+    )
+    monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
+
+    result = await dynamic_tutor.check_user_answer({}, "topic", "ans", "text")
+
+    assert result == "ok"
+    assert captured["max_tokens"] == 250
+
+
+@pytest.mark.asyncio
+async def test_check_user_answer_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def raise_error(**kwargs: object) -> _FakeCompletion:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(dynamic_tutor, "create_chat_completion", raise_error)
+    monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
+
+    result = await dynamic_tutor.check_user_answer({}, "topic", "ans", "text")
+
+    assert result == "сервер занят, попробуйте позже"


### PR DESCRIPTION
## Summary
- add dynamic tutor service that routes through LLM and formats replies
- handle RuntimeError with friendly "сервер занят, попробуйте позже" fallback
- test formatting, max token usage, and error handling

## Testing
- `pytest tests/test_dynamic_tutor.py -q --override-ini="addopts="`
- `mypy --strict services/api/app/diabetes/dynamic_tutor.py tests/test_dynamic_tutor.py`
- `ruff check services/api/app/diabetes/dynamic_tutor.py tests/test_dynamic_tutor.py`
- `pytest tests/test_dynamic_tutor.py -q` *(fails: Required test coverage of 85% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bc18720790832aa2a368e19fd66b28