### PR TITLE
[profile] Fallback to local profile on stale data

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -10,6 +10,7 @@ from typing import cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import sqlalchemy as sa
+from fastapi import HTTPException
 from sqlalchemy.orm import Session, selectinload
 from telegram import (
     InlineKeyboardButton,
@@ -85,13 +86,16 @@ from .validation import (  # noqa: E402
 )
 
 from .formatters import profile_view_formatter  # noqa: E402
+from services.api.app.services import profile as profile_service  # noqa: E402
 
 back_keyboard: ReplyKeyboardMarkup = _back_keyboard
 
 from .. import UserData  # noqa: E402
 
 
-PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(6)
+PROFILE_ICR, PROFILE_CF, PROFILE_TARGET, PROFILE_LOW, PROFILE_HIGH, PROFILE_TZ = range(
+    6
+)
 END: int = ConversationHandler.END
 
 
@@ -120,9 +124,21 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         if callable(end_conv):
             end_conv(update, context, END)
         else:
-            chat_id = getattr(update.effective_chat, "id", None) if sugar_conv.per_chat else None
-            user_id = getattr(update.effective_user, "id", None) if sugar_conv.per_user else None
-            msg_id = getattr(update.effective_message, "message_id", None) if sugar_conv.per_message else None
+            chat_id = (
+                getattr(update.effective_chat, "id", None)
+                if sugar_conv.per_chat
+                else None
+            )
+            user_id = (
+                getattr(update.effective_user, "id", None)
+                if sugar_conv.per_user
+                else None
+            )
+            msg_id = (
+                getattr(update.effective_message, "message_id", None)
+                if sugar_conv.per_message
+                else None
+            )
             key = cast(
                 tuple[int | str, ...],
                 tuple(i for i in (chat_id, user_id, msg_id) if i is not None),
@@ -132,9 +148,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             else:
                 logger.warning("sugar_conv lacks _update_state method")
 
-    help_text = (
-        "Настройки профиля доступны в приложении. Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
-    )
+    help_text = "Настройки профиля доступны в приложении. Нажмите кнопку в сообщении /profile, чтобы открыть и обновить данные."
 
     if len(args) == 1 and args[0].lower() == "help":
         await message.reply_text(help_text, parse_mode="Markdown")
@@ -153,7 +167,9 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         icr, cf, target, low, high = parse_profile_values(values)
     except ValueError as exc:
         await message.reply_text(
-            exc.args[0] if exc.args else "❗ Пожалуйста, введите корректные числа. Справка: /profile help"
+            exc.args[0]
+            if exc.args
+            else "❗ Пожалуйста, введите корректные числа. Справка: /profile help"
         )
         return END
 
@@ -232,6 +248,34 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     api, ApiException, _ = get_api()
     user_id = user.id
     profile = fetch_profile(api, ApiException, user_id)
+    if profile is None or any(
+        getattr(profile, field, None) is None for field in ("target", "low", "high")
+    ):
+        try:
+            profile_service.db.SessionLocal = SessionLocal
+            profile = await profile_service.get_profile(user_id)
+        except HTTPException as exc:
+            if exc.status_code != 404:
+                logger.exception("failed to fetch profile from DB for %s", user_id)
+                await message.reply_text(
+                    "⚠️ Не удалось загрузить профиль из локальной базы.",
+                    reply_markup=menu_keyboard(),
+                )
+                return
+            profile = None
+        except RuntimeError:
+            profile = None
+        except Exception:
+            logger.exception("failed to fetch profile from DB for %s", user_id)
+            await message.reply_text(
+                "⚠️ Не удалось загрузить профиль из локальной базы.",
+                reply_markup=menu_keyboard(),
+            )
+            return
+        if profile is not None:
+            setattr(profile, "target", getattr(profile, "target_bg", None))
+            setattr(profile, "low", getattr(profile, "low_threshold", None))
+            setattr(profile, "high", getattr(profile, "high_threshold", None))
 
     settings = config.get_settings()
     webapp_button: list[InlineKeyboardButton] | None = None
@@ -290,7 +334,9 @@ async def profile_webapp_save(
     try:
         icr, cf, target, low, high = parse_profile_values(data)
     except ValueError as exc:
-        await eff_msg.reply_text(exc.args[0] if exc.args else error_msg, reply_markup=menu_keyboard())
+        await eff_msg.reply_text(
+            exc.args[0] if exc.args else error_msg, reply_markup=menu_keyboard()
+        )
         return
     user = update.effective_user
     if user is None:
@@ -384,7 +430,9 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     button = build_timezone_webapp_button()
     if button:
         keyboard = InlineKeyboardMarkup([[button]])
-        await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
+        await message.reply_text(
+            "Можно определить автоматически:", reply_markup=keyboard
+        )
     else:
         await message.reply_text(
             "Автоматическое определение недоступно, укажите часовой пояс вручную.",
@@ -393,7 +441,9 @@ async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     return PROFILE_TZ
 
 
-async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def profile_timezone_save(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     """Save user timezone from input."""
     message = update.message
     if message is None:
@@ -418,7 +468,9 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
         button = build_timezone_webapp_button()
         if button:
             keyboard = InlineKeyboardMarkup([[button]])
-            await message.reply_text("Можно определить автоматически:", reply_markup=keyboard)
+            await message.reply_text(
+                "Можно определить автоматически:", reply_markup=keyboard
+            )
         else:
             await message.reply_text(
                 "Автоматическое определение недоступно, введите часовой пояс вручную.",
@@ -481,7 +533,9 @@ async def profile_timezone_save(update: Update, context: ContextTypes.DEFAULT_TY
     return END
 
 
-def _security_db(session: Session, user_id: int, action: str | None) -> dict[str, object]:
+def _security_db(
+    session: Session, user_id: int, action: str | None
+) -> dict[str, object]:
     profile = session.get(Profile, user_id)
     user = session.get(User, user_id)
     if not profile:
@@ -518,13 +572,19 @@ def _security_db(session: Session, user_id: int, action: str | None) -> dict[str
     if changed:
         try:
             commit(session)
-            alert = session.scalars(sa.select(Alert).filter_by(user_id=user_id).order_by(Alert.ts.desc())).first()
+            alert = session.scalars(
+                sa.select(Alert).filter_by(user_id=user_id).order_by(Alert.ts.desc())
+            ).first()
             alert_sugar = alert.sugar if alert else None
         except CommitError:
             commit_ok = False
 
     rems = session.scalars(sa.select(Reminder).filter_by(telegram_id=user_id)).all()
-    rem_text = "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems) if rems else "нет"
+    rem_text = (
+        "\n".join(f"{r.id}. {reminder_handlers._describe(r, user)}" for r in rems)
+        if rems
+        else "нет"
+    )
     return {
         "found": True,
         "commit_ok": commit_ok,
@@ -609,12 +669,20 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     keyboard = InlineKeyboardMarkup(
         [
             [
-                InlineKeyboardButton("Низкий -0.5", callback_data="profile_security:low_dec"),
-                InlineKeyboardButton("Низкий +0.5", callback_data="profile_security:low_inc"),
+                InlineKeyboardButton(
+                    "Низкий -0.5", callback_data="profile_security:low_dec"
+                ),
+                InlineKeyboardButton(
+                    "Низкий +0.5", callback_data="profile_security:low_inc"
+                ),
             ],
             [
-                InlineKeyboardButton("Высокий -0.5", callback_data="profile_security:high_dec"),
-                InlineKeyboardButton("Высокий +0.5", callback_data="profile_security:high_inc"),
+                InlineKeyboardButton(
+                    "Высокий -0.5", callback_data="profile_security:high_dec"
+                ),
+                InlineKeyboardButton(
+                    "Высокий +0.5", callback_data="profile_security:high_inc"
+                ),
             ],
             [
                 InlineKeyboardButton(
@@ -622,9 +690,15 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                     callback_data="profile_security:toggle_sos",
                 )
             ],
-            [InlineKeyboardButton("SOS контакт", callback_data="profile_security:sos_contact")],
             [
-                InlineKeyboardButton("➕ Добавить", callback_data="profile_security:add"),
+                InlineKeyboardButton(
+                    "SOS контакт", callback_data="profile_security:sos_contact"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    "➕ Добавить", callback_data="profile_security:add"
+                ),
                 InlineKeyboardButton("🗑 Удалить", callback_data="profile_security:del"),
             ],
             [InlineKeyboardButton("🔙 Назад", callback_data="profile_back")],
@@ -721,7 +795,9 @@ async def profile_target(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     try:
         target = float(text)
     except ValueError:
-        await message.reply_text("Введите целевой сахар числом.", reply_markup=back_keyboard)
+        await message.reply_text(
+            "Введите целевой сахар числом.", reply_markup=back_keyboard
+        )
         return PROFILE_TARGET
     if target <= 0:
         await message.reply_text(MSG_TARGET_GT0, reply_markup=back_keyboard)
@@ -751,7 +827,9 @@ async def profile_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     try:
         low = float(text)
     except ValueError:
-        await message.reply_text("Введите нижний порог числом.", reply_markup=back_keyboard)
+        await message.reply_text(
+            "Введите нижний порог числом.", reply_markup=back_keyboard
+        )
         return PROFILE_LOW
     if low <= 0:
         await message.reply_text(MSG_LOW_GT0, reply_markup=back_keyboard)
@@ -781,14 +859,18 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     try:
         high = float(text)
     except ValueError:
-        await message.reply_text("Введите верхний порог числом.", reply_markup=back_keyboard)
+        await message.reply_text(
+            "Введите верхний порог числом.", reply_markup=back_keyboard
+        )
         return PROFILE_HIGH
     icr = user_data.get("profile_icr")
     cf = user_data.get("profile_cf")
     target = user_data.get("profile_target")
     low = user_data.get("profile_low")
     if None in (icr, cf, target, low):
-        await message.reply_text("⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново.")
+        await message.reply_text(
+            "⚠️ Не хватает данных для сохранения профиля. Пожалуйста, начните заново."
+        )
         return END
     error = validate_profile_numbers(icr, cf, target, low, high)
     if error:
@@ -860,11 +942,15 @@ async def _photo_fallback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     return END
 
 
-async def _profile_edit_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def _profile_edit_entry(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     return await profile_edit(update, context)
 
 
-async def _profile_timezone_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def _profile_timezone_entry(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
     return await profile_timezone(update, context)
 
 
@@ -872,12 +958,16 @@ profile_conv = ConversationHandler(
     entry_points=[
         CommandHandler("profile", profile_command),
         CallbackQueryNoWarnHandler(_profile_edit_entry, pattern="^profile_edit$"),
-        CallbackQueryNoWarnHandler(_profile_timezone_entry, pattern="^profile_timezone$"),
+        CallbackQueryNoWarnHandler(
+            _profile_timezone_entry, pattern="^profile_timezone$"
+        ),
     ],
     states={
         PROFILE_ICR: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_icr)],
         PROFILE_CF: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_cf)],
-        PROFILE_TARGET: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)],
+        PROFILE_TARGET: [
+            MessageHandler(filters.TEXT & ~filters.COMMAND, profile_target)
+        ],
         PROFILE_LOW: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_low)],
         PROFILE_HIGH: [MessageHandler(filters.TEXT & ~filters.COMMAND, profile_high)],
         PROFILE_TZ: [
@@ -899,7 +989,9 @@ profile_conv = ConversationHandler(
 )
 
 
-profile_webapp_handler = MessageHandler(filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save)
+profile_webapp_handler = MessageHandler(
+    filters.StatusUpdate.WEB_APP_DATA, profile_webapp_save
+)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- fallback to local DB profile when API returns nothing or outdated data
- handle DB read errors with clear user message
- test: ensure profile_view uses locally saved profile when API data stale and adjust existing handler test

## Testing
- `ruff check services/api/app/diabetes/handlers/profile/conversation.py tests/test_profile_webapp_save_flow.py tests/test_handlers_profile.py`
- `mypy --strict services/api/app/diabetes/handlers/profile/conversation.py tests/test_profile_webapp_save_flow.py tests/test_handlers_profile.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc44cd4424832a9772af4658f2e6db