### PR TITLE
[learning] Handle lesson log errors with metrics

### DIFF
--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -305,14 +305,7 @@ async def lesson_answer_handler(update: Update, context: ContextTypes.DEFAULT_TY
     telegram_id = from_user.id if from_user else None
     user_text = message.text.strip()
     if telegram_id is not None:
-        try:
-            await add_lesson_log(telegram_id, state.topic, "user", state.step, user_text)
-        except Exception:
-            logger.exception("lesson log failed")
-            await message.reply_text(BUSY_MESSAGE, reply_markup=build_main_keyboard())
-            state.awaiting = True
-            set_state(user_data, state)
-            return
+        await add_lesson_log(telegram_id, state.topic, "user", state.step, user_text)
     state.awaiting = False
     user_data[BUSY_KEY] = True
     set_state(user_data, state)
@@ -326,12 +319,7 @@ async def lesson_answer_handler(update: Update, context: ContextTypes.DEFAULT_TY
         if feedback == BUSY_MESSAGE:
             return
         if telegram_id is not None:
-            try:
-                await add_lesson_log(telegram_id, state.topic, "assistant", state.step, feedback)
-            except Exception:
-                logger.exception("lesson log failed")
-                await message.reply_text(BUSY_MESSAGE, reply_markup=build_main_keyboard())
-                return
+            await add_lesson_log(telegram_id, state.topic, "assistant", state.step, feedback)
         next_text = await generate_step_text(profile, state.topic, state.step + 1, feedback)
         if next_text == BUSY_MESSAGE:
             await message.reply_text(next_text, reply_markup=build_main_keyboard())
@@ -339,12 +327,7 @@ async def lesson_answer_handler(update: Update, context: ContextTypes.DEFAULT_TY
         next_text = format_reply(next_text)
         await message.reply_text(next_text, reply_markup=build_main_keyboard())
         if telegram_id is not None:
-            try:
-                await add_lesson_log(telegram_id, state.topic, "assistant", state.step + 1, next_text)
-            except Exception:
-                logger.exception("lesson log failed")
-                await message.reply_text(BUSY_MESSAGE, reply_markup=build_main_keyboard())
-                return
+            await add_lesson_log(telegram_id, state.topic, "assistant", state.step + 1, next_text)
         state.step += 1
         state.last_step_text = next_text
         state.prev_summary = feedback

--- a/services/api/app/diabetes/metrics.py
+++ b/services/api/app/diabetes/metrics.py
@@ -13,3 +13,7 @@ lessons_completed: Counter = Counter(
 quiz_avg_score: Summary = Summary(
     "quiz_avg_score", "Average quiz score across completed lessons"
 )
+
+lesson_log_failures: Counter = Counter(
+    "lesson_log_failures", "Total number of lesson log write failures"
+)


### PR DESCRIPTION
## Summary
- add lesson_log_failures metric and guard lesson logging with try/except
- keep learning handlers running even if lesson log persistence fails
- test DB failure path for lesson logs

## Testing
- `pytest tests/assistant/test_logs.py tests/diabetes/test_learning_chat_handlers.py::test_lesson_answer_handler_log_error_continues -q --cov-fail-under=0`
- `mypy --strict services/api/app/diabetes/metrics.py services/api/app/diabetes/services/lesson_log.py services/api/app/diabetes/learning_handlers.py tests/assistant/test_logs.py tests/diabetes/test_learning_chat_handlers.py` (no output)
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd634ace44832ab46ebbbc3fa0b036