### PR TITLE
[learning] ensure lesson onboarding

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -123,10 +123,12 @@ async def lesson_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     user = update.effective_user
     if message is None or user is None:
         return
-    logger.info("lesson_command_start", extra={"user_id": user.id})
     if not settings.learning_mode_enabled:
         await message.reply_text("🚫 Обучение недоступно.")
         return
+    if not await ensure_overrides(update, context):
+        return
+    logger.info("lesson_command_start", extra={"user_id": user.id})
     user_data = cast(MutableMapping[str, Any], context.user_data)
     if _rate_limited(user_data, "_lesson_ts"):
         await message.reply_text(RATE_LIMIT_MESSAGE)

--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -148,6 +148,8 @@ async def lesson_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     if settings.learning_content_mode == "static":
         await legacy_handlers.lesson_command(update, context)
         return
+    if not await ensure_overrides(update, context):
+        return
     user_data = cast(MutableMapping[str, Any], context.user_data)
     if _rate_limited(user_data, "_lesson_ts"):
         await message.reply_text(RATE_LIMIT_MESSAGE)

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -91,6 +91,10 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         return None
 
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    async def fake_ensure_overrides(update: object, context: object) -> bool:
+        return True
+
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
 
     msg = DummyMessage()
     update = cast(object, SimpleNamespace(message=msg))

--- a/tests/diabetes/test_learning_handlers_rate_limit.py
+++ b/tests/diabetes/test_learning_handlers_rate_limit.py
@@ -31,6 +31,10 @@ def make_context(**kwargs: Any) -> CallbackContext[Any, Any, Any, Any]:
 @pytest.mark.asyncio
 async def test_lesson_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_mode_enabled", True)
+    async def fake_ensure_overrides(update: object, context: object) -> bool:
+        return True
+
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
 
     calls: list[str] = []
 

--- a/tests/diabetes/test_learning_logs.py
+++ b/tests/diabetes/test_learning_logs.py
@@ -35,6 +35,10 @@ def make_context(**kwargs: Any) -> CallbackContext[Any, Any, Any, Any]:
 async def test_lesson_start_logging(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     """Ensure starting a lesson logs start and completion events."""
     monkeypatch.setattr(settings, "learning_mode_enabled", True)
+    async def fake_ensure_overrides(update: object, context: object) -> bool:
+        return True
+
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
 
     async def fake_start(user_id: int, slug: str) -> SimpleNamespace:
         return SimpleNamespace(lesson_id=1)

--- a/tests/diabetes/test_learning_onboarding.py
+++ b/tests/diabetes/test_learning_onboarding.py
@@ -127,3 +127,20 @@ async def test_onboarding_reply_ignored_without_stage() -> None:
     await learning_onboarding.onboarding_reply(update, context)
     assert message.replies == []
     assert context.user_data == {}
+
+
+@pytest.mark.asyncio
+async def test_lesson_command_requires_onboarding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+    message = DummyMessage()
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}, args=["l1"]),
+    )
+    await learning_handlers.lesson_command(update, context)
+    assert message.replies == [onboarding_utils.AGE_PROMPT]


### PR DESCRIPTION
## Summary
- ensure `/lesson` checks onboarding state via `ensure_overrides`
- test lesson onboarding and adjust existing tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd38e63b0c832a99d64be62e7f7bb8