### PR TITLE
[tests] Use dict lookup for topic title

### DIFF
--- a/tests/learning/test_flow_autostart.py
+++ b/tests/learning/test_flow_autostart.py
@@ -8,7 +8,7 @@ import pytest
 from telegram import Bot, Chat, Message, MessageEntity, Update, User
 from telegram.ext import Application, CommandHandler, MessageHandler, filters
 
-from services.api.app.config import settings
+from services.api.app.config import TOPICS_RU, settings
 from services.api.app.diabetes import learning_handlers
 from services.api.app.diabetes.handlers import learning_onboarding
 
@@ -51,6 +51,8 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
     """Autostart should skip topic list and send first dynamic step."""
 
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+
+    title = next(iter(TOPICS_RU.values()))
 
     async def fake_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
         return SimpleNamespace(lesson_id=1)
@@ -125,7 +127,12 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     assert bot.sent[-1] == "шаг1"
-    assert all("Выберите тему" not in s and "Доступные темы" not in s for s in bot.sent)
+    assert all(
+        title not in s
+        and "Выберите тему" not in s
+        and "Доступные темы" not in s
+        for s in bot.sent
+    )
     assert captured_profile == {
         "age_group": "adult",
         "diabetes_type": "T2",


### PR DESCRIPTION
## Summary
- use dictionary iteration to obtain first topic title in autostart test
- assert that no topic title or topic list messages are sent during autostart

## Testing
- `pytest tests/learning/test_flow_autostart.py -q` *(fails: Coverage failure: total of 24 is less than fail-under=85)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc84a97be4832a8b6187b1768b7726