### PR TITLE
[handlers] Validate learning onboarding confirmation

### DIFF
--- a/services/api/app/diabetes/handlers/learning_onboarding.py
+++ b/services/api/app/diabetes/handlers/learning_onboarding.py
@@ -14,7 +14,7 @@ from telegram.ext import (
     filters,
 )
 
-from ..learning_onboarding import learn_reset
+from ..learning_onboarding import ONBOARDING_PROMPT, learn_reset
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,10 @@ async def onboarding_reply(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         return
     user_data = cast(dict[str, object], context.user_data)
     if not user_data.get("learning_waiting"):
+        return
+    text = (message.text or "").strip().lower()
+    if text != "да":
+        await message.reply_text(ONBOARDING_PROMPT)
         return
     user_data.pop("learning_waiting", None)
     user_data["learning_onboarded"] = True

--- a/tests/diabetes/test_learning_onboarding.py
+++ b/tests/diabetes/test_learning_onboarding.py
@@ -92,3 +92,23 @@ async def test_learning_onboarding_flow(
     finally:
         engine.dispose()
 
+
+@pytest.mark.asyncio
+async def test_onboarding_reply_requires_yes() -> None:
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={"learning_waiting": True}),
+    )
+    message1 = DummyMessage("нет")
+    update1 = cast(Update, SimpleNamespace(message=message1, effective_user=None))
+    await learning_onboarding.onboarding_reply(update1, context)
+    assert message1.replies == [onboarding_utils.ONBOARDING_PROMPT]
+    assert context.user_data.get("learning_onboarded") is None
+    assert context.user_data.get("learning_waiting") is True
+
+    message2 = DummyMessage("Да")
+    update2 = cast(Update, SimpleNamespace(message=message2, effective_user=None))
+    await learning_onboarding.onboarding_reply(update2, context)
+    assert context.user_data.get("learning_onboarded") is True
+    assert "learning_waiting" not in context.user_data
+


### PR DESCRIPTION
## Summary
- require explicit "да" to complete learning onboarding
- re-prompt on other answers and keep waiting
- test onboarding reply validation

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc501dc940832ab5560e5393ba24db