### PR TITLE
[billing] reload settings at call sites

### DIFF
--- a/services/api/app/diabetes/handlers/billing_handlers.py
+++ b/services/api/app/diabetes/handlers/billing_handlers.py
@@ -27,6 +27,7 @@ async def trial_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     if message is None or user is None:
         return
 
+    config.reload_settings()
     base = config.get_settings().api_url
     if not base:
         await message.reply_text("❌ Не настроен API_URL")
@@ -114,6 +115,7 @@ async def upgrade_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     message = update.message
     if message is None:
         return
+    config.reload_settings()
     kb = subscription_keyboard(False)
     if not kb.inline_keyboard:
         await message.reply_text("❌ Не настроена ссылка на оплату.")
@@ -144,6 +146,7 @@ async def subscription_button(update: Update, context: ContextTypes.DEFAULT_TYPE
     user = update.effective_user
     if message is None or user is None:
         return
+    config.reload_settings()
     base = config.get_settings().api_url
     if not base:
         await message.reply_text("❌ Не настроен API_URL")

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -125,14 +125,10 @@ def subscription_keyboard(trial_available: bool) -> InlineKeyboardMarkup:
     """Build inline keyboard for subscription actions."""
     from services.api.app import config
 
-    # Settings values may change during tests or runtime when environment
-    # variables are monkeypatched. Reloading here ensures we always read the
-    # latest ``SUBSCRIPTION_URL`` or ``PUBLIC_ORIGIN`` values.
-    config.reload_settings()
+    settings = config.get_settings()
     buttons: list[InlineKeyboardButton] = []
     if trial_available:
         buttons.append(InlineKeyboardButton("🎁 Trial", callback_data="trial"))
-    settings = config.get_settings()
     url = settings.subscription_url
     if not url:
         try:


### PR DESCRIPTION
## Summary
- avoid reloading config inside `subscription_keyboard`
- reload settings in billing handlers before building subscription keyboard

## Testing
- `pytest tests/test_billing_commands.py::test_trial_command_success tests/test_billing_commands.py::test_upgrade_command tests/test_billing_commands.py::test_subscription_status_flow --no-cov -q`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd21d6a410832aad1714b88d5efa17