### PR TITLE
[handlers] Restore default commands after onboarding

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -27,6 +27,7 @@ from telegram.ext import (
     CommandHandler,
     ContextTypes,
     ConversationHandler,
+    ExtBot,
     MessageHandler,
     filters,
 )
@@ -48,6 +49,7 @@ from services.api.app.diabetes.utils.ui import (
     menu_keyboard,
 )
 from services.api.app.utils import choose_variant
+import services.bot.main as bot_main
 from .reminder_jobs import DefaultJobQueue
 from . import reminder_handlers
 
@@ -493,6 +495,11 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     await _mark_user_complete(user.id)
     await _log_event(user.id, "onboarding_finished", 3, variant)
     await message.reply_text("Пропущено", reply_markup=menu_keyboard())
+    bot = cast(ExtBot[None], message.get_bot())
+    try:
+        await bot.set_my_commands(bot_main.commands)
+    except Exception as e:  # pragma: no cover - network errors
+        logger.warning("set_my_commands failed: %s", e)
     return ConversationHandler.END
 
 
@@ -554,6 +561,11 @@ async def _finish(
         "🎉 Готово! Настройка завершена.", reply_markup=menu_keyboard()
     )
     await _log_event(user_id, "onboarding_finished", 3, variant)
+    bot = cast(ExtBot[None], message.get_bot())
+    try:
+        await bot.set_my_commands(bot_main.commands)
+    except Exception as e:  # pragma: no cover - network errors
+        logger.warning("set_my_commands failed: %s", e)
     return ConversationHandler.END
 
 

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -255,6 +255,8 @@ def register_handlers(
     )
     app.add_handler(CallbackQueryHandlerT(callback_router))
 
+    old_post_init = getattr(app, "post_init", None)
+
     async def _set_commands(
         app: Application[
             ExtBot[None],
@@ -265,6 +267,8 @@ def register_handlers(
             JobQueue[ContextTypes.DEFAULT_TYPE],
         ],
     ) -> None:
+        if callable(old_post_init):
+            await old_post_init(app)
         try:
             await app.bot.set_my_commands(
                 [

--- a/tests/diabetes/test_onboarding_commands.py
+++ b/tests/diabetes/test_onboarding_commands.py
@@ -1,0 +1,32 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from telegram.ext import ConversationHandler
+
+import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
+import services.bot.main as main
+
+
+@pytest.mark.asyncio
+async def test_finish_restores_main_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = AsyncMock()
+
+    async def reply_text(text: str, **kwargs: object) -> None:  # noqa: ANN401
+        pass
+
+    message = SimpleNamespace(reply_text=reply_text, get_bot=lambda: bot)
+
+    monkeypatch.setattr(onboarding.onboarding_state, "complete_state", AsyncMock())
+    monkeypatch.setattr(onboarding, "_mark_user_complete", AsyncMock())
+    monkeypatch.setattr(
+        onboarding.reminder_handlers,
+        "create_reminder_from_preset",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(onboarding, "_log_event", AsyncMock())
+
+    result = await onboarding._finish(message, 1, {}, None)
+
+    assert result == ConversationHandler.END
+    bot.set_my_commands.assert_awaited_once_with(main.commands)

--- a/tests/diabetes/test_onboarding_flow.py
+++ b/tests/diabetes/test_onboarding_flow.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext, ConversationHandler
+from unittest.mock import AsyncMock
 
 import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
 import services.api.app.services.onboarding_state as onboarding_state
@@ -85,6 +86,9 @@ class DummyMessage:
 
     async def reply_text(self, text: str, **_: Any) -> None:  # noqa: ANN401
         self.replies.append(text)
+
+    def get_bot(self) -> Any:
+        return SimpleNamespace(set_my_commands=AsyncMock())
 
 
 class DummyQuery:

--- a/tests/diabetes/test_onboarding_reminders.py
+++ b/tests/diabetes/test_onboarding_reminders.py
@@ -8,6 +8,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from telegram import Update
 from telegram.ext import CallbackContext, ConversationHandler
+from unittest.mock import AsyncMock
 
 import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
 import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
@@ -25,6 +26,9 @@ class DummyMessage:
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
         self.kwargs.append(kwargs)
+
+    def get_bot(self) -> Any:
+        return SimpleNamespace(set_my_commands=AsyncMock())
 
 
 class DummyQuery:

--- a/tests/handlers/test_wizard_navigation.py
+++ b/tests/handlers/test_wizard_navigation.py
@@ -7,6 +7,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from telegram import Update
 from telegram.ext import CallbackContext, ConversationHandler
+from unittest.mock import AsyncMock
 
 from services.api.app.diabetes.services.db import Base, User
 import services.api.app.services.onboarding_state as onboarding_state
@@ -31,6 +32,9 @@ class DummyMessage:
 
     async def delete(self) -> None:  # pragma: no cover - interface completeness
         self.deleted = True
+
+    def get_bot(self) -> Any:
+        return SimpleNamespace(set_my_commands=AsyncMock())
 
 
 class DummyQuery:

--- a/tests/learning/test_handlers.py
+++ b/tests/learning/test_handlers.py
@@ -80,10 +80,20 @@ async def test_learning_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
 
+    async def fake_start_lesson(user_id: int, topic_slug: str) -> object:
+        return SimpleNamespace(lesson_id=1)
+
+    async def fake_next_step(user_id: int, lesson_id: int, profile: object) -> tuple[str, object | None]:
+        return next(steps), None
+
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
+
     async def fake_ensure_overrides(*args: object, **kwargs: object) -> bool:
         return True
 
     monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
+    monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
 
     bot = DummyBot()
     app = Application.builder().bot(bot).build()

--- a/tests/test_onboarding_conversation.py
+++ b/tests/test_onboarding_conversation.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 import pytest
 from telegram import Update
 from telegram.ext import CallbackContext, ConversationHandler
+from unittest.mock import AsyncMock
 
 import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
 import services.api.app.services.onboarding_state as onboarding_state
@@ -85,6 +86,9 @@ class DummyMessage:
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
         self.kwargs.append(kwargs)
+
+    def get_bot(self) -> Any:
+        return SimpleNamespace(set_my_commands=AsyncMock())
 
 
 class DummyQuery:


### PR DESCRIPTION
## Summary
- preserve existing `Application.post_init` when assigning temporary registration commands
- reset bot commands to the main menu after onboarding skips or finishes
- add coverage for reinstating default commands once onboarding completes

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd4cb7296c832ab5f89b566897115b