### PR TITLE
[learning] Add generic text handler

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -86,7 +86,9 @@ async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         await message.reply_text("🚫 Обучение недоступно.")
         return
     if settings.learning_content_mode == "dynamic":
-        from services.api.app.diabetes import learning_handlers as dynamic_learning_handlers
+        from services.api.app.diabetes import (
+            learning_handlers as dynamic_learning_handlers,
+        )
 
         await dynamic_learning_handlers.learn_command(update, context)
         return
@@ -348,8 +350,8 @@ def register_handlers(app: App) -> None:
 
     from . import learning_onboarding as onboarding
     from ..learning_handlers import (
-        lesson_answer_handler,
         lesson_callback,
+        on_any_text,
         topics_command as cmd_topics,
     )
 
@@ -370,9 +372,8 @@ def register_handlers(app: App) -> None:
     )
     app.add_handler(CallbackQueryHandler(lesson_callback, pattern="^lesson:"))
     app.add_handler(
-        MessageHandler(
-            filters.TEXT & ~filters.COMMAND, lesson_answer_handler, block=False
-        )
+        MessageHandler(filters.TEXT & ~filters.COMMAND, on_any_text, block=False),
+        group=0,
     )
 
 

--- a/tests/diabetes/test_learning_handlers.py
+++ b/tests/diabetes/test_learning_handlers.py
@@ -135,15 +135,13 @@ async def test_dynamic_lesson_callback_disabled(
 
 
 @pytest.mark.asyncio
-async def test_dynamic_lesson_answer_handler_disabled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_on_any_text_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_mode_enabled", False)
     message = DummyMessage(text="ans")
     update = cast(Update, SimpleNamespace(message=message))
     context = SimpleNamespace(user_data={})
-    await dynamic_handlers.lesson_answer_handler(update, context)
-    assert message.replies == ["режим обучения отключён"]
+    await dynamic_handlers.on_any_text(update, context)
+    assert message.replies == []
 
 
 @pytest.mark.asyncio

--- a/tests/diabetes/test_learning_handlers_rate_limit.py
+++ b/tests/diabetes/test_learning_handlers_rate_limit.py
@@ -96,7 +96,13 @@ async def test_quiz_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
 
     answers: list[int] = []
 
-    async def fake_check(user_id: int, lesson_id: int, answer: int) -> tuple[bool, str]:
+    async def fake_check(
+        user_id: int,
+        lesson_id: int,
+        profile: Mapping[str, str | None],
+        answer: int,
+        last_step_text: str | None = None,
+    ) -> tuple[bool, str]:
         answers.append(answer)
         return True, "ok"
 

--- a/tests/diabetes/test_learning_text_answer.py
+++ b/tests/diabetes/test_learning_text_answer.py
@@ -46,7 +46,13 @@ async def test_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
         assert profile == {}
         return next(questions)
 
-    async def fake_check(user_id: int, lesson_id: int, answer: int) -> tuple[bool, str]:
+    async def fake_check(
+        user_id: int,
+        lesson_id: int,
+        profile: Mapping[str, str | None],
+        answer: int,
+        last_step_text: str | None = None,
+    ) -> tuple[bool, str]:
         return True, "ok"
 
     monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next)

--- a/tests/learning/test_handlers_rate_limit.py
+++ b/tests/learning/test_handlers_rate_limit.py
@@ -15,7 +15,9 @@ class DummyMessage:
         self.text = text
         self.replies: list[str] = []
 
-    async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - helper
+    async def reply_text(
+        self, text: str, **kwargs: Any
+    ) -> None:  # pragma: no cover - helper
         self.replies.append(text)
 
 
@@ -32,12 +34,15 @@ class DummyCallback:
 @pytest.mark.asyncio
 async def test_lesson_callback_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+
     async def fake_generate_step_text(
         profile: object, topic: str, step_idx: int, prev: object
     ) -> str:
         return "step1"
 
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fake_generate_step_text
+    )
 
     times = iter([0.0, 1.0])
 
@@ -69,6 +74,7 @@ async def test_lesson_callback_rate_limit(monkeypatch: pytest.MonkeyPatch) -> No
 @pytest.mark.asyncio
 async def test_lesson_answer_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+
     async def fake_check_user_answer(
         profile: object, topic: str, answer: str, last: str
     ) -> tuple[bool, str]:
@@ -80,7 +86,9 @@ async def test_lesson_answer_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None
         return "next"
 
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fake_generate_step_text
+    )
 
     times = iter([0.0, 1.0])
 
@@ -101,11 +109,11 @@ async def test_lesson_answer_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None
     msg1 = DummyMessage(text="a1")
     update1 = cast(object, SimpleNamespace(message=msg1))
     context1 = SimpleNamespace(user_data=user_data)
-    await learning_handlers.lesson_answer_handler(update1, context1)
+    await learning_handlers.on_any_text(update1, context1)
     assert msg1.replies == ["feedback", "next"]
 
     msg2 = DummyMessage(text="a2")
     update2 = cast(object, SimpleNamespace(message=msg2))
     context2 = SimpleNamespace(user_data=user_data)
-    await learning_handlers.lesson_answer_handler(update2, context2)
+    await learning_handlers.on_any_text(update2, context2)
     assert msg2.replies == [learning_handlers.RATE_LIMIT_MESSAGE]

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -129,7 +129,7 @@ def test_register_handlers_attaches_expected_handlers(
     )
     assert any(
         isinstance(h, MessageHandler)
-        and h.callback is dynamic_learning_handlers.lesson_answer_handler
+        and h.callback is dynamic_learning_handlers.on_any_text
         for h in handlers
     )
     assert any(


### PR DESCRIPTION
## Summary
- add `assistant_chat` and `on_any_text` to route general text through learning assistant
- register new handler at group 0 before other text handlers
- cover generic text flow and disabled mode in tests

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd2e7c683c832a8ac6b506a4242cc7