### PR TITLE
[learning] add persistent learn menu

### DIFF
--- a/services/api/app/ui/keyboard.py
+++ b/services/api/app/ui/keyboard.py
@@ -1,0 +1,16 @@
+from telegram import ReplyKeyboardMarkup, KeyboardButton
+
+LEARN_BUTTON_TEXT = "🎓 Обучение"
+
+
+def build_main_keyboard() -> ReplyKeyboardMarkup:
+    return ReplyKeyboardMarkup(
+        keyboard=[[KeyboardButton(LEARN_BUTTON_TEXT)]],
+        resize_keyboard=True,
+        is_persistent=True,
+        one_time_keyboard=False,
+        input_field_placeholder="Выберите действие…",
+    )
+
+
+__all__ = ["LEARN_BUTTON_TEXT", "build_main_keyboard"]

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -82,6 +82,17 @@ def test_register_handlers_attaches_expected_handlers(
     assert billing_handlers.subscription_button in callbacks
     assert any(
         isinstance(h, CommandHandler)
+        and h.callback is learning_handlers.cmd_menu
+        and "menu" in h.commands
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, MessageHandler)
+        and h.callback is learning_handlers.on_learn_button
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CommandHandler)
         and h.callback is learning_handlers.lesson_command
         and "lesson" in h.commands
         for h in handlers


### PR DESCRIPTION
## Summary
- add reusable `build_main_keyboard` with 🎓 Обучение button
- handle `/menu` and persistent learn button in learning handlers
- register learn menu handlers and set bot commands

## Testing
- `pytest -q --cov`
- `mypy --strict services/api/app/diabetes/handlers/learning_handlers.py services/api/app/diabetes/handlers/registration.py services/api/app/ui/keyboard.py tests/test_learn_command.py tests/test_register_handlers.py`
- `ruff check services/api/app/diabetes/handlers/learning_handlers.py services/api/app/diabetes/handlers/registration.py services/api/app/ui/keyboard.py tests/test_learn_command.py tests/test_register_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc2f964354832aa2ca7f3f80bd00e4