### PR TITLE
[learning] Register topics command and update help

### DIFF
--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -27,6 +27,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "/report - отчёт\n"
         "/sugar - уровень сахара\n"
         "/gpt - чат с GPT\n"
+        "/topics - список тем\n"
         "/reminders - список напоминаний\n"
         "/cancel - отменить ввод\n"
         "/help - справка\n"

--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -11,6 +11,7 @@ from telegram.ext import (
     Application,
     ApplicationHandlerStop,
     CommandHandler,
+    CallbackQueryHandler,
     ContextTypes,
     ExtBot,
     JobQueue,
@@ -341,10 +342,14 @@ def register_handlers(app: App) -> None:
     """Register learning-related handlers on the application."""
 
     from . import learning_onboarding as onboarding
-    from ..learning_handlers import topics_command
+    from ..learning_handlers import (
+        lesson_answer_handler,
+        lesson_callback,
+        topics_command as cmd_topics,
+    )
 
     app.add_handler(CommandHandler("learn", learn_command))
-    app.add_handler(CommandHandler("topics", topics_command))
+    app.add_handler(CommandHandler("topics", cmd_topics))
     app.add_handler(CommandHandler("lesson", lesson_command))
     app.add_handler(CommandHandler("quiz", quiz_command))
     app.add_handler(CommandHandler("progress", progress_command))
@@ -356,6 +361,12 @@ def register_handlers(app: App) -> None:
     app.add_handler(
         MessageHandler(
             filters.TEXT & ~filters.COMMAND, quiz_answer_handler, block=False
+        )
+    )
+    app.add_handler(CallbackQueryHandler(lesson_callback, pattern="^lesson:"))
+    app.add_handler(
+        MessageHandler(
+            filters.TEXT & ~filters.COMMAND, lesson_answer_handler, block=False
         )
     )
 

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -250,6 +250,7 @@ def register_handlers(
             app.bot.set_my_commands(
                 [
                     BotCommand("learn", "Учебный режим"),
+                    BotCommand("topics", "Список тем"),
                     BotCommand("menu", "Показать нижнее меню"),
                 ]
             )

--- a/tests/diabetes/test_commands.py
+++ b/tests/diabetes/test_commands.py
@@ -38,6 +38,7 @@ async def test_help_mentions_webapp() -> None:
     text = message.replies[0]
     assert "/start" in text
     assert "WebApp" in text
+    assert "/topics" in text
 
 
 @pytest.mark.asyncio

--- a/tests/learning/test_flow_autostart.py
+++ b/tests/learning/test_flow_autostart.py
@@ -10,7 +10,7 @@ from telegram.ext import Application, CommandHandler, MessageHandler, filters
 from services.api.app.config import settings
 from services.api.app.diabetes import learning_handlers
 from services.api.app.diabetes.handlers import learning_onboarding
-from services.api.app.diabetes.learning_handlers import TOPICS as TOPICS_RU
+from services.api.app.config import TOPICS_RU
 
 
 class DummyBot(Bot):
@@ -58,21 +58,27 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fake_generate_step_text
+    )
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
 
     bot = DummyBot()
     app = Application.builder().bot(bot).build()
     app.add_handler(CommandHandler("learn", learning_handlers.learn_command))
     app.add_handler(
-        MessageHandler(filters.TEXT & ~filters.COMMAND, learning_onboarding.onboarding_reply)
+        MessageHandler(
+            filters.TEXT & ~filters.COMMAND, learning_onboarding.onboarding_reply
+        )
     )
     await app.initialize()
 
     user = User(id=1, is_bot=False, first_name="T")
     chat = Chat(id=1, type="private")
 
-    def _msg(mid: int, text: str, *, entities: list[MessageEntity] | None = None) -> Message:
+    def _msg(
+        mid: int, text: str, *, entities: list[MessageEntity] | None = None
+    ) -> Message:
         msg = Message(
             message_id=mid,
             date=datetime.now(),
@@ -86,7 +92,10 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # start onboarding
     await app.process_update(
-        Update(update_id=1, message=_msg(1, "/learn", entities=[MessageEntity("bot_command", 0, 6)]))
+        Update(
+            update_id=1,
+            message=_msg(1, "/learn", entities=[MessageEntity("bot_command", 0, 6)]),
+        )
     )
     await app.process_update(Update(update_id=2, message=_msg(2, "49")))
     await app.process_update(Update(update_id=3, message=_msg(3, "2")))
@@ -94,7 +103,10 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # call /learn again - should autostart first topic
     await app.process_update(
-        Update(update_id=5, message=_msg(5, "/learn", entities=[MessageEntity("bot_command", 0, 6)]))
+        Update(
+            update_id=5,
+            message=_msg(5, "/learn", entities=[MessageEntity("bot_command", 0, 6)]),
+        )
     )
 
     title = TOPICS_RU[0][1]

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -32,8 +32,7 @@ async def test_help_includes_new_features() -> None:
     await handlers.help_command(update, context)
 
     assert (
-        message.kwargs[0]["reply_markup"].keyboard
-        == handlers.menu_keyboard().keyboard
+        message.kwargs[0]["reply_markup"].keyboard == handlers.menu_keyboard().keyboard
     )
     text = message.replies[0]
     assert "🆕 Новые возможности:\n" in text
@@ -98,3 +97,20 @@ async def test_help_lists_sos_contact_command() -> None:
 
     text = message.replies[0]
     assert "/soscontact — настроить контакт для SOS-уведомлений\n" in text
+
+
+@pytest.mark.asyncio
+async def test_help_lists_topics_command() -> None:
+    """Ensure /help documents topics command."""
+
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+
+    await handlers.help_command(update, context)
+
+    text = message.replies[0]
+    assert "/topics - список тем\n" in text

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -33,6 +33,7 @@ from services.api.app.diabetes.handlers import (
     learning_handlers,
     learning_onboarding,
 )
+from services.api.app.diabetes import learning_handlers as dynamic_learning_handlers
 from services.api.app.config import reload_settings
 
 
@@ -113,6 +114,22 @@ def test_register_handlers_attaches_expected_handlers(
         isinstance(h, CommandHandler)
         and h.callback is learning_handlers.exit_command
         and "exit" in h.commands
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CommandHandler)
+        and h.callback is dynamic_learning_handlers.topics_command
+        and "topics" in h.commands
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CallbackQueryHandler)
+        and h.callback is dynamic_learning_handlers.lesson_callback
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, MessageHandler)
+        and h.callback is dynamic_learning_handlers.lesson_answer_handler
         for h in handlers
     )
     assert any(


### PR DESCRIPTION
## Summary
- register /topics command and route lesson callbacks and answers
- document /topics in help text and bot command list
- test topic command registration and help output

## Testing
- `mypy --strict .`
- `ruff check .`
- `pytest tests/test_help_command.py tests/diabetes/test_commands.py tests/test_register_handlers.py tests/learning/test_flow_autostart.py -q` *(fails: Required test coverage of 85% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bc740828f4832aa53afb3de13f7c89