### PR TITLE
[learning] Move disclaimer wrapping to message send

### DIFF
--- a/services/api/app/diabetes/curriculum_engine.py
+++ b/services/api/app/diabetes/curriculum_engine.py
@@ -84,6 +84,8 @@ async def next_step(
 
         step_idx, slug = await db.run_db(_advance_dynamic)
         text = await generate_step_text(profile, slug, step_idx, prev_summary)
+        if step_idx == 1:
+            return f"{disclaimer()}\n\n{text}", False
         return text, False
 
     def _advance_static(
@@ -171,7 +173,9 @@ async def check_answer(
         correct, feedback = await check_user_answer(
             {}, slug, str(answer), last_step_text or ""
         )
-        return correct, feedback
+        tail = disclaimer()
+        feedback = feedback.strip()
+        return correct, f"{feedback} {tail}" if feedback else tail
 
     answer_index = int(answer) - 1
 

--- a/services/api/app/diabetes/learning_prompts.py
+++ b/services/api/app/diabetes/learning_prompts.py
@@ -29,37 +29,24 @@ SYSTEM_TUTOR_RU = (
 )
 
 
-def _with_disclaimer(text: str) -> str:
-    """Append a common disclaimer to *text*.
-
-    Parameters
-    ----------
-    text: str
-        Base text that requires the disclaimer.
-    """
-    base = text.strip()
-    tail = disclaimer()
-    return f"{base} {tail}" if base else tail
-
-
 def build_explain_step(step: str) -> str:
     """Build a prompt asking and explaining a learning step."""
     prompt = f"Что ты знаешь о {step}? Объясни.".strip()
-    return _with_disclaimer(prompt)
+    return prompt
 
 
 def build_quiz_check(question: str, options: list[str]) -> str:
     """Build a prompt that checks knowledge with multiple options."""
     opts = "; ".join(options)
     prompt = f"{question}? Варианты: {opts}. Выбери один.".strip()
-    return _with_disclaimer(prompt)
+    return prompt
 
 
 def build_feedback(correct: bool, explanation: str) -> str:
     """Build feedback for quiz answers."""
     prefix = "Верно." if correct else "Неверно."
     prompt = f"{prefix} {explanation}".strip()
-    return _with_disclaimer(prompt)
+    return prompt
 
 
 def build_system_prompt(p: Mapping[str, str | None]) -> str:

--- a/tests/learning/test_curriculum_engine.py
+++ b/tests/learning/test_curriculum_engine.py
@@ -192,13 +192,13 @@ async def test_dynamic_mode_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     profile: dict[str, str] = {"age": "30"}
     await start_lesson(1, "s")
     text, completed = await next_step(1, lesson_id, profile)
-    assert text == "step 1"
+    assert text == f"{disclaimer()}\n\nstep 1"
     assert completed is False
     assert fake_generate.calls[0] is profile
 
     correct, feedback = await check_answer(1, lesson_id, "42")
     assert correct is True
-    assert feedback == "fb 42"
+    assert feedback == f"fb 42 {disclaimer()}"
 
     text, completed = await next_step(1, lesson_id, profile)
     assert text == "step 2"

--- a/tests/test_learning_prompts.py
+++ b/tests/test_learning_prompts.py
@@ -40,14 +40,14 @@ def test_system_tutor_contains_disclaimer() -> None:
         ),
     ],
 )
-def test_builder_functions_append_disclaimer(
+def test_builder_functions_without_disclaimer(
     builder: object, kwargs: dict[str, object]
 ) -> None:
-    """All builders should return non-empty text with the disclaimer."""
+    """Builders should return non-empty text without the disclaimer."""
 
     text = builder(**kwargs)  # type: ignore[arg-type]
     assert text
-    assert text.endswith(disclaimer())
+    assert disclaimer() not in text
 
 
 @pytest.mark.parametrize(
@@ -60,7 +60,7 @@ def test_build_feedback_variants(correct: bool, prefix: str) -> None:
     text = build_feedback(correct, "Пояснение")
     assert text
     assert text.startswith(prefix)
-    assert text.endswith(disclaimer())
+    assert disclaimer() not in text
 
 
 def test_build_system_prompt_limits_length() -> None:


### PR DESCRIPTION
## Summary
- stop adding medical disclaimer inside prompt builders
- wrap dynamic lesson steps and quiz feedback with disclaimer when sending to user
- adjust tests for new disclaimer handling

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd23cdd284832a8c83423ef54fef72