### PR TITLE
[billing] Add inline upgrade button and update menu

### DIFF
--- a/services/api/app/diabetes/handlers/billing_handlers.py
+++ b/services/api/app/diabetes/handlers/billing_handlers.py
@@ -4,7 +4,12 @@ import logging
 from datetime import datetime
 
 import httpx
-from telegram import KeyboardButton, Message, ReplyKeyboardMarkup, Update, WebAppInfo
+from telegram import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Message,
+    Update,
+)
 from telegram.ext import ContextTypes
 
 from ... import config
@@ -32,10 +37,10 @@ async def trial_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         await message.reply_text("❌ Не настроен API_URL")
         logger.info("billing_action=user_id:%s action=trial result=no_api_url", user.id)
         return
-    url = f"{base.rstrip('/')}/billing/trial"
+    trial_url = f"{base.rstrip('/')}/billing/trial"
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.post(url, params={"user_id": user.id}, timeout=10.0)
+            resp = await client.post(trial_url, params={"user_id": user.id}, timeout=10.0)
             resp.raise_for_status()
             data = resp.json()
     except httpx.HTTPStatusError as exc:
@@ -95,11 +100,24 @@ async def trial_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         return
     end_str = end_dt.strftime("%d.%m.%Y")
     await message.reply_text(f"🎉 Активирован trial до {end_str}")
+    sub_url = config.get_settings().subscription_url
+    if sub_url:
+        text = (
+            "🟢 Подписка PRO даёт расширенные функции:\n"
+            "• Распознавание блюд по фото\n"
+            "• Чат с GPT\n"
+            "• Расширенные напоминания\n\n"
+            "👉 Чтобы оформить подписку, нажмите кнопку ниже:"
+        )
+        kb = InlineKeyboardMarkup(
+            [[InlineKeyboardButton("Оформить PRO", url=sub_url)]]
+        )
+        await message.reply_text(text, reply_markup=kb)
     logger.info("billing_action=user_id:%s action=trial result=ok", user.id)
 
 
 async def upgrade_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Send a link to the subscription page."""
+    """Send information about PRO subscription with upgrade link."""
 
     message = update.message
     if message is None:
@@ -112,9 +130,15 @@ async def upgrade_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             update.effective_user.id if update.effective_user else "?",
         )
         return
-    button = KeyboardButton("💳 Оформить PRO", web_app=WebAppInfo(url))
-    kb = ReplyKeyboardMarkup([[button]], resize_keyboard=True, one_time_keyboard=True)
-    await message.reply_text("💳 Оформить PRO", reply_markup=kb)
+    text = (
+        "🟢 Подписка PRO даёт расширенные функции:\n"
+        "• Распознавание блюд по фото\n"
+        "• Чат с GPT\n"
+        "• Расширенные напоминания\n\n"
+        "👉 Чтобы оформить подписку, нажмите кнопку ниже:"
+    )
+    kb = InlineKeyboardMarkup([[InlineKeyboardButton("Оформить PRO", url=url)]])
+    await message.reply_text(text, reply_markup=kb)
     if update.effective_user:
         logger.info(
             "billing_action=user_id:%s action=upgrade result=ok",

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -62,7 +62,7 @@ def menu_keyboard() -> ReplyKeyboardMarkup:
             [KeyboardButton(PHOTO_BUTTON_TEXT), KeyboardButton(SUGAR_BUTTON_TEXT)],
             [KeyboardButton(DOSE_BUTTON_TEXT), KeyboardButton(REPORT_BUTTON_TEXT)],
             [KeyboardButton(QUICK_INPUT_BUTTON_TEXT), KeyboardButton(HELP_BUTTON_TEXT)],
-            [KeyboardButton(SUBSCRIPTION_BUTTON_TEXT), KeyboardButton(SOS_BUTTON_TEXT)],
+            [KeyboardButton(SOS_BUTTON_TEXT)],
         ],
         resize_keyboard=True,
         one_time_keyboard=False,

--- a/tests/test_billing_commands.py
+++ b/tests/test_billing_commands.py
@@ -23,6 +23,7 @@ class DummyMessage:
 @pytest.mark.asyncio
 async def test_trial_command_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("API_URL", "http://api.test/api")
+    monkeypatch.setenv("SUBSCRIPTION_URL", "https://pay.example/sub")
     config.reload_settings()
 
     end_date = "2025-01-15T00:00:00+00:00"
@@ -58,8 +59,22 @@ async def test_trial_command_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await billing_handlers.trial_command(update, context)
 
-    assert message.texts == ["🎉 Активирован trial до 15.01.2025"]
+    assert message.texts == [
+        "🎉 Активирован trial до 15.01.2025",
+        (
+            "🟢 Подписка PRO даёт расширенные функции:\n"
+            "• Распознавание блюд по фото\n"
+            "• Чат с GPT\n"
+            "• Расширенные напоминания\n\n"
+            "👉 Чтобы оформить подписку, нажмите кнопку ниже:"
+        ),
+    ]
+    markup = message.markups[1]
+    button = markup.inline_keyboard[0][0]
+    assert button.text == "Оформить PRO"
+    assert button.url == "https://pay.example/sub"
     monkeypatch.delenv("API_URL")
+    monkeypatch.delenv("SUBSCRIPTION_URL")
     config.reload_settings()
 
 
@@ -203,11 +218,19 @@ async def test_upgrade_command(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await billing_handlers.upgrade_command(update, context)
 
-    assert message.texts == ["💳 Оформить PRO"]
+    assert message.texts == [
+        (
+            "🟢 Подписка PRO даёт расширенные функции:\n"
+            "• Распознавание блюд по фото\n"
+            "• Чат с GPT\n"
+            "• Расширенные напоминания\n\n"
+            "👉 Чтобы оформить подписку, нажмите кнопку ниже:"
+        )
+    ]
     markup = message.markups[0]
-    button = markup.keyboard[0][0]
-    assert button.text == "💳 Оформить PRO"
-    assert button.web_app and button.web_app.url == "https://pay.example/sub"
+    button = markup.inline_keyboard[0][0]
+    assert button.text == "Оформить PRO"
+    assert button.url == "https://pay.example/sub"
     monkeypatch.delenv("SUBSCRIPTION_URL")
     config.reload_settings()
 

--- a/tests/test_menu_keyboard.py
+++ b/tests/test_menu_keyboard.py
@@ -7,5 +7,5 @@ def test_menu_keyboard_layout() -> None:
         [ui.PHOTO_BUTTON_TEXT, ui.SUGAR_BUTTON_TEXT],
         [ui.DOSE_BUTTON_TEXT, ui.REPORT_BUTTON_TEXT],
         [ui.QUICK_INPUT_BUTTON_TEXT, ui.HELP_BUTTON_TEXT],
-        [ui.SUBSCRIPTION_BUTTON_TEXT, ui.SOS_BUTTON_TEXT],
+        [ui.SOS_BUTTON_TEXT],
     ]

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -8,5 +8,5 @@ def test_menu_keyboard_webapp_layout() -> None:
         [ui.PHOTO_BUTTON_TEXT, ui.SUGAR_BUTTON_TEXT],
         [ui.DOSE_BUTTON_TEXT, ui.REPORT_BUTTON_TEXT],
         [ui.QUICK_INPUT_BUTTON_TEXT, ui.HELP_BUTTON_TEXT],
-        [ui.SUBSCRIPTION_BUTTON_TEXT, ui.SOS_BUTTON_TEXT],
+        [ui.SOS_BUTTON_TEXT],
     ]


### PR DESCRIPTION
## Summary
- drop subscription button from main menu
- show inline "Оформить PRO" button for `/upgrade` and after activating `/trial`

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc5979f9fc832a8eecb8e16aae661f