### PR TITLE
[ui] extend main keyboard with learning button

### DIFF
--- a/services/api/app/ui/keyboard.py
+++ b/services/api/app/ui/keyboard.py
@@ -1,15 +1,21 @@
 from telegram import ReplyKeyboardMarkup, KeyboardButton
 
+from services.api.app.diabetes.utils.ui import menu_keyboard
+
 LEARN_BUTTON_TEXT = "🎓 Обучение"
 
 
 def build_main_keyboard() -> ReplyKeyboardMarkup:
+    """Build main menu keyboard with an extra learning button."""
+    menu = menu_keyboard()
+    layout = [row[:] for row in menu.keyboard]
+    layout.append((KeyboardButton(LEARN_BUTTON_TEXT),))
     return ReplyKeyboardMarkup(
-        keyboard=[[KeyboardButton(LEARN_BUTTON_TEXT)]],
+        keyboard=layout,
         resize_keyboard=True,
         is_persistent=True,
         one_time_keyboard=False,
-        input_field_placeholder="Выберите действие…",
+        input_field_placeholder=menu.input_field_placeholder,
     )
 
 

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -9,14 +9,15 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
-from telegram import Update
+from telegram import Update, KeyboardButton
 from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.learning_handlers as handlers
 from services.api.app.config import Settings
 from services.api.app.diabetes.learning_fixtures import load_lessons
 from services.api.app.diabetes.services import db
-from services.api.app.ui.keyboard import build_main_keyboard
+from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
 
 
 class DummyMessage:
@@ -140,7 +141,9 @@ async def test_cmd_menu_shows_keyboard() -> None:
     assert message.replies == ["Главное меню:"]
     keyboard = message.kwargs[0].get("reply_markup")
     assert keyboard is not None
-    assert keyboard.keyboard == build_main_keyboard().keyboard
+    expected_layout = list(menu_keyboard().keyboard)
+    expected_layout.append((KeyboardButton(LEARN_BUTTON_TEXT),))
+    assert list(keyboard.keyboard) == expected_layout
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- build main keyboard from existing menu and add learning button
- update menu command test to expect learning option appended

## Testing
- `pytest tests/test_learn_command.py::test_cmd_menu_shows_keyboard -q --override-ini="addopts="`
- `mypy --strict .`
- `ruff check .`
- `pytest -q --cov` *(fails: Required test coverage of 85% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4e3ac484832a9f728ce65013ea30