### PR TITLE
billing: implement dummy checkout and webapp auth

### DIFF
--- a/services/api/app/diabetes/handlers/billing_handlers.py
+++ b/services/api/app/diabetes/handlers/billing_handlers.py
@@ -46,12 +46,39 @@ async def trial_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             user.id,
             exc.response.status_code,
         )
-        await message.reply_text("❌ Не удалось активировать пробный период. Попробуйте позже.")
+        if exc.response.status_code == 409:
+            end_dt: datetime | None = None
+            try:
+                status_url = f"{base.rstrip('/')}/billing/status"
+                async with httpx.AsyncClient() as client:
+                    stat = await client.get(
+                        status_url, params={"user_id": user.id}, timeout=10.0
+                    )
+                    stat.raise_for_status()
+                    payload: dict[str, object] = stat.json()
+                    sub = payload.get("subscription")
+                    if isinstance(sub, dict):
+                        end_raw = sub.get("endDate")
+                        if isinstance(end_raw, str):
+                            end_dt = datetime.fromisoformat(end_raw)
+            except Exception:  # pragma: no cover - best effort
+                pass
+            if end_dt is not None:
+                end_str = end_dt.strftime("%d.%m.%Y")
+                await message.reply_text(
+                    f"🎁 Пробный период уже активен до {end_str}"
+                )
+            else:
+                await message.reply_text("🎁 Пробный период уже активен")
+            return
+        await message.reply_text(
+            "❌ Не удалось активировать trial. Попробуйте позже."
+        )
         return
     except httpx.HTTPError:
         logger.exception("failed to start trial")
         logger.info("billing_action=user_id:%s action=trial result=error", user.id)
-        await message.reply_text("❌ Не удалось активировать пробный период. Попробуйте позже.")
+        await message.reply_text("❌ Не удалось активировать trial. Попробуйте позже.")
         return
 
     try:
@@ -67,7 +94,7 @@ async def trial_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         await message.reply_text("❌ Ошибка сервера.")
         return
     end_str = end_dt.strftime("%d.%m.%Y")
-    await message.reply_text(f"🎉 Пробный период активирован до {end_str}")
+    await message.reply_text(f"🎉 Активирован trial до {end_str}")
     logger.info("billing_action=user_id:%s action=trial result=ok", user.id)
 
 

--- a/services/api/app/routers/onboarding.py
+++ b/services/api/app/routers/onboarding.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 from ..schemas.user import UserContext
-from ..telegram_auth import require_tg_user
+from ..telegram_auth import check_token
 from ..services.onboarding_events import log_onboarding_event
 from ..diabetes.services.db import (
     Profile,
@@ -33,7 +33,7 @@ class EventPayload(BaseModel):
 
 
 @router.post("/events")
-async def post_event(payload: EventPayload, user: UserContext = Depends(require_tg_user)) -> dict[str, bool]:
+async def post_event(payload: EventPayload, user: UserContext = Depends(check_token)) -> dict[str, bool]:
     variant = None
     if payload.meta and isinstance(payload.meta.get("variant"), str):
         variant = payload.meta["variant"]
@@ -53,7 +53,7 @@ class StatusResponse(BaseModel):
 
 
 @router.get("/status", response_model=StatusResponse)
-async def get_status(user: UserContext = Depends(require_tg_user)) -> StatusResponse:
+async def get_status(user: UserContext = Depends(check_token)) -> StatusResponse:
     user_id = user["id"]
 
     def _load(session: Session) -> tuple[Profile | None, int, OnboardingEvent | None]:

--- a/services/api/app/schemas/billing.py
+++ b/services/api/app/schemas/billing.py
@@ -23,6 +23,12 @@ class CheckoutSchema(BaseModel):
     url: str
 
 
+class DummyCheckoutSchema(BaseModel):
+    """Checkout information for the dummy billing provider."""
+
+    checkout_id: str = Field(alias="checkout_id")
+
+
 class WebhookEvent(BaseModel):
     """Webhook event payload from billing provider."""
 

--- a/services/webapp/ui/src/pages/Subscription.tsx
+++ b/services/webapp/ui/src/pages/Subscription.tsx
@@ -90,6 +90,15 @@ const Subscription = () => {
   const [billing, setBilling] = useState<BillingStatus | null>(null);
 
   useEffect(() => {
+    if (initData) {
+      const w = window as any;
+      w.Telegram = w.Telegram || {};
+      w.Telegram.WebApp = w.Telegram.WebApp || {};
+      w.Telegram.WebApp.initData = initData;
+    }
+  }, [initData]);
+
+  useEffect(() => {
     const telegramId = resolveTelegramId(user, initData);
     if (typeof telegramId !== 'number') return;
     getBillingStatus(String(telegramId))

--- a/tests/api/test_onboarding_events.py
+++ b/tests/api/test_onboarding_events.py
@@ -18,7 +18,7 @@ from services.api.app.diabetes.services.db import (
 )
 from services.api.app.models.onboarding_event import OnboardingEvent
 from services.api.app.routers import onboarding
-from services.api.app.telegram_auth import require_tg_user
+from services.api.app.telegram_auth import check_token
 
 T = TypeVar("T")
 
@@ -52,7 +52,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
 
     from services.api.app.main import app
 
-    app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
+    app.dependency_overrides[check_token] = lambda: {"id": 1}
     return TestClient(app)
 
 

--- a/tests/billing/test_billing_webhook.py
+++ b/tests/billing/test_billing_webhook.py
@@ -56,9 +56,11 @@ def make_client(
 
 
 def create_subscription(client: TestClient) -> str:
-    resp = client.post("/api/billing/subscribe", params={"user_id": 1, "plan": "pro"})
+    resp = client.post(
+        "/api/billing/subscribe", params={"user_id": 1, "plan": "pro"}
+    )
     assert resp.status_code == 200
-    return resp.json()["id"]
+    return resp.json()["checkout_id"]
 
 
 def _sign(secret: str, event_id: str, transaction_id: str) -> str:

--- a/tests/test_onboarding_api_auth.py
+++ b/tests/test_onboarding_api_auth.py
@@ -15,7 +15,6 @@ from services.api.app.main import app
 from services.api.app.routers import onboarding as onboarding_router
 from services.api.app.services import onboarding_state
 from services.api.app.services.onboarding_events import OnboardingEvent
-from services.api.app.telegram_auth import TG_INIT_DATA_HEADER
 from tests.test_telegram_auth import TOKEN, build_init_data
 
 
@@ -73,7 +72,7 @@ def test_post_event_header_user(monkeypatch: pytest.MonkeyPatch) -> None:
     add_user(session_local, user_id=42)
     client = make_client(monkeypatch, session_local)
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
-    headers = {TG_INIT_DATA_HEADER: build_init_data(user_id=42)}
+    headers = {"Authorization": f"tg {build_init_data(user_id=42)}"}
     with client:
         resp = client.post(
             "/api/onboarding/events", json={"event": "onboarding_started"}, headers=headers
@@ -90,7 +89,7 @@ def test_status_incomplete(monkeypatch: pytest.MonkeyPatch) -> None:
     add_user(session_local, user_id=1)
     client = make_client(monkeypatch, session_local)
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
-    headers = {TG_INIT_DATA_HEADER: build_init_data(user_id=1)}
+    headers = {"Authorization": f"tg {build_init_data(user_id=1)}"}
     with client:
         resp = client.get("/api/onboarding/status", headers=headers)
     assert resp.status_code == 200
@@ -136,7 +135,7 @@ def test_status_completed(monkeypatch: pytest.MonkeyPatch) -> None:
         session.commit()
     client = make_client(monkeypatch, session_local)
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
-    headers = {TG_INIT_DATA_HEADER: build_init_data(user_id=1)}
+    headers = {"Authorization": f"tg {build_init_data(user_id=1)}"}
     with client:
         resp = client.get("/api/onboarding/status", headers=headers)
     assert resp.status_code == 200

--- a/tests/test_onboarding_router.py
+++ b/tests/test_onboarding_router.py
@@ -12,7 +12,7 @@ import services.api.app.routers.onboarding as onboarding_router
 import services.api.app.services.onboarding_events as onboarding_events
 from services.api.app.diabetes.services.db import Base, Profile, Reminder, User
 from services.api.app.models.onboarding_event import OnboardingEvent
-from services.api.app.telegram_auth import require_tg_user
+from services.api.app.telegram_auth import check_token
 from services.api.app.main import app
 
 
@@ -37,7 +37,7 @@ def make_client(monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Ses
     monkeypatch.setattr(onboarding_events, "run_db", run_db, raising=False)
     monkeypatch.setattr(onboarding_events, "SessionLocal", session_local, raising=False)
 
-    app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
+    app.dependency_overrides[check_token] = lambda: {"id": 1}
     return TestClient(app)
 
 


### PR DESCRIPTION
## Summary
- support dummy billing provider checkout with `checkout_id`
- improve trial command messaging for active trials
- authenticate onboarding routes via Telegram init data

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/billing/test_billing_subscribe.py::test_subscribe_dummy_provider -q` *(fails: Coverage failure: total of 22 is less than fail-under=85)*
- `pnpm --dir services/webapp/ui test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc25d308c8832ab35d70d6c475aa64