### PR TITLE
[webapp] Use patch profile schema for saveProfile response

### DIFF
--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -1,6 +1,10 @@
-import type { ProfileSchema } from '@sdk';
 import { tgFetch, FetchError } from '@/lib/tgFetch';
-import type { Profile, PatchProfileDto, RapidInsulin } from './types';
+import type {
+  PatchProfileDto,
+  Profile,
+  ProfilePatchSchema,
+  RapidInsulin,
+} from './types';
 
 export async function getProfile(telegramId: number): Promise<Profile | null> {
   try {
@@ -50,7 +54,7 @@ export async function saveProfile({
   sosContact?: string | null;
   sosAlertsEnabled?: boolean;
   therapyType?: string | null;
-}) {
+}): Promise<ProfilePatchSchema> {
   try {
     const body: Record<string, unknown> = {
       telegramId,
@@ -95,7 +99,7 @@ export async function saveProfile({
       body.therapyType = therapyType;
     }
 
-    return await tgFetch<ProfileSchema>('/profiles', {
+    return await tgFetch<ProfilePatchSchema>('/profiles', {
       method: 'POST',
       body,
     });
@@ -125,4 +129,4 @@ export async function patchProfile(payload: PatchProfileDto) {
   }
 }
 
-export type { RapidInsulin, PatchProfileDto, Profile };
+export type { RapidInsulin, PatchProfileDto, Profile, ProfilePatchSchema };

--- a/services/webapp/ui/src/features/profile/types.ts
+++ b/services/webapp/ui/src/features/profile/types.ts
@@ -25,3 +25,7 @@ export type PatchProfileDto = Partial<
   >
 >;
 
+export type ProfilePatchSchema = {
+  telegramId: number;
+} & Partial<Omit<ProfileSchema, "telegramId">> & ProfileSettingsIn;
+

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -104,7 +104,7 @@ describe('profile api', () => {
       );
     vi.stubGlobal('fetch', mockFetch);
 
-    await saveProfile({
+    const result = await saveProfile({
       telegramId: 1,
       target: 5,
       low: 4,
@@ -136,6 +136,7 @@ describe('profile api', () => {
       sosContact: null,
       therapyType: 'none',
     });
+    expect(result).toEqual({ telegramId: 1, target: 5, low: 4, high: 10 });
   });
 
   it('throws error when patchProfile request fails', async () => {


### PR DESCRIPTION
## Summary
- define `ProfilePatchSchema` and use it in `saveProfile`
- adjust `saveProfile` return type and generic
- extend profile API test to assert returned data

## Testing
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui exec vitest run --config vitest.config.ts --reporter=dot` *(fails: produced excessive warnings; see logs)*
- `pytest -q --cov` *(fails: unrecognized arguments --cov due to plugin)*
- `mypy --strict .` *(interrupted: took too long)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc90bde4a0832a9f4d7b053aadfc58