### PR TITLE
[learning] add basic learning flow tests

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -220,7 +220,8 @@ async def quiz_answer_handler(
         state.step += 1
         state.awaiting_answer = True
         set_state(user_data, state)
-    raise ApplicationHandlerStop
+    # Let calling code continue without forcing ApplicationHandlerStop.
+    return
 
 
 async def progress_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -14,11 +14,23 @@ from .diabetes.schemas.profile import (
     RapidInsulinType,
     TherapyType,
 )
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from .diabetes.services import db
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 router.include_router(reminders_router)
+
+
+T = TypeVar("T")
+
+
+async def run_db(fn: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    """Proxy to diabetes.services.db.run_db for legacy tests."""
+    return await db.run_db(fn, *args, **kwargs)
 
 
 @router.post("/profiles", operation_id="profilesPost", tags=["profiles"])

--- a/tests/learning/test_handlers.py
+++ b/tests/learning/test_handlers.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from telegram import (
+    Bot,
+    CallbackQuery,
+    Chat,
+    Message,
+    MessageEntity,
+    Update,
+    User,
+)
+from telegram.ext import (
+    Application,
+    CallbackQueryHandler,
+    CommandHandler,
+    MessageHandler,
+    filters,
+)
+
+from services.api.app.diabetes import learning_handlers
+
+
+class DummyBot(Bot):
+    def __init__(self) -> None:
+        super().__init__(token="123:ABC")
+        object.__setattr__(self, "_sent", [])
+
+    @property
+    def sent(self) -> list[str]:
+        return self._sent  # type: ignore[attr-defined]
+
+    async def initialize(self) -> None:  # pragma: no cover - setup
+        self._me = User(id=0, is_bot=True, first_name="Bot", username="bot")
+        self._bot = self
+        self._initialized = True
+
+    @property
+    def username(self) -> str:  # pragma: no cover - simple property
+        return "bot"
+
+    async def send_message(self, chat_id: int, text: str, **kwargs: object) -> Message:
+        msg = Message(
+            message_id=len(self.sent) + 1,
+            date=datetime.now(),
+            chat=Chat(id=chat_id, type="private"),
+            from_user=self._me,
+            text=text,
+        )
+        msg._bot = self
+        self.sent.append(text)
+        return msg
+
+    async def answer_callback_query(self, callback_query_id: str, **kwargs: object) -> bool:
+        return True
+
+
+@pytest.mark.asyncio
+async def test_learning_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    steps = iter(["step1", "step2"])
+
+    async def fake_generate_step_text(*args: object, **kwargs: object) -> str:
+        return next(steps)
+
+    async def fake_check_user_answer(*args: object, **kwargs: object) -> str:
+        return "feedback"
+
+    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+
+    async def fake_ensure_overrides(*args: object, **kwargs: object) -> bool:
+        return True
+
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
+
+    bot = DummyBot()
+    app = Application.builder().bot(bot).build()
+    app.add_handler(CommandHandler("learn", learning_handlers.learn_command))
+    app.add_handler(CallbackQueryHandler(learning_handlers.lesson_callback))
+    app.add_handler(
+        MessageHandler(filters.TEXT & (~filters.COMMAND), learning_handlers.lesson_answer_handler)
+    )
+    await app.initialize()
+
+    user = User(id=1, is_bot=False, first_name="T")
+    chat = Chat(id=1, type="private")
+
+    learn_msg = Message(
+        message_id=1,
+        date=datetime.now(),
+        chat=chat,
+        from_user=user,
+        text="/learn",
+        entities=[MessageEntity(type="bot_command", offset=0, length=6)],
+    )
+    learn_msg._bot = bot
+    await app.process_update(Update(update_id=1, message=learn_msg))
+
+    cb_message = Message(message_id=2, date=datetime.now(), chat=chat, from_user=user)
+    cb_message._bot = bot
+    callback = CallbackQuery(
+        id="1",
+        from_user=user,
+        chat_instance="1",
+        data="lesson:xe_basics",
+        message=cb_message,
+    )
+    callback._bot = bot
+    await app.process_update(Update(update_id=2, callback_query=callback))
+
+    ans_msg = Message(message_id=3, date=datetime.now(), chat=chat, from_user=user, text="42")
+    ans_msg._bot = bot
+    await app.process_update(Update(update_id=3, message=ans_msg))
+
+    assert bot.sent == ["Выберите тему:", "step1", "feedback", "step2"]
+
+    await app.shutdown()

--- a/tests/learning/test_prompts.py
+++ b/tests/learning/test_prompts.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from services.api.app.diabetes.learning_prompts import (
+    build_system_prompt,
+    build_user_prompt_step,
+)
+
+
+def test_build_system_prompt_includes_profile() -> None:
+    profile = {
+        "diabetes_type": "1",
+        "therapyType": "pump",
+        "learning_level": "novice",
+        "carbUnits": "XE",
+        "age_group": "teen",
+    }
+    prompt = build_system_prompt(profile)
+    assert "тип диабета=1" in prompt
+    assert "терапия=pump" in prompt
+    assert "углеводы=XE" in prompt
+    assert "простым языком, дружелюбно" in prompt
+
+
+def test_build_user_prompt_step_contains_goal_and_instruction() -> None:
+    long_summary = "prev" * 200
+    prompt = build_user_prompt_step("xe_basics", 2, long_summary)
+    assert "xe_basics" in prompt
+    assert "Номер шага: 2" in prompt
+    assert prompt.endswith("Ответ не показывай.")
+    assert len(prompt) <= 1_500


### PR DESCRIPTION
## Summary
- test system/user prompt builders
- test dynamic tutor step-answer-feedback
- exercise learning handlers flow via Telegram Application
- avoid extraneous ApplicationHandlerStop
- expose run_db helper in legacy API

## Testing
- `pytest -q`
- `mypy --strict services/api/app/legacy.py tests/learning/test_prompts.py tests/learning/test_dynamic_tutor.py tests/learning/test_handlers.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc21ff346c832aa39661300e0087ef