### PR TITLE
[webapp] use ProfilePatchSchema for saveProfile

### DIFF
--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -1,6 +1,10 @@
-import type { ProfileSchema } from '@sdk';
 import { tgFetch, FetchError } from '@/lib/tgFetch';
-import type { Profile, PatchProfileDto, RapidInsulin } from './types';
+import type {
+  Profile,
+  PatchProfileDto,
+  ProfilePatchSchema,
+  RapidInsulin,
+} from './types';
 
 export async function getProfile(telegramId: number): Promise<Profile | null> {
   try {
@@ -50,7 +54,7 @@ export async function saveProfile({
   sosContact?: string | null;
   sosAlertsEnabled?: boolean;
   therapyType?: string | null;
-}) {
+}): Promise<ProfilePatchSchema> {
   try {
     const body: Record<string, unknown> = {
       telegramId,
@@ -95,7 +99,7 @@ export async function saveProfile({
       body.therapyType = therapyType;
     }
 
-    return await tgFetch<ProfileSchema>('/profile', {
+    return await tgFetch<ProfilePatchSchema>('/profile', {
       method: 'POST',
       body,
     });

--- a/services/webapp/ui/src/features/profile/types.ts
+++ b/services/webapp/ui/src/features/profile/types.ts
@@ -8,6 +8,10 @@ export type RapidInsulin = "aspart" | "lispro" | "glulisine" | "regular";
 
 export type Profile = ProfileSchema & ProfileSettingsOut;
 
+export type ProfilePatchSchema = {
+  telegramId: number;
+} & Partial<Omit<Profile, "telegramId">>;
+
 export type PatchProfileDto = Partial<
   Pick<
     ProfileSettingsIn,

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -95,7 +95,14 @@ describe('profile api', () => {
       .fn()
       .mockResolvedValue(
         new Response(
-          JSON.stringify({ telegramId: 1, target: 5, low: 4, high: 10 }),
+          JSON.stringify({
+            telegramId: 1,
+            target: 5,
+            low: 4,
+            high: 10,
+            dia: 4,
+            roundStep: 0.5,
+          }),
           {
             status: 200,
             headers: { 'Content-Type': 'application/json' },
@@ -103,8 +110,7 @@ describe('profile api', () => {
         ),
       );
     vi.stubGlobal('fetch', mockFetch);
-
-    await saveProfile({
+    const result = await saveProfile({
       telegramId: 1,
       target: 5,
       low: 4,
@@ -135,6 +141,15 @@ describe('profile api', () => {
       sosAlertsEnabled: true,
       sosContact: null,
       therapyType: 'none',
+    });
+
+    expect(result).toEqual({
+      telegramId: 1,
+      target: 5,
+      low: 4,
+      high: 10,
+      dia: 4,
+      roundStep: 0.5,
     });
   });
 


### PR DESCRIPTION
## Summary
- add `ProfilePatchSchema` type for extended profile data
- update `saveProfile` to return `ProfilePatchSchema`
- adjust API tests for new profile response

## Testing
- `pnpm --filter ./services/webapp/ui exec eslint src/features/profile/api.ts src/features/profile/types.ts tests/profile.api.test.ts`
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui exec vitest run tests/profile.api.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bc93a6394c832ab2283f8d001bd225