### PR TITLE
[billing] локализация сообщений trial

### DIFF
--- a/services/api/app/routers/billing.py
+++ b/services/api/app/routers/billing.py
@@ -130,9 +130,13 @@ async def start_trial(
             if existing is not None:
                 status = SubStatus(existing.status)
                 if status is SubStatus.trial:
-                    raise HTTPException(status_code=409, detail="Trial already active")
+                    raise HTTPException(
+                        status_code=409,
+                        detail="Пробный период уже активен",
+                    )
                 raise HTTPException(
-                    status_code=409, detail="subscription already active"
+                    status_code=409,
+                    detail="Подписка уже активна",
                 )
             return _create_trial(session)
 
@@ -155,7 +159,10 @@ async def start_trial(
             },
             exc_info=exc,
         )
-        raise HTTPException(status_code=400, detail="invalid enum value") from exc
+        raise HTTPException(
+            status_code=400,
+            detail="недопустимое значение перечисления",
+        ) from exc
     except IntegrityError as exc:
         logger.warning(
             "trial creation failed",
@@ -167,9 +174,15 @@ async def start_trial(
             },
             exc_info=exc,
         )
-        raise HTTPException(status_code=409, detail="Trial already active") from exc
+        raise HTTPException(
+            status_code=409,
+            detail="Пробный период уже активен",
+        ) from exc
     if trial is None:
-        raise HTTPException(status_code=500, detail="trial retrieval failed")
+        raise HTTPException(
+            status_code=500,
+            detail="не удалось получить пробный период",
+        )
 
     return SubscriptionSchema.model_validate(trial, from_attributes=True)
 

--- a/tests/test_billing_trial.py
+++ b/tests/test_billing_trial.py
@@ -117,7 +117,7 @@ def test_trial_repeat_call(monkeypatch: pytest.MonkeyPatch) -> None:
     assert resp1.status_code == 200
     data1 = resp1.json()
     assert resp2.status_code == 409
-    assert resp2.json()["detail"] == "Trial already active"
+    assert resp2.json()["detail"] == "Пробный период уже активен"
     assert data1["plan"] == "pro"
     assert data1["status"] == SubStatus.trial.value
     count_stmt = select(func.count()).select_from(Subscription)
@@ -155,7 +155,7 @@ def test_trial_conflicts_with_active_subscription(
     with client:
         resp = client.post("/api/billing/trial", params={"user_id": 1})
     assert resp.status_code == 409
-    assert resp.json()["detail"] == "subscription already active"
+    assert resp.json()["detail"] == "Подписка уже активна"
 
 
 def test_trial_repeat_call_after_expiration(
@@ -178,7 +178,7 @@ def test_trial_repeat_call_after_expiration(
     with client:
         resp2 = client.post("/api/billing/trial", params={"user_id": 1})
     assert resp2.status_code == 409
-    assert resp2.json()["detail"] == "Trial already active"
+    assert resp2.json()["detail"] == "Пробный период уже активен"
     count_stmt = select(func.count()).select_from(Subscription)
     with session_local() as session:
         count = session.scalar(count_stmt)
@@ -207,7 +207,7 @@ def test_trial_integrity_error(
         with client:
             resp = client.post("/api/billing/trial", params={"user_id": 1})
     assert resp.status_code == 409
-    assert resp.json()["detail"] == "Trial already active"
+    assert resp.json()["detail"] == "Пробный период уже активен"
     assert len(caplog.records) == 1
     record = caplog.records[0]
     assert record.user_id == 1
@@ -238,7 +238,7 @@ def test_trial_invalid_enum(
         with client:
             resp = client.post("/api/billing/trial", params={"user_id": 1})
     assert resp.status_code == 400
-    assert resp.json()["detail"] == "invalid enum value"
+    assert resp.json()["detail"] == "недопустимое значение перечисления"
     assert len(caplog.records) == 1
     record = caplog.records[0]
     assert record.user_id == 1


### PR DESCRIPTION
## Summary
- translate trial subscription conflict messages to Russian
- localize error details for invalid enum and trial retrieval
- update billing trial tests to expect Russian messages

## Testing
- `ruff check services/api/app/routers/billing.py tests/test_billing_trial.py`
- `mypy --strict services/api/app/routers/billing.py tests/test_billing_trial.py`
- `pytest tests/test_billing_trial.py -q` *(fails: Required test coverage of 85% not reached. Total coverage: 21.68%)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1a301ca8832aacb0f68b9e759589