### PR TITLE
[handlers] Delegate dynamic /learn flow

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -85,6 +85,11 @@ async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     if not settings.learning_mode_enabled:
         await message.reply_text("🚫 Обучение недоступно.")
         return
+    if settings.learning_content_mode == "dynamic":
+        from services.api.app.diabetes import learning_handlers as dynamic_learning_handlers
+
+        await dynamic_learning_handlers.learn_command(update, context)
+        return
     if not await ensure_overrides(update, context):
         return
     model = settings.learning_command_model

--- a/services/api/tests/test_learning_mode_toggle.py
+++ b/services/api/tests/test_learning_mode_toggle.py
@@ -59,6 +59,7 @@ async def test_learning_mode_enabled_lists_lessons(
 
     monkeypatch.setenv("LEARNING_MODE_ENABLED", "true")
     monkeypatch.setenv("LEARNING_ENABLED", "1")
+    monkeypatch.setenv("LEARNING_CONTENT_MODE", "static")
     settings = config.reload_settings()
 
     SessionLocal = setup_db()
@@ -109,6 +110,7 @@ async def test_learning_mode_disabled_denies_access(
 ) -> None:
     monkeypatch.setenv("LEARNING_MODE_ENABLED", "false")
     monkeypatch.setenv("LEARNING_ENABLED", "0")
+    monkeypatch.setenv("LEARNING_CONTENT_MODE", "static")
     settings = config.reload_settings()
     monkeypatch.setattr(learning_handlers, "settings", settings)
 

--- a/tests/diabetes/test_learning_handlers.py
+++ b/tests/diabetes/test_learning_handlers.py
@@ -66,6 +66,7 @@ def setup_db() -> sessionmaker[Session]:
 async def test_learn_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(settings, "learning_mode_enabled", True)
     monkeypatch.setattr(settings, "learning_command_model", "super-model")
+    monkeypatch.setattr(settings, "learning_content_mode", "static")
     sample = [
         {
             "title": "Sample",

--- a/tests/diabetes/test_learning_onboarding.py
+++ b/tests/diabetes/test_learning_onboarding.py
@@ -48,6 +48,7 @@ async def test_learning_onboarding_flow(
 ) -> None:
     monkeypatch.setattr(settings, "learning_mode_enabled", True)
     monkeypatch.setattr(settings, "learning_command_model", "test-model")
+    monkeypatch.setattr(settings, "learning_content_mode", "static")
 
     sample = [{"title": "Sample", "steps": ["s1"], "quiz": []}]
     path = tmp_path / "lessons.json"

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -46,7 +46,13 @@ async def test_learn_command_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     """When flag is disabled the command should warn the user."""
 
     monkeypatch.setattr(
-        handlers, "settings", Settings(LEARNING_MODE_ENABLED="0", _env_file=None)
+        handlers,
+        "settings",
+        Settings(
+            LEARNING_MODE_ENABLED="0",
+            LEARNING_CONTENT_MODE="static",
+            _env_file=None,
+        ),
     )
     message = DummyMessage()
     update = cast(
@@ -74,7 +80,12 @@ async def test_learn_command_no_lessons(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(
         handlers,
         "settings",
-        Settings(LEARNING_MODE_ENABLED="1", LEARNING_COMMAND_MODEL="m", _env_file=None),
+        Settings(
+            LEARNING_MODE_ENABLED="1",
+            LEARNING_COMMAND_MODEL="m",
+            LEARNING_CONTENT_MODE="static",
+            _env_file=None,
+        ),
     )
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message, effective_user=None))
@@ -124,7 +135,12 @@ async def test_learn_command_lists_lessons(
     monkeypatch.setattr(
         handlers,
         "settings",
-        Settings(LEARNING_MODE_ENABLED="1", LEARNING_COMMAND_MODEL="m", _env_file=None),
+        Settings(
+            LEARNING_MODE_ENABLED="1",
+            LEARNING_COMMAND_MODEL="m",
+            LEARNING_CONTENT_MODE="static",
+            _env_file=None,
+        ),
     )
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message, effective_user=None))


### PR DESCRIPTION
## Summary
- Delegate `/learn` in legacy handlers to dynamic learning module when `LEARNING_CONTENT_MODE=dynamic`
- Ensure tests explicitly use static content mode when listing lessons

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd120d2c44832a955e3eaeaec3b86e