### PR TITLE
[learning] Add lesson logging

### DIFF
--- a/services/api/alembic/versions/20251004_lesson_logs.py
+++ b/services/api/alembic/versions/20251004_lesson_logs.py
@@ -1,0 +1,47 @@
+"""lesson logs table
+
+Revision ID: 20251004_lesson_logs
+Revises: 20251003_onboarding_event
+Create Date: 2025-10-04
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20251004_lesson_logs"
+down_revision: Union[str, Sequence[str], None] = "20251003_onboarding_event"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.create_table(
+        "lesson_logs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("telegram_id", sa.BigInteger(), sa.ForeignKey("users.telegram_id"), nullable=False),
+        sa.Column("topic_slug", sa.String(), nullable=False),
+        sa.Column("role", sa.String(), nullable=False),
+        sa.Column("step_idx", sa.Integer(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_lesson_logs_telegram_id", "lesson_logs", ["telegram_id"])
+    op.create_index("ix_lesson_logs_topic_slug", "lesson_logs", ["topic_slug"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.drop_index("ix_lesson_logs_topic_slug", table_name="lesson_logs")
+    op.drop_index("ix_lesson_logs_telegram_id", table_name="lesson_logs")
+    op.drop_table("lesson_logs")

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -63,10 +63,6 @@ class Settings(BaseSettings):
         alias="LEARNING_MODE_ENABLED",
         validation_alias=AliasChoices("LEARNING_MODE_ENABLED", "LEARNING_ENABLED"),
     )
-    learning_content_mode: Literal["static", "dynamic"] = Field(
-        default="static",
-        alias="LEARNING_CONTENT_MODE",
-    )
     learning_model_default: str = Field(default="gpt-4o-mini", alias="LEARNING_MODEL_DEFAULT")
     learning_prompt_cache: bool = Field(default=True, alias="LEARNING_PROMPT_CACHE")
     learning_content_mode: Literal["dynamic", "static"] = Field(

--- a/services/api/app/diabetes/handlers/learning_onboarding.py
+++ b/services/api/app/diabetes/handlers/learning_onboarding.py
@@ -16,6 +16,8 @@ from telegram.ext import (
 
 from ..learning_onboarding import ensure_overrides, learn_reset
 
+__all__ = ["onboarding_reply", "register_handlers", "learn_reset"]
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:

--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -15,6 +15,7 @@ from .dynamic_tutor import check_user_answer, generate_step_text
 from .learning_onboarding import ensure_overrides
 from .learning_state import LearnState, clear_state, get_state, set_state
 from .services.gpt_client import format_reply
+from .services.lesson_log import add_lesson_log
 
 logger = logging.getLogger(__name__)
 
@@ -77,9 +78,13 @@ async def _start_lesson(
 ) -> None:
     """Generate and send the first learning step."""
 
+    if message.from_user is None:
+        return
+    telegram_id = message.from_user.id
     text = await generate_step_text(profile, topic_slug, 1, None)
     text = format_reply(text)
     await message.reply_text(text)
+    await add_lesson_log(telegram_id, topic_slug, "assistant", 1, text)
     state = LearnState(
         topic=topic_slug,
         step=1,
@@ -142,7 +147,7 @@ async def lesson_answer_handler(
     """Process user's answer and move to the next step."""
 
     message = update.message
-    if message is None or not message.text:
+    if message is None or not message.text or message.from_user is None:
         return
     if settings.learning_content_mode == "static":
         await legacy_handlers.quiz_answer_handler(update, context)
@@ -155,16 +160,23 @@ async def lesson_answer_handler(
         await message.reply_text(RATE_LIMIT_MESSAGE)
         return
     profile = _get_profile(user_data)
+    telegram_id = message.from_user.id
+    user_text = message.text.strip()
+    await add_lesson_log(telegram_id, state.topic, "user", state.step, user_text)
     feedback = await check_user_answer(
-        profile, state.topic, message.text.strip(), state.last_step_text or ""
+        profile, state.topic, user_text, state.last_step_text or ""
     )
     feedback = format_reply(feedback)
     await message.reply_text(feedback)
+    await add_lesson_log(telegram_id, state.topic, "assistant", state.step, feedback)
     next_text = await generate_step_text(
         profile, state.topic, state.step + 1, feedback
     )
     next_text = format_reply(next_text)
     await message.reply_text(next_text)
+    await add_lesson_log(
+        telegram_id, state.topic, "assistant", state.step + 1, next_text
+    )
     state.step += 1
     state.last_step_text = next_text
     state.prev_summary = feedback

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from typing import Optional, Sequence
+from datetime import datetime
 
 import sqlalchemy as sa
-from sqlalchemy import BigInteger, Boolean, ForeignKey, Integer, String, Text
+from sqlalchemy import BigInteger, Boolean, ForeignKey, Integer, String, Text, TIMESTAMP
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -92,3 +93,21 @@ class LessonProgress(Base):
 
     user: Mapped[User] = relationship("User")
     lesson: Mapped[Lesson] = relationship("Lesson", back_populates="progresses")
+
+
+class LessonLog(Base):
+    __tablename__ = "lesson_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    telegram_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True
+    )
+    topic_slug: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    role: Mapped[str] = mapped_column(String, nullable=False)
+    step_idx: Mapped[int] = mapped_column(Integer, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False
+    )
+
+    user: Mapped[User] = relationship("User")

--- a/services/api/app/diabetes/services/lesson_log.py
+++ b/services/api/app/diabetes/services/lesson_log.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from ..models_learning import LessonLog
+from .db import SessionLocal, run_db
+from .repository import CommitError, commit
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["add_lesson_log", "get_lesson_logs"]
+
+
+async def add_lesson_log(
+    telegram_id: int,
+    topic_slug: str,
+    role: str,
+    step_idx: int,
+    content: str,
+) -> None:
+    """Insert a lesson log entry."""
+
+    def _add(session: Session) -> None:
+        session.add(
+            LessonLog(
+                telegram_id=telegram_id,
+                topic_slug=topic_slug,
+                role=role,
+                step_idx=step_idx,
+                content=content,
+            )
+        )
+        commit(session)
+
+    try:
+        await run_db(_add, sessionmaker=SessionLocal)
+    except CommitError:  # pragma: no cover - logging only
+        logger.exception("Failed to add lesson log for %s", telegram_id)
+
+
+async def get_lesson_logs(telegram_id: int, topic_slug: str) -> list[LessonLog]:
+    """Fetch lesson logs for a user and topic."""
+
+    def _get(session: Session) -> list[LessonLog]:
+        return (
+            session.query(LessonLog)
+            .filter_by(telegram_id=telegram_id, topic_slug=topic_slug)
+            .order_by(LessonLog.id)
+            .all()
+        )
+
+    return await run_db(_get, sessionmaker=SessionLocal)

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -12,6 +12,7 @@ from services.api.app.diabetes.learning_state import LearnState, get_state, set_
 class DummyMessage:
     def __init__(self, text: str | None = None) -> None:
         self.text = text
+        self.from_user = SimpleNamespace(id=1)
         self.replies: list[str] = []
         self.markups: list[InlineKeyboardMarkup | None] = []
 
@@ -40,6 +41,10 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
     async def fake_generate_step_text(*args: object, **kwargs: object) -> str:
         return "step1?"
     monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    async def fake_add_log(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
 
     msg = DummyMessage()
     update = cast(object, SimpleNamespace(message=msg))
@@ -76,6 +81,10 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+    async def fake_add_log(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
 
     msg = DummyMessage()
     update = cast(object, SimpleNamespace(message=msg))

--- a/tests/learning/test_curriculum.py
+++ b/tests/learning/test_curriculum.py
@@ -13,6 +13,7 @@ from services.api.app.diabetes.learning_fixtures import load_lessons
 from services.api.app.diabetes.learning_prompts import disclaimer
 from services.api.app.diabetes.models_learning import Lesson, LessonProgress, QuizQuestion
 from services.api.app.diabetes.services import db, gpt_client
+from services.api.app.config import settings
 
 
 @pytest.mark.asyncio()
@@ -24,6 +25,7 @@ async def test_happy_path_one_lesson(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     db.SessionLocal.configure(bind=engine)
     db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(settings, "learning_content_mode", "static")
 
     await load_lessons(
         "content/lessons_v0.json",

--- a/tests/learning/test_curriculum_engine.py
+++ b/tests/learning/test_curriculum_engine.py
@@ -36,6 +36,7 @@ async def test_curriculum_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     db.SessionLocal.configure(bind=engine)
     db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(settings, "learning_content_mode", "static")
 
     await load_lessons(
         "content/lessons_v0.json",
@@ -119,6 +120,7 @@ async def test_lesson_without_quiz(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     db.SessionLocal.configure(bind=engine)
     db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(settings, "learning_content_mode", "static")
 
     with db.SessionLocal() as session:
         session.add(db.User(telegram_id=1, thread_id="t1"))

--- a/tests/learning/test_handlers.py
+++ b/tests/learning/test_handlers.py
@@ -72,6 +72,10 @@ async def test_learning_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+    async def fake_add_log(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
 
     async def fake_ensure_overrides(*args: object, **kwargs: object) -> bool:
         return True

--- a/tests/learning/test_lesson_logs.py
+++ b/tests/learning/test_lesson_logs.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.services import db
+from services.api.app.diabetes.services.lesson_log import (
+    add_lesson_log,
+    get_lesson_logs,
+)
+from services.api.app.diabetes.models_learning import LessonLog  # noqa: F401
+
+
+@pytest.fixture()
+def setup_db() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.SessionLocal.configure(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+    with db.SessionLocal() as session:
+        session.add(db.User(telegram_id=1, thread_id="t"))
+        session.commit()
+
+
+@pytest.mark.asyncio
+async def test_add_and_get_logs(setup_db: None) -> None:
+    await add_lesson_log(1, "topic", "assistant", 1, "hi")
+    await add_lesson_log(1, "topic", "user", 1, "answer")
+    logs = await get_lesson_logs(1, "topic")
+    assert [log.role for log in logs] == ["assistant", "user"]
+    assert logs[0].content == "hi"
+    assert logs[1].content == "answer"
+    assert isinstance(logs[0].created_at, type(logs[1].created_at))

--- a/tests/learning/test_lesson_metrics.py
+++ b/tests/learning/test_lesson_metrics.py
@@ -10,6 +10,7 @@ from services.api.app.diabetes.curriculum_engine import (
     next_step,
     start_lesson,
 )
+from services.api.app.config import settings
 from services.api.app.diabetes.learning_fixtures import load_lessons
 from services.api.app.diabetes.models_learning import (
     Lesson,
@@ -26,6 +27,7 @@ async def test_lesson_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
     engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
     db.SessionLocal.configure(bind=engine)
     db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(settings, "learning_content_mode", "static")
 
     await load_lessons(
         "content/lessons_v0.json",


### PR DESCRIPTION
## Summary
- add LessonLog model and migration
- log user and assistant turns in dynamic learning
- cover lesson log service with tests

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc5ec4ea08832a9739e5a17e40cb19