### PR TITLE
[learning] handle gpt errors in static curriculum

### DIFF
--- a/tests/diabetes/test_curriculum_busy.py
+++ b/tests/diabetes/test_curriculum_busy.py
@@ -17,7 +17,9 @@ class DummyMessage:
         self.replies: list[str] = []
         self.markups: list[Any] = []
 
-    async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - helper
+    async def reply_text(
+        self, text: str, **kwargs: Any
+    ) -> None:  # pragma: no cover - helper
         self.replies.append(text)
         self.markups.append(kwargs.get("reply_markup"))
 
@@ -30,7 +32,9 @@ async def test_dynamic_learn_command_busy(monkeypatch: pytest.MonkeyPatch) -> No
         return True
 
     monkeypatch.setattr(dynamic_handlers, "ensure_overrides", fake_ensure_overrides)
-    monkeypatch.setattr(dynamic_handlers, "choose_initial_topic", lambda _profile: ("slug", "t"))
+    monkeypatch.setattr(
+        dynamic_handlers, "choose_initial_topic", lambda _profile: ("slug", "t")
+    )
 
     async def fake_start_lesson(user_id: int, slug: str) -> object:
         return SimpleNamespace(lesson_id=1)
@@ -43,13 +47,17 @@ async def test_dynamic_learn_command_busy(monkeypatch: pytest.MonkeyPatch) -> No
     ) -> tuple[str, bool]:
         return BUSY_MESSAGE, False
 
-    monkeypatch.setattr(dynamic_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(
+        dynamic_handlers.curriculum_engine, "start_lesson", fake_start_lesson
+    )
     monkeypatch.setattr(dynamic_handlers.curriculum_engine, "next_step", fake_next_step)
 
     def fail_generate_learning_plan(_text: str) -> list[str]:
         raise AssertionError("should not be called")
 
-    monkeypatch.setattr(dynamic_handlers, "generate_learning_plan", fail_generate_learning_plan)
+    monkeypatch.setattr(
+        dynamic_handlers, "generate_learning_plan", fail_generate_learning_plan
+    )
 
     async def fail_add_log(*args: object, **kwargs: object) -> None:
         raise AssertionError("should not be called")
@@ -57,7 +65,9 @@ async def test_dynamic_learn_command_busy(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fail_add_log)
 
     msg = DummyMessage()
-    update = cast(object, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=7)))
+    update = cast(
+        object, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=7))
+    )
     context = SimpleNamespace(user_data={})
 
     await dynamic_handlers.learn_command(update, context)
@@ -81,8 +91,15 @@ async def test_legacy_lesson_command_busy(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(legacy_handlers.curriculum_engine, "start_lesson", fake_start)
     monkeypatch.setattr(legacy_handlers.curriculum_engine, "next_step", fake_next)
 
+    async def fake_ensure_overrides(update: object, context: object) -> bool:
+        return True
+
+    monkeypatch.setattr(legacy_handlers, "ensure_overrides", fake_ensure_overrides)
+
     msg = DummyMessage()
-    update = cast(object, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=7)))
+    update = cast(
+        object, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=7))
+    )
     context = SimpleNamespace(user_data={}, args=["slug"])
 
     await legacy_handlers.lesson_command(update, context)

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -16,9 +16,13 @@ class DummyMessage:
         self.replies: list[str] = []
         self.markups: list[InlineKeyboardMarkup | None] = []
 
-    async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - helper
+    async def reply_text(
+        self, text: str, **kwargs: Any
+    ) -> None:  # pragma: no cover - helper
         self.replies.append(text)
-        self.markups.append(cast(InlineKeyboardMarkup | None, kwargs.get("reply_markup")))
+        self.markups.append(
+            cast(InlineKeyboardMarkup | None, kwargs.get("reply_markup"))
+        )
 
 
 class DummyCallback:
@@ -41,11 +45,15 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
     monkeypatch.setattr(learning_handlers, "TOPICS_RU", {"slug": "Topic"})
+    monkeypatch.setattr(learning_handlers, "TOPICS_RU", {"slug": "Topic"})
+    monkeypatch.setattr(learning_handlers, "TOPICS_RU", {"slug": "Topic"})
 
     async def fake_generate_step_text(*args: object, **kwargs: object) -> str:
         return "step1?"
 
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fake_generate_step_text
+    )
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -78,13 +86,19 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
 async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
-    async def fake_generate_step_text(profile: object, topic: str, step_idx: int, prev: object) -> str:
+    async def fake_generate_step_text(
+        profile: object, topic: str, step_idx: int, prev: object
+    ) -> str:
         return f"step{step_idx}?"
 
-    async def fake_check_user_answer(profile: object, topic: str, answer: str, last: str) -> tuple[bool, str]:
+    async def fake_check_user_answer(
+        profile: object, topic: str, answer: str, last: str
+    ) -> tuple[bool, str]:
         return True, "feedback"
 
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fake_generate_step_text
+    )
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
@@ -96,7 +110,7 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         return True
 
     monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
-
+    monkeypatch.setattr(learning_handlers, "TOPICS_RU", {"slug": "Topic"})
 
     msg = DummyMessage()
     update = cast(object, SimpleNamespace(message=msg))
@@ -121,6 +135,11 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_lesson_command_unknown_topic(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
     monkeypatch.setattr(learning_handlers, "TOPICS_RU", {"known": "Topic"})
+
+    async def fake_ensure_overrides(update: object, context: object) -> bool:
+        return True
+
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
 
     called = False
 
@@ -193,7 +212,9 @@ async def test_learn_command_autostarts_when_topics_hidden(
         return True
 
     monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
-    monkeypatch.setattr(learning_handlers, "choose_initial_topic", lambda _: ("slug", "t"))
+    monkeypatch.setattr(
+        learning_handlers, "choose_initial_topic", lambda _: ("slug", "t")
+    )
 
     progress = SimpleNamespace(lesson_id=1)
 
@@ -213,8 +234,12 @@ async def test_learn_command_autostarts_when_topics_hidden(
         return "first", False
 
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
-    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
-    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
+    )
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "next_step", fake_next_step
+    )
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -222,7 +247,9 @@ async def test_learn_command_autostarts_when_topics_hidden(
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
 
     msg = DummyMessage()
-    update = cast(object, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=7)))
+    update = cast(
+        object, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=7))
+    )
     context = SimpleNamespace(user_data={})
 
     await learning_handlers.learn_command(update, context)
@@ -239,7 +266,13 @@ async def test_lesson_answer_ignores_busy(monkeypatch: pytest.MonkeyPatch) -> No
     user_data: dict[str, Any] = {}
     set_state(
         user_data,
-        LearnState(topic="slug", step=1, awaiting_answer=True, learn_busy=True, last_step_text="q"),
+        LearnState(
+            topic="slug",
+            step=1,
+            awaiting_answer=True,
+            learn_busy=True,
+            last_step_text="q",
+        ),
     )
     update = cast(object, SimpleNamespace(message=msg))
     context = SimpleNamespace(user_data=user_data)
@@ -255,14 +288,18 @@ async def test_lesson_answer_handler_error_keeps_state(
 ) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
-    async def fake_check_user_answer(*args: object, **kwargs: object) -> tuple[bool, str]:
+    async def fake_check_user_answer(
+        *args: object, **kwargs: object
+    ) -> tuple[bool, str]:
         return False, dynamic_tutor.BUSY_MESSAGE
 
     async def fail_generate_step_text(*args: object, **kwargs: object) -> str:
         raise AssertionError("should not be called")
 
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fail_generate_step_text)
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fail_generate_step_text
+    )
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None


### PR DESCRIPTION
## Summary
- guard gpt step explanations against errors and fall back to BUSY_MESSAGE
- extend curriculum engine tests for GPT error handling
- stabilize busy-message and learning handler tests

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd3e43391c832ab4ddd1322c808345