### PR TITLE
[billing] use WebApp subscription keyboard

### DIFF
--- a/services/api/app/diabetes/handlers/billing_handlers.py
+++ b/services/api/app/diabetes/handlers/billing_handlers.py
@@ -4,12 +4,7 @@ import logging
 from datetime import datetime
 
 import httpx
-from telegram import (
-    InlineKeyboardButton,
-    InlineKeyboardMarkup,
-    Message,
-    Update,
-)
+from telegram import Message, Update
 from telegram.ext import ContextTypes
 
 from ... import config
@@ -100,17 +95,14 @@ async def trial_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         return
     end_str = end_dt.strftime("%d.%m.%Y")
     await message.reply_text(f"🎉 Активирован trial до {end_str}")
-    sub_url = config.get_settings().subscription_url
-    if sub_url:
+    kb = subscription_keyboard(False)
+    if kb.inline_keyboard:
         text = (
             "🟢 Подписка PRO даёт расширенные функции:\n"
             "• Распознавание блюд по фото\n"
             "• Чат с GPT\n"
             "• Расширенные напоминания\n\n"
             "👉 Чтобы оформить подписку, нажмите кнопку ниже:"
-        )
-        kb = InlineKeyboardMarkup(
-            [[InlineKeyboardButton("Оформить PRO", url=sub_url)]]
         )
         await message.reply_text(text, reply_markup=kb)
     logger.info("billing_action=user_id:%s action=trial result=ok", user.id)
@@ -122,8 +114,8 @@ async def upgrade_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     message = update.message
     if message is None:
         return
-    url = config.get_settings().subscription_url
-    if not url:
+    kb = subscription_keyboard(False)
+    if not kb.inline_keyboard:
         await message.reply_text("❌ Не настроена ссылка на оплату.")
         logger.info(
             "billing_action=user_id:%s action=upgrade result=error",
@@ -137,7 +129,6 @@ async def upgrade_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         "• Расширенные напоминания\n\n"
         "👉 Чтобы оформить подписку, нажмите кнопку ниже:"
     )
-    kb = InlineKeyboardMarkup([[InlineKeyboardButton("Оформить PRO", url=url)]])
     await message.reply_text(text, reply_markup=kb)
     if update.effective_user:
         logger.info(

--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -347,7 +347,7 @@ def register_handlers(app: App) -> None:
     app.add_handler(CommandHandler("quiz", quiz_command))
     app.add_handler(CommandHandler("progress", progress_command))
     app.add_handler(CommandHandler("exit", exit_command))
-    app.add_handler(CommandHandler("learn_reset", onboarding.learn_reset))  # type: ignore[attr-defined]
+    app.add_handler(CommandHandler("learn_reset", onboarding.learn_reset))
     app.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, onboarding.onboarding_reply)
     )

--- a/tests/learning/test_lesson_metrics.py
+++ b/tests/learning/test_lesson_metrics.py
@@ -19,7 +19,6 @@ from services.api.app.diabetes.models_learning import (
     QuizQuestion,
 )
 from services.api.app.diabetes.services import db, gpt_client
-from services.api.app.config import settings
 
 
 @pytest.mark.asyncio

--- a/tests/test_billing_commands.py
+++ b/tests/test_billing_commands.py
@@ -23,7 +23,7 @@ class DummyMessage:
 @pytest.mark.asyncio
 async def test_trial_command_success(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("API_URL", "http://api.test/api")
-    monkeypatch.setenv("SUBSCRIPTION_URL", "https://pay.example/sub")
+    monkeypatch.setenv("PUBLIC_ORIGIN", "http://example.org")
     config.reload_settings()
 
     end_date = "2025-01-15T00:00:00+00:00"
@@ -71,10 +71,10 @@ async def test_trial_command_success(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
     markup = message.markups[1]
     button = markup.inline_keyboard[0][0]
-    assert button.text == "Оформить PRO"
-    assert button.url == "https://pay.example/sub"
+    assert button.text == "💳 Оформить PRO"
+    assert button.web_app and button.web_app.url == config.build_ui_url("/subscription")
     monkeypatch.delenv("API_URL")
-    monkeypatch.delenv("SUBSCRIPTION_URL")
+    monkeypatch.delenv("PUBLIC_ORIGIN")
     config.reload_settings()
 
 
@@ -203,7 +203,7 @@ async def test_trial_command_bad_end_date(monkeypatch: pytest.MonkeyPatch, paylo
 
 @pytest.mark.asyncio
 async def test_upgrade_command(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("SUBSCRIPTION_URL", "https://pay.example/sub")
+    monkeypatch.setenv("PUBLIC_ORIGIN", "http://example.org")
     config.reload_settings()
 
     message = DummyMessage()
@@ -229,9 +229,9 @@ async def test_upgrade_command(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
     markup = message.markups[0]
     button = markup.inline_keyboard[0][0]
-    assert button.text == "Оформить PRO"
-    assert button.url == "https://pay.example/sub"
-    monkeypatch.delenv("SUBSCRIPTION_URL")
+    assert button.text == "💳 Оформить PRO"
+    assert button.web_app and button.web_app.url == config.build_ui_url("/subscription")
+    monkeypatch.delenv("PUBLIC_ORIGIN")
     config.reload_settings()
 
 


### PR DESCRIPTION
## Summary
- use unified subscription_keyboard for trial and upgrade commands
- handle missing Telegram users in learning handlers
- fix tests and lint warnings

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc69988fa0832aa9e026b83e819abd