### PR TITLE
[profile] Fix get_profile_settings returning defaults

### DIFF
--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -143,8 +143,32 @@ async def patch_user_settings(
 
 async def get_profile_settings(telegram_id: int) -> ProfileSettingsOut:
     """Return current profile settings for ``telegram_id``."""
+    profile = await get_profile(telegram_id)
+    tz = profile.timezone or "UTC"
+    tz_auto = profile.timezone_auto if profile.timezone_auto is not None else True
 
-    return await patch_user_settings(telegram_id, ProfileSettingsIn())
+    return ProfileSettingsOut(
+        timezone=tz,
+        timezoneAuto=tz_auto,
+        dia=profile.dia,
+        roundStep=profile.round_step,
+        carbUnits=CarbUnits(profile.carb_units),
+        gramsPerXe=profile.grams_per_xe,
+        glucoseUnits=GlucoseUnits(profile.glucose_units),
+        sosContact=profile.sos_contact,
+        sosAlertsEnabled=(
+            profile.sos_alerts_enabled
+            if profile.sos_alerts_enabled is not None
+            else True
+        ),
+        therapyType=TherapyType(profile.therapy_type),
+        rapidInsulinType=(
+            RapidInsulinType(profile.insulin_type) if profile.insulin_type else None
+        ),
+        maxBolus=profile.max_bolus,
+        preBolus=profile.prebolus_min,
+        afterMealMinutes=profile.postmeal_check_min,
+    )
 
 
 async def save_timezone(telegram_id: int, tz: str, *, auto: bool) -> bool:


### PR DESCRIPTION
## Summary
- fetch profile settings via get_profile instead of empty patch
- test profile GET returns saved settings after PATCH

## Testing
- `ruff check services/api/app/services/profile.py tests/test_profile_patch_endpoint.py`
- `mypy --strict services/api/app/services/profile.py tests/test_profile_patch_endpoint.py` *(fails: services/api/app/diabetes/handlers/learning_handlers.py: error: Unused "type: ignore" comment)*
- `pytest tests/test_profile_patch_endpoint.py::test_profile_get_returns_updated_values tests/test_profile_patch_endpoint.py::test_profile_get_returns_saved_settings -q` *(fails: Coverage failure: total of 22 is less than fail-under=85)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6f6e025c832a95f06b8f3eaa9576