### PR TITLE
[ui] add home menu sections

### DIFF
--- a/services/webapp/ui/src/pages/Home.tsx
+++ b/services/webapp/ui/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { Star } from 'lucide-react';
+import { Star, Clock, User, Bell, LineChart } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { MedicalHeader } from '@/components/MedicalHeader';
@@ -9,13 +9,45 @@ import { fetchDayStats } from '@/api/stats';
 
 const menuItems = [
   {
+    id: 'history',
+    title: 'История',
+    icon: Clock,
+    description: 'Журнал измерений',
+    route: '/history',
+    color: 'medical-blue',
+  },
+  {
+    id: 'profile',
+    title: 'Профиль',
+    icon: User,
+    description: 'Ваши настройки',
+    route: '/profile',
+    color: 'medical-teal',
+  },
+  {
+    id: 'reminders',
+    title: 'Напоминания',
+    icon: Bell,
+    description: 'Управление напоминаниями',
+    route: '/reminders',
+    color: 'medical-success',
+  },
+  {
+    id: 'analytics',
+    title: 'Аналитика',
+    icon: LineChart,
+    description: 'Статистика и отчёты',
+    route: '/analytics',
+    color: 'medical-warning',
+  },
+  {
     id: 'subscription',
     title: 'Подписка',
     icon: Star,
     description: 'Тарифы и оплата',
     route: '/subscription',
-    color: 'medical-warning'
-  }
+    color: 'medical-warning',
+  },
 ];
 
 const Home = () => {

--- a/services/webapp/ui/tests/Home.test.tsx
+++ b/services/webapp/ui/tests/Home.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: { sugar: 0, breadUnits: 0, insulin: 0 }, isLoading: false, error: null }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('../src/hooks/useTelegram', () => ({
+  useTelegram: () => ({ user: { id: 1, first_name: 'Test' } }),
+}));
+
+import Home from '../src/pages/Home';
+
+describe('Home page', () => {
+  afterEach(() => cleanup());
+
+  it('renders all menu tiles', () => {
+    const { getByText } = render(<Home />);
+    expect(getByText('История')).toBeTruthy();
+    expect(getByText('Профиль')).toBeTruthy();
+    expect(getByText('Напоминания')).toBeTruthy();
+    expect(getByText('Аналитика')).toBeTruthy();
+    expect(getByText('Подписка')).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- expand Home page menu with History, Profile, Reminders, Analytics
- test home page renders all tiles

## Testing
- `pnpm --filter ./services/webapp/ui lint` (fails: Unexpected any)
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q` (fails: unrecognized arguments --cov)
- `mypy --strict .` (fails: interrupted)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd1fab8b28832abe6a6fb8574d84f2