### PR TITLE
feat: track assistant history and reset command

### DIFF
--- a/services/api/app/diabetes/assistant_state.py
+++ b/services/api/app/diabetes/assistant_state.py
@@ -1,0 +1,57 @@
+"""Helper utilities for storing assistant conversation state in ``user_data``."""
+
+from __future__ import annotations
+
+from typing import MutableMapping, cast
+
+ASSISTANT_MAX_TURNS: int = 20
+ASSISTANT_SUMMARY_TRIGGER: int = 40
+
+HISTORY_KEY = "assistant_history"
+SUMMARY_KEY = "assistant_summary"
+
+
+def summarize(parts: list[str]) -> str:
+    """Summarize *parts* into a single string.
+
+    The default implementation simply joins messages with spaces.  Tests may
+    monkeypatch this function to provide deterministic summaries.
+    """
+    return " ".join(parts)
+
+
+def add_turn(user_data: MutableMapping[str, object], text: str) -> None:
+    """Append assistant reply ``text`` to ``user_data`` keeping short history.
+
+    When the number of stored turns reaches :data:`ASSISTANT_SUMMARY_TRIGGER`,
+    older entries beyond :data:`ASSISTANT_MAX_TURNS` are summarized and the
+    summary is stored under ``assistant_summary`` key.
+    """
+    history = cast(list[str], user_data.setdefault(HISTORY_KEY, []))
+    history.append(text)
+    if len(history) >= ASSISTANT_SUMMARY_TRIGGER:
+        old = history[:-ASSISTANT_MAX_TURNS]
+        if old:
+            summary = summarize(old)
+            prev = cast(str | None, user_data.get(SUMMARY_KEY))
+            user_data[SUMMARY_KEY] = f"{prev} {summary}".strip() if prev else summary
+        del history[:-ASSISTANT_MAX_TURNS]
+    elif len(history) > ASSISTANT_MAX_TURNS:
+        del history[:-ASSISTANT_MAX_TURNS]
+
+
+def reset(user_data: MutableMapping[str, object]) -> None:
+    """Remove assistant history and summary from ``user_data``."""
+    user_data.pop(HISTORY_KEY, None)
+    user_data.pop(SUMMARY_KEY, None)
+
+
+__all__ = [
+    "ASSISTANT_MAX_TURNS",
+    "ASSISTANT_SUMMARY_TRIGGER",
+    "HISTORY_KEY",
+    "SUMMARY_KEY",
+    "summarize",
+    "add_turn",
+    "reset",
+]

--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -10,6 +10,7 @@ from .learning_handlers import learn_command, topics_command
 from .handlers.onboarding_handlers import (
     reset_onboarding as _reset_onboarding,
 )
+from .assistant_state import reset as _reset_assistant
 
 logger = logging.getLogger(__name__)
 
@@ -57,4 +58,21 @@ async def reset_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     )
 
 
-__all__ = ["help_command", "reset_onboarding", "learn_command", "topics_command"]
+async def reset_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Clear assistant conversation history and summary."""
+
+    message = update.effective_message
+    if message is None:
+        return
+    user_data = cast(dict[str, object], context.user_data)
+    _reset_assistant(user_data)
+    await message.reply_text("История очищена.")
+
+
+__all__ = [
+    "help_command",
+    "reset_onboarding",
+    "reset_command",
+    "learn_command",
+    "topics_command",
+]

--- a/tests/test_assistant_state.py
+++ b/tests/test_assistant_state.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from services.api.app.diabetes import assistant_state
+from services.api.app.diabetes import commands
+
+
+@pytest.mark.asyncio
+async def test_history_trim_and_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(assistant_state, "ASSISTANT_MAX_TURNS", 2)
+    monkeypatch.setattr(assistant_state, "ASSISTANT_SUMMARY_TRIGGER", 3)
+
+    def fake_summary(parts: list[str]) -> str:
+        return ",".join(parts)
+
+    monkeypatch.setattr(assistant_state, "summarize", fake_summary)
+
+    data: dict[str, Any] = {}
+    assistant_state.add_turn(data, "a1")
+    assistant_state.add_turn(data, "a2")
+    assert data[assistant_state.HISTORY_KEY] == ["a1", "a2"]
+
+    assistant_state.add_turn(data, "a3")
+    assert data[assistant_state.HISTORY_KEY] == ["a2", "a3"]
+    assert data[assistant_state.SUMMARY_KEY] == "a1"
+
+
+@pytest.mark.asyncio
+async def test_reset_command_clears(monkeypatch: pytest.MonkeyPatch) -> None:
+    user_data: dict[str, Any] = {
+        assistant_state.HISTORY_KEY: ["x"],
+        assistant_state.SUMMARY_KEY: "y",
+    }
+    replies: list[str] = []
+
+    class DummyMessage:
+        async def reply_text(self, text: str, **_: Any) -> None:
+            replies.append(text)
+
+    update = SimpleNamespace(effective_message=DummyMessage())
+    context = SimpleNamespace(user_data=user_data)
+    await commands.reset_command(update, context)
+    assert user_data == {}
+    assert replies and "очищ" in replies[0].lower()


### PR DESCRIPTION
## Summary
- maintain assistant conversation history with summarization utilities
- add `/reset` command to clear assistant history and summary

## Testing
- `pytest tests/test_assistant_state.py -q` *(fails: Coverage failure: total of 25 is less than fail-under=85)*
- `mypy --strict services/api/app/diabetes/assistant_state.py services/api/app/diabetes/commands.py tests/test_assistant_state.py`
- `ruff check services/api/app/diabetes/assistant_state.py services/api/app/diabetes/commands.py tests/test_assistant_state.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd34c4a634832a88066a65089e8c54