### PR TITLE
[learning] manage busy flag outside LearnState and ignore double clicks

### DIFF
--- a/services/api/app/diabetes/learning_state.py
+++ b/services/api/app/diabetes/learning_state.py
@@ -12,11 +12,9 @@ class LearnState:
 
     topic: str
     step: int
-    awaiting_answer: bool
-    learn_busy: bool = False
-    disclaimer_shown: bool = False
     last_step_text: str | None = None
     prev_summary: str | None = None
+    awaiting: bool = True
 
 
 def get_state(data: MutableMapping[str, object]) -> LearnState | None:

--- a/tests/diabetes/test_learning_state.py
+++ b/tests/diabetes/test_learning_state.py
@@ -8,7 +8,7 @@ from services.api.app.diabetes.learning_state import (
 
 def test_state_roundtrip() -> None:
     data: dict[str, object] = {}
-    state = LearnState(topic="t", step=1, awaiting_answer=True, last_step_text="a")
+    state = LearnState(topic="t", step=1, awaiting=True, last_step_text="a")
     set_state(data, state)
     assert get_state(data) == state
     clear_state(data)

--- a/tests/learning/test_handlers_rate_limit.py
+++ b/tests/learning/test_handlers_rate_limit.py
@@ -39,6 +39,7 @@ async def test_lesson_callback_rate_limit(monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
     monkeypatch.setattr(learning_handlers, "TOPICS_RU", {"slug": "Topic"})
+
     async def fake_start_lesson(user_id: int, topic_slug: str) -> object:
         return SimpleNamespace(lesson_id=1)
 
@@ -112,7 +113,7 @@ async def test_lesson_answer_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None
     user_data: dict[str, object] = {}
     learning_handlers.set_state(
         user_data,
-        LearnState(topic="slug", step=1, awaiting_answer=True, last_step_text="q"),
+        LearnState(topic="slug", step=1, awaiting=True, last_step_text="q"),
     )
 
     msg1 = DummyMessage(text="a1")

--- a/tests/learning/test_on_any_text.py
+++ b/tests/learning/test_on_any_text.py
@@ -22,7 +22,7 @@ class DummyMessage:
 async def test_on_any_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
     user_data: dict[str, object] = {}
-    set_state(user_data, LearnState(topic="t", step=1, awaiting_answer=True, last_step_text="q"))
+    set_state(user_data, LearnState(topic="t", step=1, awaiting=True, last_step_text="q"))
     called = False
 
     async def fake_check_user_answer(
@@ -64,7 +64,7 @@ async def test_on_any_text_idontknow(monkeypatch: pytest.MonkeyPatch) -> None:
     user_data: dict[str, object] = {}
     set_state(
         user_data,
-        LearnState(topic="t", step=1, awaiting_answer=True, last_step_text="q"),
+        LearnState(topic="t", step=1, awaiting=True, last_step_text="q"),
     )
     called = False
 


### PR DESCRIPTION
## Summary
- Simplify `LearnState` to track only topic, step, text snapshots and awaiting flag
- Guard lesson answer handling with a separate `learn_busy` flag and reset awaiting state in `finally`
- Add regression test ensuring double clicks are ignored while busy

## Testing
- `pytest -q` *(fails: Table 'assistant_memory' is already defined)*
- `mypy --strict services/api/app/diabetes/learning_state.py services/api/app/diabetes/learning_handlers.py services/api/app/diabetes/handlers/learning_handlers.py tests/diabetes/test_learning_chat_handlers.py tests/diabetes/test_learning_state.py tests/learning/test_on_any_text.py tests/learning/test_handlers_rate_limit.py`
- `ruff check services/api/app/diabetes/learning_state.py services/api/app/diabetes/learning_handlers.py services/api/app/diabetes/handlers/learning_handlers.py tests/diabetes/test_learning_chat_handlers.py tests/diabetes/test_learning_state.py tests/learning/test_handlers_rate_limit.py tests/learning/test_on_any_text.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd5d88e69c832a9df4d830e759f891