### PR TITLE
[services] Handle missing OpenAI key with static reply

### DIFF
--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -364,3 +364,14 @@ async def test_create_chat_completion_retry(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert calls == 2
 
+
+@pytest.mark.asyncio
+async def test_create_chat_completion_without_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", None)
+    monkeypatch.setattr(gpt_client, "_async_client", None)
+    completion = await gpt_client.create_chat_completion(model="m", messages=[])
+    content = completion.choices[0].message.content or ""
+    assert "OpenAI API key is not configured" in content
+


### PR DESCRIPTION
## Summary
- return friendly static message when OpenAI key is missing
- add regression test for missing key in gpt client

## Testing
- `pytest tests/test_gpt_client.py::test_create_chat_completion_without_api_key -q`
- `mypy --strict services/api/app/diabetes/services/gpt_client.py tests/test_gpt_client.py`
- `ruff check services/api/app/diabetes/services/gpt_client.py tests/test_gpt_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd6124ed04832a85eb0df2cc8482eb