### PR TITLE
[learning] add initial topic chooser

### DIFF
--- a/services/api/app/diabetes/learning_utils.py
+++ b/services/api/app/diabetes/learning_utils.py
@@ -1,0 +1,40 @@
+"""Miscellaneous utilities for the learning module."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+NOVICE_LEVELS = {"novice", "beginner", "a"}
+INSULIN_THERAPIES = {"insulin", "mixed"}
+
+__all__ = ["choose_initial_topic"]
+
+
+def choose_initial_topic(profile: Mapping[str, str | None]) -> tuple[str, str]:
+    """Choose an initial learning topic based on ``profile``.
+
+    For novices with insulin therapy the user learns about insulin usage first.
+    Novices on non-insulin therapy start with diabetes basics. Non-novices are
+    directed to carbohydrate counting for insulin therapy and healthy eating for
+    non-insulin therapy.
+    """
+
+    level = str(profile.get("learning_level", "novice")).lower()
+    therapy = str(
+        profile.get("therapyType") or profile.get("therapy_type") or "insulin"
+    ).lower()
+
+    is_novice = level in NOVICE_LEVELS
+    is_insulin = therapy in INSULIN_THERAPIES
+
+    if is_novice:
+        return (
+            ("insulin-usage", "Инсулин")
+            if is_insulin
+            else ("basics-of-diabetes", "Основы диабета")
+        )
+    return (
+        ("xe_basics", "Хлебные единицы")
+        if is_insulin
+        else ("healthy-eating", "Здоровое питание")
+    )

--- a/tests/learning/test_learning_utils.py
+++ b/tests/learning/test_learning_utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from services.api.app.diabetes.learning_utils import choose_initial_topic
+
+
+def test_choose_initial_topic_novice_insulin() -> None:
+    profile = {"learning_level": "novice", "therapyType": "insulin"}
+    assert choose_initial_topic(profile) == ("insulin-usage", "Инсулин")
+
+
+def test_choose_initial_topic_novice_non_insulin() -> None:
+    profile = {"learning_level": "novice", "therapyType": "tablets"}
+    assert choose_initial_topic(profile) == ("basics-of-diabetes", "Основы диабета")
+
+
+def test_choose_initial_topic_non_novice_insulin() -> None:
+    profile = {"learning_level": "expert", "therapyType": "insulin"}
+    assert choose_initial_topic(profile) == ("xe_basics", "Хлебные единицы")
+
+
+def test_choose_initial_topic_non_novice_non_insulin() -> None:
+    profile = {"learning_level": "expert", "therapyType": "none"}
+    assert choose_initial_topic(profile) == ("healthy-eating", "Здоровое питание")


### PR DESCRIPTION
## Summary
- add `choose_initial_topic` utility to select lesson based on learning level and therapy type
- cover initial topic selection with tests for novice/non-novice and insulin/non-insulin profiles

## Testing
- `pytest tests/learning/test_learning_utils.py -q --no-cov`
- `mypy --strict services/api/app/diabetes/learning_utils.py`
- `ruff check services/api/app/diabetes/learning_utils.py tests/learning/test_learning_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc6b02a374832ab7fce7417e9fdf98