### PR TITLE
[learning] Handle busy next_step result

### DIFF
--- a/scripts/probe_learn.py
+++ b/scripts/probe_learn.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from services.api.app import config
 from services.api.app.diabetes import curriculum_engine
+from services.api.app.diabetes.dynamic_tutor import BUSY_MESSAGE
 from services.api.app.diabetes.models_learning import (
     LessonProgress,
     LessonStep,
@@ -60,6 +61,9 @@ async def main(user_id: int, lesson_slug: str) -> None:
 
     while True:
         text, completed = await curriculum_engine.next_step(user_id, lesson_id, {})
+        if text == BUSY_MESSAGE:
+            print(text)
+            break
         if text is None and completed:
             break
         print(text)

--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -34,6 +34,7 @@ from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.utils.ui import menu_keyboard
 from ...ui.keyboard import build_main_keyboard
 from ..learning_onboarding import ensure_overrides
+from ..dynamic_tutor import BUSY_MESSAGE
 
 if TYPE_CHECKING:
     App: TypeAlias = Application[
@@ -146,6 +147,10 @@ async def lesson_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         lesson_id = progress.lesson_id
         user_data["lesson_id"] = lesson_id
     text, completed = await curriculum_engine.next_step(user.id, lesson_id, {})
+    if text == BUSY_MESSAGE:
+        await message.reply_text(BUSY_MESSAGE)
+        user_data.pop("lesson_id", None)
+        return
     if text is None and completed:
         await message.reply_text("Урок завершён")
         clear_state(user_data)
@@ -208,6 +213,9 @@ async def quiz_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             set_state(user_data, state)
         await message.reply_text(feedback)
         question, completed = await curriculum_engine.next_step(user.id, lesson_id, {})
+        if question == BUSY_MESSAGE:
+            await message.reply_text(BUSY_MESSAGE)
+            return
         if question is None and completed:
             await message.reply_text("Опрос завершён")
             clear_state(user_data)
@@ -223,6 +231,9 @@ async def quiz_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             set_state(user_data, state)
         return
     question, completed = await curriculum_engine.next_step(user.id, lesson_id, {})
+    if question == BUSY_MESSAGE:
+        await message.reply_text(BUSY_MESSAGE)
+        return
     if question is None and completed:
         await message.reply_text("Опрос завершён")
         clear_state(user_data)
@@ -272,6 +283,9 @@ async def quiz_answer_handler(
         set_state(user_data, state)
     await message.reply_text(feedback)
     question, completed = await curriculum_engine.next_step(user.id, lesson_id, {})
+    if question == BUSY_MESSAGE:
+        await message.reply_text(BUSY_MESSAGE)
+        return
     if question is None and completed:
         await message.reply_text("Опрос завершён")
         clear_state(user_data)

--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -94,7 +94,8 @@ async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     slug, _ = choose_initial_topic(profile)
     progress = await curriculum_engine.start_lesson(user.id, slug)
     text, _ = await curriculum_engine.next_step(user.id, progress.lesson_id, profile)
-    if text is None:
+    if text is None or text == BUSY_MESSAGE:
+        await message.reply_text(BUSY_MESSAGE, reply_markup=build_main_keyboard())
         return
     plan = generate_learning_plan(text)
     user_data["learning_plan"] = plan

--- a/tests/diabetes/test_curriculum_busy.py
+++ b/tests/diabetes/test_curriculum_busy.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+from typing import Any, Mapping, cast
+
+import pytest
+
+from services.api.app.config import settings
+from services.api.app.diabetes import learning_handlers as dynamic_handlers
+from services.api.app.diabetes.dynamic_tutor import BUSY_MESSAGE
+from services.api.app.diabetes.handlers import learning_handlers as legacy_handlers
+from services.api.app.diabetes.learning_state import get_state
+
+
+class DummyMessage:
+    def __init__(self, text: str | None = None) -> None:
+        self.text = text
+        self.from_user = SimpleNamespace(id=1)
+        self.replies: list[str] = []
+        self.markups: list[Any] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - helper
+        self.replies.append(text)
+        self.markups.append(kwargs.get("reply_markup"))
+
+
+@pytest.mark.asyncio
+async def test_dynamic_learn_command_busy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+
+    async def fake_ensure_overrides(update: object, context: object) -> bool:
+        return True
+
+    monkeypatch.setattr(dynamic_handlers, "ensure_overrides", fake_ensure_overrides)
+    monkeypatch.setattr(dynamic_handlers, "choose_initial_topic", lambda _profile: ("slug", "t"))
+
+    async def fake_start_lesson(user_id: int, slug: str) -> object:
+        return SimpleNamespace(lesson_id=1)
+
+    async def fake_next_step(
+        user_id: int,
+        lesson_id: int,
+        profile: Mapping[str, str | None],
+        prev_summary: str | None = None,
+    ) -> tuple[str, bool]:
+        return BUSY_MESSAGE, False
+
+    monkeypatch.setattr(dynamic_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(dynamic_handlers.curriculum_engine, "next_step", fake_next_step)
+
+    def fail_generate_learning_plan(_text: str) -> list[str]:
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(dynamic_handlers, "generate_learning_plan", fail_generate_learning_plan)
+
+    async def fail_add_log(*args: object, **kwargs: object) -> None:
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fail_add_log)
+
+    msg = DummyMessage()
+    update = cast(object, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=7)))
+    context = SimpleNamespace(user_data={})
+
+    await dynamic_handlers.learn_command(update, context)
+
+    assert msg.replies == [BUSY_MESSAGE]
+    assert get_state(context.user_data) is None
+
+
+@pytest.mark.asyncio
+async def test_legacy_lesson_command_busy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+
+    async def fake_start(user_id: int, slug: str) -> object:
+        return SimpleNamespace(lesson_id=1)
+
+    async def fake_next(
+        user_id: int, lesson_id: int, profile: Mapping[str, str | None]
+    ) -> tuple[str, bool]:
+        return BUSY_MESSAGE, False
+
+    monkeypatch.setattr(legacy_handlers.curriculum_engine, "start_lesson", fake_start)
+    monkeypatch.setattr(legacy_handlers.curriculum_engine, "next_step", fake_next)
+
+    msg = DummyMessage()
+    update = cast(object, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=7)))
+    context = SimpleNamespace(user_data={}, args=["slug"])
+
+    await legacy_handlers.lesson_command(update, context)
+
+    assert msg.replies == [BUSY_MESSAGE]
+    assert get_state(context.user_data) is None
+    assert context.user_data.get("lesson_id") is None


### PR DESCRIPTION
## Summary
- stop lesson launch when `curriculum_engine.next_step` reports BUSY_MESSAGE
- forward BUSY_MESSAGE for quiz flow and reset pending lesson id
- add tests for busy curriculum_engine responses

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd38e421c4832ab51fe08d4a098cf6