### PR TITLE
[learning] add on_any_text handler for general queries

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -23,6 +23,7 @@ from telegram import BotCommand
 from .common_handlers import help_command, smart_input_help
 from .router import callback_router
 from . import learning_handlers
+from services.api.app.diabetes import learning_handlers as dynamic_learning_handlers
 from ..utils.ui import (
     PROFILE_BUTTON_TEXT,
     REMINDERS_BUTTON_TEXT,
@@ -227,6 +228,14 @@ def register_handlers(
             filters.Regex(re.escape(SOS_BUTTON_TEXT)),
             sos_handlers.sos_contact_start,
         )
+    )
+    app.add_handler(
+        MessageHandlerT(
+            filters.TEXT & ~filters.COMMAND,
+            dynamic_learning_handlers.on_any_text,
+            block=False,
+        ),
+        group=0,
     )
     app.add_handler(
         MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler)

--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -6,7 +6,7 @@ import time
 from typing import Any, Mapping, MutableMapping, cast
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
-from telegram.ext import ContextTypes
+from telegram.ext import ApplicationHandlerStop, ContextTypes
 
 from services.api.app.config import TOPICS_RU, settings
 from services.api.app.ui.keyboard import build_main_keyboard
@@ -16,7 +16,12 @@ from .handlers import learning_handlers as legacy_handlers
 from .learning_onboarding import ensure_overrides
 from .learning_state import LearnState, clear_state, get_state, set_state
 from .learning_utils import choose_initial_topic
-from .services.gpt_client import format_reply
+from .learning_prompts import build_system_prompt
+from .llm_router import LLMTask
+from .services.gpt_client import (
+    create_learning_chat_completion,
+    format_reply,
+)
 from .services.lesson_log import add_lesson_log
 
 logger = logging.getLogger(__name__)
@@ -240,6 +245,48 @@ async def lesson_answer_handler(
     set_state(user_data, state)
 
 
+async def assistant_chat(
+    profile: Mapping[str, str | None], text: str
+) -> str:
+    """Answer a general user question via the learning LLM."""
+
+    system = build_system_prompt(profile)
+    user = text[:400]
+    try:
+        return await create_learning_chat_completion(
+            task=LLMTask.EXPLAIN_STEP,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            max_tokens=200,
+        )
+    except RuntimeError:
+        return "сервер занят, попробуйте позже"
+
+
+async def on_any_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle any incoming text either as an answer or a general query."""
+
+    message = update.message
+    if message is None or not message.text:
+        return
+    if not settings.learning_mode_enabled:
+        return
+    if settings.learning_content_mode != "dynamic":
+        return
+    user_data = cast(MutableMapping[str, Any], context.user_data)
+    state = get_state(user_data)
+    if state is not None and state.awaiting_answer and state.last_step_text:
+        await lesson_answer_handler(update, context)
+        raise ApplicationHandlerStop
+    profile = _get_profile(user_data)
+    reply = await assistant_chat(profile, message.text.strip())
+    reply = format_reply(reply)
+    await message.reply_text(reply, reply_markup=build_main_keyboard())
+    raise ApplicationHandlerStop
+
+
 async def exit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Exit the current lesson and clear stored state."""
 
@@ -265,5 +312,6 @@ __all__ = [
     "lesson_command",
     "lesson_callback",
     "lesson_answer_handler",
+    "on_any_text",
     "exit_command",
 ]

--- a/tests/learning/test_on_any_text.py
+++ b/tests/learning/test_on_any_text.py
@@ -1,0 +1,87 @@
+import pytest
+from types import SimpleNamespace
+from typing import Any, Mapping
+
+from services.api.app.config import settings
+from services.api.app.diabetes import learning_handlers
+from services.api.app.diabetes.learning_state import LearnState, set_state
+from telegram.ext import ApplicationHandlerStop
+
+
+class DummyMessage:
+    def __init__(self, text: str | None = None) -> None:
+        self.text = text
+        self.from_user = SimpleNamespace(id=1)
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_on_any_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+    user_data: dict[str, object] = {}
+    set_state(user_data, LearnState(topic="t", step=1, awaiting_answer=True, last_step_text="q"))
+    called = False
+
+    async def fake_check_user_answer(
+        profile: Mapping[str, str | None], topic: str, answer: str, last: str
+    ) -> tuple[bool, str]:
+        nonlocal called
+        called = True
+        assert answer == "ans"
+        assert last == "q"
+        return True, "fb"
+
+    async def fake_generate_step_text(
+        profile: Mapping[str, str | None], topic: str, step_idx: int, prev: object
+    ) -> str:
+        return "next"
+
+    monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+
+    async def fake_add_log(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
+
+    msg = DummyMessage("ans")
+    update = SimpleNamespace(message=msg)
+    context = SimpleNamespace(user_data=user_data)
+
+    with pytest.raises(ApplicationHandlerStop):
+        await learning_handlers.on_any_text(update, context)
+    assert called
+    assert msg.replies == ["fb", "next"]
+
+
+@pytest.mark.asyncio
+async def test_on_any_text_general(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+    user_data: dict[str, object] = {}
+    called = False
+
+    async def fake_assistant_chat(profile: Mapping[str, str | None], text: str) -> str:
+        nonlocal called
+        called = True
+        assert text == "hello"
+        return "reply"
+
+    async def fake_check_user_answer(*args: object, **kwargs: object) -> tuple[bool, str]:
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(learning_handlers, "assistant_chat", fake_assistant_chat)
+    monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
+
+    msg = DummyMessage("hello")
+    update = SimpleNamespace(message=msg)
+    context = SimpleNamespace(user_data=user_data)
+
+    with pytest.raises(ApplicationHandlerStop):
+        await learning_handlers.on_any_text(update, context)
+    assert called
+    assert msg.replies == ["reply"]

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -132,6 +132,10 @@ def test_register_handlers_attaches_expected_handlers(
         and h.callback is dynamic_learning_handlers.lesson_answer_handler
         for h in handlers
     )
+    assert dynamic_learning_handlers.on_any_text in callbacks
+    assert callbacks.index(dynamic_learning_handlers.on_any_text) < callbacks.index(
+        gpt_handlers.freeform_handler
+    )
     assert any(
         isinstance(h, CommandHandler)
         and h.callback is learning_onboarding.learn_reset


### PR DESCRIPTION
## Summary
- handle general text via new `on_any_text` that routes learning answers or general assistant chat
- register `on_any_text` before other text handlers
- test text routing and handler registration

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `pytest tests/learning/test_on_any_text.py -q --no-cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd342419c0832aa65968da6751d8ef