### PR TITLE
[onboarding] Preserve default commands and guide via chat

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -64,6 +64,12 @@ warnings.filterwarnings(
 
 logger = logging.getLogger(__name__)
 
+# Hint shown after onboarding is finished or skipped.
+ONBOARDING_HINT = (
+    "Попробуйте /learn — учебный режим, /topics — список тем, "
+    "/menu — показать меню."
+)
+
 # Conversation states
 PROFILE, TIMEZONE, REMINDERS = range(3)
 ONB_PROFILE_ICR = PROFILE
@@ -500,6 +506,7 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         await bot.set_my_commands(bot_main.commands)
     except Exception as e:  # pragma: no cover - network errors
         logger.warning("set_my_commands failed: %s", e)
+    await message.reply_text(ONBOARDING_HINT)
     return ConversationHandler.END
 
 
@@ -566,6 +573,7 @@ async def _finish(
         await bot.set_my_commands(bot_main.commands)
     except Exception as e:  # pragma: no cover - network errors
         logger.warning("set_my_commands failed: %s", e)
+    await message.reply_text(ONBOARDING_HINT)
     return ConversationHandler.END
 
 

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -18,7 +18,6 @@ from telegram.ext import (
 from sqlalchemy.exc import SQLAlchemyError
 from typing import TYPE_CHECKING, TypeAlias
 
-from telegram import BotCommand
 
 from .common_handlers import help_command, smart_input_help
 from .router import callback_router
@@ -254,33 +253,6 @@ def register_handlers(
         )
     )
     app.add_handler(CallbackQueryHandlerT(callback_router))
-
-    old_post_init = getattr(app, "post_init", None)
-
-    async def _set_commands(
-        app: Application[
-            ExtBot[None],
-            ContextTypes.DEFAULT_TYPE,
-            dict[str, object],
-            dict[str, object],
-            dict[str, object],
-            JobQueue[ContextTypes.DEFAULT_TYPE],
-        ],
-    ) -> None:
-        if callable(old_post_init):
-            await old_post_init(app)
-        try:
-            await app.bot.set_my_commands(
-                [
-                    BotCommand("learn", "Учебный режим"),
-                    BotCommand("topics", "Список тем"),
-                    BotCommand("menu", "Показать нижнее меню"),
-                ]
-            )
-        except Exception as e:  # pragma: no cover - network errors
-            logger.warning("set_my_commands failed: %s", e)
-
-    app.post_init = _set_commands
 
     async def _clear_waiting_flags(context: ContextTypes.DEFAULT_TYPE) -> None:
         for data in context.application.user_data.values():

--- a/tests/diabetes/test_onboarding_commands.py
+++ b/tests/diabetes/test_onboarding_commands.py
@@ -30,3 +30,25 @@ async def test_finish_restores_main_commands(monkeypatch: pytest.MonkeyPatch) ->
 
     assert result == ConversationHandler.END
     bot.set_my_commands.assert_awaited_once_with(main.commands)
+
+
+@pytest.mark.asyncio
+async def test_skip_restores_main_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = AsyncMock()
+
+    async def reply_text(text: str, **kwargs: object) -> None:  # noqa: ANN401
+        pass
+
+    message = SimpleNamespace(reply_text=reply_text, get_bot=lambda: bot)
+    query = SimpleNamespace(message=message, data="onb_skip", answer=AsyncMock())
+    update = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={}, bot_data={})
+
+    monkeypatch.setattr(onboarding.onboarding_state, "complete_state", AsyncMock())
+    monkeypatch.setattr(onboarding, "_mark_user_complete", AsyncMock())
+    monkeypatch.setattr(onboarding, "_log_event", AsyncMock())
+
+    result = await onboarding.onboarding_skip(update, context)
+
+    assert result == ConversationHandler.END
+    bot.set_my_commands.assert_awaited_once_with(main.commands)


### PR DESCRIPTION
## Summary
- remove startup hook that replaced default commands
- add chat hint for `/learn`, `/topics`, `/menu` after onboarding
- test that default command list remains after onboarding flow

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd59322dfc832aa3702d70b2483763