### PR TITLE
[learning] add busy flag and robust llm handling

### DIFF
--- a/services/api/app/diabetes/learning_state.py
+++ b/services/api/app/diabetes/learning_state.py
@@ -15,6 +15,7 @@ class LearnState:
     awaiting_answer: bool
     last_step_text: str | None = None
     prev_summary: str | None = None
+    learn_busy: bool = False
 
 
 def get_state(data: MutableMapping[str, object]) -> LearnState | None:


### PR DESCRIPTION
## Summary
- handle OpenAI chat failures with broad exception logging and fallback
- add transient `learn_busy` flag to lesson state and ignore concurrent inputs
- ensure lesson handler logs errors and keeps awaiting state accurate

## Testing
- `pytest tests/diabetes/test_learning_chat_handlers.py tests/learning/test_handlers_rate_limit.py -q` *(fails: Coverage failure: total of 26 is less than fail-under=85)*
- `mypy --strict services/api/app/diabetes/dynamic_tutor.py services/api/app/diabetes/learning_state.py services/api/app/diabetes/learning_handlers.py tests/diabetes/test_learning_chat_handlers.py`
- `ruff check services/api/app/diabetes/dynamic_tutor.py services/api/app/diabetes/learning_state.py services/api/app/diabetes/learning_handlers.py tests/diabetes/test_learning_chat_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd2e826404832a99f6033da6a25e8e