### PR TITLE
[assistant] Persist summarized memory to database

### DIFF
--- a/services/api/app/assistant/services/memory_service.py
+++ b/services/api/app/assistant/services/memory_service.py
@@ -1,64 +1,93 @@
 from __future__ import annotations
 
-from typing import cast
+from datetime import datetime, timezone
+from typing import MutableMapping, cast
 
-from sqlalchemy import BigInteger, ForeignKey, Text
-from sqlalchemy.orm import Mapped, Session, mapped_column
+from sqlalchemy.orm import Session
 
-from ...diabetes.services.db import Base, SessionLocal, run_db
+from ...diabetes import assistant_state
+from ...diabetes.services.db import SessionLocal, run_db
 from ...diabetes.services.repository import commit
-from ...types import SessionProtocol
+from ..models import AssistantMemory
+from ..repositories.memory import (
+    get_memory as repo_get_memory,
+    upsert_memory as repo_upsert_memory,
+)
+
+__all__ = [
+    "AssistantMemory",
+    "get_memory",
+    "save_memory",
+    "clear_memory",
+    "record_turn",
+]
 
 
-class AssistantMemory(Base):
-    """Persisted memory summary for assistant conversations."""
+async def get_memory(user_id: int) -> AssistantMemory | None:
+    """Return stored memory for ``user_id`` if present."""
 
-    __tablename__ = "assistant_memory"
-
-    user_id: Mapped[int] = mapped_column(
-        BigInteger,
-        ForeignKey("users.telegram_id", ondelete="CASCADE"),
-        primary_key=True,
-    )
-    memory: Mapped[str] = mapped_column(Text, nullable=False)
-
-
-async def get_memory(user_id: int) -> str | None:
-    """Return stored memory summary for ``user_id`` if present."""
-
-    def _get(session: SessionProtocol) -> str | None:
-        record = cast(AssistantMemory | None, session.get(AssistantMemory, user_id))
-        return None if record is None else record.memory
+    def _get(session: Session) -> AssistantMemory | None:
+        return repo_get_memory(session, user_id)
 
     return await run_db(_get, sessionmaker=SessionLocal)
 
 
-async def save_memory(user_id: int, memory: str) -> None:
-    """Persist ``memory`` for ``user_id`` overwriting existing value."""
+async def save_memory(
+    user_id: int, *, summary_text: str, turn_count: int, last_turn_at: datetime
+) -> AssistantMemory:
+    """Persist ``summary_text`` for ``user_id`` overwriting existing value."""
 
-    def _save(session: SessionProtocol) -> None:
-        record = cast(AssistantMemory | None, session.get(AssistantMemory, user_id))
-        if record is None:
-            record = AssistantMemory(user_id=user_id, memory=memory)
-            cast(Session, session).add(record)
-        else:
-            record.memory = memory
-        commit(cast(Session, session))
+    def _save(session: Session) -> AssistantMemory:
+        return repo_upsert_memory(
+            session,
+            user_id=user_id,
+            summary_text=summary_text,
+            turn_count=turn_count,
+            last_turn_at=last_turn_at,
+        )
 
-    await run_db(_save, sessionmaker=SessionLocal)
+    return await run_db(_save, sessionmaker=SessionLocal)
 
 
 async def clear_memory(user_id: int) -> None:
     """Remove stored memory for ``user_id`` if present."""
 
-    def _clear(session: SessionProtocol) -> None:
-        record = cast(AssistantMemory | None, session.get(AssistantMemory, user_id))
+    def _clear(session: Session) -> None:
+        record = repo_get_memory(session, user_id)
         if record is None:
             return
         session.delete(record)
-        commit(cast(Session, session))
+        commit(session)
 
     await run_db(_clear, sessionmaker=SessionLocal)
 
 
-__all__ = ["AssistantMemory", "get_memory", "save_memory", "clear_memory"]
+async def record_turn(
+    user_id: int,
+    user_data: MutableMapping[str, object],
+    text: str,
+    *,
+    now: datetime | None = None,
+) -> None:
+    """Record assistant reply and persist summary if threshold exceeded."""
+
+    summarized = assistant_state.add_turn(user_data, text)
+    if summarized == 0:
+        return
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    summary = cast(str, user_data[assistant_state.SUMMARY_KEY])
+
+    def _save(session: Session) -> None:
+        existing = repo_get_memory(session, user_id)
+        prev_count = 0 if existing is None else existing.turn_count
+        repo_upsert_memory(
+            session,
+            user_id=user_id,
+            summary_text=summary,
+            turn_count=prev_count + summarized,
+            last_turn_at=now,
+        )
+
+    await run_db(_save, sessionmaker=SessionLocal)

--- a/services/api/app/diabetes/assistant_state.py
+++ b/services/api/app/diabetes/assistant_state.py
@@ -20,24 +20,31 @@ def summarize(parts: list[str]) -> str:
     return " ".join(parts)
 
 
-def add_turn(user_data: MutableMapping[str, object], text: str) -> None:
+def add_turn(user_data: MutableMapping[str, object], text: str) -> int:
     """Append assistant reply ``text`` to ``user_data`` keeping short history.
 
     When the number of stored turns reaches :data:`ASSISTANT_SUMMARY_TRIGGER`,
     older entries beyond :data:`ASSISTANT_MAX_TURNS` are summarized and the
     summary is stored under ``assistant_summary`` key.
+
+    Returns the number of turns summarized on this call.  The return value can
+    be used by higher-level services to persist summaries in a database when
+    new portions are produced.
     """
     history = cast(list[str], user_data.setdefault(HISTORY_KEY, []))
     history.append(text)
+    summarized = 0
     if len(history) >= ASSISTANT_SUMMARY_TRIGGER:
         old = history[:-ASSISTANT_MAX_TURNS]
         if old:
             summary = summarize(old)
             prev = cast(str | None, user_data.get(SUMMARY_KEY))
             user_data[SUMMARY_KEY] = f"{prev} {summary}".strip() if prev else summary
+            summarized = len(old)
         del history[:-ASSISTANT_MAX_TURNS]
     elif len(history) > ASSISTANT_MAX_TURNS:
         del history[:-ASSISTANT_MAX_TURNS]
+    return summarized
 
 
 def reset(user_data: MutableMapping[str, object]) -> None:

--- a/tests/assistant/test_memory_service.py
+++ b/tests/assistant/test_memory_service.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from services.api.app.assistant.services import memory_service
 from services.api.app.diabetes import commands
+from services.api.app.diabetes.services import db
 
 
 @pytest.fixture()
@@ -18,28 +20,50 @@ def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_connection, connection_record) -> None:  # pragma: no cover - setup
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
     SessionLocal = sessionmaker(bind=engine, class_=Session)
-    memory_service.Base.metadata.create_all(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
     monkeypatch.setattr(memory_service, "SessionLocal", SessionLocal)
+    with SessionLocal() as session:
+        session.add(db.User(telegram_id=1, thread_id=""))
+        session.commit()
     return SessionLocal
 
 
 @pytest.mark.asyncio
 async def test_save_and_get_memory(setup_db: sessionmaker[Session]) -> None:
-    await memory_service.save_memory(1, "hello")
-    assert await memory_service.get_memory(1) == "hello"
+    now = datetime.now(tz=timezone.utc)
+    await memory_service.save_memory(
+        1, summary_text="hello", turn_count=1, last_turn_at=now
+    )
+    mem = await memory_service.get_memory(1)
+    assert mem is not None
+    assert mem.summary_text == "hello"
+    assert mem.turn_count == 1
 
 
 @pytest.mark.asyncio
 async def test_clear_memory(setup_db: sessionmaker[Session]) -> None:
-    await memory_service.save_memory(1, "hello")
+    now = datetime.now(tz=timezone.utc)
+    await memory_service.save_memory(
+        1, summary_text="hello", turn_count=1, last_turn_at=now
+    )
     await memory_service.clear_memory(1)
     assert await memory_service.get_memory(1) is None
 
 
 @pytest.mark.asyncio
 async def test_reset_command_clears_memory(setup_db: sessionmaker[Session]) -> None:
-    await memory_service.save_memory(1, "hello")
+    now = datetime.now(tz=timezone.utc)
+    await memory_service.save_memory(
+        1, summary_text="hello", turn_count=1, last_turn_at=now
+    )
 
     class DummyMessage:
         def __init__(self) -> None:

--- a/tests/assistant/test_memory_summary.py
+++ b/tests/assistant/test_memory_summary.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.assistant.services import memory_service
+from services.api.app.diabetes import assistant_state
+from services.api.app.diabetes.services import db
+
+
+@pytest.fixture()
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_connection, connection_record) -> None:  # pragma: no cover - setup
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(memory_service, "SessionLocal", SessionLocal)
+    with SessionLocal() as session:
+        session.add(db.User(telegram_id=1, thread_id=""))
+        session.commit()
+    return SessionLocal
+
+
+@pytest.mark.asyncio
+async def test_summary_persisted(
+    monkeypatch: pytest.MonkeyPatch, setup_db: sessionmaker[Session]
+) -> None:
+    monkeypatch.setattr(assistant_state, "ASSISTANT_MAX_TURNS", 2)
+    monkeypatch.setattr(assistant_state, "ASSISTANT_SUMMARY_TRIGGER", 3)
+
+    def fake_summary(parts: list[str]) -> str:
+        return ",".join(parts)
+
+    monkeypatch.setattr(assistant_state, "summarize", fake_summary)
+
+    user_data: dict[str, object] = {}
+    base = datetime.now(tz=timezone.utc)
+    for i in range(3):
+        await memory_service.record_turn(
+            1, user_data, f"a{i}", now=base + timedelta(minutes=i)
+        )
+
+    mem = await memory_service.get_memory(1)
+    assert mem is not None
+    assert mem.summary_text == "a0"
+    assert mem.turn_count == 1
+    last = mem.last_turn_at.replace(tzinfo=timezone.utc)
+    assert abs(last - (base + timedelta(minutes=2))) < timedelta(seconds=1)
+    assert user_data[assistant_state.HISTORY_KEY] == ["a1", "a2"]


### PR DESCRIPTION
## Summary
- track number of summarized turns when trimming assistant history
- persist conversation summaries to `assistant_memory` and keep turn counts
- ensure `/reset` clears in-memory and stored summaries

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/assistant/test_memory_service.py tests/assistant/test_memory_summary.py -q` *(fails: Required test coverage of 85% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5cbca988832abb259537cb721c19