### PR TITLE
[utils] Drop redundant settings reload in subscription keyboard

### DIFF
--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -125,7 +125,6 @@ def subscription_keyboard(trial_available: bool) -> InlineKeyboardMarkup:
     """Build inline keyboard for subscription actions."""
     from services.api.app import config
 
-    config.reload_settings()
     buttons: list[InlineKeyboardButton] = []
     if trial_available:
         buttons.append(InlineKeyboardButton("🎁 Trial", callback_data="trial"))


### PR DESCRIPTION
## Summary
- remove repeated `config.reload_settings()` from `subscription_keyboard`
- allow tests to override `SUBSCRIPTION_URL` and `PUBLIC_ORIGIN` reliably

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc8da3f7b8832abb75bbb615dfe90f