### PR TITLE
[gpt] Track assistant history and reset command

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -183,6 +183,7 @@ def register_handlers(
     if learning_enabled:
         learning_handlers.register_handlers(app)
     app.add_handler(CommandHandlerT("gpt", gpt_handlers.chat_with_gpt))
+    app.add_handler(CommandHandlerT("reset", gpt_handlers.reset_command))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))
     app.add_handler(

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -275,6 +275,13 @@ def test_register_handlers_attaches_expected_handlers(
     ]
     assert gpt_cmd and "gpt" in gpt_cmd[0].commands
 
+    reset_cmd = [
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is gpt_handlers.reset_command
+    ]
+    assert reset_cmd and "reset" in reset_cmd[0].commands
+
     history_cmd = [
         h
         for h in handlers


### PR DESCRIPTION
## Summary
- Record chat turns in `assistant_history` and summarize old turns when the history grows too long
- Add `/reset` command to clear stored history and summary
- Test history trimming, summarization, and command registration

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd348c73b4832a929d2b531e066591