### PR TITLE
[storage] add TTL cleanup jobs

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -11,7 +11,9 @@ from pydantic import AliasChoices, Field, field_validator
 try:  # pragma: no cover - import guard
     from pydantic_settings import BaseSettings, SettingsConfigDict
 except ModuleNotFoundError as exc:  # pragma: no cover - executed at import time
-    raise ImportError("`pydantic-settings` is required. Install it with `pip install pydantic-settings`.") from exc
+    raise ImportError(
+        "`pydantic-settings` is required. Install it with `pip install pydantic-settings`."
+    ) from exc
 
 
 logger = logging.getLogger(__name__)
@@ -62,15 +64,21 @@ class Settings(BaseSettings):
     api_url: Optional[str] = Field(default=None, alias="API_URL")
     subscription_url: Optional[str] = Field(default=None, alias="SUBSCRIPTION_URL")
     openai_api_key: Optional[str] = Field(default=None, alias="OPENAI_API_KEY")
-    openai_assistant_id: Optional[str] = Field(default=None, alias="OPENAI_ASSISTANT_ID")
-    openai_command_model: str = Field(default="gpt-4o-mini", alias="OPENAI_COMMAND_MODEL")
+    openai_assistant_id: Optional[str] = Field(
+        default=None, alias="OPENAI_ASSISTANT_ID"
+    )
+    openai_command_model: str = Field(
+        default="gpt-4o-mini", alias="OPENAI_COMMAND_MODEL"
+    )
     api_key_min_length: int = Field(default=32, alias="API_KEY_MIN_LENGTH")
     learning_mode_enabled: bool = Field(
         default=True,
         alias="LEARNING_MODE_ENABLED",
         validation_alias=AliasChoices("LEARNING_MODE_ENABLED", "LEARNING_ENABLED"),
     )
-    learning_model_default: str = Field(default="gpt-4o-mini", alias="LEARNING_MODEL_DEFAULT")
+    learning_model_default: str = Field(
+        default="gpt-4o-mini", alias="LEARNING_MODEL_DEFAULT"
+    )
     learning_prompt_cache: bool = Field(default=True, alias="LEARNING_PROMPT_CACHE")
     learning_prompt_cache_size: int = Field(
         default=128, alias="LEARNING_PROMPT_CACHE_SIZE"
@@ -84,18 +92,32 @@ class Settings(BaseSettings):
     learning_logging_required: bool = Field(
         default=True, alias="LEARNING_LOGGING_REQUIRED"
     )
+    lesson_logs_ttl_days: int = Field(default=14, alias="LESSON_LOGS_TTL_DAYS")
+    assistant_memory_ttl_days: int = Field(
+        default=60, alias="ASSISTANT_MEMORY_TTL_DAYS"
+    )
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
-    learning_assistant_id: Optional[str] = Field(default=None, alias="LEARNING_ASSISTANT_ID")
-    learning_command_model: str = Field(default="gpt-4o-mini", alias="LEARNING_COMMAND_MODEL")
+    learning_assistant_id: Optional[str] = Field(
+        default=None, alias="LEARNING_ASSISTANT_ID"
+    )
+    learning_command_model: str = Field(
+        default="gpt-4o-mini", alias="LEARNING_COMMAND_MODEL"
+    )
     font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
-    onboarding_video_url: Optional[str] = Field(default=None, alias="ONBOARDING_VIDEO_URL")
+    onboarding_video_url: Optional[str] = Field(
+        default=None, alias="ONBOARDING_VIDEO_URL"
+    )
     telegram_token: Optional[str] = Field(default=None, alias="TELEGRAM_TOKEN")
-    telegram_payments_provider_token: Optional[str] = Field(default=None, alias="TELEGRAM_PAYMENTS_PROVIDER_TOKEN")
+    telegram_payments_provider_token: Optional[str] = Field(
+        default=None, alias="TELEGRAM_PAYMENTS_PROVIDER_TOKEN"
+    )
     admin_id: Optional[int] = Field(default=None, alias="ADMIN_ID")
 
     @field_validator("log_level", mode="before")
     @classmethod
-    def parse_log_level(cls, v: int | str | None) -> int:  # pragma: no cover - simple parsing
+    def parse_log_level(
+        cls, v: int | str | None
+    ) -> int:  # pragma: no cover - simple parsing
         if isinstance(v, str):
             v_lower = v.lower()
             level_map: dict[str, int] = {


### PR DESCRIPTION
## Summary
- add configurable TTL settings for lesson logs and assistant memory
- schedule JobQueue task to purge stale lesson logs and memory
- test cleanup logic and job registration

## Testing
- `mypy --strict .`
- `ruff check services/api/app/assistant/services/memory_service.py services/api/app/config.py services/api/app/diabetes/handlers/registration.py services/api/app/diabetes/services/lesson_log.py tests/assistant/test_memory_service.py tests/learning/test_lesson_logs.py tests/test_register_handlers.py`
- `pytest -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'application')*

------
https://chatgpt.com/codex/tasks/task_e_68bd612d5bb4832a88d08a6d3ab2b30c