### PR TITLE
[webapp] Validate profile timezone

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -617,6 +617,18 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     }
 
     const { data: parsed, errors } = parseProfile(profile, therapyType);
+    let timezoneValid = timezones.includes(profile.timezone);
+    if (!timezoneValid) {
+      try {
+        new Intl.DateTimeFormat("en-US", { timeZone: profile.timezone });
+        timezoneValid = true;
+      } catch {
+        timezoneValid = false;
+      }
+    }
+    if (!timezoneValid) {
+      errors.timezone = "invalid";
+    }
     if (Object.keys(errors).length) {
       setFieldErrors(errors);
       toast({


### PR DESCRIPTION
## Summary
- validate timezone before saving profile, marking invalid values

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `pnpm --dir services/webapp/ui lint` *(fails: Unexpected any in tests)*
- `pnpm --dir services/webapp/ui test` *(fails: JavaScript heap out of memory)*
- `pnpm --dir services/webapp/ui typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bc929eabac832a9ac185707094f149