### PR TITLE
[webapp] Add loading indicator for profile

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { Save } from "lucide-react";
+import { Save, Loader2 } from "lucide-react";
 
 import { MedicalHeader } from "@/components/MedicalHeader";
 import { useToast } from "@/hooks/use-toast";
@@ -662,6 +662,14 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     setWarningOpen(false);
   };
 
+  if (!loaded) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-background to-secondary/20 flex items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
   return (
     <>
       <Modal
@@ -1235,6 +1243,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
               className="w-full flex items-center justify-center gap-2"
               variant="medical"
               size="lg"
+              disabled={!loaded}
             >
               <Save className="w-4 h-4" />
               {t('profile.save')}


### PR DESCRIPTION
## Summary
- show spinner until profile data loads
- disable profile save button until data is loaded

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any in tests)*
- `pnpm --filter ./services/webapp/ui exec eslint src/pages/Profile.tsx`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test` *(fails: JavaScript heap out of memory)*
- `pytest -q --cov` *(fails: unrecognized arguments: --cov)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc92b62504832a92908b187702e2f2