### PR TITLE
[webapp] Ignore rapid insulin for non-insulin therapy

### DIFF
--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -101,6 +101,7 @@ describe("parseProfile", () => {
     expect(result.errors).toEqual({});
     expect(result.data.icr).toBe(0);
     expect(result.data.cf).toBe(0);
+    expect(result.data.rapidInsulinType).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- Avoid sending rapid insulin type when therapy is tablets or none
- Skip undefined rapid insulin type in patch and save logic
- Cover non-insulin therapy rapid insulin behavior in tests

## Testing
- `pnpm --filter ./services/webapp/ui exec vitest run --config vitest.config.ts --maxWorkers=1` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bc92afde74832aa00936e101daa8a8