### PR TITLE
[learning] Add topics command and auto-start logic

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -68,6 +68,9 @@ class Settings(BaseSettings):
     learning_content_mode: Literal["dynamic", "static"] = Field(
         default="dynamic", alias="LEARNING_CONTENT_MODE"
     )
+    learning_ui_show_topics: bool = Field(
+        default=True, alias="LEARNING_UI_SHOW_TOPICS"
+    )
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
     learning_assistant_id: Optional[str] = Field(default=None, alias="LEARNING_ASSISTANT_ID")
     learning_command_model: str = Field(default="gpt-4o-mini", alias="LEARNING_COMMAND_MODEL")

--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -7,6 +7,7 @@ from telegram import Update
 from telegram.ext import ContextTypes
 
 from .handlers.learning_handlers import learn_command
+from .learning_handlers import topics_command
 from .handlers.onboarding_handlers import (
     reset_onboarding as _reset_onboarding,
 )
@@ -19,6 +20,7 @@ HELP_TEXT = "\n".join(
         "/start - начать работу с ботом",
         "/help - краткая справка",
         "/learn - режим обучения",
+        "/topics - выбор темы обучения",
         "/reset_onboarding - сбросить мастер настройки",
         "/trial - Включить trial",
         "/upgrade - Оформить PRO",
@@ -56,4 +58,4 @@ async def reset_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     )
 
 
-__all__ = ["help_command", "reset_onboarding", "learn_command"]
+__all__ = ["help_command", "reset_onboarding", "learn_command", "topics_command"]

--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -341,13 +341,15 @@ def register_handlers(app: App) -> None:
     """Register learning-related handlers on the application."""
 
     from . import learning_onboarding as onboarding
+    from .. import learning_handlers as chat_learning
 
     app.add_handler(CommandHandler("learn", learn_command))
+    app.add_handler(CommandHandler("topics", chat_learning.topics_command))
     app.add_handler(CommandHandler("lesson", lesson_command))
     app.add_handler(CommandHandler("quiz", quiz_command))
     app.add_handler(CommandHandler("progress", progress_command))
     app.add_handler(CommandHandler("exit", exit_command))
-    app.add_handler(CommandHandler("learn_reset", onboarding.learn_reset))  # type: ignore[attr-defined]
+    app.add_handler(CommandHandler("learn_reset", onboarding.learn_reset))
     app.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, onboarding.onboarding_reply)
     )

--- a/services/api/app/diabetes/learning_topics.py
+++ b/services/api/app/diabetes/learning_topics.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+# Mapping of topic slug to human readable Russian title
+TOPICS_RU: dict[str, str] = {
+    "xe_basics": "Хлебные единицы",
+    "healthy-eating": "Здоровое питание",
+    "basics-of-diabetes": "Основы диабета",
+    "insulin-usage": "Инсулин",
+}
+
+
+async def choose_initial_topic(profile: Mapping[str, str | None]) -> str:
+    """Return an initial topic slug for the user profile.
+
+    Currently selects the first available topic; more complex logic can be
+    implemented later based on *profile*.
+    """
+
+    return next(iter(TOPICS_RU))
+
+
+__all__ = ["TOPICS_RU", "choose_initial_topic"]

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -7,6 +7,7 @@ from telegram import InlineKeyboardMarkup, ReplyKeyboardMarkup
 
 from services.api.app.config import settings
 from services.api.app.diabetes import learning_handlers
+from services.api.app.diabetes import learning_topics
 from services.api.app.diabetes.learning_state import LearnState, get_state, set_state
 
 
@@ -15,11 +16,17 @@ class DummyMessage:
         self.text = text
         self.from_user = SimpleNamespace(id=1)
         self.replies: list[str] = []
-        self.markups: list[InlineKeyboardMarkup | None] = []
+        self.markups: list[
+            InlineKeyboardMarkup | ReplyKeyboardMarkup | None
+        ] = []
 
-    async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - helper
+    async def reply_text(
+        self, text: str, **kwargs: Any
+    ) -> None:  # pragma: no cover - helper
         self.replies.append(text)
-        self.markups.append(cast(InlineKeyboardMarkup | None, kwargs.get("reply_markup")))
+        self.markups.append(
+            cast(InlineKeyboardMarkup | ReplyKeyboardMarkup | None, kwargs.get("reply_markup"))
+        )
 
 
 class DummyCallback:
@@ -39,17 +46,26 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
         return True
 
     monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
-    monkeypatch.setattr(learning_handlers, "TOPICS", [("slug", "Topic")])
-    async def fake_generate_step_text(*args: object, **kwargs: object) -> str:
-        return "step1?"
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(learning_topics, "TOPICS_RU", {"slug": "Topic"})
+    monkeypatch.setattr(learning_handlers, "TOPICS_RU", {"slug": "Topic"})
+
+    async def fake_start_lesson(*args: object, **kwargs: object) -> object:
+        return SimpleNamespace(lesson_id=1)
+
+    async def fake_next_step(*args: object, **kwargs: object) -> tuple[str, bool]:
+        return "step1?", False
+
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
+
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     msg = DummyMessage()
-    update = cast(object, SimpleNamespace(message=msg))
+    update = cast(object, SimpleNamespace(message=msg, effective_message=msg))
     context = SimpleNamespace(user_data={})
 
     await learning_handlers.learn_command(update, context)
@@ -65,6 +81,7 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
 
     await learning_handlers.lesson_callback(update_cb, context_cb)
     assert msg2.replies == ["step1?"]
+    assert isinstance(msg2.markups[0], ReplyKeyboardMarkup)
     state = get_state(context_cb.user_data)
     assert state is not None and state.step == 1 and state.awaiting_answer
 
@@ -88,6 +105,16 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         return None
 
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
+
+    async def fake_start_lesson(*args: object, **kwargs: object) -> object:
+        return SimpleNamespace(lesson_id=1)
+
+    async def fake_next_step(*args: object, **kwargs: object) -> tuple[str, bool]:
+        return "step1?", False
+
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
 
     msg = DummyMessage()
     update = cast(object, SimpleNamespace(message=msg))
@@ -95,6 +122,7 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await learning_handlers.lesson_command(update, context)
     assert msg.replies == ["step1?"]
+    assert isinstance(msg.markups[0], ReplyKeyboardMarkup)
 
     msg2 = DummyMessage(text="ans")
     update2 = cast(object, SimpleNamespace(message=msg2))
@@ -102,8 +130,51 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await learning_handlers.lesson_answer_handler(update2, context2)
     assert msg2.replies == ["feedback", "step2?"]
+    assert msg2.markups[0] is None
+    assert isinstance(msg2.markups[1], ReplyKeyboardMarkup)
     state = get_state(context2.user_data)
     assert state is not None and state.step == 2 and state.awaiting_answer
+
+
+@pytest.mark.asyncio
+async def test_learn_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+    monkeypatch.setattr(settings, "learning_ui_show_topics", False)
+
+    async def fake_ensure_overrides(update: object, context: object) -> bool:
+        return True
+
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
+    monkeypatch.setattr(learning_topics, "TOPICS_RU", {"slug": "Topic"})
+
+    async def fake_choose(_profile: object) -> str:
+        return "slug"
+
+    monkeypatch.setattr(learning_handlers, "choose_initial_topic", fake_choose)
+
+    async def fake_start_lesson(*args: object, **kwargs: object) -> object:
+        return SimpleNamespace(lesson_id=1)
+
+    async def fake_next_step(*args: object, **kwargs: object) -> tuple[str, bool]:
+        return "step1?", False
+
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
+    async def fake_add_log2(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log2)
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
+
+    msg = DummyMessage()
+    update = cast(object, SimpleNamespace(message=msg))
+    context = SimpleNamespace(user_data={})
+
+    await learning_handlers.learn_command(update, context)
+    assert msg.replies == ["step1?"]
+    assert isinstance(msg.markups[0], ReplyKeyboardMarkup)
+    state = get_state(context.user_data)
+    assert state is not None and state.step == 1 and state.awaiting_answer
 
 
 @pytest.mark.asyncio

--- a/tests/diabetes/test_learning_handlers.py
+++ b/tests/diabetes/test_learning_handlers.py
@@ -21,6 +21,7 @@ class DummyMessage:
     def __init__(self, text: str | None = None) -> None:
         self.text = text
         self.replies: list[str] = []
+        self.from_user = SimpleNamespace(id=1)
 
     async def reply_text(
         self, text: str, **kwargs: Any

--- a/tests/learning/test_handlers_rate_limit.py
+++ b/tests/learning/test_handlers_rate_limit.py
@@ -14,6 +14,7 @@ class DummyMessage:
     def __init__(self, text: str | None = None) -> None:
         self.text = text
         self.replies: list[str] = []
+        self.from_user = SimpleNamespace(id=1)
 
     async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - helper
         self.replies.append(text)
@@ -38,6 +39,18 @@ async def test_lesson_callback_rate_limit(monkeypatch: pytest.MonkeyPatch) -> No
         return "step1"
 
     monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    async def fake_start_lesson(*args: object, **kwargs: object) -> object:
+        return SimpleNamespace(lesson_id=1)
+
+    async def fake_next_step(*args: object, **kwargs: object) -> tuple[str, bool]:
+        return "step1", False
+
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
+    async def fake_add_log(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
 
     times = iter([0.0, 1.0])
 
@@ -81,6 +94,10 @@ async def test_lesson_answer_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None
 
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
     monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    async def fake_add_log2(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log2)
 
     times = iter([0.0, 1.0])
 

--- a/tests/learning/test_lesson_metrics.py
+++ b/tests/learning/test_lesson_metrics.py
@@ -19,7 +19,6 @@ from services.api.app.diabetes.models_learning import (
     QuizQuestion,
 )
 from services.api.app.diabetes.services import db, gpt_client
-from services.api.app.config import settings
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add configurable `learning_ui_show_topics` toggle
- allow auto-starting lessons or manual topic selection
- expose `/topics` command and register handler

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc6b02130c832a9bb473aa57a1ba68