### PR TITLE
[learn] Support legacy button text

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -37,6 +37,9 @@ from ..utils.ui import (
 )
 from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
 
+OLD_LEARN_BUTTON_TEXT = "🎓 Обучение"
+LEARN_BUTTON_PATTERN = rf"^(?:{re.escape(LEARN_BUTTON_TEXT)}|{re.escape(OLD_LEARN_BUTTON_TEXT)})$"
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -167,7 +170,7 @@ def register_handlers(
     app.add_handler(CommandHandlerT("menu", learning_handlers.cmd_menu))
     app.add_handler(
         MessageHandlerT(
-            filters.TEXT & filters.Regex(rf"^{re.escape(LEARN_BUTTON_TEXT)}$"),
+            filters.TEXT & filters.Regex(LEARN_BUTTON_PATTERN),
             learning_handlers.on_learn_button,
         )
     )

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 import json
+import re
 
 import pytest
 from sqlalchemy import create_engine
@@ -13,6 +14,7 @@ from telegram import Update, KeyboardButton
 from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.learning_handlers as handlers
+from services.api.app.diabetes.handlers import registration
 from services.api.app.config import Settings
 from services.api.app.diabetes.learning_fixtures import load_lessons
 from services.api.app.diabetes.services import db
@@ -188,6 +190,11 @@ async def test_cmd_menu_shows_keyboard() -> None:
     expected_layout = list(menu_keyboard().keyboard)
     expected_layout.append((KeyboardButton(LEARN_BUTTON_TEXT),))
     assert list(keyboard.keyboard) == expected_layout
+    assert not any(
+        button.text == registration.OLD_LEARN_BUTTON_TEXT
+        for row in keyboard.keyboard
+        for button in row
+    )
 
 
 @pytest.mark.asyncio
@@ -210,3 +217,9 @@ async def test_on_learn_button_calls_learn(monkeypatch: pytest.MonkeyPatch) -> N
     await handlers.on_learn_button(update, context)
 
     assert called["v"] is True
+
+
+def test_old_learn_button_text_matches_pattern() -> None:
+    assert re.fullmatch(
+        registration.LEARN_BUTTON_PATTERN, registration.OLD_LEARN_BUTTON_TEXT
+    )


### PR DESCRIPTION
## Summary
- Accept both "Учебный режим" and deprecated "Обучение" button texts in handler registration
- Ensure main keyboard uses only the new caption
- Cover legacy button caption in tests

## Testing
- `make ci` *(fails: No rule to make target 'ci')*
- `pytest` *(fails: async def functions are not natively supported)*
- `pytest tests/test_learn_command.py tests/learning/test_handlers_e2e.py -q` *(fails: coverage 25% < 85%)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd5aad4e9c832aa58c4efd05e78489