### PR TITLE
[ui] Add AI assistant button to main keyboard

### DIFF
--- a/services/api/app/ui/keyboard.py
+++ b/services/api/app/ui/keyboard.py
@@ -3,13 +3,15 @@ from telegram import ReplyKeyboardMarkup, KeyboardButton
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
 LEARN_BUTTON_TEXT = "🎓 Учебный режим"
+ASSISTANT_AI_BUTTON_TEXT = "🤖 Ассистент_AI"
 
 
 def build_main_keyboard() -> ReplyKeyboardMarkup:
-    """Build main menu keyboard with an extra learning button."""
+    """Build main menu keyboard with extra learning and assistant buttons."""
     menu = menu_keyboard()
     layout = [row[:] for row in menu.keyboard]
     layout.append((KeyboardButton(LEARN_BUTTON_TEXT),))
+    layout.append((KeyboardButton(ASSISTANT_AI_BUTTON_TEXT),))
     return ReplyKeyboardMarkup(
         keyboard=layout,
         resize_keyboard=True,
@@ -19,4 +21,8 @@ def build_main_keyboard() -> ReplyKeyboardMarkup:
     )
 
 
-__all__ = ["LEARN_BUTTON_TEXT", "build_main_keyboard"]
+__all__ = [
+    "LEARN_BUTTON_TEXT",
+    "ASSISTANT_AI_BUTTON_TEXT",
+    "build_main_keyboard",
+]

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -19,7 +19,10 @@ from services.api.app.config import Settings
 from services.api.app.diabetes.learning_fixtures import load_lessons
 from services.api.app.diabetes.services import db
 from services.api.app.diabetes.utils.ui import menu_keyboard
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import (
+    ASSISTANT_AI_BUTTON_TEXT,
+    LEARN_BUTTON_TEXT,
+)
 
 
 class DummyMessage:
@@ -189,6 +192,7 @@ async def test_cmd_menu_shows_keyboard() -> None:
     assert keyboard is not None
     expected_layout = list(menu_keyboard().keyboard)
     expected_layout.append((KeyboardButton(LEARN_BUTTON_TEXT),))
+    expected_layout.append((KeyboardButton(ASSISTANT_AI_BUTTON_TEXT),))
     assert list(keyboard.keyboard) == expected_layout
     assert not any(
         button.text == registration.OLD_LEARN_BUTTON_TEXT

--- a/tests/ui/test_keyboard_regression.py
+++ b/tests/ui/test_keyboard_regression.py
@@ -1,0 +1,23 @@
+import services.api.app.diabetes.utils.ui as ui
+import services.api.app.ui.keyboard as kb
+
+
+def test_main_keyboard_preserves_buttons() -> None:
+    menu_layout = [[btn.text for btn in row] for row in ui.menu_keyboard().keyboard]
+    keyboard_layout = [
+        [btn.text for btn in row] for row in kb.build_main_keyboard().keyboard
+    ]
+    assert keyboard_layout == menu_layout + [
+        [kb.LEARN_BUTTON_TEXT],
+        [kb.ASSISTANT_AI_BUTTON_TEXT],
+    ]
+
+
+def test_confirm_keyboard_steps_inline_buttons() -> None:
+    markup = ui.confirm_keyboard("back")
+    texts = [[btn.text for btn in row] for row in markup.inline_keyboard]
+    assert texts == [
+        ["✅ Подтвердить", "✏️ Исправить"],
+        ["❌ Отмена"],
+        ["🔙 Назад"],
+    ]


### PR DESCRIPTION
## Summary
- add AI assistant button to main keyboard layout
- verify reply and inline keyboards with regression tests
- update learn command test for new keyboard layout

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q` *(fails: AttributeError in learning handlers and others, 24 failed)*
- `pytest tests/ui/test_keyboard_regression.py tests/test_learn_command.py::test_cmd_menu_shows_keyboard -q --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68bd66b105b4832aa05696d0ce07cda8