### PR TITLE
[ui] store Telegram init data for auth

### DIFF
--- a/services/webapp/ui/src/lib/telegram-auth.ts
+++ b/services/webapp/ui/src/lib/telegram-auth.ts
@@ -6,17 +6,42 @@ export function getDevInitData(): string | null {
     const ls = localStorage.getItem(LS_KEY);
     if (ls) return ls;
   }
-  const envData = (import.meta.env as Record<string, string | undefined>).VITE_TELEGRAM_INIT_DATA;
+  const envData = (import.meta.env as Record<string, string | undefined>)
+    .VITE_TELEGRAM_INIT_DATA;
   return envData ?? null;
+}
+
+let storedInitData: string | null = null;
+
+export function setTelegramInitData(data: string): void {
+  storedInitData = data;
+  try {
+    localStorage.setItem(LS_KEY, data);
+  } catch {
+    /* ignore */
+  }
+}
+
+function getStoredInitData(): string | null {
+  if (storedInitData) return storedInitData;
+  try {
+    const ls = localStorage.getItem(LS_KEY);
+    if (ls) {
+      storedInitData = ls;
+      return ls;
+    }
+  } catch {
+    /* ignore */
+  }
+  if (import.meta.env.DEV) {
+    return getDevInitData();
+  }
+  return null;
 }
 
 export function getTelegramAuthHeaders(): Record<string, string> {
   const headers: Record<string, string> = {};
-  const globalInitData = (
-    window as unknown as { Telegram?: { WebApp?: { initData?: string } } }
-  )?.Telegram?.WebApp?.initData;
-  const initData =
-    globalInitData || (import.meta.env.DEV ? getDevInitData() : null);
+  const initData = getStoredInitData();
   if (initData) {
     headers[HEADER] = `tg ${initData}`;
   }

--- a/services/webapp/ui/src/pages/Subscription.tsx
+++ b/services/webapp/ui/src/pages/Subscription.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/api/billing';
 import { useTelegram } from '@/hooks/useTelegram';
 import { useTelegramInitData } from '@/hooks/useTelegramInitData';
+import { setTelegramInitData } from '@/lib/telegram-auth';
 import { resolveTelegramId } from './resolveTelegramId';
 
 interface TariffPlan {
@@ -91,10 +92,7 @@ const Subscription = () => {
 
   useEffect(() => {
     if (initData) {
-      const w = window as any;
-      w.Telegram = w.Telegram || {};
-      w.Telegram.WebApp = w.Telegram.WebApp || {};
-      w.Telegram.WebApp.initData = initData;
+      setTelegramInitData(initData);
     }
   }, [initData]);
 

--- a/services/webapp/ui/src/shared/api/onboarding.ts
+++ b/services/webapp/ui/src/shared/api/onboarding.ts
@@ -1,3 +1,5 @@
+import { getTelegramAuthHeaders, setTelegramInitData } from '@/lib/telegram-auth';
+
 export function getInitDataRaw(): string | null {
   const initData =
     (window as unknown as { Telegram?: { WebApp?: { initData?: string } } })
@@ -19,18 +21,15 @@ export async function postOnboardingEvent(
   step?: string,
   meta?: any,
 ) {
-  const initData = getInitDataRaw();
-
-  if (!initData) {
+  const rawInitData = getInitDataRaw();
+  if (rawInitData) {
+    setTelegramInitData(rawInitData);
+  }
+  const headers = getTelegramAuthHeaders();
+  if (!headers.Authorization) {
     return;
   }
-
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
-  if (initData) {
-    headers['X-Telegram-Init-Data'] = initData;
-  }
+  headers['Content-Type'] = 'application/json';
 
   const res = await fetch('/api/onboarding/events', {
     method: 'POST',
@@ -41,15 +40,13 @@ export async function postOnboardingEvent(
 }
 
 export async function getOnboardingStatus() {
-  const initData = getInitDataRaw();
-
-  if (!initData) {
-    return;
+  const rawInitData = getInitDataRaw();
+  if (rawInitData) {
+    setTelegramInitData(rawInitData);
   }
-
-  const headers: Record<string, string> = {};
-  if (initData) {
-    headers['X-Telegram-Init-Data'] = initData;
+  const headers = getTelegramAuthHeaders();
+  if (!headers.Authorization) {
+    return;
   }
   const res = await fetch('/api/onboarding/status', { headers });
   if (!res.ok) throw new Error('Failed to get onboarding status');

--- a/services/webapp/ui/tests/onboarding.api.test.ts
+++ b/services/webapp/ui/tests/onboarding.api.test.ts
@@ -9,6 +9,7 @@ describe('onboarding api', () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     delete (window as any).Telegram;
+    localStorage.clear();
   });
 
   it('throws error when postOnboardingEvent request fails', async () => {
@@ -23,7 +24,7 @@ describe('onboarding api', () => {
       '/api/onboarding/events',
       expect.objectContaining({
         method: 'POST',
-        headers: expect.objectContaining({ 'X-Telegram-Init-Data': 'init' }),
+        headers: expect.objectContaining({ Authorization: 'tg init' }),
       }),
     );
   });
@@ -39,7 +40,7 @@ describe('onboarding api', () => {
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/onboarding/status',
       expect.objectContaining({
-        headers: expect.objectContaining({ 'X-Telegram-Init-Data': 'init' }),
+        headers: expect.objectContaining({ Authorization: 'tg init' }),
       }),
     );
   });
@@ -82,7 +83,7 @@ describe('onboarding api', () => {
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/onboarding/events',
       expect.objectContaining({
-        headers: expect.objectContaining({ 'X-Telegram-Init-Data': 'from-url' }),
+        headers: expect.objectContaining({ Authorization: 'tg from-url' }),
       }),
     );
   });


### PR DESCRIPTION
## Summary
- add setter and storage for Telegram init data and use it in auth header
- persist init data from Subscription page and reuse in onboarding API
- update onboarding API tests for new Authorization header

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any)*
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test` *(fails: JavaScript heap out of memory)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc8487fcc8832aa84538ef2b8041ee