### PR TITLE
[learning] parse dynamic answer correctness

### DIFF
--- a/services/api/app/diabetes/curriculum_engine.py
+++ b/services/api/app/diabetes/curriculum_engine.py
@@ -161,8 +161,10 @@ async def check_answer(
             return lesson.slug
 
         slug = await db.run_db(_get_slug)
-        feedback = await check_user_answer({}, slug, str(answer), last_step_text or "")
-        return True, feedback
+        correct, feedback = await check_user_answer(
+            {}, slug, str(answer), last_step_text or ""
+        )
+        return correct, feedback
 
     answer_index = int(answer) - 1
 

--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -223,7 +223,7 @@ async def lesson_answer_handler(
     user_text = message.text.strip()
     if telegram_id is not None:
         await add_lesson_log(telegram_id, state.topic, "user", state.step, user_text)
-    feedback = await check_user_answer(
+    _correct, feedback = await check_user_answer(
         profile, state.topic, user_text, state.last_step_text or ""
     )
     feedback = format_reply(feedback)

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -81,8 +81,8 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     async def fake_check_user_answer(
         profile: object, topic: str, answer: str, last: str
-    ) -> str:
-        return "feedback"
+    ) -> tuple[bool, str]:
+        return True, "feedback"
 
     monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)

--- a/tests/learning/test_curriculum_engine.py
+++ b/tests/learning/test_curriculum_engine.py
@@ -180,8 +180,8 @@ async def test_dynamic_mode_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     async def fake_check(
         profile: object, slug: str, answer: str, last: str
-    ) -> str:
-        return f"fb {answer}"
+    ) -> tuple[bool, str]:
+        return True, f"fb {answer}"
 
     monkeypatch.setattr(curriculum_engine, "generate_step_text", fake_generate)
     monkeypatch.setattr(curriculum_engine, "check_user_answer", fake_check)

--- a/tests/learning/test_dynamic_tutor.py
+++ b/tests/learning/test_dynamic_tutor.py
@@ -25,10 +25,11 @@ async def test_step_answer_feedback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
 
     step = await dynamic_tutor.generate_step_text({}, "topic", 1, None)
-    feedback = await dynamic_tutor.check_user_answer({}, "topic", "42", step)
+    correct, feedback = await dynamic_tutor.check_user_answer({}, "topic", "42", step)
 
     assert step == "step1"
     assert feedback == "feedback"
+    assert correct is False
 
 
 @pytest.mark.asyncio
@@ -44,7 +45,8 @@ async def test_runtimeerror_returns_fallback(
     monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
 
     step = await dynamic_tutor.generate_step_text({}, "topic", 1, None)
-    feedback = await dynamic_tutor.check_user_answer({}, "topic", "42", "step")
+    correct, feedback = await dynamic_tutor.check_user_answer({}, "topic", "42", "step")
 
     assert step == "сервер занят, попробуйте позже"
+    assert correct is False
     assert feedback == "сервер занят, попробуйте позже"

--- a/tests/learning/test_handlers.py
+++ b/tests/learning/test_handlers.py
@@ -70,8 +70,8 @@ async def test_learning_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_generate_step_text(*args: object, **kwargs: object) -> str:
         return next(steps)
 
-    async def fake_check_user_answer(*args: object, **kwargs: object) -> str:
-        return "feedback"
+    async def fake_check_user_answer(*args: object, **kwargs: object) -> tuple[bool, str]:
+        return True, "feedback"
 
     monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)

--- a/tests/learning/test_handlers_rate_limit.py
+++ b/tests/learning/test_handlers_rate_limit.py
@@ -71,8 +71,8 @@ async def test_lesson_answer_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
     async def fake_check_user_answer(
         profile: object, topic: str, answer: str, last: str
-    ) -> str:
-        return "feedback"
+    ) -> tuple[bool, str]:
+        return True, "feedback"
 
     async def fake_generate_step_text(
         profile: object, topic: str, step_idx: int, prev: object

--- a/tests/test_dynamic_tutor.py
+++ b/tests/test_dynamic_tutor.py
@@ -50,16 +50,17 @@ async def test_check_user_answer_uses_max_tokens(
 
     async def fake_create_chat_completion(**kwargs: object) -> _FakeCompletion:
         captured.update(kwargs)
-        return _FakeCompletion("ok")
+        return _FakeCompletion("Верно. Всё отлично")
 
     monkeypatch.setattr(
         dynamic_tutor, "create_chat_completion", fake_create_chat_completion
     )
     monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
 
-    result = await dynamic_tutor.check_user_answer({}, "topic", "ans", "text")
+    correct, result = await dynamic_tutor.check_user_answer({}, "topic", "ans", "text")
 
-    assert result == "ok"
+    assert correct is True
+    assert result == "Верно. Всё отлично"
     assert captured["max_tokens"] == 250
 
 
@@ -71,6 +72,7 @@ async def test_check_user_answer_runtime(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(dynamic_tutor, "create_chat_completion", raise_error)
     monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
 
-    result = await dynamic_tutor.check_user_answer({}, "topic", "ans", "text")
+    correct, result = await dynamic_tutor.check_user_answer({}, "topic", "ans", "text")
 
+    assert correct is False
     assert result == "сервер занят, попробуйте позже"


### PR DESCRIPTION
## Summary
- parse tutor feedback to determine correctness in dynamic learning mode
- return correctness flag from curriculum engine
- adjust handlers and tests for new API

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc812b10ec832a9393a09e56cf002b