### PR TITLE
[learning] add topics command and auto-start lessons

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -6,7 +6,7 @@ from typing import cast
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from .handlers.learning_handlers import learn_command
+from .learning_handlers import learn_command, topics_command
 from .handlers.onboarding_handlers import (
     reset_onboarding as _reset_onboarding,
 )
@@ -19,6 +19,7 @@ HELP_TEXT = "\n".join(
         "/start - начать работу с ботом",
         "/help - краткая справка",
         "/learn - режим обучения",
+        "/topics - список тем",
         "/reset_onboarding - сбросить мастер настройки",
         "/trial - Включить trial",
         "/upgrade - Оформить PRO",
@@ -56,4 +57,4 @@ async def reset_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     )
 
 
-__all__ = ["help_command", "reset_onboarding", "learn_command"]
+__all__ = ["help_command", "reset_onboarding", "learn_command", "topics_command"]

--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -341,8 +341,10 @@ def register_handlers(app: App) -> None:
     """Register learning-related handlers on the application."""
 
     from . import learning_onboarding as onboarding
+    from ..learning_handlers import topics_command
 
     app.add_handler(CommandHandler("learn", learn_command))
+    app.add_handler(CommandHandler("topics", topics_command))
     app.add_handler(CommandHandler("lesson", lesson_command))
     app.add_handler(CommandHandler("quiz", quiz_command))
     app.add_handler(CommandHandler("progress", progress_command))

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -35,11 +35,12 @@ class DummyCallback:
 @pytest.mark.asyncio
 async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+    monkeypatch.setattr(settings, "learning_ui_show_topics", True)
     async def fake_ensure_overrides(update: object, context: object) -> bool:
         return True
 
     monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
-    monkeypatch.setattr(learning_handlers, "TOPICS", [("slug", "Topic")])
+    monkeypatch.setattr(learning_handlers, "TOPICS_RU", {"slug": "Topic"})
     async def fake_generate_step_text(*args: object, **kwargs: object) -> str:
         return "step1?"
     monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
@@ -65,6 +66,7 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
 
     await learning_handlers.lesson_callback(update_cb, context_cb)
     assert msg2.replies == ["step1?"]
+    assert isinstance(msg2.markups[0], ReplyKeyboardMarkup)
     state = get_state(context_cb.user_data)
     assert state is not None and state.step == 1 and state.awaiting_answer
 
@@ -95,6 +97,7 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await learning_handlers.lesson_command(update, context)
     assert msg.replies == ["step1?"]
+    assert isinstance(msg.markups[0], ReplyKeyboardMarkup)
 
     msg2 = DummyMessage(text="ans")
     update2 = cast(object, SimpleNamespace(message=msg2))
@@ -102,6 +105,7 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await learning_handlers.lesson_answer_handler(update2, context2)
     assert msg2.replies == ["feedback", "step2?"]
+    assert all(isinstance(m, ReplyKeyboardMarkup) for m in msg2.markups)
     state = get_state(context2.user_data)
     assert state is not None and state.step == 2 and state.awaiting_answer
 
@@ -119,4 +123,45 @@ async def test_exit_command_clears_state(
 
     await learning_handlers.exit_command(update, context)
     assert msg.replies == ["Учебная сессия завершена."]
+    assert isinstance(msg.markups[0], ReplyKeyboardMarkup)
     assert get_state(user_data) is None
+
+
+@pytest.mark.asyncio
+async def test_learn_command_autostarts_when_topics_hidden(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+    monkeypatch.setattr(settings, "learning_ui_show_topics", False)
+
+    async def fake_ensure_overrides(update: object, context: object) -> bool:
+        return True
+
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
+    monkeypatch.setattr(learning_handlers, "choose_initial_topic", lambda _: "slug")
+
+    progress = SimpleNamespace(lesson_id=1)
+    async def fake_start_lesson(user_id: int, slug: str) -> object:
+        assert slug == "slug"
+        return progress
+
+    async def fake_next_step(user_id: int, lesson_id: int) -> tuple[str, bool]:
+        assert lesson_id == 1
+        return "first", False
+
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
+    async def fake_add_log(*args: object, **kwargs: object) -> None:
+        return None
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+
+    msg = DummyMessage()
+    update = cast(object, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=7)))
+    context = SimpleNamespace(user_data={})
+
+    await learning_handlers.learn_command(update, context)
+    assert msg.replies == ["first"]
+    assert isinstance(msg.markups[0], ReplyKeyboardMarkup)
+    state = get_state(context.user_data)
+    assert state is not None and state.topic == "slug" and state.step == 1

--- a/tests/learning/test_handlers.py
+++ b/tests/learning/test_handlers.py
@@ -64,6 +64,7 @@ class DummyBot(Bot):
 @pytest.mark.asyncio
 async def test_learning_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+    monkeypatch.setattr(settings, "learning_ui_show_topics", True)
     steps = iter(["step1", "step2"])
 
     async def fake_generate_step_text(*args: object, **kwargs: object) -> str:

--- a/tests/learning/test_handlers_e2e.py
+++ b/tests/learning/test_handlers_e2e.py
@@ -52,6 +52,7 @@ class DummyBot(Bot):
 @pytest.mark.asyncio
 async def test_keyboard_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+    monkeypatch.setattr(settings, "learning_ui_show_topics", True)
     async def fake_ensure_overrides(*_args: object, **_kwargs: object) -> bool:
         return True
 


### PR DESCRIPTION
## Summary
- show topic list with new /topics command
- start initial lesson automatically when topics UI disabled
- display main keyboard with all generated lesson steps

## Testing
- `pytest tests/diabetes/test_learning_chat_handlers.py tests/learning/test_handlers.py tests/learning/test_handlers_e2e.py -q --cov=services.api.app.diabetes.learning_handlers --cov-report=term-missing --cov-fail-under=0`
- `ruff check services/api/app/diabetes/learning_handlers.py services/api/app/diabetes/commands.py services/api/app/diabetes/handlers/learning_handlers.py tests/diabetes/test_learning_chat_handlers.py tests/learning/test_handlers.py tests/learning/test_handlers_e2e.py`
- `mypy --strict services/api/app/diabetes/learning_handlers.py services/api/app/diabetes/commands.py services/api/app/diabetes/handlers/learning_handlers.py tests/diabetes/test_learning_chat_handlers.py tests/learning/test_handlers.py tests/learning/test_handlers_e2e.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc70045764832abba0a328036b05b2