### PR TITLE
[api] return full profile in profile endpoints

### DIFF
--- a/services/api/app/diabetes/schemas/profile.py
+++ b/services/api/app/diabetes/schemas/profile.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from datetime import time
 from pydantic import BaseModel, Field, AliasChoices, ConfigDict, model_validator
 
 
@@ -37,6 +38,29 @@ class GlucoseUnits(str, Enum):
 class ProfileSettingsIn(BaseModel):
     """Incoming user settings for profile configuration."""
 
+    icr: float | None = None
+    cf: float | None = None
+    target: float | None = None
+    low: float | None = Field(
+        default=None,
+        alias="low",
+        validation_alias=AliasChoices("low", "targetLow"),
+    )
+    high: float | None = Field(
+        default=None,
+        alias="high",
+        validation_alias=AliasChoices("high", "targetHigh"),
+    )
+    quietStart: time | None = Field(
+        default=None,
+        alias="quietStart",
+        validation_alias=AliasChoices("quietStart", "quiet_start"),
+    )
+    quietEnd: time | None = Field(
+        default=None,
+        alias="quietEnd",
+        validation_alias=AliasChoices("quietEnd", "quiet_end"),
+    )
     timezone: str | None = None
     timezoneAuto: bool | None = Field(
         default=None,

--- a/services/api/app/routers/profile.py
+++ b/services/api/app/routers/profile.py
@@ -6,7 +6,8 @@ import logging
 
 from fastapi import APIRouter, Depends, Query
 
-from ..diabetes.schemas.profile import ProfileSettingsIn, ProfileSettingsOut
+from ..diabetes.schemas.profile import ProfileSettingsIn
+from ..schemas.profile import ProfileSchema
 from ..schemas.user import UserContext
 from ..services.profile import get_profile_settings, patch_user_settings
 from ..telegram_auth import require_tg_user
@@ -24,19 +25,19 @@ async def profile_self(user: UserContext = Depends(require_tg_user)) -> UserCont
     return user
 
 
-@router.get("/profile", response_model=ProfileSettingsOut)
-async def profile(user: UserContext = Depends(require_tg_user)) -> ProfileSettingsOut:
+@router.get("/profile", response_model=ProfileSchema)
+async def profile(user: UserContext = Depends(require_tg_user)) -> ProfileSchema:
     """Return current profile settings."""
 
     return await get_profile_settings(user["id"])
 
 
-@router.patch("/profile", response_model=ProfileSettingsOut)
+@router.patch("/profile", response_model=ProfileSchema)
 async def profile_patch(
     data: ProfileSettingsIn,
     device_tz: str | None = Query(None, alias="deviceTz"),
     user: UserContext = Depends(require_tg_user),
-) -> ProfileSettingsOut:
+) -> ProfileSchema:
     """Update profile settings."""
 
     return await patch_user_settings(user["id"], data, device_tz)

--- a/services/api/app/schemas/profile.py
+++ b/services/api/app/schemas/profile.py
@@ -96,6 +96,52 @@ class ProfileSchema(_ProfileBase):
         alias="timezoneAuto",
         validation_alias=AliasChoices("timezoneAuto", "timezone_auto"),
     )
+    dia: float = 4.0
+    roundStep: float = Field(
+        default=0.5,
+        alias="roundStep",
+        validation_alias=AliasChoices("roundStep", "round_step"),
+    )
+    carbUnits: CarbUnits = Field(
+        default=CarbUnits.GRAMS,
+        alias="carbUnits",
+        validation_alias=AliasChoices("carbUnits", "carb_units"),
+    )
+    gramsPerXe: float = Field(
+        default=12.0,
+        alias="gramsPerXe",
+        validation_alias=AliasChoices("gramsPerXe", "grams_per_xe"),
+    )
+    glucoseUnits: GlucoseUnits = Field(
+        default=GlucoseUnits.MMOL_L,
+        alias="glucoseUnits",
+        validation_alias=AliasChoices("glucoseUnits", "glucose_units"),
+    )
+    rapidInsulinType: RapidInsulinType | None = Field(
+        default=None,
+        alias="rapidInsulinType",
+        validation_alias=AliasChoices("rapidInsulinType", "rapid_insulin_type"),
+    )
+    maxBolus: float = Field(
+        default=10.0,
+        alias="maxBolus",
+        validation_alias=AliasChoices("maxBolus", "max_bolus"),
+    )
+    preBolus: int = Field(
+        default=0,
+        alias="preBolus",
+        validation_alias=AliasChoices("preBolus", "pre_bolus", "prebolus_min"),
+    )
+    afterMealMinutes: int = Field(
+        default=0,
+        alias="afterMealMinutes",
+        validation_alias=AliasChoices(
+            "afterMealMinutes",
+            "after_meal_minutes",
+            "postMealCheckMin",
+            "postmeal_check_min",
+        ),
+    )
 
 
 class ProfileUpdateSchema(_ProfileBase):


### PR DESCRIPTION
## Summary
- expose full ProfileSchema for GET/PATCH /profile
- persist and return complete profile settings
- test that icr/cf/target/low/high survive PATCH/GET round trip

## Testing
- `pytest -q --cov` *(fails: test_flow_autostart)*
- `mypy --strict services/api/app/routers/profile.py services/api/app/services/profile.py services/api/app/diabetes/schemas/profile.py services/api/app/schemas/profile.py tests/test_profile_patch_endpoint.py`
- `ruff check services/api/app/services/profile.py services/api/app/routers/profile.py services/api/app/diabetes/schemas/profile.py services/api/app/schemas/profile.py tests/test_profile_patch_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc7d376518832aad28df96e8c2eaa3