### PR TITLE
bot: add subscription webapp auth

### DIFF
--- a/services/api/app/diabetes/handlers/billing_handlers.py
+++ b/services/api/app/diabetes/handlers/billing_handlers.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime
 
 import httpx
-from telegram import Message, Update
+from telegram import KeyboardButton, Message, ReplyKeyboardMarkup, Update, WebAppInfo
 from telegram.ext import ContextTypes
 
 from ... import config
@@ -77,16 +77,17 @@ async def upgrade_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     message = update.message
     if message is None:
         return
-    try:
-        url = config.build_ui_url("/subscription")
-    except RuntimeError:
+    url = config.get_settings().subscription_url
+    if not url:
         await message.reply_text("❌ Не настроена ссылка на оплату.")
         logger.info(
             "billing_action=user_id:%s action=upgrade result=error",
             update.effective_user.id if update.effective_user else "?",
         )
         return
-    await message.reply_text(f"💳 Оформить PRO: {url}")
+    button = KeyboardButton("💳 Оформить PRO", web_app=WebAppInfo(url))
+    kb = ReplyKeyboardMarkup([[button]], resize_keyboard=True, one_time_keyboard=True)
+    await message.reply_text("💳 Оформить PRO", reply_markup=kb)
     if update.effective_user:
         logger.info(
             "billing_action=user_id:%s action=upgrade result=ok",

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -129,10 +129,13 @@ def subscription_keyboard(trial_available: bool) -> InlineKeyboardMarkup:
     buttons: list[InlineKeyboardButton] = []
     if trial_available:
         buttons.append(InlineKeyboardButton("🎁 Trial", callback_data="trial"))
-    try:
-        url = config.build_ui_url("/subscription")
-    except RuntimeError:
-        url = None
+    settings = config.get_settings()
+    url = settings.subscription_url
+    if not url:
+        try:
+            url = config.build_ui_url("/subscription")
+        except RuntimeError:
+            url = None
     if url:
         buttons.append(
             InlineKeyboardButton(

--- a/services/webapp/ui/src/api/billing.auth.test.ts
+++ b/services/webapp/ui/src/api/billing.auth.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('billing auth', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it('sends Authorization header when initData present', async () => {
+    vi.doMock('@/lib/telegram-auth', () => ({
+      getTelegramAuthHeaders: () => ({ Authorization: 'tg test' }),
+    }));
+    const fetchMock = vi.fn().mockImplementation((_: string, init: RequestInit) => {
+      const headers = init.headers as Headers;
+      expect(headers.get('Authorization')).toBe('tg test');
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            featureFlags: {
+              billingEnabled: true,
+              paywallMode: 'soft',
+              testMode: false,
+            },
+            subscription: null,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { getBillingStatus } = await import('./billing');
+    const res = await getBillingStatus('1');
+    expect(res?.subscription).toBeNull();
+  });
+
+  it('fails with 401 when initData missing', async () => {
+    vi.doMock('@/lib/telegram-auth', () => ({
+      getTelegramAuthHeaders: () => ({}) ,
+    }));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ detail: 'unauthorized' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const { getBillingStatus } = await import('./billing');
+      await expect(getBillingStatus('1')).rejects.toThrow('unauthorized');
+    });
+  });
+

--- a/services/webapp/ui/src/api/stats.test.ts
+++ b/services/webapp/ui/src/api/stats.test.ts
@@ -17,7 +17,7 @@ vi.mock('@sdk/apis', () => ({
 }));
 
 vi.mock('@/lib/telegram-auth', () => ({
-  getTelegramAuthHeaders: vi.fn(() => ({ 'x-telegram-init-data': 'test' })),
+  getTelegramAuthHeaders: vi.fn(() => ({ Authorization: 'tg test' })),
 }));
 
 import { fetchAnalytics, fetchDayStats } from './stats';
@@ -37,7 +37,7 @@ describe('stats api', () => {
 
     expect(Configuration).toHaveBeenCalledWith({
       basePath: '/api',
-      headers: { 'x-telegram-init-data': 'test' },
+      headers: { Authorization: 'tg test' },
     });
     expect(DefaultApi).toHaveBeenCalledWith(configInstance);
     expect(mockGetAnalytics).toHaveBeenCalledWith({ telegramId: 1 });
@@ -52,7 +52,7 @@ describe('stats api', () => {
 
     expect(Configuration).toHaveBeenCalledWith({
       basePath: '/api',
-      headers: { 'x-telegram-init-data': 'test' },
+      headers: { Authorization: 'tg test' },
     });
     expect(DefaultApi).toHaveBeenCalledWith(configInstance);
     expect(mockGetStats).toHaveBeenCalledWith({ telegramId: 2 });

--- a/services/webapp/ui/src/hooks/useTelegramInitData.ts
+++ b/services/webapp/ui/src/hooks/useTelegramInitData.ts
@@ -1,6 +1,7 @@
 export function useTelegramInitData(): string | null {
   try {
-    return localStorage.getItem("tg_init_data");
+    const globalData = (window as any)?.Telegram?.WebApp?.initData;
+    return globalData || localStorage.getItem("tg_init_data");
   } catch {
     return null;
   }

--- a/services/webapp/ui/src/lib/telegram-auth.ts
+++ b/services/webapp/ui/src/lib/telegram-auth.ts
@@ -1,4 +1,4 @@
-const HEADER = 'x-telegram-init-data';
+const HEADER = 'Authorization';
 const LS_KEY = 'tg_init_data';
 
 export function getDevInitData(): string | null {
@@ -18,7 +18,7 @@ export function getTelegramAuthHeaders(): Record<string, string> {
   const initData =
     globalInitData || (import.meta.env.DEV ? getDevInitData() : null);
   if (initData) {
-    headers[HEADER] = initData;
+    headers[HEADER] = `tg ${initData}`;
   }
   return headers;
 }

--- a/services/webapp/ui/src/pages/Subscription.tsx
+++ b/services/webapp/ui/src/pages/Subscription.tsx
@@ -84,7 +84,9 @@ const Subscription = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
   const { user } = useTelegram();
-  const initData = useTelegramInitData();
+  const storedInitData = useTelegramInitData();
+  const initData =
+    (window as any)?.Telegram?.WebApp?.initData ?? storedInitData;
   const [billing, setBilling] = useState<BillingStatus | null>(null);
 
   useEffect(() => {

--- a/tests/test_billing_commands.py
+++ b/tests/test_billing_commands.py
@@ -143,7 +143,7 @@ async def test_trial_command_bad_end_date(monkeypatch: pytest.MonkeyPatch, paylo
 
 @pytest.mark.asyncio
 async def test_upgrade_command(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("PUBLIC_ORIGIN", "http://example.org")
+    monkeypatch.setenv("SUBSCRIPTION_URL", "https://pay.example/sub")
     config.reload_settings()
 
     message = DummyMessage()
@@ -158,8 +158,12 @@ async def test_upgrade_command(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await billing_handlers.upgrade_command(update, context)
 
-    assert message.texts == ["💳 Оформить PRO: http://example.org/ui/subscription"]
-    monkeypatch.delenv("PUBLIC_ORIGIN")
+    assert message.texts == ["💳 Оформить PRO"]
+    markup = message.markups[0]
+    button = markup.keyboard[0][0]
+    assert button.text == "💳 Оформить PRO"
+    assert button.web_app and button.web_app.url == "https://pay.example/sub"
+    monkeypatch.delenv("SUBSCRIPTION_URL")
     config.reload_settings()
 
 


### PR DESCRIPTION
## Summary
- add WebApp upgrade button using `SUBSCRIPTION_URL`
- propagate Telegram initData via Authorization header in WebApp
- cover subscription auth flows with tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test` *(fails: profile.api.test.ts > does not send insulin fields for non-insulin profiles)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1c7275a0832a83072758bc247a47