### PR TITLE
[learning] Add simple planner and navigation commands

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -373,6 +373,8 @@ def register_handlers(app: App) -> None:
         lesson_answer_handler,
         lesson_callback,
         topics_command as cmd_topics,
+        plan_command,
+        skip_command,
     )
 
     app.add_handler(CommandHandler("learn", learn_command))
@@ -380,6 +382,8 @@ def register_handlers(app: App) -> None:
     app.add_handler(CommandHandler("lesson", lesson_command))
     app.add_handler(CommandHandler("quiz", quiz_command))
     app.add_handler(CommandHandler("progress", progress_command))
+    app.add_handler(CommandHandler("plan", plan_command))
+    app.add_handler(CommandHandler("skip", skip_command))
     app.add_handler(CommandHandler("exit", exit_command))
     app.add_handler(CommandHandler("learn_reset", onboarding.learn_reset))
     app.add_handler(

--- a/services/api/app/diabetes/planner.py
+++ b/services/api/app/diabetes/planner.py
@@ -1,0 +1,26 @@
+"""Utilities for building and formatting learning plans."""
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def generate_learning_plan(first_step: str | None = None) -> list[str]:
+    """Generate a basic learning plan.
+
+    Parameters
+    ----------
+    first_step:
+        Optional text for the first plan step.
+    """
+
+    return [
+        first_step or "Шаг 1: основы диабета",
+        "Шаг 2: контроль питания",
+        "Шаг 3: мониторинг сахара",
+    ]
+
+
+def pretty_plan(plan: Sequence[str]) -> str:
+    """Return a human friendly representation of *plan*."""
+
+    return "\n".join(f"{i + 1}. {step}" for i, step in enumerate(plan))

--- a/tests/learning/test_plan_handlers.py
+++ b/tests/learning/test_plan_handlers.py
@@ -1,0 +1,95 @@
+from types import SimpleNamespace
+from typing import Any, Mapping, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.config import settings
+from services.api.app.diabetes import learning_handlers
+from services.api.app.diabetes.planner import generate_learning_plan, pretty_plan
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs: object) -> None:
+        self.replies.append(text)
+
+
+def test_generate_and_pretty_plan() -> None:
+    plan = generate_learning_plan("step1")
+    assert plan[0] == "step1"
+    assert pretty_plan(plan[:2]) == "1. step1\n2. Шаг 2: контроль питания"
+
+
+@pytest.mark.asyncio
+async def test_learn_command_stores_plan(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+
+    async def fake_ensure_overrides(*args: object, **kwargs: object) -> bool:
+        return True
+
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
+
+    async def fake_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
+        return SimpleNamespace(lesson_id=1)
+
+    async def fake_next_step(
+        user_id: int,
+        lesson_id: int,
+        profile: Mapping[str, str | None],
+        prev_summary: str | None = None,
+    ) -> tuple[str, bool]:
+        return "step1", False
+
+    async def fake_add_log(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
+    )
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "next_step", fake_next_step
+    )
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+
+    message = DummyMessage()
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
+    )
+
+    await learning_handlers.learn_command(update, context)
+
+    assert context.user_data["learning_plan_index"] == 0
+    assert context.user_data["learning_plan"][0] == "step1"
+    assert message.replies == ["step1"]
+
+
+@pytest.mark.asyncio
+async def test_plan_and_skip_commands() -> None:
+    plan = ["step1", "step2"]
+    user_data = {"learning_plan": plan, "learning_plan_index": 0}
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data=user_data),
+    )
+
+    await learning_handlers.plan_command(update, context)
+    assert message.replies[-1] == pretty_plan(plan)
+
+    await learning_handlers.skip_command(update, context)
+    assert message.replies[-1] == "step2"
+    assert user_data["learning_plan_index"] == 1
+
+    await learning_handlers.skip_command(update, context)
+    assert message.replies[-1] == "План завершён."
+    assert user_data["learning_plan_index"] == 2


### PR DESCRIPTION
## Summary
- generate and format basic learning plans
- store plan on /learn and handle /plan and /skip commands
- cover planner and navigation handlers with tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd33fcea6c832abb8241fc336a613f