### PR TITLE
[learning] add interactive lesson handlers

### DIFF
--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -1,0 +1,106 @@
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import InlineKeyboardMarkup
+
+from services.api.app.diabetes import learning_handlers
+from services.api.app.diabetes.learning_state import LearnState, get_state, set_state
+
+
+class DummyMessage:
+    def __init__(self, text: str | None = None) -> None:
+        self.text = text
+        self.replies: list[str] = []
+        self.markups: list[InlineKeyboardMarkup | None] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - helper
+        self.replies.append(text)
+        self.markups.append(cast(InlineKeyboardMarkup | None, kwargs.get("reply_markup")))
+
+
+class DummyCallback:
+    def __init__(self, message: DummyMessage, data: str) -> None:
+        self.message = message
+        self.data = data
+        self.answered = False
+
+    async def answer(self) -> None:  # pragma: no cover - helper
+        self.answered = True
+
+
+@pytest.mark.asyncio
+async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_ensure_overrides(update: object, context: object) -> bool:
+        return True
+
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
+    monkeypatch.setattr(learning_handlers, "TOPICS", [("slug", "Topic")])
+    async def fake_generate_step_text(*args: object, **kwargs: object) -> str:
+        return "step1?"
+    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+
+    msg = DummyMessage()
+    update = cast(object, SimpleNamespace(message=msg))
+    context = SimpleNamespace(user_data={})
+
+    await learning_handlers.learn_command(update, context)
+    markup = msg.markups[0]
+    assert isinstance(markup, InlineKeyboardMarkup)
+    assert markup.inline_keyboard[0][0].callback_data == "lesson:slug"
+
+    msg2 = DummyMessage()
+    query = DummyCallback(msg2, "lesson:slug")
+    update_cb = cast(object, SimpleNamespace(callback_query=query))
+    context_cb = SimpleNamespace(user_data={})
+
+    await learning_handlers.lesson_callback(update_cb, context_cb)
+    assert msg2.replies == ["step1?"]
+    state = get_state(context_cb.user_data)
+    assert state is not None and state.step == 1 and state.awaiting_answer
+
+
+@pytest.mark.asyncio
+async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_generate_step_text(
+        profile: object, topic: str, step_idx: int, prev: object
+    ) -> str:
+        return f"step{step_idx}?"
+
+    async def fake_check_user_answer(
+        profile: object, topic: str, answer: str, last: str
+    ) -> str:
+        return "feedback"
+
+    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+
+    msg = DummyMessage()
+    update = cast(object, SimpleNamespace(message=msg))
+    context = SimpleNamespace(user_data={}, args=["slug"])
+
+    await learning_handlers.lesson_command(update, context)
+    assert msg.replies == ["step1?"]
+
+    msg2 = DummyMessage(text="ans")
+    update2 = cast(object, SimpleNamespace(message=msg2))
+    context2 = SimpleNamespace(user_data=context.user_data)
+
+    await learning_handlers.lesson_answer_handler(update2, context2)
+    assert msg2.replies == ["feedback", "step2?"]
+    state = get_state(context2.user_data)
+    assert state is not None and state.step == 2 and state.awaiting_answer
+
+
+@pytest.mark.asyncio
+async def test_exit_command_clears_state() -> None:
+    msg = DummyMessage()
+    update = cast(object, SimpleNamespace(message=msg))
+    user_data: dict[str, Any] = {}
+    set_state(user_data, LearnState("t", 1, True))
+    context = SimpleNamespace(user_data=user_data)
+
+    await learning_handlers.exit_command(update, context)
+    assert msg.replies == ["Учебная сессия завершена."]
+    assert get_state(user_data) is None


### PR DESCRIPTION
## Summary
- add new interactive learning handlers with topic menu, step flow, and feedback
- track learning state and rate limit lesson and answer events
- test chat-based lesson flow

## Testing
- `pytest tests/diabetes/test_learning_chat_handlers.py -q -o addopts=`
- `mypy --strict services/api/app/diabetes/learning_handlers.py`
- `ruff check services/api/app/diabetes/learning_handlers.py tests/diabetes/test_learning_chat_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc1ee48134832aaa9ed85271fc86e7