### PR TITLE
[webapp] align profile API paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,14 @@ fetch('http://localhost:8000/api/onboarding/status', {
 
 ### Создание профиля
 ```bash
-curl -X POST http://localhost:8000/api/profiles \
+curl -X POST http://localhost:8000/api/profile \
   -H 'Content-Type: application/json' \
   -d '{"telegramId":777,"icr":1.0,"cf":1.0,"target":5.0,"low":4.0,"high":6.0}'
 ```
 
 ### Получение профиля
 ```bash
-curl http://localhost:8000/api/profiles?telegramId=777
+curl http://localhost:8000/api/profile?telegramId=777
 ```
 
 ## Переменные окружения

--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -5,7 +5,7 @@ import type { Profile, PatchProfileDto, RapidInsulin } from './types';
 export async function getProfile(telegramId: number): Promise<Profile | null> {
   try {
     return await tgFetch<Profile>(
-      `/profiles?telegramId=${telegramId}`,
+      `/profile?telegramId=${telegramId}`,
     );
   } catch (error) {
     if (error instanceof FetchError) {
@@ -95,7 +95,7 @@ export async function saveProfile({
       body.therapyType = therapyType;
     }
 
-    return await tgFetch<ProfileSchema>('/profiles', {
+    return await tgFetch<ProfileSchema>('/profile', {
       method: 'POST',
       body,
     });

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -26,7 +26,7 @@ describe('profile api', () => {
       'Не удалось получить профиль: boom',
     );
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/profiles?telegramId=1',
+      '/api/profile?telegramId=1',
       expect.any(Object),
     );
   });
@@ -45,7 +45,7 @@ describe('profile api', () => {
     const result = await getProfile(1);
     expect(result).toBeNull();
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/profiles?telegramId=1',
+      '/api/profile?telegramId=1',
       expect.any(Object),
     );
   });
@@ -65,7 +65,7 @@ describe('profile api', () => {
       'Не удалось получить профиль: Некорректный ответ сервера',
     );
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/profiles?telegramId=1',
+      '/api/profile?telegramId=1',
       expect.any(Object),
     );
   });
@@ -85,7 +85,7 @@ describe('profile api', () => {
       saveProfile({ telegramId: 1, icr: 1, cf: 2, target: 5, low: 4, high: 10 }),
     ).rejects.toThrow('Не удалось сохранить профиль: fail');
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/profiles',
+      '/api/profile',
       expect.objectContaining({ method: 'POST' }),
     );
   });
@@ -119,7 +119,7 @@ describe('profile api', () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/profiles',
+      '/api/profile',
       expect.objectContaining({ method: 'POST', body: expect.any(String) }),
     );
     const body = JSON.parse(mockFetch.mock.calls[0][1]!.body as string);


### PR DESCRIPTION
## Summary
- align webapp profile fetch/save calls with singular `/profile` backend endpoint
- update profile API tests and README examples accordingly

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any in existing tests)*
- `pnpm --filter ./services/webapp/ui test` *(fails: profile.onboarding and ProfileHelpSheet tests)*
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc8c364e90832aa2cb6964fe60af8c