### PR TITLE
[learning] Use inline onboarding buttons

### DIFF
--- a/services/api/app/diabetes/handlers/learning_onboarding.py
+++ b/services/api/app/diabetes/handlers/learning_onboarding.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, TypeAlias, cast
 
-from telegram import Update
+from telegram import Message, Update
 from telegram.ext import (
     Application,
+    CallbackQueryHandler,
     CommandHandler,
     ContextTypes,
     ExtBot,
@@ -14,9 +15,14 @@ from telegram.ext import (
     filters,
 )
 
-from ..learning_onboarding import ensure_overrides, learn_reset
+from ..learning_onboarding import CB_PREFIX, ensure_overrides, learn_reset
 
-__all__ = ["onboarding_reply", "register_handlers", "learn_reset"]
+__all__ = [
+    "onboarding_reply",
+    "onboarding_callback",
+    "register_handlers",
+    "learn_reset",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +58,33 @@ async def onboarding_reply(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         await message.reply_text("Ответы сохранены. Отправьте /learn чтобы продолжить.")
 
 
+async def onboarding_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle button presses during learning onboarding."""
+    logger.debug("onboarding_callback", extra={"user": update.effective_user})
+    query = update.callback_query
+    if query is None or query.data is None:
+        return
+    await query.answer()
+    user_data = cast(dict[str, object], context.user_data)
+    stage = cast(str | None, user_data.get("learn_onboarding_stage"))
+    if stage is None:
+        return
+    data = query.data.removeprefix(CB_PREFIX)
+    overrides = cast(
+        dict[str, str], user_data.setdefault("learn_profile_overrides", {})
+    )
+    overrides[stage] = data
+    user_data.pop("learn_onboarding_stage", None)
+    if await ensure_overrides(update, context):
+        message = cast("Message | None", query.message)
+        if message is not None:
+            await message.reply_text(
+                "Ответы сохранены. Отправьте /learn чтобы продолжить."
+            )
+
+
 def register_handlers(app: App) -> None:
     """Register learning onboarding handlers on the application."""
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, onboarding_reply))
+    app.add_handler(CallbackQueryHandler(onboarding_callback, pattern=f"^{CB_PREFIX}"))
     app.add_handler(CommandHandler("learn_reset", learn_reset))


### PR DESCRIPTION
## Summary
- swap reply keyboards for inline buttons in learning onboarding
- handle button callbacks and register handler
- cover callback flow with tests

## Testing
- `pytest tests/diabetes/test_learning_onboarding.py::test_learning_onboarding_callback_flow -q --no-cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd3e29d9b4832a888a581f42658ecd