### PR TITLE
[learning] add initial topic selection tests

### DIFF
--- a/services/api/app/diabetes/learning_topics.py
+++ b/services/api/app/diabetes/learning_topics.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def choose_initial_topic(profile: Mapping[str, str | None]) -> str:
+    """Return the initial topic slug based on a user's profile.
+
+    - Novice users on insulin therapy start with ``xe_basics``.
+    - Novice users on non-insulin therapy start with ``healthy-eating``.
+    - Users with intermediate or advanced knowledge start with ``basics-of-diabetes``.
+    """
+
+    level = (profile.get("learning_level") or "").lower()
+    therapy = (profile.get("therapy_type") or "").lower()
+
+    if level != "novice":
+        return "basics-of-diabetes"
+    if therapy in {"insulin", "mixed"}:
+        return "xe_basics"
+    return "healthy-eating"
+
+
+__all__ = ["choose_initial_topic"]

--- a/tests/learning/test_choose_initial_topic.py
+++ b/tests/learning/test_choose_initial_topic.py
@@ -1,0 +1,20 @@
+import pytest
+
+from services.api.app.diabetes.learning_topics import choose_initial_topic
+
+
+def test_novice_insulin_returns_xe_basics() -> None:
+    profile = {"therapy_type": "insulin", "learning_level": "novice"}
+    assert choose_initial_topic(profile) == "xe_basics"
+
+
+@pytest.mark.parametrize("therapy", ["tablets", "none"])
+def test_novice_non_insulin_returns_healthy_eating(therapy: str) -> None:
+    profile = {"therapy_type": therapy, "learning_level": "novice"}
+    assert choose_initial_topic(profile) == "healthy-eating"
+
+
+@pytest.mark.parametrize("level", ["intermediate", "advanced"])
+def test_non_novice_returns_basics_of_diabetes(level: str) -> None:
+    profile = {"therapy_type": "insulin", "learning_level": level}
+    assert choose_initial_topic(profile) == "basics-of-diabetes"


### PR DESCRIPTION
## Summary
- add `choose_initial_topic` helper mapping profile traits to first lesson
- test learning topic selection for therapy types and skill levels

## Testing
- `ruff check services/api/app/diabetes/learning_topics.py tests/learning/test_choose_initial_topic.py`
- `mypy --strict services/api/app/diabetes/learning_topics.py tests/learning/test_choose_initial_topic.py`
- `pytest tests/learning/test_choose_initial_topic.py -q` *(fails: Coverage failure: total of 22 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6b06e1b4832a98d7b54412d5f215