### PR TITLE
[assistant] Persist progress after each step

### DIFF
--- a/services/api/app/diabetes/curriculum_engine.py
+++ b/services/api/app/diabetes/curriculum_engine.py
@@ -20,6 +20,7 @@ from .metrics import lessons_completed, lessons_started, quiz_avg_score
 from .models_learning import Lesson, LessonProgress, LessonStep, QuizQuestion
 from .services import db, gpt_client
 from .services.repository import commit
+from ..assistant.services import progress_service
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +89,7 @@ async def next_step(
             return progress.current_step, lesson.slug
 
         step_idx, slug = await db.run_db(_advance_dynamic)
+        await progress_service.upsert_progress(user_id, slug, step_idx)
         text = await generate_step_text(profile, slug, step_idx, prev_summary)
         if step_idx == 1:
             return f"{disclaimer()}\n\n{text}", False
@@ -95,9 +97,12 @@ async def next_step(
 
     def _advance_static(
         session: Session,
-    ) -> tuple[str | None, str | None, bool, bool, int, bool]:
+    ) -> tuple[str | None, str | None, bool, bool, int, bool, str]:
         progress = session.execute(
             sa.select(LessonProgress).filter_by(user_id=user_id, lesson_id=lesson_id)
+        ).scalar_one()
+        lesson = session.execute(
+            sa.select(Lesson).filter_by(id=lesson_id)
         ).scalar_one()
         steps = session.scalars(
             sa.select(LessonStep)
@@ -110,7 +115,7 @@ async def next_step(
             progress.current_step += 1
             step_idx = progress.current_step
             commit(session)
-            return step.content, None, first_step, False, step_idx, False
+            return step.content, None, first_step, False, step_idx, False, lesson.slug
         questions = session.scalars(
             sa.select(QuizQuestion)
             .filter_by(lesson_id=lesson_id)
@@ -129,11 +134,12 @@ async def next_step(
                 first_question,
                 progress.current_step,
                 False,
+                lesson.slug,
             )
         if not progress.completed:
             progress.completed = True
             commit(session)
-        return None, None, False, False, progress.current_step, True
+        return None, None, False, False, progress.current_step, True, lesson.slug
 
     (
         step_content,
@@ -142,8 +148,10 @@ async def next_step(
         first_question,
         step_idx,
         completed,
+        slug,
     ) = await db.run_db(_advance_static)
     if step_content is not None and step_idx is not None:
+        await progress_service.upsert_progress(user_id, slug, step_idx)
         start = time.monotonic()
         try:
             text = await gpt_client.create_learning_chat_completion(

--- a/tests/assistant/test_progress_integration.py
+++ b/tests/assistant/test_progress_integration.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.config import settings
+from services.api.app.diabetes import curriculum_engine
+from services.api.app.diabetes.models_learning import Lesson
+from services.api.app.diabetes.services import db, gpt_client
+from services.api.app.assistant.services import progress_service
+
+
+@pytest.fixture(autouse=True)
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(progress_service, "SessionLocal", SessionLocal, raising=False)
+    db.Base.metadata.create_all(bind=engine)
+    yield
+    db.dispose_engine(engine)
+
+
+@pytest.mark.asyncio()
+async def test_progress_saved_each_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+
+    with db.SessionLocal() as session:
+        session.add(db.User(telegram_id=1, thread_id="t1"))
+        lesson = Lesson(slug="intro", title="Intro", content="desc")
+        session.add(lesson)
+        session.commit()
+        lesson_id = lesson.id
+        slug = lesson.slug
+
+    async def fake_completion(**kwargs: object) -> str:  # noqa: ANN401 - test stub
+        return "text"
+
+    monkeypatch.setattr(
+        gpt_client, "create_learning_chat_completion", fake_completion
+    )
+
+    await curriculum_engine.start_lesson(1, slug)
+
+    await curriculum_engine.next_step(1, lesson_id, {})
+    progress1 = await progress_service.get_progress(1, slug)
+    assert progress1 is not None
+    assert progress1.step == 1
+
+    await curriculum_engine.next_step(1, lesson_id, {})
+    progress2 = await progress_service.get_progress(1, slug)
+    assert progress2 is not None
+    assert progress2.step == 2
+


### PR DESCRIPTION
## Summary
- persist assistant learning progress after each step transition
- wrap progress upsert in a transaction for atomic writes
- reuse `AssistantMemory` model in memory service
- add integration test to ensure progress is saved

## Testing
- `pytest tests/assistant/test_progress_integration.py -q --no-cov`
- `mypy services/api/app/assistant/services/memory_service.py services/api/app/assistant/services/progress_service.py services/api/app/diabetes/curriculum_engine.py tests/assistant/test_progress_integration.py --strict`
- `ruff check .`
- `pytest -q --cov` *(fails: No module named 'trio')*

------
https://chatgpt.com/codex/tasks/task_e_68bd5d71a24c832abaa1b8cd3f5846a7