### PR TITLE
[learning] support legacy learn button label

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -35,7 +35,7 @@ from ..utils.ui import (
     SOS_BUTTON_TEXT,
     SUBSCRIPTION_BUTTON_TEXT,
 )
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT, LEARN_BUTTON_OLD_TEXT
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +167,10 @@ def register_handlers(
     app.add_handler(CommandHandlerT("menu", learning_handlers.cmd_menu))
     app.add_handler(
         MessageHandlerT(
-            filters.TEXT & filters.Regex(rf"^{re.escape(LEARN_BUTTON_TEXT)}$"),
+            filters.TEXT
+            & filters.Regex(
+                rf"^(?:{re.escape(LEARN_BUTTON_TEXT)}|{re.escape(LEARN_BUTTON_OLD_TEXT)})$"
+            ),
             learning_handlers.on_learn_button,
         )
     )

--- a/services/api/app/ui/keyboard.py
+++ b/services/api/app/ui/keyboard.py
@@ -3,6 +3,7 @@ from telegram import ReplyKeyboardMarkup, KeyboardButton
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
 LEARN_BUTTON_TEXT = "🎓 Обучение"
+LEARN_BUTTON_OLD_TEXT = "🤖 Учебный режим"
 
 
 def build_main_keyboard() -> ReplyKeyboardMarkup:
@@ -19,4 +20,4 @@ def build_main_keyboard() -> ReplyKeyboardMarkup:
     )
 
 
-__all__ = ["LEARN_BUTTON_TEXT", "build_main_keyboard"]
+__all__ = ["LEARN_BUTTON_TEXT", "LEARN_BUTTON_OLD_TEXT", "build_main_keyboard"]

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 import json
+import re
 
 import pytest
 from sqlalchemy import create_engine
@@ -17,7 +18,7 @@ from services.api.app.config import Settings
 from services.api.app.diabetes.learning_fixtures import load_lessons
 from services.api.app.diabetes.services import db
 from services.api.app.diabetes.utils.ui import menu_keyboard
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT, LEARN_BUTTON_OLD_TEXT
 
 
 class DummyMessage:
@@ -188,6 +189,11 @@ async def test_cmd_menu_shows_keyboard() -> None:
     expected_layout = list(menu_keyboard().keyboard)
     expected_layout.append((KeyboardButton(LEARN_BUTTON_TEXT),))
     assert list(keyboard.keyboard) == expected_layout
+    assert all(
+        button.text != LEARN_BUTTON_OLD_TEXT
+        for row in keyboard.keyboard
+        for button in row
+    )
 
 
 @pytest.mark.asyncio
@@ -210,3 +216,10 @@ async def test_on_learn_button_calls_learn(monkeypatch: pytest.MonkeyPatch) -> N
     await handlers.on_learn_button(update, context)
 
     assert called["v"] is True
+
+
+def test_old_button_regex_matches() -> None:
+    pattern = re.compile(
+        rf"^(?:{re.escape(LEARN_BUTTON_TEXT)}|{re.escape(LEARN_BUTTON_OLD_TEXT)})$"
+    )
+    assert pattern.fullmatch(LEARN_BUTTON_OLD_TEXT)


### PR DESCRIPTION
## Summary
- accept both new and legacy learn button labels
- keep keyboard layout with new label only
- cover legacy label in tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd57c2cd24832abf0bb50faaedd914