### PR TITLE
[learning] normalize onboarding inputs

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -347,7 +347,7 @@ def register_handlers(app: App) -> None:
     app.add_handler(CommandHandler("quiz", quiz_command))
     app.add_handler(CommandHandler("progress", progress_command))
     app.add_handler(CommandHandler("exit", exit_command))
-    app.add_handler(CommandHandler("learn_reset", onboarding.learn_reset))  # type: ignore[attr-defined]
+    app.add_handler(CommandHandler("learn_reset", onboarding.learn_reset))
     app.add_handler(
         MessageHandler(filters.TEXT & ~filters.COMMAND, onboarding.onboarding_reply)
     )

--- a/services/api/app/diabetes/handlers/learning_onboarding.py
+++ b/services/api/app/diabetes/handlers/learning_onboarding.py
@@ -40,14 +40,8 @@ async def onboarding_reply(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if message is None or not message.text:
         return
     user_data = cast(dict[str, object], context.user_data)
-    stage = cast(str | None, user_data.get("learn_onboarding_stage"))
-    if stage is None:
+    if "learn_onboarding_stage" not in user_data:
         return
-    overrides = cast(
-        dict[str, str], user_data.setdefault("learn_profile_overrides", {})
-    )
-    overrides[stage] = message.text.strip()
-    user_data.pop("learn_onboarding_stage", None)
     if await ensure_overrides(update, context):
         await message.reply_text("Ответы сохранены. Отправьте /learn чтобы продолжить.")
 

--- a/services/api/app/diabetes/learning_onboarding.py
+++ b/services/api/app/diabetes/learning_onboarding.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
-from typing import cast
+from typing import Mapping, cast
 
-from telegram import Update
+from telegram import ReplyKeyboardMarkup, Update
 from telegram.ext import ContextTypes
 
 logger = logging.getLogger(__name__)
@@ -16,11 +16,93 @@ AGE_PROMPT = "Укажите вашу возрастную группу."
 DIABETES_TYPE_PROMPT = "Укажите тип диабета."
 LEARNING_LEVEL_PROMPT = "Укажите ваш уровень знаний."
 
-_ORDER = [
-    ("age_group", AGE_PROMPT),
-    ("diabetes_type", DIABETES_TYPE_PROMPT),
-    ("learning_level", LEARNING_LEVEL_PROMPT),
-]
+_PROMPTS: Mapping[str, str] = {
+    "age_group": AGE_PROMPT,
+    "diabetes_type": DIABETES_TYPE_PROMPT,
+    "learning_level": LEARNING_LEVEL_PROMPT,
+}
+
+_KEYBOARDS: Mapping[str, ReplyKeyboardMarkup] = {
+    "age_group": ReplyKeyboardMarkup(
+        [["teen", "adult"], ["60+"]],
+        resize_keyboard=True,
+        one_time_keyboard=True,
+    ),
+    "diabetes_type": ReplyKeyboardMarkup(
+        [["T1", "T2"]],
+        resize_keyboard=True,
+        one_time_keyboard=True,
+    ),
+    "learning_level": ReplyKeyboardMarkup(
+        [["novice", "intermediate", "expert"]],
+        resize_keyboard=True,
+        one_time_keyboard=True,
+    ),
+}
+
+_ORDER = ["age_group", "diabetes_type", "learning_level"]
+
+
+def _norm_age_group(raw: str) -> str | None:
+    """Normalize age group value from *raw* input."""
+
+    text = raw.strip().lower()
+    if not text:
+        return None
+    if text.isdigit():
+        age = int(text)
+        if age >= 60:
+            return "60+"
+        if age >= 18:
+            return "adult"
+        if age >= 13:
+            return "teen"
+        return "child"
+    mapping = {
+        "teen": "teen",
+        "подросток": "teen",
+        "adult": "adult",
+        "взрослый": "adult",
+        "60+": "60+",
+        "senior": "60+",
+        "elder": "60+",
+    }
+    return mapping.get(text)
+
+
+def _norm_diabetes_type(raw: str) -> str | None:
+    """Normalize diabetes type from *raw* input."""
+
+    text = raw.strip().lower().replace(" ", "")
+    mapping = {
+        "1": "T1",
+        "t1": "T1",
+        "type1": "T1",
+        "тип1": "T1",
+        "2": "T2",
+        "t2": "T2",
+        "type2": "T2",
+        "тип2": "T2",
+    }
+    return mapping.get(text)
+
+
+def _norm_level(raw: str) -> str | None:
+    """Normalize learning level from *raw* input."""
+
+    text = raw.strip().lower()
+    mapping = {
+        "0": "novice",
+        "1": "intermediate",
+        "2": "expert",
+        "novice": "novice",
+        "beginner": "novice",
+        "intermediate": "intermediate",
+        "advanced": "expert",
+        "expert": "expert",
+        "pro": "expert",
+    }
+    return mapping.get(text)
 
 
 async def ensure_overrides(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
@@ -28,22 +110,47 @@ async def ensure_overrides(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
     Sequentially ask the user for ``age_group``, ``diabetes_type`` and
     ``learning_level``. Answers are stored in
-    ``ctx.user_data['learn_profile_overrides']``. While onboarding is in
-    progress the function returns ``False`` so that callers can stop further
-    processing. ``True`` is returned once all fields are collected.
+    ``ctx.user_data['learn_profile_overrides']`` in normalized form. While
+    onboarding is in progress the function returns ``False`` so that callers can
+    stop further processing. ``True`` is returned once all fields are collected.
     """
 
     user_data = cast(dict[str, object], context.user_data)
     overrides = cast(
         dict[str, str], user_data.setdefault("learn_profile_overrides", {})
     )
-    for key, prompt in _ORDER:
-        if not overrides.get(key):
-            message = update.message
+    message = update.message
+    stage = cast(str | None, user_data.get("learn_onboarding_stage"))
+    raw_text = getattr(message, "text", None)
+    text = raw_text.strip() if raw_text else None
+
+    if stage and text:
+        norm: str | None
+        if stage == "age_group":
+            norm = _norm_age_group(text)
+        elif stage == "diabetes_type":
+            norm = _norm_diabetes_type(text)
+        else:
+            norm = _norm_level(text)
+        if norm is None:
             if message is not None:
-                await message.reply_text(prompt)
-            user_data["learn_onboarding_stage"] = key
+                await message.reply_text(
+                    _PROMPTS[stage], reply_markup=_KEYBOARDS.get(stage)
+                )
             return False
+        overrides[stage] = norm
+        user_data.pop("learn_onboarding_stage", None)
+        stage = None
+
+    for key in _ORDER:
+        if not overrides.get(key):
+            user_data["learn_onboarding_stage"] = key
+            if message is not None:
+                await message.reply_text(
+                    _PROMPTS[key], reply_markup=_KEYBOARDS.get(key)
+                )
+            return False
+
     user_data.pop("learn_onboarding_stage", None)
     user_data["learning_onboarded"] = True
     return True
@@ -63,3 +170,4 @@ async def learn_reset(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     message = update.message
     if message is not None:
         await message.reply_text("Learning onboarding reset. Отправьте /learn.")
+

--- a/tests/diabetes/test_learning_onboarding.py
+++ b/tests/diabetes/test_learning_onboarding.py
@@ -86,8 +86,8 @@ async def test_learning_onboarding_flow(
         ]
         assert context.user_data["learn_profile_overrides"] == {
             "age_group": "adult",
-            "diabetes_type": "type1",
-            "learning_level": "beginner",
+            "diabetes_type": "T1",
+            "learning_level": "novice",
         }
 
         message5 = DummyMessage()

--- a/tests/learning/test_lesson_metrics.py
+++ b/tests/learning/test_lesson_metrics.py
@@ -19,7 +19,6 @@ from services.api.app.diabetes.models_learning import (
     QuizQuestion,
 )
 from services.api.app.diabetes.services import db, gpt_client
-from services.api.app.config import settings
 
 
 @pytest.mark.asyncio

--- a/tests/learning/test_onboarding_normalization.py
+++ b/tests/learning/test_onboarding_normalization.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from services.api.app.diabetes.learning_onboarding import (
+    _norm_age_group,
+    _norm_diabetes_type,
+    _norm_level,
+)
+
+
+def test_norm_age_group_number() -> None:
+    assert _norm_age_group("49") == "adult"
+
+
+def test_norm_diabetes_type_number() -> None:
+    assert _norm_diabetes_type("2") == "T2"
+
+
+def test_norm_level_zero() -> None:
+    assert _norm_level("0") == "novice"


### PR DESCRIPTION
## Summary
- normalize user onboarding answers with helper parsers
- prompt with reply keyboards and store normalized values
- cover onboarding normalization with unit tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc6b039568832ab56f3fb32218329e