### PR TITLE
[ui] handle onboarding init data

### DIFF
--- a/services/webapp/ui/src/components/OnboardingProgress.tsx
+++ b/services/webapp/ui/src/components/OnboardingProgress.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { hasInitData } from '@/shared/initData';
 
 interface OnboardingStatus {
   completed: boolean;
@@ -15,6 +16,7 @@ const OnboardingProgress = () => {
   const [data, setData] = useState<OnboardingStatus | null>(null);
 
   useEffect(() => {
+    if (!hasInitData()) return;
     let active = true;
     import('@/shared/api/onboarding')
       .then((mod) => mod.getOnboardingStatus?.())

--- a/services/webapp/ui/src/shared/initData.ts
+++ b/services/webapp/ui/src/shared/initData.ts
@@ -1,0 +1,15 @@
+export function hasInitData(): boolean {
+  const initData =
+    (window as unknown as { Telegram?: { WebApp?: { initData?: string } } })
+      .Telegram?.WebApp?.initData;
+
+  if (initData) {
+    return true;
+  }
+
+  const urlData = new URLSearchParams(window.location.search).get(
+    'tgWebAppData',
+  );
+
+  return Boolean(urlData);
+}

--- a/services/webapp/ui/tests/OnboardingProgress.test.tsx
+++ b/services/webapp/ui/tests/OnboardingProgress.test.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
+vi.mock('@/shared/api/onboarding');
+vi.mock('@/shared/initData', () => ({ hasInitData: vi.fn() }));
+
+import '@testing-library/jest-dom';
 import OnboardingProgress from '../src/components/OnboardingProgress';
 import { getOnboardingStatus } from '../src/shared/api/onboarding';
-import '@testing-library/jest-dom';
+import { hasInitData } from '../src/shared/initData';
 
-vi.mock('@/shared/api/onboarding');
+const mockHasInitData = hasInitData as unknown as vi.Mock;
 
 describe('OnboardingProgress', () => {
   afterEach(() => {
@@ -15,6 +19,7 @@ describe('OnboardingProgress', () => {
   });
 
   it('shows completed badge', async () => {
+    mockHasInitData.mockReturnValue(true);
     (getOnboardingStatus as any).mockResolvedValue({
       completed: true,
       step: null,
@@ -25,6 +30,7 @@ describe('OnboardingProgress', () => {
   });
 
   it('shows steps when not completed', async () => {
+    mockHasInitData.mockReturnValue(true);
     (getOnboardingStatus as any).mockResolvedValue({
       completed: false,
       step: 'profile',
@@ -33,5 +39,12 @@ describe('OnboardingProgress', () => {
     render(<OnboardingProgress />);
     expect(await screen.findByText('Профиль')).toBeInTheDocument();
     expect(screen.getByText('Напоминания')).toBeInTheDocument();
+  });
+
+  it('skips fetch and render without init data', () => {
+    mockHasInitData.mockReturnValue(false);
+    render(<OnboardingProgress />);
+    expect(screen.queryByLabelText('Onboarding progress')).toBeNull();
+    expect(getOnboardingStatus).not.toHaveBeenCalled();
   });
 });

--- a/services/webapp/ui/tests/initData.test.ts
+++ b/services/webapp/ui/tests/initData.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { hasInitData } from '../src/shared/initData';
+
+describe('hasInitData', () => {
+  afterEach(() => {
+    delete (window as any).Telegram;
+    vi.unstubAllGlobals();
+  });
+
+  it('returns true when Telegram initData present', () => {
+    (window as any).Telegram = { WebApp: { initData: 'init' } };
+    expect(hasInitData()).toBe(true);
+  });
+
+  it('returns true when tgWebAppData param present', () => {
+    vi.stubGlobal('location', { search: '?tgWebAppData=from-url' } as any);
+    expect(hasInitData()).toBe(true);
+  });
+
+  it('returns false when no init data', () => {
+    expect(hasInitData()).toBe(false);
+  });
+});

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -120,23 +120,22 @@ describe('profile api', () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/profiles',
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({
-          telegramId: 1,
-          target: 5,
-          low: 4,
-          high: 10,
-          timezone: 'UTC',
-          timezoneAuto: false,
-          quietStart: '23:00',
-          quietEnd: '07:00',
-          sosAlertsEnabled: true,
-          sosContact: null,
-          therapyType: 'none',
-        }),
-      }),
+      expect.objectContaining({ method: 'POST', body: expect.any(String) }),
     );
+    const body = JSON.parse(mockFetch.mock.calls[0][1]!.body as string);
+    expect(body).toEqual({
+      telegramId: 1,
+      target: 5,
+      low: 4,
+      high: 10,
+      timezone: 'UTC',
+      timezoneAuto: false,
+      quietStart: '23:00',
+      quietEnd: '07:00',
+      sosAlertsEnabled: true,
+      sosContact: null,
+      therapyType: 'none',
+    });
   });
 
   it('throws error when patchProfile request fails', async () => {


### PR DESCRIPTION
## Summary
- skip onboarding status request when Telegram init data absent
- add init data helper and test coverage
- adjust profile API test to parse request body

## Testing
- `pnpm --filter ./services/webapp/ui test -- --globals tests/OnboardingProgress.test.tsx tests/initData.test.ts`
- `pnpm --filter ./services/webapp/ui test -- --globals tests/profile.api.test.ts`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict services/api/app/diabetes` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc848fd754832aaa36603d2204d383