### PR TITLE
learning: integrate curriculum engine for step updates

### DIFF
--- a/services/api/app/diabetes/curriculum_engine.py
+++ b/services/api/app/diabetes/curriculum_engine.py
@@ -55,7 +55,9 @@ async def start_lesson(user_id: int, lesson_slug: str) -> LessonProgress:
     return progress
 
 
-async def next_step(user_id: int, lesson_id: int) -> tuple[str | None, bool]:
+async def next_step(
+    user_id: int, lesson_id: int, prev_feedback: str | None = None
+) -> tuple[str | None, bool]:
     """Advance the lesson and return the next piece of content.
 
     Behaviour is determined by ``settings.learning_content_mode``:
@@ -75,8 +77,9 @@ async def next_step(user_id: int, lesson_id: int) -> tuple[str | None, bool]:
             progress.current_step += 1
             commit(session)
             return progress.current_step, lesson.slug
+
         step_idx, slug = await db.run_db(_advance_dynamic)
-        text = await generate_step_text({}, slug, step_idx, None)
+        text = await generate_step_text({}, slug, step_idx, prev_feedback)
         return text, False
 
     def _advance_static(

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -41,12 +41,25 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
     monkeypatch.setattr(learning_handlers, "TOPICS_RU", {"slug": "Topic"})
-    async def fake_generate_step_text(*args: object, **kwargs: object) -> str:
-        return "step1?"
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    progress = SimpleNamespace(lesson_id=1)
+
+    async def fake_start(user_id: int, slug: str) -> SimpleNamespace:
+        return progress
+
+    async def fake_next(
+        user_id: int, lesson_id: int, prev_feedback: str | None = None
+    ) -> tuple[str, bool]:
+        return "step1?", False
+
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "start_lesson", fake_start
+    )
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "next_step", fake_next
+    )
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
 
     msg = DummyMessage()
@@ -74,18 +87,31 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
 @pytest.mark.asyncio
 async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
-    async def fake_generate_step_text(
-        profile: object, topic: str, step_idx: int, prev: object
-    ) -> str:
-        return f"step{step_idx}?"
+    progress = SimpleNamespace(lesson_id=1)
 
-    async def fake_check_user_answer(
-        profile: object, topic: str, answer: str, last: str
-    ) -> str:
-        return "feedback"
+    async def fake_start(user_id: int, slug: str) -> SimpleNamespace:
+        return progress
 
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
-    monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+    async def fake_next(
+        user_id: int, lesson_id: int, prev_feedback: str | None = None
+    ) -> tuple[str, bool]:
+        step_idx = 1 if prev_feedback is None else 2
+        return f"step{step_idx}?", False
+
+    async def fake_check(
+        user_id: int, lesson_id: int, answer: str, last: str
+    ) -> tuple[bool, str]:
+        return True, "feedback"
+
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "start_lesson", fake_start
+    )
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "next_step", fake_next
+    )
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "check_answer", fake_check
+    )
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 
@@ -145,7 +171,9 @@ async def test_learn_command_autostarts_when_topics_hidden(
         assert slug == "slug"
         return progress
 
-    async def fake_next_step(user_id: int, lesson_id: int) -> tuple[str, bool]:
+    async def fake_next_step(
+        user_id: int, lesson_id: int, prev_feedback: str | None = None
+    ) -> tuple[str, bool]:
         assert lesson_id == 1
         return "first", False
 

--- a/tests/diabetes/test_learning_handlers_rate_limit.py
+++ b/tests/diabetes/test_learning_handlers_rate_limit.py
@@ -40,7 +40,9 @@ async def test_lesson_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
 
     steps = iter([("step1", False), ("step2", False), (None, True)])
 
-    async def fake_next(user_id: int, lesson_id: int) -> tuple[str | None, bool]:
+    async def fake_next(
+        user_id: int, lesson_id: int, prev_feedback: str | None = None
+    ) -> tuple[str | None, bool]:
         calls.append("next")
         return next(steps)
 
@@ -85,7 +87,9 @@ async def test_quiz_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
 
     questions = iter([("Q1", False), ("Q2", False), (None, True)])
 
-    async def fake_next(user_id: int, lesson_id: int) -> tuple[str | None, bool]:
+    async def fake_next(
+        user_id: int, lesson_id: int, prev_feedback: str | None = None
+    ) -> tuple[str | None, bool]:
         return next(questions)
 
     answers: list[int] = []

--- a/tests/diabetes/test_learning_logs.py
+++ b/tests/diabetes/test_learning_logs.py
@@ -39,7 +39,9 @@ async def test_lesson_start_logging(monkeypatch: pytest.MonkeyPatch, caplog: pyt
     async def fake_start(user_id: int, slug: str) -> SimpleNamespace:
         return SimpleNamespace(lesson_id=1)
 
-    async def fake_next(user_id: int, lesson_id: int) -> tuple[str | None, bool]:
+    async def fake_next(
+        user_id: int, lesson_id: int, prev_feedback: str | None = None
+    ) -> tuple[str | None, bool]:
         return None, True
 
     monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start)

--- a/tests/diabetes/test_learning_text_answer.py
+++ b/tests/diabetes/test_learning_text_answer.py
@@ -40,7 +40,9 @@ async def test_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
 
     questions = iter([("Q1", False), (None, True)])
 
-    async def fake_next(user_id: int, lesson_id: int) -> tuple[str | None, bool]:
+    async def fake_next(
+        user_id: int, lesson_id: int, prev_feedback: str | None = None
+    ) -> tuple[str | None, bool]:
         return next(questions)
 
     async def fake_check(user_id: int, lesson_id: int, answer: int) -> tuple[bool, str]:

--- a/tests/learning/test_curriculum_engine.py
+++ b/tests/learning/test_curriculum_engine.py
@@ -190,6 +190,11 @@ async def test_dynamic_mode_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     text, completed = await next_step(1, lesson_id)
     assert text == "step 1"
     assert completed is False
+    with db.SessionLocal() as session:
+        progress = session.query(LessonProgress).filter_by(
+            user_id=1, lesson_id=lesson_id
+        ).one()
+        assert progress.current_step == 1
 
     correct, feedback = await check_answer(1, lesson_id, "42")
     assert correct is True
@@ -198,3 +203,8 @@ async def test_dynamic_mode_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     text, completed = await next_step(1, lesson_id)
     assert text == "step 2"
     assert completed is False
+    with db.SessionLocal() as session:
+        progress = session.query(LessonProgress).filter_by(
+            user_id=1, lesson_id=lesson_id
+        ).one()
+        assert progress.current_step == 2

--- a/tests/learning/test_handlers.py
+++ b/tests/learning/test_handlers.py
@@ -67,14 +67,28 @@ async def test_learning_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_ui_show_topics", True)
     steps = iter(["step1", "step2"])
 
-    async def fake_generate_step_text(*args: object, **kwargs: object) -> str:
-        return next(steps)
+    async def fake_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
+        return SimpleNamespace(lesson_id=1)
 
-    async def fake_check_user_answer(*args: object, **kwargs: object) -> str:
-        return "feedback"
+    async def fake_next_step(
+        user_id: int, lesson_id: int, prev_feedback: str | None = None
+    ) -> tuple[str, bool]:
+        return next(steps), False
 
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
-    monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+    async def fake_check_answer(
+        user_id: int, lesson_id: int, answer: str, last_step: str
+    ) -> tuple[bool, str]:
+        return True, "feedback"
+
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
+    )
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "next_step", fake_next_step
+    )
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "check_answer", fake_check_answer
+    )
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 


### PR DESCRIPTION
## Summary
- use curriculum_engine for dynamic lesson start and step generation so DB progress stays in sync
- allow next_step to accept previous feedback for dynamic content
- adjust tests to verify LessonProgress.current_step increments

## Testing
- `pytest -q --cov` *(fails: unrecognized arguments)*
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc8108eea8832a96fdfd6ee1eaffa0