### PR TITLE
[learning] Track lesson state and handle quiz answers

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -37,7 +37,9 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     CommandHandlerT: TypeAlias = CommandHandler[ContextTypes.DEFAULT_TYPE, object]
     MessageHandlerT: TypeAlias = MessageHandler[ContextTypes.DEFAULT_TYPE, object]
-    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, object]
+    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[
+        ContextTypes.DEFAULT_TYPE, object
+    ]
 else:
     CommandHandlerT = CommandHandler
     MessageHandlerT = MessageHandler
@@ -60,9 +62,17 @@ def register_profile_handlers(
 
     app.add_handler(profile.profile_conv)
     app.add_handler(profile.profile_webapp_handler)
-    app.add_handler(MessageHandlerT(filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view))
-    app.add_handler(CallbackQueryHandlerT(profile.profile_security, pattern="^profile_security"))
-    app.add_handler(CallbackQueryHandlerT(profile.profile_back, pattern="^profile_back$"))
+    app.add_handler(
+        MessageHandlerT(
+            filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view
+        )
+    )
+    app.add_handler(
+        CallbackQueryHandlerT(profile.profile_security, pattern="^profile_security")
+    )
+    app.add_handler(
+        CallbackQueryHandlerT(profile.profile_back, pattern="^profile_back$")
+    )
 
 
 def register_reminder_handlers(
@@ -90,7 +100,9 @@ def register_reminder_handlers(
             reminder_handlers.reminders_list,
         )
     )
-    app.add_handler(CallbackQueryHandlerT(reminder_handlers.reminder_callback, pattern="^remind_"))
+    app.add_handler(
+        CallbackQueryHandlerT(reminder_handlers.reminder_callback, pattern="^remind_")
+    )
 
     # --- DEBUG HANDLERS ---
     try:
@@ -167,10 +179,19 @@ def register_handlers(
         app.add_handler(CommandHandlerT("progress", learning_handlers.progress_command))
         app.add_handler(CommandHandlerT("exit", learning_handlers.exit_command))
         learning_onboarding.register_handlers(app)
+        app.add_handler(
+            MessageHandlerT(
+                filters.TEXT & ~filters.COMMAND,
+                learning_handlers.quiz_answer_handler,
+                block=False,
+            )
+        )
     app.add_handler(CommandHandlerT("gpt", gpt_handlers.chat_with_gpt))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))
-    app.add_handler(CallbackQueryHandlerT(billing_handlers.trial_command, pattern="^trial$"))
+    app.add_handler(
+        CallbackQueryHandlerT(billing_handlers.trial_command, pattern="^trial$")
+    )
     register_reminder_handlers(app)
     app.add_handler(CommandHandlerT("alertstats", alert_handlers.alert_stats))
     app.add_handler(CommandHandlerT("hypoalert", security_handlers.hypo_alert_faq))
@@ -186,9 +207,19 @@ def register_handlers(
             reporting_handlers.history_view,
         )
     )
-    app.add_handler(MessageHandlerT(filters.Regex(re.escape(PHOTO_BUTTON_TEXT)), photo_handlers.photo_prompt))
-    app.add_handler(MessageHandlerT(filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help))
-    app.add_handler(MessageHandlerT(filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command))
+    app.add_handler(
+        MessageHandlerT(
+            filters.Regex(re.escape(PHOTO_BUTTON_TEXT)), photo_handlers.photo_prompt
+        )
+    )
+    app.add_handler(
+        MessageHandlerT(
+            filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help
+        )
+    )
+    app.add_handler(
+        MessageHandlerT(filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command)
+    )
     app.add_handler(
         MessageHandlerT(
             filters.Regex(re.escape(SUBSCRIPTION_BUTTON_TEXT)),
@@ -201,11 +232,21 @@ def register_handlers(
             sos_handlers.sos_contact_start,
         )
     )
-    app.add_handler(MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler))
+    app.add_handler(
+        MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler)
+    )
     app.add_handler(MessageHandlerT(filters.PHOTO, photo_handlers.photo_handler))
     app.add_handler(MessageHandlerT(filters.Document.IMAGE, photo_handlers.doc_handler))
-    app.add_handler(CallbackQueryHandlerT(reporting_handlers.report_period_callback, pattern="^report_back$"))
-    app.add_handler(CallbackQueryHandlerT(reporting_handlers.report_period_callback, pattern="^report_period:"))
+    app.add_handler(
+        CallbackQueryHandlerT(
+            reporting_handlers.report_period_callback, pattern="^report_back$"
+        )
+    )
+    app.add_handler(
+        CallbackQueryHandlerT(
+            reporting_handlers.report_period_callback, pattern="^report_period:"
+        )
+    )
     app.add_handler(CallbackQueryHandlerT(callback_router))
 
     async def _clear_waiting_flags(context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/services/api/app/diabetes/learning_state.py
+++ b/services/api/app/diabetes/learning_state.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import MutableMapping
+
+KEY = "learn_state"
+
+
+@dataclass
+class LearnState:
+    """Ephemeral lesson state stored in ``context.user_data``."""
+
+    topic: str
+    step: int
+    awaiting_answer: bool
+    last_step_text: str | None = None
+    prev_summary: str | None = None
+
+
+def get_state(data: MutableMapping[str, object]) -> LearnState | None:
+    """Return ``LearnState`` from ``data`` if present."""
+
+    raw = data.get(KEY)
+    if isinstance(raw, dict):
+        try:
+            return LearnState(**raw)
+        except TypeError:
+            return None
+    return None
+
+
+def set_state(data: MutableMapping[str, object], state: LearnState) -> None:
+    """Store ``state`` in ``data``."""
+
+    data[KEY] = asdict(state)
+
+
+def clear_state(data: MutableMapping[str, object]) -> None:
+    """Remove lesson state from ``data`` if it exists."""
+
+    data.pop(KEY, None)

--- a/tests/diabetes/test_learning_state.py
+++ b/tests/diabetes/test_learning_state.py
@@ -1,0 +1,15 @@
+from services.api.app.diabetes.learning_state import (
+    LearnState,
+    clear_state,
+    get_state,
+    set_state,
+)
+
+
+def test_state_roundtrip() -> None:
+    data: dict[str, object] = {}
+    state = LearnState(topic="t", step=1, awaiting_answer=True, last_step_text="a")
+    set_state(data, state)
+    assert get_state(data) == state
+    clear_state(data)
+    assert get_state(data) is None

--- a/tests/diabetes/test_learning_text_answer.py
+++ b/tests/diabetes/test_learning_text_answer.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.config import settings
+from services.api.app.diabetes.handlers import learning_handlers
+from services.api.app.diabetes.learning_state import get_state
+
+
+class DummyMessage:
+    def __init__(self, text: str = "") -> None:
+        self.replies: list[str] = []
+        self.text = text
+
+    async def reply_text(
+        self, text: str, **kwargs: Any
+    ) -> None:  # pragma: no cover - helper
+        self.replies.append(text)
+
+
+def make_update(text: str = "") -> Update:
+    user = SimpleNamespace(id=1)
+    return cast(
+        Update, SimpleNamespace(message=DummyMessage(text), effective_user=user)
+    )
+
+
+def make_context(**kwargs: Any) -> CallbackContext[Any, Any, Any, Any]:
+    data: dict[str, Any] = {"user_data": {}, "args": []}
+    data.update(kwargs)
+    return cast(CallbackContext[Any, Any, Any, Any], SimpleNamespace(**data))
+
+
+@pytest.mark.asyncio
+async def test_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+
+    questions = iter(["Q1", None])
+
+    async def fake_next(user_id: int, lesson_id: int) -> str | None:
+        return next(questions, None)
+
+    async def fake_check(user_id: int, lesson_id: int, answer: int) -> tuple[bool, str]:
+        return True, "ok"
+
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "check_answer", fake_check)
+
+    user_data = {"lesson_id": 1}
+
+    upd1 = make_update()
+    ctx1 = make_context(user_data=user_data, args=[])
+    await learning_handlers.quiz_command(upd1, ctx1)
+    msg1 = cast(DummyMessage, upd1.message)
+    assert msg1.replies == ["Q1"]
+
+    upd2 = make_update("1")
+    ctx2 = make_context(user_data=user_data)
+    await learning_handlers.quiz_answer_handler(upd2, ctx2)
+    msg2 = cast(DummyMessage, upd2.message)
+    assert msg2.replies == ["ok", "Опрос завершён"]
+    assert get_state(user_data) is None

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -70,7 +70,9 @@ def test_register_handlers_attaches_expected_handlers(
     assert reporting_handlers.report_request in callbacks
     assert reporting_handlers.history_view in callbacks
     assert any(
-        isinstance(h, CommandHandler) and h.callback is reporting_handlers.history_view and "history" in h.commands
+        isinstance(h, CommandHandler)
+        and h.callback is reporting_handlers.history_view
+        and "history" in h.commands
         for h in handlers
     )
     assert gpt_handlers.chat_with_gpt in callbacks
@@ -79,19 +81,27 @@ def test_register_handlers_attaches_expected_handlers(
     assert billing_handlers.upgrade_command in callbacks
     assert billing_handlers.subscription_button in callbacks
     assert any(
-        isinstance(h, CommandHandler) and h.callback is learning_handlers.lesson_command and "lesson" in h.commands
+        isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.lesson_command
+        and "lesson" in h.commands
         for h in handlers
     )
     assert any(
-        isinstance(h, CommandHandler) and h.callback is learning_handlers.quiz_command and "quiz" in h.commands
+        isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.quiz_command
+        and "quiz" in h.commands
         for h in handlers
     )
     assert any(
-        isinstance(h, CommandHandler) and h.callback is learning_handlers.progress_command and "progress" in h.commands
+        isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.progress_command
+        and "progress" in h.commands
         for h in handlers
     )
     assert any(
-        isinstance(h, CommandHandler) and h.callback is learning_handlers.exit_command and "exit" in h.commands
+        isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.exit_command
+        and "exit" in h.commands
         for h in handlers
     )
     assert any(
@@ -101,19 +111,37 @@ def test_register_handlers_attaches_expected_handlers(
         for h in handlers
     )
     assert any(
-        isinstance(h, MessageHandler) and h.callback is learning_onboarding.onboarding_reply
+        isinstance(h, MessageHandler)
+        and h.callback is learning_onboarding.onboarding_reply
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, MessageHandler)
+        and h.callback is learning_handlers.quiz_answer_handler
         for h in handlers
     )
     # Reminder handlers should be registered
-    assert any(isinstance(h, CallbackQueryHandler) and h.callback is rh.reminder_action_cb for h in handlers)
-    assert any(isinstance(h, MessageHandler) and h.callback is rh.reminder_webapp_save for h in handlers)
-    assert any(isinstance(h, CommandHandler) and h.callback is rh.add_reminder for h in handlers)
+    assert any(
+        isinstance(h, CallbackQueryHandler) and h.callback is rh.reminder_action_cb
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, MessageHandler) and h.callback is rh.reminder_webapp_save
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CommandHandler) and h.callback is rh.add_reminder
+        for h in handlers
+    )
 
     onb_conv = [
         h
         for h in handlers
         if isinstance(h, ConversationHandler)
-        and any(isinstance(ep, CommandHandler) and "start" in ep.commands for ep in h.entry_points)
+        and any(
+            isinstance(ep, CommandHandler) and "start" in ep.commands
+            for ep in h.entry_points
+        )
     ]
     assert onb_conv == []
 
@@ -121,9 +149,15 @@ def test_register_handlers_attaches_expected_handlers(
     assert dose_calc.dose_conv in conv_handlers
     assert sugar_handlers.sugar_conv in conv_handlers
     assert profile_handlers.profile_conv in conv_handlers
-    conv_cmds = [ep for ep in dose_calc.dose_conv.entry_points if isinstance(ep, CommandHandler)]
+    conv_cmds = [
+        ep for ep in dose_calc.dose_conv.entry_points if isinstance(ep, CommandHandler)
+    ]
     assert conv_cmds and "dose" in conv_cmds[0].commands
-    sugar_conv_cmds = [ep for ep in sugar_handlers.sugar_conv.entry_points if isinstance(ep, CommandHandler)]
+    sugar_conv_cmds = [
+        ep
+        for ep in sugar_handlers.sugar_conv.entry_points
+        if isinstance(ep, CommandHandler)
+    ]
     assert sugar_conv_cmds and "sugar" in sugar_conv_cmds[0].commands
     profile_conv_cmd = [
         ep
@@ -142,67 +176,111 @@ def test_register_handlers_attaches_expected_handlers(
     assert profile_conv_cb
 
     text_handlers = [
-        h for h in handlers if isinstance(h, MessageHandler) and h.callback is gpt_handlers.freeform_handler
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is gpt_handlers.freeform_handler
     ]
     assert text_handlers
 
     photo_handler_msgs = [
-        h for h in handlers if isinstance(h, MessageHandler) and h.callback is photo_handlers.photo_handler
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is photo_handlers.photo_handler
     ]
     assert photo_handler_msgs
 
-    doc_handlers = [h for h in handlers if isinstance(h, MessageHandler) and h.callback is photo_handlers.doc_handler]
+    doc_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is photo_handlers.doc_handler
+    ]
     assert doc_handlers
 
     photo_prompt_handlers = [
-        h for h in handlers if isinstance(h, MessageHandler) and h.callback is photo_handlers.photo_prompt
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is photo_handlers.photo_prompt
     ]
     assert photo_prompt_handlers
 
-    sugar_cmd = [h for h in handlers if isinstance(h, CommandHandler) and h.callback is sugar_handlers.sugar_start]
+    sugar_cmd = [
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is sugar_handlers.sugar_start
+    ]
     assert not sugar_cmd
 
-    cancel_cmd = [h for h in handlers if isinstance(h, CommandHandler) and h.callback is dose_calc.dose_cancel]
+    cancel_cmd = [
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is dose_calc.dose_cancel
+    ]
     assert cancel_cmd and "cancel" in cancel_cmd[0].commands
 
     profile_view_handlers = [
-        h for h in handlers if isinstance(h, MessageHandler) and h.callback is profile_handlers.profile_view
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler) and h.callback is profile_handlers.profile_view
     ]
     assert profile_view_handlers
 
     report_handlers = [
-        h for h in handlers if isinstance(h, MessageHandler) and h.callback is reporting_handlers.report_request
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler)
+        and h.callback is reporting_handlers.report_request
     ]
     assert report_handlers
 
     report_cmd = [
-        h for h in handlers if isinstance(h, CommandHandler) and h.callback is reporting_handlers.report_request
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler)
+        and h.callback is reporting_handlers.report_request
     ]
     assert report_cmd and "report" in report_cmd[0].commands
 
-    gpt_cmd = [h for h in handlers if isinstance(h, CommandHandler) and h.callback is gpt_handlers.chat_with_gpt]
+    gpt_cmd = [
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is gpt_handlers.chat_with_gpt
+    ]
     assert gpt_cmd and "gpt" in gpt_cmd[0].commands
 
     history_cmd = [
-        h for h in handlers if isinstance(h, CommandHandler) and h.callback is reporting_handlers.history_view
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler)
+        and h.callback is reporting_handlers.history_view
     ]
     assert history_cmd and "history" in history_cmd[0].commands
 
     history_handlers = [
-        h for h in handlers if isinstance(h, MessageHandler) and h.callback is reporting_handlers.history_view
+        h
+        for h in handlers
+        if isinstance(h, MessageHandler)
+        and h.callback is reporting_handlers.history_view
     ]
     assert history_handlers
 
-    cb_handlers = [h for h in handlers if isinstance(h, CallbackQueryHandler) and h.callback is callback_router]
+    cb_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, CallbackQueryHandler) and h.callback is callback_router
+    ]
     assert cb_handlers
     report_cb_handlers = [
         h
         for h in handlers
-        if isinstance(h, CallbackQueryHandler) and h.callback is reporting_handlers.report_period_callback
+        if isinstance(h, CallbackQueryHandler)
+        and h.callback is reporting_handlers.report_period_callback
     ]
     assert report_cb_handlers
     profile_back_handlers = [
-        h for h in handlers if isinstance(h, CallbackQueryHandler) and h.callback is profile_handlers.profile_back
+        h
+        for h in handlers
+        if isinstance(h, CallbackQueryHandler)
+        and h.callback is profile_handlers.profile_back
     ]
     assert profile_back_handlers
 
@@ -217,7 +295,9 @@ def test_register_handlers_skips_learning_handlers_when_disabled(
     register_handlers(app)
 
     handlers = app.handlers[0]
-    commands = [cmd for h in handlers if isinstance(h, CommandHandler) for cmd in h.commands]
+    commands = [
+        cmd for h in handlers if isinstance(h, CommandHandler) for cmd in h.commands
+    ]
     for name in ["learn", "lesson", "quiz", "progress", "exit", "learn_reset"]:
         assert name not in commands
     monkeypatch.setenv("LEARNING_MODE_ENABLED", "1")
@@ -236,7 +316,8 @@ def test_register_learning_onboarding_handlers() -> None:
         for h in handlers
     )
     assert any(
-        isinstance(h, MessageHandler) and h.callback is learning_onboarding.onboarding_reply
+        isinstance(h, MessageHandler)
+        and h.callback is learning_onboarding.onboarding_reply
         for h in handlers
     )
 
@@ -254,11 +335,20 @@ def test_register_profile_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert profile_handlers.profile_conv in handlers
     assert profile_handlers.profile_webapp_handler in handlers
-    assert any(isinstance(h, MessageHandler) and h.callback is profile_handlers.profile_view for h in handlers)
     assert any(
-        isinstance(h, CallbackQueryHandler) and h.callback is profile_handlers.profile_security for h in handlers
+        isinstance(h, MessageHandler) and h.callback is profile_handlers.profile_view
+        for h in handlers
     )
-    assert any(isinstance(h, CallbackQueryHandler) and h.callback is profile_handlers.profile_back for h in handlers)
+    assert any(
+        isinstance(h, CallbackQueryHandler)
+        and h.callback is profile_handlers.profile_security
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CallbackQueryHandler)
+        and h.callback is profile_handlers.profile_back
+        for h in handlers
+    )
 
 
 def test_register_reminder_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -281,13 +371,28 @@ def test_register_reminder_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
     assert called
     handlers = app.handlers[0]
 
-    assert any(isinstance(h, CommandHandler) and h.callback is rh.reminders_list for h in handlers)
-    assert any(isinstance(h, CommandHandler) and h.callback is rh.add_reminder for h in handlers)
+    assert any(
+        isinstance(h, CommandHandler) and h.callback is rh.reminders_list
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CommandHandler) and h.callback is rh.add_reminder
+        for h in handlers
+    )
     assert rh.reminder_action_handler in handlers
     assert rh.reminder_webapp_handler in handlers
-    assert any(isinstance(h, CommandHandler) and h.callback is rh.delete_reminder for h in handlers)
-    assert any(isinstance(h, MessageHandler) and h.callback is rh.reminders_list for h in handlers)
-    assert any(isinstance(h, CallbackQueryHandler) and h.callback is rh.reminder_callback for h in handlers)
+    assert any(
+        isinstance(h, CommandHandler) and h.callback is rh.delete_reminder
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, MessageHandler) and h.callback is rh.reminders_list
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CallbackQueryHandler) and h.callback is rh.reminder_callback
+        for h in handlers
+    )
 
 
 def test_register_reminder_handlers_missing_debug_module(
@@ -317,7 +422,11 @@ async def test_reminders_command_renders_list(
 ) -> None:
     app = ApplicationBuilder().token("TESTTOKEN").build()
     register_reminder_handlers(app)
-    handler = next(h for h in app.handlers[0] if isinstance(h, CommandHandler) and "reminders" in h.commands)
+    handler = next(
+        h
+        for h in app.handlers[0]
+        if isinstance(h, CommandHandler) and "reminders" in h.commands
+    )
 
     monkeypatch.setattr(rh, "run_db", None)
 
@@ -334,7 +443,9 @@ async def test_reminders_command_renders_list(
 
     keyboard = InlineKeyboardMarkup([[InlineKeyboardButton("btn", callback_data="1")]])
 
-    def fake_render(session: Session, user_id: int) -> tuple[str, InlineKeyboardMarkup | None]:
+    def fake_render(
+        session: Session, user_id: int
+    ) -> tuple[str, InlineKeyboardMarkup | None]:
         assert session is session_obj
         assert user_id == 1
         return "rendered", keyboard


### PR DESCRIPTION
## Summary
- maintain lesson progress and awaiting-answer flag in user data
- interpret plain text messages as quiz answers when awaiting
- register handler for quiz answers and add tests

## Testing
- `ruff check .`
- `mypy --strict services/api/app/diabetes/learning_state.py services/api/app/diabetes/handlers/learning_handlers.py services/api/app/diabetes/handlers/registration.py tests/diabetes/test_learning_state.py tests/diabetes/test_learning_text_answer.py tests/test_register_handlers.py`
- `pytest -q` *(fails: see log)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1bfc8a88832a8e3c6645ef7f46fe