### PR TITLE
[learning] hydrate lesson state from database

### DIFF
--- a/services/api/app/assistant/services/memory_service.py
+++ b/services/api/app/assistant/services/memory_service.py
@@ -1,26 +1,14 @@
 from __future__ import annotations
 
 from typing import cast
+from datetime import datetime
 
-from sqlalchemy import BigInteger, ForeignKey, Text
-from sqlalchemy.orm import Mapped, Session, mapped_column
+from sqlalchemy.orm import Session
 
-from ...diabetes.services.db import Base, SessionLocal, run_db
+from ...diabetes.services.db import Base, SessionLocal, run_db  # noqa: F401
 from ...diabetes.services.repository import commit
 from ...types import SessionProtocol
-
-
-class AssistantMemory(Base):
-    """Persisted memory summary for assistant conversations."""
-
-    __tablename__ = "assistant_memory"
-
-    user_id: Mapped[int] = mapped_column(
-        BigInteger,
-        ForeignKey("users.telegram_id", ondelete="CASCADE"),
-        primary_key=True,
-    )
-    memory: Mapped[str] = mapped_column(Text, nullable=False)
+from ..models import AssistantMemory
 
 
 async def get_memory(user_id: int) -> str | None:
@@ -28,7 +16,7 @@ async def get_memory(user_id: int) -> str | None:
 
     def _get(session: SessionProtocol) -> str | None:
         record = cast(AssistantMemory | None, session.get(AssistantMemory, user_id))
-        return None if record is None else record.memory
+        return None if record is None else record.summary_text
 
     return await run_db(_get, sessionmaker=SessionLocal)
 
@@ -39,10 +27,16 @@ async def save_memory(user_id: int, memory: str) -> None:
     def _save(session: SessionProtocol) -> None:
         record = cast(AssistantMemory | None, session.get(AssistantMemory, user_id))
         if record is None:
-            record = AssistantMemory(user_id=user_id, memory=memory)
+            record = AssistantMemory(
+                user_id=user_id,
+                summary_text=memory,
+                turn_count=0,
+                last_turn_at=datetime.utcnow(),
+            )
             cast(Session, session).add(record)
         else:
-            record.memory = memory
+            record.summary_text = memory
+            record.last_turn_at = datetime.utcnow()
         commit(cast(Session, session))
 
     await run_db(_save, sessionmaker=SessionLocal)

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -153,6 +153,7 @@ def register_handlers(
         sugar_handlers,
         gpt_handlers,
         billing_handlers,
+        learning_onboarding,
     )
     from services.api.app.config import reload_settings, settings
 
@@ -181,7 +182,41 @@ def register_handlers(
     app.add_handler(CommandHandlerT("cancel", dose_calc.dose_cancel))
     app.add_handler(CommandHandlerT("help", help_command))
     if learning_enabled:
-        learning_handlers.register_handlers(app)
+        app.add_handler(CommandHandlerT("learn", learning_handlers.learn_command))
+        app.add_handler(CommandHandlerT("lesson", learning_handlers.lesson_command))
+        app.add_handler(CommandHandlerT("quiz", learning_handlers.quiz_command))
+        app.add_handler(CommandHandlerT("progress", learning_handlers.progress_command))
+        app.add_handler(CommandHandlerT("exit", learning_handlers.exit_command))
+        app.add_handler(CommandHandlerT("topics", dynamic_learning_handlers.topics_command))
+        app.add_handler(CommandHandlerT("plan", dynamic_learning_handlers.plan_command))
+        app.add_handler(CommandHandlerT("skip", dynamic_learning_handlers.skip_command))
+        app.add_handler(CommandHandlerT("learn_reset", learning_onboarding.learn_reset))
+        app.add_handler(
+            MessageHandlerT(
+                filters.TEXT & ~filters.COMMAND,
+                learning_onboarding.onboarding_reply,
+            )
+        )
+        app.add_handler(
+            MessageHandlerT(
+                filters.TEXT & ~filters.COMMAND,
+                learning_handlers.quiz_answer_handler,
+                block=False,
+            )
+        )
+        app.add_handler(
+            CallbackQueryHandlerT(
+                dynamic_learning_handlers.lesson_callback,
+                pattern="^lesson:",
+            )
+        )
+        app.add_handler(
+            MessageHandlerT(
+                filters.TEXT & ~filters.COMMAND,
+                dynamic_learning_handlers.lesson_answer_handler,
+                block=False,
+            )
+        )
     app.add_handler(CommandHandlerT("gpt", gpt_handlers.chat_with_gpt))
     app.add_handler(CommandHandlerT("reset", gpt_handlers.reset_command))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))

--- a/tests/assistant/test_hydration_db.py
+++ b/tests/assistant/test_hydration_db.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from telegram import Bot, Chat, Message, Update, User
+from telegram.ext import Application, MessageHandler, filters
+
+from services.api.app.diabetes import learning_handlers
+from services.api.app.diabetes.services import db
+from services.api.app.diabetes.models_learning import Lesson, LessonLog, LessonProgress, User as DbUser
+
+
+class DummyBot(Bot):
+    """Bot collecting sent texts for assertions."""
+
+    def __init__(self) -> None:  # pragma: no cover - simple setup
+        super().__init__(token="123:ABC")
+        object.__setattr__(self, "_sent", [])
+
+    @property
+    def sent(self) -> list[str]:  # pragma: no cover - simple property
+        return self._sent  # type: ignore[attr-defined]
+
+    async def initialize(self) -> None:  # pragma: no cover - setup
+        self._me = User(id=0, is_bot=True, first_name="Bot", username="bot")  # type: ignore[attr-defined]
+        self._bot = self
+        self._initialized = True
+
+    @property
+    def username(self) -> str:  # pragma: no cover - simple property
+        return "bot"
+
+    async def send_message(self, chat_id: int, text: str, **kwargs: Any) -> Message:
+        msg = Message(
+            message_id=len(self.sent) + 1,
+            date=datetime.now(),
+            chat=Chat(id=chat_id, type="private"),
+            from_user=self._me,
+            text=text,
+        )
+        msg._bot = self
+        self.sent.append(text)
+        return msg
+
+
+@pytest.fixture(autouse=True)
+def setup_db() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.SessionLocal.configure(bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+    learning_handlers.SessionLocal = db.SessionLocal  # type: ignore[assignment]
+    yield
+    db.dispose_engine(engine)
+
+
+@pytest.mark.asyncio()
+async def test_hydration_from_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = DummyBot()
+    app = Application.builder().bot(bot).build()
+    app.add_handler(
+        MessageHandler(filters.TEXT & ~filters.COMMAND, learning_handlers.on_any_text)
+    )
+    await app.initialize()
+
+    user_id = 1
+    with db.SessionLocal() as session:
+        user = DbUser(telegram_id=user_id, thread_id="t1")
+        lesson = Lesson(slug="t1", title="Intro", content="c")
+        session.add_all([user, lesson])
+        session.commit()
+        progress = LessonProgress(
+            user_id=user_id, lesson_id=lesson.id, current_step=3, completed=False
+        )
+        log = LessonLog(
+            telegram_id=user_id,
+            topic_slug="t1",
+            role="assistant",
+            step_idx=3,
+            content="snapshot",
+        )
+        session.add_all([progress, log])
+        session.commit()
+
+    called: dict[str, Any] = {}
+
+    async def fake_lesson_answer_handler(update: Update, context: Any) -> None:
+        state = learning_handlers.get_state(context.user_data)
+        called["state"] = state
+
+    monkeypatch.setattr(learning_handlers, "lesson_answer_handler", fake_lesson_answer_handler)
+
+    user = User(id=user_id, is_bot=False, first_name="T")
+    chat = Chat(id=1, type="private")
+    msg = Message(
+        message_id=1,
+        date=datetime.now(),
+        chat=chat,
+        from_user=user,
+        text="answer",
+    )
+    msg._bot = bot
+
+    await app.process_update(Update(update_id=1, message=msg))
+
+    assert "state" in called
+    state = called["state"]
+    assert state.topic == "t1"
+    assert state.step == 3
+    assert state.last_step_text == "snapshot"
+    data = app.user_data[user_id]
+    assert data["learning_module_idx"] == 0
+    assert data["learning_plan_index"] == 2
+    assert data["learning_plan"][0] == "snapshot"
+
+    await app.shutdown()


### PR DESCRIPTION
## Summary
- register learning commands directly in handler registration
- persist and hydrate learning state from database with legacy key fallback
- test restoring state from DB

## Testing
- `pytest -q` *(fails: tests/learning/test_handlers.py::test_learning_flow, tests/learning/test_handlers_e2e.py::test_keyboard_persistence)*
- `mypy --strict .` *(failed: interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd5d1cadbc832a94918f1d64f1223c