### PR TITLE
[learning] Guard tutor chat with busy state

### DIFF
--- a/services/api/app/diabetes/learning_state.py
+++ b/services/api/app/diabetes/learning_state.py
@@ -13,6 +13,7 @@ class LearnState:
     topic: str
     step: int
     awaiting_answer: bool
+    learn_busy: bool = False
     disclaimer_shown: bool = False
     last_step_text: str | None = None
     prev_summary: str | None = None

--- a/tests/learning/test_dynamic_tutor.py
+++ b/tests/learning/test_dynamic_tutor.py
@@ -33,13 +33,11 @@ async def test_runtimeerror_returns_fallback(
     async def raise_runtime_error(**kwargs: object) -> str:
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(
-        dynamic_tutor, "create_learning_chat_completion", raise_runtime_error
-    )
+    monkeypatch.setattr(dynamic_tutor, "create_learning_chat_completion", raise_runtime_error)
 
     step = await dynamic_tutor.generate_step_text({}, "topic", 1, None)
     correct, feedback = await dynamic_tutor.check_user_answer({}, "topic", "42", "step")
 
-    assert step == "сервер занят, попробуйте позже"
+    assert step == dynamic_tutor.BUSY_MESSAGE
     assert correct is False
-    assert feedback == "сервер занят, попробуйте позже"
+    assert feedback == dynamic_tutor.BUSY_MESSAGE

--- a/tests/test_dynamic_tutor.py
+++ b/tests/test_dynamic_tutor.py
@@ -22,17 +22,15 @@ async def test_generate_step_text_formats_reply(
 
 
 @pytest.mark.asyncio
-async def test_generate_step_text_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_generate_step_text_error(monkeypatch: pytest.MonkeyPatch) -> None:
     async def raise_error(**kwargs: object) -> str:
-        raise RuntimeError("boom")
+        raise ValueError("boom")
 
-    monkeypatch.setattr(
-        dynamic_tutor, "create_learning_chat_completion", raise_error
-    )
+    monkeypatch.setattr(dynamic_tutor, "create_learning_chat_completion", raise_error)
 
     result = await dynamic_tutor.generate_step_text({}, "t", 1, None)
 
-    assert result == "сервер занят, попробуйте позже"
+    assert result == dynamic_tutor.BUSY_MESSAGE
 
 
 @pytest.mark.asyncio
@@ -59,16 +57,13 @@ async def test_check_user_answer_uses_max_tokens(
 
 
 @pytest.mark.asyncio
-async def test_check_user_answer_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_check_user_answer_error(monkeypatch: pytest.MonkeyPatch) -> None:
     async def raise_error(**kwargs: object) -> str:
-        raise RuntimeError("boom")
+        raise ValueError("boom")
 
-    monkeypatch.setattr(
-        dynamic_tutor, "create_learning_chat_completion", raise_error
-    )
+    monkeypatch.setattr(dynamic_tutor, "create_learning_chat_completion", raise_error)
 
     correct, result = await dynamic_tutor.check_user_answer({}, "topic", "ans", "text")
 
     assert correct is False
-    assert result == "сервер занят, попробуйте позже"
-
+    assert result == dynamic_tutor.BUSY_MESSAGE


### PR DESCRIPTION
## Summary
- add BUSY_MESSAGE fallback with contextual logging for tutor chat
- track transient learn_busy state to avoid concurrent lesson answers
- test tutor error fallback and busy flag behaviour

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68bd34aa0490832aaf4a0eb02571c324