### PR TITLE
[config] add topics mapping and ui flag

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -16,6 +16,13 @@ except ModuleNotFoundError as exc:  # pragma: no cover - executed at import time
 
 logger = logging.getLogger(__name__)
 
+TOPICS_RU: dict[str, str] = {
+    "xe_basics": "Хлебные единицы",
+    "healthy-eating": "Здоровое питание",
+    "basics-of-diabetes": "Основы диабета",
+    "insulin-usage": "Инсулин",
+}
+
 
 class Settings(BaseSettings):
     """Runtime application configuration.
@@ -67,6 +74,9 @@ class Settings(BaseSettings):
     learning_prompt_cache: bool = Field(default=True, alias="LEARNING_PROMPT_CACHE")
     learning_content_mode: Literal["dynamic", "static"] = Field(
         default="dynamic", alias="LEARNING_CONTENT_MODE"
+    )
+    learning_ui_show_topics: bool = Field(
+        default=False, alias="LEARNING_UI_SHOW_TOPICS"
     )
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
     learning_assistant_id: Optional[str] = Field(default=None, alias="LEARNING_ASSISTANT_ID")
@@ -154,3 +164,14 @@ def build_ui_url(path: str) -> str:
     if base:
         return f"{origin}/{base}/{rel}"
     return f"{origin}/{rel}"
+
+
+__all__ = [
+    "TOPICS_RU",
+    "Settings",
+    "settings",
+    "get_settings",
+    "reload_settings",
+    "get_db_password",
+    "build_ui_url",
+]

--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -7,11 +7,11 @@ from typing import Any, Mapping, MutableMapping, cast
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
 from telegram.ext import ContextTypes
-from services.api.app.ui.keyboard import build_main_keyboard
 
-from services.api.app.config import settings
-from .handlers import learning_handlers as legacy_handlers
+from services.api.app.config import TOPICS_RU, settings
+from services.api.app.ui.keyboard import build_main_keyboard
 from .dynamic_tutor import check_user_answer, generate_step_text
+from .handlers import learning_handlers as legacy_handlers
 from .learning_onboarding import ensure_overrides
 from .learning_state import LearnState, clear_state, get_state, set_state
 from .services.gpt_client import format_reply
@@ -22,12 +22,7 @@ logger = logging.getLogger(__name__)
 RATE_LIMIT_SECONDS = 3.0
 RATE_LIMIT_MESSAGE = "⏳ Подождите немного перед следующим запросом."
 
-TOPICS: list[tuple[str, str]] = [
-    ("xe_basics", "Хлебные единицы"),
-    ("healthy-eating", "Здоровое питание"),
-    ("basics-of-diabetes", "Основы диабета"),
-    ("insulin-usage", "Инсулин"),
-]
+TOPICS: list[tuple[str, str]] = list(TOPICS_RU.items())
 
 
 def _rate_limited(user_data: MutableMapping[str, Any], key: str) -> bool:


### PR DESCRIPTION
## Summary
- add `learning_ui_show_topics` flag and exportable `TOPICS_RU` mapping for Russian topic titles
- reuse `TOPICS_RU` in dynamic learning handlers to build topic list

## Testing
- `pytest tests/diabetes/test_learning_chat_handlers.py::test_learn_command_and_callback -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: Unused "type: ignore" comment)*
- `ruff check .` *(fails: redefinition of `settings` in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6aff23a4832ab52f364fad3abd11