### PR TITLE
[learning] Support dynamic curriculum engine

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import AliasChoices, Field, field_validator
 
@@ -62,6 +62,10 @@ class Settings(BaseSettings):
         default=True,
         alias="LEARNING_MODE_ENABLED",
         validation_alias=AliasChoices("LEARNING_MODE_ENABLED", "LEARNING_ENABLED"),
+    )
+    learning_content_mode: Literal["static", "dynamic"] = Field(
+        default="static",
+        alias="LEARNING_CONTENT_MODE",
     )
     learning_model_default: str = Field(default="gpt-4o-mini", alias="LEARNING_MODEL_DEFAULT")
     learning_prompt_cache: bool = Field(default=True, alias="LEARNING_PROMPT_CACHE")


### PR DESCRIPTION
## Summary
- add `learning_content_mode` setting for static or dynamic lessons
- extend curriculum engine with dynamic step generation and answer checking
- test dynamic curriculum flow via start/next/check/next sequence

## Testing
- `pytest tests/learning/test_curriculum_engine.py -q` *(fails: Coverage failure: total of 26 is less than fail-under=85)*
- `mypy --strict services/api/app/diabetes/curriculum_engine.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc5b77cb54832a83dd59c940a86895