### PR TITLE
[learning] respect learning mode flag

### DIFF
--- a/tests/diabetes/test_learning_handlers.py
+++ b/tests/diabetes/test_learning_handlers.py
@@ -1,27 +1,31 @@
-import json
-from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, sessionmaker
-from sqlalchemy.pool import StaticPool
 from telegram import Update
 from telegram.ext import CallbackContext
 
 from services.api.app.config import settings
-from services.api.app.diabetes.handlers import learning_handlers
-from services.api.app.diabetes.learning_fixtures import load_lessons
-from services.api.app.diabetes.services import db
+from services.api.app.diabetes import learning_handlers
 
 
 class DummyMessage:
-    def __init__(self) -> None:
+    def __init__(self, text: str | None = None) -> None:
         self.replies: list[str] = []
+        self.text = text
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - helper
         self.replies.append(text)
+
+
+class DummyCallback:
+    def __init__(self, message: DummyMessage, data: str = "lesson:slug") -> None:
+        self.message = message
+        self.data = data
+        self.answered = False
+
+    async def answer(self) -> None:  # pragma: no cover - helper
+        self.answered = True
 
 
 @pytest.mark.asyncio
@@ -34,43 +38,78 @@ async def test_learn_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(user_data={}),
     )
     await learning_handlers.learn_command(update, context)
-    assert message.replies == ["🚫 Обучение недоступно."]
-
-
-def setup_db() -> sessionmaker[Session]:
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SessionLocal = sessionmaker(bind=engine, class_=Session)
-    db.Base.metadata.create_all(bind=engine)
-    return SessionLocal
+    assert message.replies == ["режим обучения отключён"]
 
 
 @pytest.mark.asyncio
-async def test_learn_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setattr(settings, "learning_mode_enabled", True)
-    monkeypatch.setattr(settings, "learning_command_model", "super-model")
-    sample = [
-        {
-            "title": "Sample",
-            "steps": ["s1"],
-            "quiz": [
-                {"question": "q1", "options": ["1", "2", "3"], "answer": 1}
-            ],
-        }
-    ]
-    path = tmp_path / "lessons.json"
-    path.write_text(json.dumps(sample), encoding="utf-8")
-    SessionLocal = setup_db()
-    await load_lessons(path, sessionmaker=SessionLocal)
-    monkeypatch.setattr(learning_handlers, "SessionLocal", SessionLocal)
+async def test_lesson_command_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", False)
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message, effective_user=None))
+    update = cast(Update, SimpleNamespace(message=message))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={"learning_onboarded": True}),
+        SimpleNamespace(user_data={}, args=[]),
+    )
+    await learning_handlers.lesson_command(update, context)
+    assert message.replies == ["режим обучения отключён"]
+
+
+@pytest.mark.asyncio
+async def test_lesson_callback_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", False)
+    msg = DummyMessage()
+    query = DummyCallback(msg)
+    update = cast(Update, SimpleNamespace(callback_query=query))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
+    )
+    await learning_handlers.lesson_callback(update, context)
+    assert msg.replies == ["режим обучения отключён"]
+    assert query.answered is True
+
+
+@pytest.mark.asyncio
+async def test_lesson_answer_handler_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", False)
+    message = DummyMessage(text="ans")
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
+    )
+    await learning_handlers.lesson_answer_handler(update, context)
+    assert message.replies == ["режим обучения отключён"]
+
+
+@pytest.mark.asyncio
+async def test_exit_command_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", False)
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
+    )
+    await learning_handlers.exit_command(update, context)
+    assert message.replies == ["режим обучения отключён"]
+
+
+@pytest.mark.asyncio
+async def test_learn_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+
+    async def fake_ensure_overrides(*args: object, **kwargs: object) -> bool:
+        return True
+
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
     )
     await learning_handlers.learn_command(update, context)
-    assert "super-model" in message.replies[0]
+    assert message.replies[:2] == ["Выберите тему:", "Доступные темы:"]

--- a/tests/learning/test_handlers.py
+++ b/tests/learning/test_handlers.py
@@ -130,7 +130,9 @@ async def test_static_mode_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
         called.append((update, context))
 
     monkeypatch.setattr(
-        learning_handlers, "settings", SimpleNamespace(learning_content_mode="static")
+        learning_handlers,
+        "settings",
+        SimpleNamespace(learning_content_mode="static", learning_mode_enabled=True),
     )
     monkeypatch.setattr(learning_handlers.legacy_handlers, "learn_command", fake_learn_command)
 


### PR DESCRIPTION
## Summary
- skip learning handlers when learning_mode_enabled is disabled
- cover handler skips with new tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc5e117610832a901926caf13acb57