### PR TITLE
[handlers] Load assistant memory from DB and register reset commands

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -157,6 +157,7 @@ def register_handlers(
         gpt_handlers,
         billing_handlers,
     )
+    from services.api.app.diabetes import commands as bot_commands
     from services.api.app.config import reload_settings, settings
 
     reload_settings()
@@ -183,10 +184,11 @@ def register_handlers(
     app.add_handler(sos_handlers.sos_contact_conv)
     app.add_handler(CommandHandlerT("cancel", dose_calc.dose_cancel))
     app.add_handler(CommandHandlerT("help", help_command))
+    app.add_handler(CommandHandlerT("reset_onboarding", bot_commands.reset_onboarding))
     if learning_enabled:
         learning_handlers.register_handlers(app)
     app.add_handler(CommandHandlerT("gpt", gpt_handlers.chat_with_gpt))
-    app.add_handler(CommandHandlerT("reset", gpt_handlers.reset_command))
+    app.add_handler(CommandHandlerT("reset", bot_commands.reset_command))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))
     app.add_handler(

--- a/tests/test_assistant_memory_integration.py
+++ b/tests/test_assistant_memory_integration.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.diabetes import commands
+from services.api.app.diabetes.handlers import gpt_handlers
+from services.api.app.assistant.services import memory_service
+
+
+class DummyMessage:
+    def __init__(self, text: str | None = None) -> None:
+        self.text = text
+        self.texts: list[str] = []
+
+    async def reply_text(self, text: str, **_: Any) -> None:
+        self.texts.append(text)
+
+
+@pytest.mark.asyncio
+async def test_memory_loaded_and_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_memory(user_id: int) -> Any:
+        assert user_id == 1
+        return SimpleNamespace(summary_text="prev")
+
+    cleared: dict[str, bool] = {"called": False}
+
+    async def fake_clear_memory(user_id: int) -> None:
+        assert user_id == 1
+        cleared["called"] = True
+
+    monkeypatch.setattr(memory_service, "get_memory", fake_get_memory)
+    monkeypatch.setattr(commands, "_clear_memory", fake_clear_memory)
+
+    message = DummyMessage("hi")
+    user = SimpleNamespace(id=1)
+    update = cast(Update, SimpleNamespace(message=message, effective_user=user))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
+    )
+
+    await gpt_handlers.chat_with_gpt(update, context)
+    assert context.user_data.get("assistant_summary") == "prev"
+
+    reset_update = cast(Update, SimpleNamespace(effective_message=DummyMessage(), effective_user=user))
+    reset_context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data=context.user_data),
+    )
+    await commands.reset_command(reset_update, reset_context)
+    assert reset_context.user_data == {}
+    assert cleared["called"]

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -34,6 +34,7 @@ from services.api.app.diabetes.handlers import (
     learning_onboarding,
 )
 from services.api.app.diabetes import learning_handlers as dynamic_learning_handlers
+from services.api.app.diabetes import commands
 from services.api.app.config import reload_settings
 
 
@@ -282,9 +283,15 @@ def test_register_handlers_attaches_expected_handlers(
     reset_cmd = [
         h
         for h in handlers
-        if isinstance(h, CommandHandler) and h.callback is gpt_handlers.reset_command
+        if isinstance(h, CommandHandler) and h.callback is commands.reset_command
     ]
     assert reset_cmd and "reset" in reset_cmd[0].commands
+    reset_onb_cmd = [
+        h
+        for h in handlers
+        if isinstance(h, CommandHandler) and h.callback is commands.reset_onboarding
+    ]
+    assert reset_onb_cmd and "reset_onboarding" in reset_onb_cmd[0].commands
 
     history_cmd = [
         h


### PR DESCRIPTION
## Summary
- register reset and onboarding reset commands
- load assistant summary from storage on first message
- test assistant memory loading and reset

## Testing
- `pytest --no-cov -q tests/test_register_handlers.py tests/test_assistant_memory_integration.py tests/test_gpt_handlers.py::test_reset_command_clears_history`
- `ruff check services/api/app/diabetes/handlers/gpt_handlers.py services/api/app/diabetes/handlers/registration.py tests/test_register_handlers.py tests/test_assistant_memory_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd62408470832a8429d9c4993aa854