### PR TITLE
[handlers] support legacy reminder jobs and alias commands

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -94,7 +94,12 @@ def register_reminder_handlers(
 
     from . import reminder_handlers
 
-    app.add_handler(CommandHandlerT("reminders", reminder_handlers.reminders_list))
+    app.add_handler(
+        CommandHandlerT(
+            ["reminders", "reminder", "remind"],
+            reminder_handlers.reminders_list,
+        )
+    )
     app.add_handler(CommandHandlerT("addreminder", reminder_handlers.add_reminder))
     app.add_handler(reminder_handlers.reminder_action_handler)
     app.add_handler(reminder_handlers.reminder_webapp_handler)
@@ -275,6 +280,7 @@ def register_handlers(
                     BotCommand("learn", "Учебный режим"),
                     BotCommand("topics", "Список тем"),
                     BotCommand("menu", "Показать нижнее меню"),
+                    BotCommand("reminders", "Мои напоминания"),
                 ]
             )
         except Exception as e:  # pragma: no cover - network errors

--- a/services/api/app/diabetes/utils/jobs.py
+++ b/services/api/app/diabetes/utils/jobs.py
@@ -274,6 +274,9 @@ def _remove_jobs(job_queue: DefaultJobQueue, base_name: str) -> int:
     removed.
     """
     names = {base_name, f"{base_name}_after", f"{base_name}_snooze"}
+    if base_name.startswith("reminder_"):
+        legacy = base_name.replace("reminder_", "remind_")
+        names.update({legacy, f"{legacy}_after", f"{legacy}_snooze"})
     removed = 0
 
     scheduler = getattr(job_queue, "scheduler", None)

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -414,6 +414,12 @@ def test_register_reminder_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
         isinstance(h, CommandHandler) and h.callback is rh.reminders_list
         for h in handlers
     )
+    rem_handler = next(
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is rh.reminders_list
+    )
+    assert {"reminders", "reminder", "remind"} <= set(rem_handler.commands)
     assert any(
         isinstance(h, CommandHandler) and h.callback is rh.add_reminder
         for h in handlers

--- a/tests/test_schedule_all_aliases.py
+++ b/tests/test_schedule_all_aliases.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import time
+from typing import cast
+
+import services.api.app.diabetes.handlers.reminder_handlers as handlers
+from services.api.app.diabetes.handlers.reminder_jobs import DefaultJobQueue
+from services.api.app.diabetes.services.db import Reminder, User as DbUser
+from tests.test_schedule_all_queries import DummyJobQueue, _setup_session
+
+
+def test_schedule_all_removes_legacy_jobs() -> None:
+    TestSession, _ = _setup_session()
+    handlers.SessionLocal = TestSession
+    with TestSession() as session:
+        session.add(DbUser(telegram_id=1, thread_id="t"))
+        rem = Reminder(
+            telegram_id=1,
+            type="sugar",
+            time=time(8, 0),
+            kind="at_time",
+            is_enabled=True,
+        )
+        session.add(rem)
+        session.commit()
+        rem_id = rem.id
+
+    job_queue = cast(DefaultJobQueue, DummyJobQueue())
+    old_job = job_queue.run_daily(lambda *a, **k: None, time(8, 0), name=f"remind_{rem_id}")
+    handlers.schedule_all(job_queue)
+
+    assert old_job.removed is True
+    assert all(
+        j.removed for j in job_queue.jobs() if j.name == f"remind_{rem_id}"
+    )
+    names = [job.name for job in job_queue.jobs()]
+    assert f"reminder_{rem_id}" in names
+    new_job = next(j for j in job_queue.jobs() if j.name == f"reminder_{rem_id}")
+    assert new_job.removed is False


### PR DESCRIPTION
## Summary
- support /remind and /reminder aliases in reminder registration and bot command list
- clean up legacy `remind_` jobs when scheduling from DB
- test reminder job alias cleanup and handler registration

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd595f8d70832abefa9207f20387d8