### PR TITLE
[learning] pass profile to check_user_answer

### DIFF
--- a/scripts/probe_learn.py
+++ b/scripts/probe_learn.py
@@ -65,7 +65,7 @@ async def main(user_id: int, lesson_slug: str) -> None:
         print(text)
         if steps_done >= step_total and quiz_index < len(questions):
             answer = questions[quiz_index].correct_option
-            _, feedback = await curriculum_engine.check_answer(user_id, lesson_id, answer)
+            _, feedback = await curriculum_engine.check_answer(user_id, lesson_id, {}, answer)
             print(feedback)
             quiz_index += 1
         else:

--- a/services/api/app/diabetes/curriculum_engine.py
+++ b/services/api/app/diabetes/curriculum_engine.py
@@ -155,10 +155,11 @@ async def next_step(
 async def check_answer(
     user_id: int,
     lesson_id: int,
+    profile: Mapping[str, str | None],
     answer: int | str,
     last_step_text: str | None = None,
 ) -> tuple[bool, str]:
-    """Check user's answer and return feedback."""
+    """Check user's answer using the given profile and return feedback."""
 
     if settings.learning_content_mode == "dynamic":
         def _get_slug(session: Session) -> str:
@@ -169,7 +170,7 @@ async def check_answer(
 
         slug = await db.run_db(_get_slug)
         correct, feedback = await check_user_answer(
-            {}, slug, str(answer), last_step_text or ""
+            profile, slug, str(answer), last_step_text or ""
         )
         return correct, feedback
 

--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -193,7 +193,7 @@ async def quiz_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             state.awaiting_answer = False
             set_state(user_data, state)
         _correct, feedback = await curriculum_engine.check_answer(
-            user.id, lesson_id, answer
+            user.id, lesson_id, {}, answer
         )
         await message.reply_text(feedback)
         question, completed = await curriculum_engine.next_step(user.id, lesson_id, {})
@@ -248,7 +248,7 @@ async def quiz_answer_handler(
     state.awaiting_answer = False
     set_state(user_data, state)
     _correct, feedback = await curriculum_engine.check_answer(
-        user.id, lesson_id, answer
+        user.id, lesson_id, {}, answer
     )
     await message.reply_text(feedback)
     question, completed = await curriculum_engine.next_step(user.id, lesson_id, {})

--- a/tests/learning/test_curriculum.py
+++ b/tests/learning/test_curriculum.py
@@ -72,7 +72,7 @@ async def test_happy_path_one_lesson(monkeypatch: pytest.MonkeyPatch) -> None:
     assert question_text.endswith(first_opts)
 
     for idx, q in enumerate(questions):
-        correct, feedback = await check_answer(1, lesson_id, q.correct_option + 1)
+        correct, feedback = await check_answer(1, lesson_id, {}, q.correct_option + 1)
         assert correct is True
         assert feedback
         text, completed = await next_step(1, lesson_id, {})

--- a/tests/learning/test_curriculum_engine.py
+++ b/tests/learning/test_curriculum_engine.py
@@ -91,7 +91,7 @@ async def test_curriculum_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert question_text.endswith(first_opts)
 
     for idx, q in enumerate(questions):
-        correct, feedback = await check_answer(1, lesson_id, q.correct_option + 1)
+        correct, feedback = await check_answer(1, lesson_id, {}, q.correct_option + 1)
         assert correct is True
         assert feedback
         if idx < len(questions) - 1:
@@ -196,7 +196,7 @@ async def test_dynamic_mode_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert completed is False
     assert fake_generate.calls[0] is profile
 
-    correct, feedback = await check_answer(1, lesson_id, "42")
+    correct, feedback = await check_answer(1, lesson_id, profile, "42")
     assert correct is True
     assert feedback == "fb 42"
 

--- a/tests/learning/test_lesson_metrics.py
+++ b/tests/learning/test_lesson_metrics.py
@@ -69,7 +69,7 @@ async def test_lesson_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
     assert completed is False
 
     for idx, q in enumerate(questions):
-        await check_answer(1, lesson_id, q.correct_option + 1)
+        await check_answer(1, lesson_id, {}, q.correct_option + 1)
         text, completed = await next_step(1, lesson_id, {})
         if idx < len(questions) - 1:
             assert text is not None


### PR DESCRIPTION
## Summary
- include profile in `curriculum_engine.check_answer`
- forward profile to `check_user_answer`
- adjust handlers and tests for new signature

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported, coverage 55%)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68bd23cd762c832aa5751d19b5f5751d