### PR TITLE
[gpt] Track assistant history with summarization

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -45,6 +45,8 @@ class UserData(TypedDict, total=False):
     __file_path: str
     reminder_id: int
     chat_id: int
+    assistant_history: list[str]
+    assistant_summary: str
 
 
 from .dose_calc import _cancel_then  # noqa: E402

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -183,6 +183,7 @@ def register_handlers(
     if learning_enabled:
         learning_handlers.register_handlers(app)
     app.add_handler(CommandHandlerT("gpt", gpt_handlers.chat_with_gpt))
+    app.add_handler(CommandHandlerT("reset", gpt_handlers.reset_chat))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))
     app.add_handler(

--- a/tests/diabetes/test_learning_handlers_rate_limit.py
+++ b/tests/diabetes/test_learning_handlers_rate_limit.py
@@ -96,7 +96,10 @@ async def test_quiz_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
 
     answers: list[int] = []
 
-    async def fake_check(user_id: int, lesson_id: int, answer: int) -> tuple[bool, str]:
+    async def fake_check(
+        user_id: int, lesson_id: int, profile: Mapping[str, str | None], answer: int
+    ) -> tuple[bool, str]:
+        assert profile == {}
         answers.append(answer)
         return True, "ok"
 

--- a/tests/diabetes/test_learning_text_answer.py
+++ b/tests/diabetes/test_learning_text_answer.py
@@ -46,7 +46,10 @@ async def test_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
         assert profile == {}
         return next(questions)
 
-    async def fake_check(user_id: int, lesson_id: int, answer: int) -> tuple[bool, str]:
+    async def fake_check(
+        user_id: int, lesson_id: int, profile: Mapping[str, str | None], answer: int
+    ) -> tuple[bool, str]:
+        assert profile == {}
         return True, "ok"
 
     monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next)

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -77,10 +77,17 @@ def test_register_handlers_attaches_expected_handlers(
         for h in handlers
     )
     assert gpt_handlers.chat_with_gpt in callbacks
+    assert gpt_handlers.reset_chat in callbacks
     assert security_handlers.hypo_alert_faq in callbacks
     assert billing_handlers.trial_command in callbacks
     assert billing_handlers.upgrade_command in callbacks
     assert billing_handlers.subscription_button in callbacks
+    assert any(
+        isinstance(h, CommandHandler)
+        and h.callback is gpt_handlers.reset_chat
+        and "reset" in h.commands
+        for h in handlers
+    )
     assert any(
         isinstance(h, CommandHandler)
         and h.callback is learning_handlers.cmd_menu


### PR DESCRIPTION
## Summary
- store assistant chat history in user_data with configurable turn limit
- summarize old chat turns and support `/reset` to clear conversation
- register reset command and extend tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd2e7f03c4832a95654939090ce64b