### PR TITLE
[learning] Guard lesson logs with feature flag

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -81,6 +81,9 @@ class Settings(BaseSettings):
     learning_ui_show_topics: bool = Field(
         default=False, alias="LEARNING_UI_SHOW_TOPICS"
     )
+    learning_logging_required: bool = Field(
+        default=True, alias="LEARNING_LOGGING_REQUIRED"
+    )
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
     learning_assistant_id: Optional[str] = Field(default=None, alias="LEARNING_ASSISTANT_ID")
     learning_command_model: str = Field(default="gpt-4o-mini", alias="LEARNING_COMMAND_MODEL")

--- a/services/api/app/diabetes/services/lesson_log.py
+++ b/services/api/app/diabetes/services/lesson_log.py
@@ -4,9 +4,10 @@ import logging
 
 from sqlalchemy.orm import Session
 
+from ...config import settings
 from ..models_learning import LessonLog
 from .db import SessionLocal, run_db
-from .repository import CommitError, commit
+from .repository import commit
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,9 @@ async def add_lesson_log(
 ) -> None:
     """Insert a lesson log entry."""
 
+    if not settings.learning_logging_required:
+        return
+
     def _add(session: Session) -> None:
         session.add(
             LessonLog(
@@ -36,7 +40,7 @@ async def add_lesson_log(
 
     try:
         await run_db(_add, sessionmaker=SessionLocal)
-    except CommitError:  # pragma: no cover - logging only
+    except Exception:  # pragma: no cover - logging only
         logger.exception("Failed to add lesson log for %s", telegram_id)
 
 

--- a/tests/assistant/test_logs.py
+++ b/tests/assistant/test_logs.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from services.api.app.config import settings
+from services.api.app.diabetes.services import lesson_log
+from services.api.app.diabetes.services.lesson_log import add_lesson_log
+
+
+@pytest.mark.asyncio
+async def test_skip_when_logging_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """add_lesson_log should no-op when feature flag is disabled."""
+
+    monkeypatch.setattr(settings, "learning_logging_required", False)
+
+    async def fail_run_db(*_: object, **__: object) -> None:  # pragma: no cover - sanity
+        raise AssertionError("run_db should not be called")
+
+    monkeypatch.setattr(lesson_log, "run_db", fail_run_db)
+
+    await add_lesson_log(1, "topic", "assistant", 1, "hi")
+
+
+@pytest.mark.asyncio
+async def test_add_lesson_log_handles_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Errors during logging must not bubble up."""
+
+    monkeypatch.setattr(settings, "learning_logging_required", True)
+
+    async def fail_run_db(*_: object, **__: object) -> None:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(lesson_log, "run_db", fail_run_db)
+
+    await add_lesson_log(1, "topic", "assistant", 1, "hi")


### PR DESCRIPTION
## Summary
- add `learning_logging_required` flag to configuration to toggle lesson log storage
- skip lesson log writes when flag disabled and swallow logging failures
- cover logging resilience with new tests

## Testing
- `pytest -c /dev/null tests/assistant/test_logs.py tests/learning/test_lesson_logs.py -q --cov=services.api.app.diabetes.services.lesson_log --cov-fail-under=85`
- `mypy --strict services/api/app/diabetes/services/lesson_log.py services/api/app/config.py tests/assistant/test_logs.py`
- `ruff check services/api/app/diabetes/services/lesson_log.py services/api/app/config.py tests/assistant/test_logs.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd59559a48832ab848a5239a894b2e