### PR TITLE
[utils] Reload settings before building subscription keyboard

### DIFF
--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -125,6 +125,10 @@ def subscription_keyboard(trial_available: bool) -> InlineKeyboardMarkup:
     """Build inline keyboard for subscription actions."""
     from services.api.app import config
 
+    # Settings values may change during tests or runtime when environment
+    # variables are monkeypatched. Reloading here ensures we always read the
+    # latest ``SUBSCRIPTION_URL`` or ``PUBLIC_ORIGIN`` values.
+    config.reload_settings()
     buttons: list[InlineKeyboardButton] = []
     if trial_available:
         buttons.append(InlineKeyboardButton("🎁 Trial", callback_data="trial"))


### PR DESCRIPTION
## Summary
- reload runtime settings before generating subscription keyboard to pick up env changes

## Testing
- `ruff check services/api/app/diabetes/utils/ui.py tests/test_billing_commands.py`
- `mypy --strict services/api/app/diabetes/utils/ui.py tests/test_billing_commands.py`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68bc944f312c832a880e95ba15400a44