### PR TITLE
[billing] Disable IP filter in webhook tests

### DIFF
--- a/tests/billing/test_billing_webhook.py
+++ b/tests/billing/test_billing_webhook.py
@@ -71,7 +71,12 @@ def _sign(secret: str, event_id: str, transaction_id: str) -> str:
 def test_webhook_activates_subscription(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     session_local = setup_db()
     secret = "testsecret"
-    client = make_client(monkeypatch, session_local, BILLING_WEBHOOK_SECRET=secret)
+    monkeypatch.setenv("BILLING_WEBHOOK_IPS", "")
+    client = make_client(
+        monkeypatch,
+        session_local,
+        BILLING_WEBHOOK_SECRET=secret,
+    )
     checkout_id = create_subscription(client)
     event_id = "evt1"
     sig = _sign(secret, event_id, checkout_id)
@@ -105,7 +110,12 @@ def test_webhook_activates_subscription(monkeypatch: pytest.MonkeyPatch, caplog:
 def test_webhook_duplicate_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
     session_local = setup_db()
     secret = "testsecret"
-    client = make_client(monkeypatch, session_local, BILLING_WEBHOOK_SECRET=secret)
+    monkeypatch.setenv("BILLING_WEBHOOK_IPS", "")
+    client = make_client(
+        monkeypatch,
+        session_local,
+        BILLING_WEBHOOK_SECRET=secret,
+    )
     checkout_id = create_subscription(client)
     event_id = "evt2"
     sig = _sign(secret, event_id, checkout_id)


### PR DESCRIPTION
## Summary
- ensure billing webhook tests disable IP filtering before client creation

## Testing
- `ruff check tests/billing/test_billing_webhook.py`
- `mypy --strict tests/billing/test_billing_webhook.py`
- `pytest -o addopts="" tests/billing/test_billing_webhook.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc84a683b8832a8cfe4f288b9773d1