### PR TITLE
[profiles] preserve settings on partial updates

### DIFF
--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -6,6 +6,12 @@ from datetime import time
 from fastapi import HTTPException
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
+from ..diabetes.schemas.profile import (
+    CarbUnits,
+    GlucoseUnits,
+    RapidInsulinType,
+)
+
 
 class _ProfileBase(BaseModel):
     telegramId: int = Field(
@@ -118,3 +124,56 @@ class ProfileUpdateSchema(_ProfileBase):
         alias="timezoneAuto",
         validation_alias=AliasChoices("timezoneAuto", "timezone_auto"),
     )
+
+
+class ProfilePatchSchema(ProfileUpdateSchema):
+    """Profile update payload including extended settings."""
+
+    dia: float | None = None
+    roundStep: float | None = Field(
+        default=None,
+        alias="roundStep",
+        validation_alias=AliasChoices("roundStep", "round_step"),
+    )
+    carbUnits: CarbUnits | None = Field(
+        default=None,
+        alias="carbUnits",
+        validation_alias=AliasChoices("carbUnits", "carb_units"),
+    )
+    gramsPerXe: float | None = Field(
+        default=None,
+        alias="gramsPerXe",
+        validation_alias=AliasChoices("gramsPerXe", "grams_per_xe"),
+    )
+    glucoseUnits: GlucoseUnits | None = Field(
+        default=None,
+        alias="glucoseUnits",
+        validation_alias=AliasChoices("glucoseUnits", "glucose_units"),
+    )
+    rapidInsulinType: RapidInsulinType | None = Field(
+        default=None,
+        alias="rapidInsulinType",
+        validation_alias=AliasChoices("rapidInsulinType", "rapid_insulin_type"),
+    )
+    maxBolus: float | None = Field(
+        default=None,
+        alias="maxBolus",
+        validation_alias=AliasChoices("maxBolus", "max_bolus"),
+    )
+    preBolus: int | None = Field(
+        default=None,
+        alias="preBolus",
+        validation_alias=AliasChoices("preBolus", "pre_bolus", "prebolus_min"),
+    )
+    afterMealMinutes: int | None = Field(
+        default=None,
+        alias="afterMealMinutes",
+        validation_alias=AliasChoices(
+            "afterMealMinutes",
+            "after_meal_minutes",
+            "postMealCheckMin",
+            "postmeal_check_min",
+        ),
+    )
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -213,6 +213,7 @@ async def save_profile(data: ProfileUpdateSchema | ProfileSchema) -> None:
             "sosAlertsEnabled": "sos_alerts_enabled",
             "timezone": "timezone",
             "timezoneAuto": "timezone_auto",
+            "therapyType": "therapy_type",
         }
 
         profile_data: dict[str, object] = {"telegram_id": data.telegramId}

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -525,10 +525,6 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     },
   ): Promise<void> => {
     try {
-      if (Object.keys(data.patch).length > 0) {
-        await patchProfileMutation.mutateAsync(data.patch);
-      }
-
       const payload: {
         telegramId: number;
         target: number;
@@ -563,6 +559,9 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
       }
 
       await saveProfile(payload);
+      if (Object.keys(data.patch).length > 0) {
+        await patchProfileMutation.mutateAsync(data.patch);
+      }
       queryClient.invalidateQueries({ queryKey: ["profile"] });
       setOriginal(profile);
       if (data.therapyType) {


### PR DESCRIPTION
## Summary
- ensure profile POST/PATCH only updates provided fields and add PATCH endpoint
- keep previous profile settings during partial save
- adjust webapp save flow to patch after saving profile

## Testing
- `pytest tests/test_profiles_api.py -q --cov-fail-under=0`
- `mypy --strict services/api/app/schemas/profile.py services/api/app/legacy.py services/api/app/services/profile.py tests/test_profiles_api.py`
- `ruff check services/api/app/legacy.py services/api/app/schemas/profile.py services/api/app/services/profile.py tests/test_profiles_api.py`
- `cd services/webapp/ui && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc189ffa0c832a802a2c57414a4489