### PR TITLE
[profile] fix profile load effect deps

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -454,7 +454,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     return () => {
       cancelled = true;
     };
-  }, [user, initData, toast, t]); // при желании можно сузить зависимости до [user, initData]
+  }, [user, initData]);
 
   const handleInputChange = (field: keyof ProfileForm, value: string) => {
     setFieldErrors((prev) => ({ ...prev, [field]: undefined }));


### PR DESCRIPTION
## Summary
- ensure profile load effect depends only on user and initData
- keep saveProfile before patchProfileMutation

## Testing
- `pytest -q` (fails: No module named 'trio'; async tests require plugin)
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui test`


------
https://chatgpt.com/codex/tasks/task_e_68bc25672240832aba065e0f94482a93