### PR TITLE
[learning] Parse LLM feedback for answer correctness

### DIFF
--- a/services/api/app/diabetes/curriculum_engine.py
+++ b/services/api/app/diabetes/curriculum_engine.py
@@ -24,6 +24,17 @@ from .services.repository import commit
 logger = logging.getLogger(__name__)
 
 
+def _is_feedback_correct(feedback: str) -> bool:
+    """Return ``True`` if tutor's feedback marks the answer as correct."""
+
+    text = feedback.lower()
+    if "неверно" in text or "почти" in text:
+        return False
+    if "верно" in text or "правиль" in text:
+        return True
+    return False
+
+
 async def start_lesson(user_id: int, lesson_slug: str) -> LessonProgress:
     """Start or reset a lesson for a user and return progress."""
 
@@ -169,7 +180,8 @@ async def check_answer(
 
         slug = await db.run_db(_get_slug)
         feedback = await check_user_answer({}, slug, str(answer), last_step_text or "")
-        return True, feedback
+        correct = _is_feedback_correct(feedback)
+        return correct, feedback
 
     answer_index = int(answer) - 1
 

--- a/tests/diabetes/test_learning_handlers_rate_limit.py
+++ b/tests/diabetes/test_learning_handlers_rate_limit.py
@@ -40,7 +40,9 @@ async def test_lesson_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
 
     steps = iter([("step1", False), ("step2", False), (None, True)])
 
-    async def fake_next(user_id: int, lesson_id: int) -> tuple[str | None, bool]:
+    async def fake_next(
+        user_id: int, lesson_id: int, profile: object
+    ) -> tuple[str | None, bool]:
         calls.append("next")
         return next(steps)
 
@@ -85,7 +87,9 @@ async def test_quiz_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
 
     questions = iter([("Q1", False), ("Q2", False), (None, True)])
 
-    async def fake_next(user_id: int, lesson_id: int) -> tuple[str | None, bool]:
+    async def fake_next(
+        user_id: int, lesson_id: int, profile: object
+    ) -> tuple[str | None, bool]:
         return next(questions)
 
     answers: list[int] = []

--- a/tests/diabetes/test_learning_logs.py
+++ b/tests/diabetes/test_learning_logs.py
@@ -39,7 +39,9 @@ async def test_lesson_start_logging(monkeypatch: pytest.MonkeyPatch, caplog: pyt
     async def fake_start(user_id: int, slug: str) -> SimpleNamespace:
         return SimpleNamespace(lesson_id=1)
 
-    async def fake_next(user_id: int, lesson_id: int) -> tuple[str | None, bool]:
+    async def fake_next(
+        user_id: int, lesson_id: int, profile: object
+    ) -> tuple[str | None, bool]:
         return None, True
 
     monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start)

--- a/tests/diabetes/test_learning_text_answer.py
+++ b/tests/diabetes/test_learning_text_answer.py
@@ -40,7 +40,9 @@ async def test_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
 
     questions = iter([("Q1", False), (None, True)])
 
-    async def fake_next(user_id: int, lesson_id: int) -> tuple[str | None, bool]:
+    async def fake_next(
+        user_id: int, lesson_id: int, profile: object
+    ) -> tuple[str | None, bool]:
         return next(questions)
 
     async def fake_check(user_id: int, lesson_id: int, answer: int) -> tuple[bool, str]:

--- a/tests/learning/test_curriculum_engine.py
+++ b/tests/learning/test_curriculum_engine.py
@@ -184,7 +184,9 @@ async def test_dynamic_mode_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_check(
         profile: object, slug: str, answer: str, last: str
     ) -> str:
-        return f"fb {answer}"
+        return (
+            "Верно, продолжай!" if answer == "42" else "Неверно, попробуй ещё."
+        )
 
     monkeypatch.setattr(curriculum_engine, "generate_step_text", fake_generate)
     monkeypatch.setattr(curriculum_engine, "check_user_answer", fake_check)
@@ -198,8 +200,12 @@ async def test_dynamic_mode_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     correct, feedback = await check_answer(1, lesson_id, "42")
     assert correct is True
-    assert feedback == "fb 42"
+    assert feedback == "Верно, продолжай!"
 
     text, completed = await next_step(1, lesson_id, profile)
     assert text == "step 2"
     assert completed is False
+
+    wrong, fb_wrong = await check_answer(1, lesson_id, "0")
+    assert wrong is False
+    assert fb_wrong == "Неверно, попробуй ещё."


### PR DESCRIPTION
## Summary
- infer correctness from tutor feedback in dynamic curriculum mode
- expose correctness boolean to callers and extend tests
- adjust rate-limit and logging tests for new next_step signature

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc856263b8832aaa507ec2bb4c1f79