### PR TITLE
learning: normalize onboarding inputs

### DIFF
--- a/services/api/tests/test_learning_mode_toggle.py
+++ b/services/api/tests/test_learning_mode_toggle.py
@@ -86,9 +86,9 @@ async def test_learning_mode_enabled_lists_lessons(
             user_data={
                 "learning_onboarded": True,
                 "learn_profile_overrides": {
-                    "age_group": "a",
-                    "diabetes_type": "b",
-                    "learning_level": "c",
+                    "age_group": "adult",
+                    "diabetes_type": "T1",
+                    "learning_level": "novice",
                 },
             }
         ),
@@ -120,9 +120,9 @@ async def test_learning_mode_disabled_denies_access(
             user_data={
                 "learning_onboarded": True,
                 "learn_profile_overrides": {
-                    "age_group": "a",
-                    "diabetes_type": "b",
-                    "learning_level": "c",
+                    "age_group": "adult",
+                    "diabetes_type": "T1",
+                    "learning_level": "novice",
                 },
             }
         ),

--- a/tests/diabetes/test_learning_handlers.py
+++ b/tests/diabetes/test_learning_handlers.py
@@ -86,9 +86,9 @@ async def test_learn_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
             user_data={
                 "learning_onboarded": True,
                 "learn_profile_overrides": {
-                    "age_group": "a",
-                    "diabetes_type": "b",
-                    "learning_level": "c",
+                    "age_group": "adult",
+                    "diabetes_type": "T1",
+                    "learning_level": "novice",
                 },
             }
         ),

--- a/tests/diabetes/test_learning_onboarding.py
+++ b/tests/diabetes/test_learning_onboarding.py
@@ -86,8 +86,8 @@ async def test_learning_onboarding_flow(
         ]
         assert context.user_data["learn_profile_overrides"] == {
             "age_group": "adult",
-            "diabetes_type": "type1",
-            "learning_level": "beginner",
+            "diabetes_type": "T1",
+            "learning_level": "novice",
         }
 
         message5 = DummyMessage()

--- a/tests/learning/test_onboarding_normalization.py
+++ b/tests/learning/test_onboarding_normalization.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from services.api.app.diabetes.learning_onboarding import (
+    _norm_age_group,
+    _norm_diabetes_type,
+    _norm_level,
+)
+
+
+def test_norm_age_group_numeric() -> None:
+    assert _norm_age_group("49") == "adult"
+
+
+def test_norm_diabetes_type_numeric() -> None:
+    assert _norm_diabetes_type("2") == "T2"
+
+
+def test_norm_level_numeric() -> None:
+    assert _norm_level("0") == "novice"

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -84,9 +84,9 @@ async def test_learn_command_no_lessons(monkeypatch: pytest.MonkeyPatch) -> None
             user_data={
                 "learning_onboarded": True,
                 "learn_profile_overrides": {
-                    "age_group": "a",
-                    "diabetes_type": "b",
-                    "learning_level": "c",
+                    "age_group": "adult",
+                    "diabetes_type": "T1",
+                    "learning_level": "novice",
                 },
             }
         ),
@@ -134,9 +134,9 @@ async def test_learn_command_lists_lessons(
             user_data={
                 "learning_onboarded": True,
                 "learn_profile_overrides": {
-                    "age_group": "a",
-                    "diabetes_type": "b",
-                    "learning_level": "c",
+                    "age_group": "adult",
+                    "diabetes_type": "T1",
+                    "learning_level": "novice",
                 },
             }
         ),


### PR DESCRIPTION
## Summary
- normalize age, diabetes type, and learning level with helper functions
- prompt learning onboarding using reply keyboards and store normalized overrides
- cover numeric onboarding answers in dedicated tests

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68bc70744134832abbc7cde303575857