### PR TITLE
[assistant] add learning progress tracking

### DIFF
--- a/services/api/alembic/versions/20251006_add_learning_progress.py
+++ b/services/api/alembic/versions/20251006_add_learning_progress.py
@@ -1,0 +1,68 @@
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20251006_add_learning_progress"
+down_revision: Union[str, Sequence[str], None] = (
+    "20251005_add_assistant_memory",
+    "20251005_add_learning_plans",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "learning_progress",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "user_id", sa.BigInteger(), sa.ForeignKey("users.telegram_id"), nullable=False
+        ),
+        sa.Column(
+            "plan_id", sa.Integer(), sa.ForeignKey("learning_plans.id"), nullable=False
+        ),
+        sa.Column(
+            "progress_json",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_learning_progress_user_id_plan_id",
+        "learning_progress",
+        ["user_id", "plan_id"],
+    )
+    op.create_index(
+        "ix_learning_progress_updated_at",
+        "learning_progress",
+        ["updated_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_learning_progress_updated_at",
+        table_name="learning_progress",
+        postgresql_if_exists=True,
+    )
+    op.drop_index(
+        "ix_learning_progress_user_id_plan_id",
+        table_name="learning_progress",
+        postgresql_if_exists=True,
+    )
+    op.drop_table("learning_progress")

--- a/services/api/app/assistant/repositories/progress.py
+++ b/services/api/app/assistant/repositories/progress.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from ...diabetes.models_learning import LearningProgress
+from ...diabetes.services.db import SessionLocal, run_db
+from ...diabetes.services.repository import commit
+from ...types import SessionProtocol
+
+__all__ = ["get_progress", "upsert_progress"]
+
+
+async def get_progress(user_id: int, plan_id: int) -> LearningProgress | None:
+    """Return progress for a user and plan if present."""
+
+    def _get(session: SessionProtocol) -> LearningProgress | None:
+        stmt = sa.select(LearningProgress).where(
+            LearningProgress.user_id == user_id,
+            LearningProgress.plan_id == plan_id,
+        )
+        sess = cast(Session, session)
+        return cast(LearningProgress | None, sess.scalar(stmt))
+
+    return await run_db(_get, sessionmaker=SessionLocal)
+
+
+async def upsert_progress(user_id: int, plan_id: int, progress_json: dict[str, Any]) -> LearningProgress:
+    """Insert or update learning progress for a user and plan."""
+
+    def _upsert(session: SessionProtocol) -> LearningProgress:
+        stmt = sa.select(LearningProgress).where(
+            LearningProgress.user_id == user_id,
+            LearningProgress.plan_id == plan_id,
+        )
+        sess = cast(Session, session)
+        progress = cast(LearningProgress | None, sess.scalar(stmt))
+        if progress is None:
+            progress = LearningProgress(user_id=user_id, plan_id=plan_id, progress_json=progress_json)
+            sess.add(progress)
+        else:
+            progress.progress_json = progress_json
+        commit(sess)
+        sess.refresh(progress)
+        return progress
+
+    return await run_db(_upsert, sessionmaker=SessionLocal)

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -13,29 +13,45 @@ from .services.db import Base, User
 
 class LearningPlan(Base):
     __tablename__ = "learning_plans"
+    __table_args__ = (sa.Index("ix_learning_plans_user_id_is_active", "user_id", "is_active"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.true())
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    plan_json: Mapped[dict[str, Any]] = mapped_column(sa.JSON().with_variant(JSONB, "postgresql"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False)
+    updated_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), onupdate=sa.func.now())
+
+    user: Mapped[User] = relationship("User")
+    progresses: Mapped[list["LearningProgress"]] = relationship(
+        "LearningProgress", back_populates="plan", cascade="all, delete-orphan"
+    )
+
+
+class LearningProgress(Base):
+    __tablename__ = "learning_progress"
     __table_args__ = (
-        sa.Index("ix_learning_plans_user_id_is_active", "user_id", "is_active"),
+        sa.Index("ix_learning_progress_user_id_plan_id", "user_id", "plan_id"),
+        sa.Index("ix_learning_progress_updated_at", "updated_at"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), nullable=False
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), nullable=False)
+    plan_id: Mapped[int] = mapped_column(ForeignKey("learning_plans.id"), nullable=False)
+    progress_json: Mapped[dict[str, Any]] = mapped_column(
+        sa.JSON().with_variant(JSONB, "postgresql"), nullable=False, default=dict
     )
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=True, server_default=sa.true()
-    )
-    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
-    plan_json: Mapped[dict[str, Any]] = mapped_column(
-        sa.JSON().with_variant(JSONB, "postgresql"), nullable=False
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False
-    )
-    updated_at: Mapped[Optional[datetime]] = mapped_column(
-        TIMESTAMP(timezone=True), onupdate=sa.func.now()
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+        nullable=False,
     )
 
     user: Mapped[User] = relationship("User")
+    plan: Mapped["LearningPlan"] = relationship("LearningPlan", back_populates="progresses")
 
 
 class Lesson(Base):
@@ -45,9 +61,7 @@ class Lesson(Base):
     slug: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
     title: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=True, server_default=sa.true()
-    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.true())
 
     steps: Mapped[list["LessonStep"]] = relationship(
         "LessonStep",
@@ -68,13 +82,9 @@ class QuizQuestion(Base):
     __tablename__ = "quiz_questions"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    lesson_id: Mapped[int] = mapped_column(
-        ForeignKey("lessons.id"), nullable=False, index=True
-    )
+    lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)
     question: Mapped[str] = mapped_column(Text, nullable=False)
-    options: Mapped[Sequence[str]] = mapped_column(
-        sa.JSON().with_variant(JSONB, "postgresql"), nullable=False
-    )
+    options: Mapped[Sequence[str]] = mapped_column(sa.JSON().with_variant(JSONB, "postgresql"), nullable=False)
     correct_option: Mapped[int] = mapped_column(Integer, nullable=False)
 
     lesson: Mapped[Lesson] = relationship("Lesson", back_populates="questions")
@@ -82,16 +92,10 @@ class QuizQuestion(Base):
 
 class LessonStep(Base):
     __tablename__ = "lesson_steps"
-    __table_args__ = (
-        sa.UniqueConstraint(
-            "lesson_id", "step_order", name="lesson_steps_lesson_order_key"
-        ),
-    )
+    __table_args__ = (sa.UniqueConstraint("lesson_id", "step_order", name="lesson_steps_lesson_order_key"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    lesson_id: Mapped[int] = mapped_column(
-        ForeignKey("lessons.id"), nullable=False, index=True
-    )
+    lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)
     step_order: Mapped[int] = mapped_column(Integer, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
 
@@ -100,19 +104,11 @@ class LessonStep(Base):
 
 class LessonProgress(Base):
     __tablename__ = "lesson_progress"
-    __table_args__ = (
-        sa.UniqueConstraint(
-            "user_id", "lesson_id", name="lesson_progress_user_lesson_key"
-        ),
-    )
+    __table_args__ = (sa.UniqueConstraint("user_id", "lesson_id", name="lesson_progress_user_lesson_key"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True
-    )
-    lesson_id: Mapped[int] = mapped_column(
-        ForeignKey("lessons.id"), nullable=False, index=True
-    )
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True)
+    lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)
     completed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     current_step: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     current_question: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
@@ -126,15 +122,11 @@ class LessonLog(Base):
     __tablename__ = "lesson_logs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    telegram_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True
-    )
+    telegram_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True)
     topic_slug: Mapped[str] = mapped_column(String, nullable=False, index=True)
     role: Mapped[str] = mapped_column(String, nullable=False)
     step_idx: Mapped[int] = mapped_column(Integer, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False
-    )
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False)
 
     user: Mapped[User] = relationship("User")

--- a/tests/assistant/test_progress_repo.py
+++ b/tests/assistant/test_progress_repo.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.assistant.repositories import progress
+from services.api.app.diabetes.models_learning import LearningPlan
+from services.api.app.diabetes.services import db
+
+
+@pytest.fixture()
+def session_local(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_connection, connection_record) -> None:  # pragma: no cover - setup
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    session_local = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(progress, "SessionLocal", session_local)
+    return session_local
+
+
+@pytest.mark.asyncio
+async def test_get_and_upsert(session_local: sessionmaker[Session]) -> None:
+    with session_local() as session:
+        session.add(db.User(telegram_id=1, thread_id=""))
+        plan = LearningPlan(user_id=1, version=1, plan_json={})
+        session.add(plan)
+        session.commit()
+        plan_id = plan.id
+
+    assert await progress.get_progress(1, plan_id) is None
+
+    prog = await progress.upsert_progress(1, plan_id, {"step": 1})
+    assert prog.progress_json == {"step": 1}
+
+    fetched = await progress.get_progress(1, plan_id)
+    assert fetched is not None
+    assert fetched.progress_json == {"step": 1}
+
+    prog2 = await progress.upsert_progress(1, plan_id, {"step": 2})
+    assert prog2.progress_json == {"step": 2}
+    fetched2 = await progress.get_progress(1, plan_id)
+    assert fetched2 is not None
+    assert fetched2.progress_json == {"step": 2}


### PR DESCRIPTION
## Summary
- add `LearningProgress` model with indices and relations
- implement repository helpers for learning progress
- test progress repository and add migration

## Testing
- `ruff check services/api/app/diabetes/models_learning.py services/api/app/assistant/repositories/progress.py tests/assistant/test_progress_repo.py`
- `mypy --strict services/api/app/assistant/repositories/progress.py services/api/app/diabetes/models_learning.py tests/assistant/test_progress_repo.py`
- `pytest -o addopts="--cov=services.api.app.assistant.repositories.progress --cov=services.api.app.diabetes.models_learning --cov-report=term-missing --cov-fail-under=85" tests/assistant/test_progress_repo.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd5befe1b4832ab23a2d9f9b950011