### PR TITLE
[assistant] implement plan service

### DIFF
--- a/services/api/app/assistant/services/plan_service.py
+++ b/services/api/app/assistant/services/plan_service.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from ...diabetes.models_learning import LearningPlan
+from ...diabetes.services.db import SessionLocal, run_db
+from ...diabetes.services.repository import commit
+from ...types import SessionProtocol
+
+logger = logging.getLogger(__name__)
+
+
+async def get_active_plan(user_id: int) -> LearningPlan | None:
+    """Return active learning plan for ``user_id`` if any."""
+
+    def _get(session: SessionProtocol) -> LearningPlan | None:
+        stmt = sa.select(LearningPlan).where(
+            LearningPlan.user_id == user_id, LearningPlan.is_active.is_(True)
+        )
+        sess = cast(Session, session)
+        return cast(LearningPlan | None, sess.scalar(stmt))
+
+    return await run_db(_get, sessionmaker=SessionLocal)
+
+
+async def create_plan(
+    user_id: int,
+    *,
+    version: int,
+    plan_json: dict[str, Any],
+) -> int:
+    """Create new active plan for ``user_id`` replacing previous one."""
+
+    def _create(session: SessionProtocol) -> int:
+        sess = cast(Session, session)
+        sess.execute(
+            sa.update(LearningPlan)
+            .where(LearningPlan.user_id == user_id, LearningPlan.is_active.is_(True))
+            .values(is_active=False)
+        )
+        plan = LearningPlan(
+            user_id=user_id,
+            version=version,
+            plan_json=plan_json,
+            is_active=True,
+        )
+        sess.add(plan)
+        commit(sess)
+        sess.refresh(plan)
+        assert plan.id is not None
+        return plan.id
+
+    return cast(int, await run_db(_create, sessionmaker=SessionLocal))
+
+
+async def deactivate_plan(plan_id: int) -> None:
+    """Deactivate plan with ``plan_id`` if it exists."""
+
+    def _deactivate(session: SessionProtocol) -> None:
+        plan = cast(LearningPlan | None, session.get(LearningPlan, plan_id))
+        if plan is None or not plan.is_active:
+            return
+        plan.is_active = False
+        commit(cast(Session, session))
+
+    await run_db(_deactivate, sessionmaker=SessionLocal)
+
+
+__all__ = ["get_active_plan", "create_plan", "deactivate_plan"]

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -14,7 +14,13 @@ from .services.db import Base, User
 class LearningPlan(Base):
     __tablename__ = "learning_plans"
     __table_args__ = (
-        sa.Index("ix_learning_plans_user_id_is_active", "user_id", "is_active"),
+        sa.Index(
+            "ix_learning_plans_user_id_is_active",
+            "user_id",
+            unique=True,
+            sqlite_where=sa.text("is_active"),
+            postgresql_where=sa.text("is_active"),
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)

--- a/tests/assistant/test_plan_service.py
+++ b/tests/assistant/test_plan_service.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.diabetes.services import db
+from services.api.app.assistant.services import plan_service
+from services.api.app.assistant.repositories import plans
+from services.api.app.diabetes.services.repository import CommitError
+
+
+@pytest.fixture(autouse=True)
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(plan_service, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(plans, "SessionLocal", SessionLocal, raising=False)
+    yield
+    db.dispose_engine(engine)
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_active() -> None:
+    plan_id = await plan_service.create_plan(1, version=1, plan_json={"a": 1})
+    active = await plan_service.get_active_plan(1)
+    assert active is not None
+    assert active.id == plan_id
+    assert active.plan_json == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_create_deactivates_previous() -> None:
+    first = await plan_service.create_plan(1, version=1, plan_json={"a": 1})
+    second = await plan_service.create_plan(1, version=2, plan_json={"b": 2})
+    active = await plan_service.get_active_plan(1)
+    assert active is not None and active.id == second
+    first_plan = await plans.get_plan(first)
+    second_plan = await plans.get_plan(second)
+    assert first_plan is not None and first_plan.is_active is False
+    assert second_plan is not None and second_plan.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_deactivate_plan() -> None:
+    plan_id = await plan_service.create_plan(1, version=1, plan_json={})
+    await plan_service.deactivate_plan(plan_id)
+    assert await plan_service.get_active_plan(1) is None
+
+
+@pytest.mark.asyncio
+async def test_unique_index_enforced() -> None:
+    await plans.create_plan(1, version=1, plan_json={})
+    with pytest.raises(CommitError):
+        await plans.create_plan(1, version=2, plan_json={})


### PR DESCRIPTION
## Summary
- add plan service to manage active learning plans
- enforce single active plan per user via partial index
- cover service behaviour with tests

## Testing
- `ruff check services/api/app/assistant/services/plan_service.py tests/assistant/test_plan_service.py services/api/app/diabetes/models_learning.py`
- `mypy --strict services/api/app/assistant/services/plan_service.py tests/assistant/test_plan_service.py services/api/app/diabetes/models_learning.py`
- `pytest tests/assistant/test_plan_service.py -q -p no:cov -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68bd5c37d77c832ab29f0830a5075125