### PR TITLE
[learning] Use learning chat completion with cache

### DIFF
--- a/tests/diabetes/test_learning_handlers_rate_limit.py
+++ b/tests/diabetes/test_learning_handlers_rate_limit.py
@@ -96,7 +96,14 @@ async def test_quiz_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
 
     answers: list[int] = []
 
-    async def fake_check(user_id: int, lesson_id: int, answer: int) -> tuple[bool, str]:
+    async def fake_check(
+        user_id: int,
+        lesson_id: int,
+        profile: Mapping[str, str | None],
+        answer: int,
+        last_step_text: str | None = None,
+    ) -> tuple[bool, str]:
+        assert profile == {}
         answers.append(answer)
         return True, "ok"
 

--- a/tests/diabetes/test_learning_text_answer.py
+++ b/tests/diabetes/test_learning_text_answer.py
@@ -46,7 +46,14 @@ async def test_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
         assert profile == {}
         return next(questions)
 
-    async def fake_check(user_id: int, lesson_id: int, answer: int) -> tuple[bool, str]:
+    async def fake_check(
+        user_id: int,
+        lesson_id: int,
+        profile: Mapping[str, str | None],
+        answer: int,
+        last_step_text: str | None = None,
+    ) -> tuple[bool, str]:
+        assert profile == {}
         return True, "ok"
 
     monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next)

--- a/tests/learning/test_dynamic_tutor.py
+++ b/tests/learning/test_dynamic_tutor.py
@@ -1,28 +1,22 @@
 from __future__ import annotations
 
-import types
-
 import pytest
 
 from services.api.app.diabetes import dynamic_tutor
-
-
-class _FakeCompletion:
-    def __init__(self, text: str) -> None:
-        self.choices = [
-            types.SimpleNamespace(message=types.SimpleNamespace(content=text))
-        ]
 
 
 @pytest.mark.asyncio
 async def test_step_answer_feedback(monkeypatch: pytest.MonkeyPatch) -> None:
     texts = iter(["step1", "feedback"])
 
-    async def fake_create_chat_completion(**kwargs: object) -> _FakeCompletion:
-        return _FakeCompletion(next(texts))
+    async def fake_create_learning_chat_completion(**kwargs: object) -> str:
+        return next(texts)
 
-    monkeypatch.setattr(dynamic_tutor, "create_chat_completion", fake_create_chat_completion)
-    monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
+    monkeypatch.setattr(
+        dynamic_tutor,
+        "create_learning_chat_completion",
+        fake_create_learning_chat_completion,
+    )
 
     step = await dynamic_tutor.generate_step_text({}, "topic", 1, None)
     correct, feedback = await dynamic_tutor.check_user_answer({}, "topic", "42", step)
@@ -36,13 +30,12 @@ async def test_step_answer_feedback(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_runtimeerror_returns_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def raise_runtime_error(**kwargs: object) -> None:
+    async def raise_runtime_error(**kwargs: object) -> str:
         raise RuntimeError("boom")
 
     monkeypatch.setattr(
-        dynamic_tutor, "create_chat_completion", raise_runtime_error
+        dynamic_tutor, "create_learning_chat_completion", raise_runtime_error
     )
-    monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
 
     step = await dynamic_tutor.generate_step_text({}, "topic", 1, None)
     correct, feedback = await dynamic_tutor.check_user_answer({}, "topic", "42", "step")

--- a/tests/test_dynamic_tutor.py
+++ b/tests/test_dynamic_tutor.py
@@ -1,28 +1,20 @@
-import types
-
 import pytest
 
 from services.api.app.diabetes import dynamic_tutor
-
-
-class _FakeCompletion:
-    def __init__(self, content: str) -> None:
-        self.choices = [
-            types.SimpleNamespace(message=types.SimpleNamespace(content=content))
-        ]
 
 
 @pytest.mark.asyncio
 async def test_generate_step_text_formats_reply(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def fake_create_chat_completion(**kwargs: object) -> _FakeCompletion:
-        return _FakeCompletion("a" * 900 + "\n\n" + "b" * 900)
+    async def fake_create_learning_chat_completion(**kwargs: object) -> str:
+        return "a" * 800 + "\n\n" + "b" * 800
 
     monkeypatch.setattr(
-        dynamic_tutor, "create_chat_completion", fake_create_chat_completion
+        dynamic_tutor,
+        "create_learning_chat_completion",
+        fake_create_learning_chat_completion,
     )
-    monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
 
     result = await dynamic_tutor.generate_step_text({}, "t", 1, None)
 
@@ -31,11 +23,12 @@ async def test_generate_step_text_formats_reply(
 
 @pytest.mark.asyncio
 async def test_generate_step_text_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def raise_error(**kwargs: object) -> _FakeCompletion:
+    async def raise_error(**kwargs: object) -> str:
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(dynamic_tutor, "create_chat_completion", raise_error)
-    monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
+    monkeypatch.setattr(
+        dynamic_tutor, "create_learning_chat_completion", raise_error
+    )
 
     result = await dynamic_tutor.generate_step_text({}, "t", 1, None)
 
@@ -48,14 +41,15 @@ async def test_check_user_answer_uses_max_tokens(
 ) -> None:
     captured: dict[str, object] = {}
 
-    async def fake_create_chat_completion(**kwargs: object) -> _FakeCompletion:
+    async def fake_create_learning_chat_completion(**kwargs: object) -> str:
         captured.update(kwargs)
-        return _FakeCompletion("ok")
+        return "ok"
 
     monkeypatch.setattr(
-        dynamic_tutor, "create_chat_completion", fake_create_chat_completion
+        dynamic_tutor,
+        "create_learning_chat_completion",
+        fake_create_learning_chat_completion,
     )
-    monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
 
     correct, result = await dynamic_tutor.check_user_answer({}, "topic", "ans", "text")
 
@@ -66,13 +60,15 @@ async def test_check_user_answer_uses_max_tokens(
 
 @pytest.mark.asyncio
 async def test_check_user_answer_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def raise_error(**kwargs: object) -> _FakeCompletion:
+    async def raise_error(**kwargs: object) -> str:
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(dynamic_tutor, "create_chat_completion", raise_error)
-    monkeypatch.setattr(dynamic_tutor.LLMRouter, "choose_model", lambda self, task: "m")
+    monkeypatch.setattr(
+        dynamic_tutor, "create_learning_chat_completion", raise_error
+    )
 
     correct, result = await dynamic_tutor.check_user_answer({}, "topic", "ans", "text")
 
     assert correct is False
     assert result == "сервер занят, попробуйте позже"
+

--- a/tests/test_learning_prompt_cache.py
+++ b/tests/test_learning_prompt_cache.py
@@ -33,7 +33,10 @@ async def test_learning_cache_reuses_response(monkeypatch: pytest.MonkeyPatch) -
     )
     monkeypatch.setattr(gpt_client, "_learning_cache", {})
 
-    messages = [{"role": "user", "content": "hi"}]
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+    ]
 
     await gpt_client.create_learning_chat_completion(
         task=LLMTask.EXPLAIN_STEP, messages=messages
@@ -70,7 +73,10 @@ async def test_learning_cache_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(gpt_client, "_learning_cache", {})
 
-    messages = [{"role": "user", "content": "hi"}]
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+    ]
 
     await gpt_client.create_learning_chat_completion(
         task=LLMTask.EXPLAIN_STEP, messages=messages
@@ -80,3 +86,77 @@ async def test_learning_cache_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_learning_cache_key_components(monkeypatch: pytest.MonkeyPatch) -> None:
+    call_count = 0
+
+    async def fake_create_chat_completion(*, model: str, **kwargs: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="ok"))]
+        )
+
+    monkeypatch.setattr(
+        gpt_client, "create_chat_completion", fake_create_chat_completion
+    )
+    monkeypatch.setattr(
+        config, "get_settings", lambda: SimpleNamespace(learning_prompt_cache=True)
+    )
+    monkeypatch.setattr(
+        gpt_client,
+        "_learning_router",
+        gpt_client.LLMRouter("m1"),
+        raising=False,
+    )
+    monkeypatch.setattr(gpt_client, "_learning_cache", {})
+
+    msg_base = [
+        {"role": "system", "content": "sys1"},
+        {"role": "user", "content": "u1"},
+    ]
+
+    # initial call populates cache
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_base
+    )
+    # same prompts => hit
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_base
+    )
+    assert call_count == 1
+
+    # different system prompt => miss
+    msg_system = [
+        {"role": "system", "content": "sys2"},
+        {"role": "user", "content": "u1"},
+    ]
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_system
+    )
+    assert call_count == 2
+
+    # different user prompt => miss
+    msg_user = [
+        {"role": "system", "content": "sys1"},
+        {"role": "user", "content": "u2"},
+    ]
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_user
+    )
+    assert call_count == 3
+
+    # different model => miss
+    monkeypatch.setattr(
+        gpt_client,
+        "_learning_router",
+        gpt_client.LLMRouter("m2"),
+        raising=False,
+    )
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_base
+    )
+    
+    assert call_count == 4


### PR DESCRIPTION
## Summary
- route dynamic tutor through learning chat client and drop local model selection
- prevent cache collisions by hashing model, system, and user prompts
- expand tests to cover cache hits and misses and adjust signatures

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd2e762624832ab4a95c5ea7c7a935