### PR TITLE
[assistant] Buffer lesson logs and batch flush

### DIFF
--- a/services/api/app/diabetes/services/lesson_log.py
+++ b/services/api/app/diabetes/services/lesson_log.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+from dataclasses import asdict, dataclass
 
 from sqlalchemy.orm import Session
 
@@ -11,7 +13,47 @@ from .repository import commit
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["add_lesson_log", "get_lesson_logs"]
+__all__ = [
+    "add_lesson_log",
+    "get_lesson_logs",
+    "flush_pending_logs",
+    "start_flush_task",
+]
+
+
+@dataclass(slots=True)
+class _PendingLog:
+    telegram_id: int
+    topic_slug: str
+    role: str
+    step_idx: int
+    content: str
+
+
+pending_logs: list[_PendingLog] = []
+_flush_task: asyncio.Task[None] | None = None
+_FLUSH_INTERVAL = 5.0
+
+
+async def flush_pending_logs() -> None:
+    """Flush accumulated logs to the database."""
+
+    if not pending_logs:
+        return
+
+    entries = [LessonLog(**asdict(log)) for log in pending_logs]
+
+    def _flush(session: Session) -> None:
+        session.add_all(entries)
+        commit(session)
+
+    try:
+        await run_db(_flush, sessionmaker=SessionLocal)
+    except Exception:  # pragma: no cover - logging only
+        logger.exception("Failed to flush %s lesson logs", len(entries))
+        return
+
+    pending_logs.clear()
 
 
 async def add_lesson_log(
@@ -21,27 +63,36 @@ async def add_lesson_log(
     step_idx: int,
     content: str,
 ) -> None:
-    """Insert a lesson log entry."""
+    """Queue a lesson log entry and attempt to flush."""
 
     if not settings.learning_logging_required:
         return
 
-    def _add(session: Session) -> None:
-        session.add(
-            LessonLog(
-                telegram_id=telegram_id,
-                topic_slug=topic_slug,
-                role=role,
-                step_idx=step_idx,
-                content=content,
-            )
+    pending_logs.append(
+        _PendingLog(
+        telegram_id=telegram_id,
+        topic_slug=topic_slug,
+        role=role,
+        step_idx=step_idx,
+        content=content,
         )
-        commit(session)
+    )
 
-    try:
-        await run_db(_add, sessionmaker=SessionLocal)
-    except Exception:  # pragma: no cover - logging only
-        logger.exception("Failed to add lesson log for %s", telegram_id)
+    await flush_pending_logs()
+
+
+async def _flush_periodically(interval: float) -> None:
+    while True:
+        await asyncio.sleep(interval)
+        await flush_pending_logs()
+
+
+def start_flush_task(interval: float = _FLUSH_INTERVAL) -> None:
+    """Start background task that periodically flushes logs."""
+
+    global _flush_task
+    if _flush_task is None or _flush_task.done():
+        _flush_task = asyncio.create_task(_flush_periodically(interval))
 
 
 async def get_lesson_logs(telegram_id: int, topic_slug: str) -> list[LessonLog]:

--- a/tests/assistant/test_logs.py
+++ b/tests/assistant/test_logs.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import pytest
 
 from services.api.app.config import settings
+from typing import Callable
+
 from services.api.app.diabetes.services import lesson_log
 from services.api.app.diabetes.services.lesson_log import add_lesson_log
+from services.api.app.diabetes.models_learning import LessonLog
 
 
 @pytest.mark.asyncio
@@ -33,3 +36,39 @@ async def test_add_lesson_log_handles_errors(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(lesson_log, "run_db", fail_run_db)
 
     await add_lesson_log(1, "topic", "assistant", 1, "hi")
+
+
+@pytest.mark.asyncio
+async def test_logs_queue_and_flush(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Queued logs are flushed once DB is available."""
+
+    monkeypatch.setattr(settings, "learning_logging_required", True)
+
+    lesson_log.pending_logs.clear()
+
+    async def fail_run_db(*_: object, **__: object) -> None:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(lesson_log, "run_db", fail_run_db)
+
+    await add_lesson_log(1, "topic", "assistant", 1, "hi")
+    await add_lesson_log(1, "topic", "assistant", 2, "there")
+
+    assert len(lesson_log.pending_logs) == 2
+
+    inserted: list[LessonLog] = []
+
+    class DummySession:
+        def add_all(self, objs: list[LessonLog]) -> None:
+            inserted.extend(objs)
+
+    async def ok_run_db(fn: Callable[[DummySession], None], *args: object, **kwargs: object) -> None:
+        fn(DummySession())
+
+    monkeypatch.setattr(lesson_log, "run_db", ok_run_db)
+    monkeypatch.setattr(lesson_log, "commit", lambda _: None)
+
+    await add_lesson_log(1, "topic", "assistant", 3, "third")
+
+    assert len(inserted) == 3
+    assert not lesson_log.pending_logs


### PR DESCRIPTION
## Summary
- queue lesson logs and flush in batches when DB available
- add periodic flush background task
- cover log queue flush behaviour with tests

## Testing
- `pytest tests/assistant/test_logs.py -q` *(fails: Required test coverage of 85% not reached)*
- `pytest -q --cov --cov-report=term-missing --cov-fail-under=85` *(fails: Table 'assistant_memory' is already defined for this MetaData instance)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd5d8d6130832a818ff2060c9be0b5