### PR TITLE
[tests] Add dynamic tutor fallback and format reply length tests

### DIFF
--- a/tests/learning/test_dynamic_tutor.py
+++ b/tests/learning/test_dynamic_tutor.py
@@ -29,3 +29,22 @@ async def test_step_answer_feedback(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert step == "step1"
     assert feedback == "feedback"
+
+
+@pytest.mark.asyncio
+async def test_runtimeerror_returns_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def raise_runtime_error(**kwargs: object) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        dynamic_tutor, "create_chat_completion", raise_runtime_error
+    )
+    monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
+
+    step = await dynamic_tutor.generate_step_text({}, "topic", 1, None)
+    feedback = await dynamic_tutor.check_user_answer({}, "topic", "42", "step")
+
+    assert step == "сервер занят, попробуйте позже"
+    assert feedback == "сервер занят, попробуйте позже"

--- a/tests/test_format_reply.py
+++ b/tests/test_format_reply.py
@@ -5,3 +5,9 @@ def test_format_reply_truncates_and_splits() -> None:
     text = "one\n\n" + "x" * 900 + "\n\n\nthree"
     result = format_reply(text, max_len=10)
     assert result == "one\n\n" + "x" * 10 + "\n\nthree"
+
+
+def test_format_reply_truncates_to_default_limit() -> None:
+    text = "a" * 900 + "\n\n" + "b" * 1000
+    result = format_reply(text)
+    assert result == "a" * 800 + "\n\n" + "b" * 800


### PR DESCRIPTION
## Summary
- add dynamic tutor test verifying fallback message when OpenAI chat fails
- ensure `format_reply` truncates paragraphs at the default 800 character limit

## Testing
- `pytest -q --cov` *(fails: ModuleNotFoundError: No module named 'trio')*
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68bc5b7c4660832a9867677e1daf1179