### PR TITLE
[tests] cover learning plan and assistant memory repos

### DIFF
--- a/tests/assistant/test_memory_repo.py
+++ b/tests/assistant/test_memory_repo.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.assistant.repositories import memory
+from services.api.app.diabetes.services import db
+
+
+@pytest.fixture()
+def session_local() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_connection, connection_record) -> None:  # pragma: no cover - setup
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    session_local = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    return session_local
+
+
+def test_get_and_upsert(session_local: sessionmaker[Session]) -> None:
+    with session_local() as session:
+        session.add(db.User(telegram_id=1, thread_id=""))
+        session.commit()
+        assert memory.get_memory(session, 1) is None
+
+        now = datetime.now(tz=timezone.utc)
+        mem = memory.upsert_memory(session, user_id=1, turn_count=1, last_turn_at=now)
+        assert mem.turn_count == 1
+        assert mem.last_turn_at.replace(tzinfo=timezone.utc) == now
+
+        mem2 = memory.upsert_memory(session, user_id=1, turn_count=2, last_turn_at=now)
+        assert mem2.turn_count == 2
+
+        fetched = memory.get_memory(session, 1)
+        assert fetched is not None
+        assert fetched.turn_count == 2
+        assert fetched.last_turn_at.replace(tzinfo=timezone.utc) == now

--- a/tests/assistant/test_plans_repo.py
+++ b/tests/assistant/test_plans_repo.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from services.api.app.diabetes.services import db
 from services.api.app.assistant.repositories import plans
+from services.api.app.diabetes.services import db
 
 
 @pytest.fixture()
@@ -14,6 +16,13 @@ def session_local(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_connection, connection_record) -> None:  # pragma: no cover - setup
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
     session_local = sessionmaker(bind=engine, class_=Session)
     db.Base.metadata.create_all(bind=engine)
     monkeypatch.setattr(plans, "SessionLocal", session_local)
@@ -22,6 +31,9 @@ def session_local(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
 
 @pytest.mark.asyncio
 async def test_create_and_get(session_local: sessionmaker[Session]) -> None:
+    with session_local() as session:
+        session.add(db.User(telegram_id=1, thread_id=""))
+        session.commit()
     plan_id = await plans.create_plan(1, version=1, plan_json={"a": 1})
     assert plan_id > 0
     fetched = await plans.get_plan(plan_id)
@@ -33,6 +45,9 @@ async def test_create_and_get(session_local: sessionmaker[Session]) -> None:
 
 @pytest.mark.asyncio
 async def test_get_active(session_local: sessionmaker[Session]) -> None:
+    with session_local() as session:
+        session.add(db.User(telegram_id=1, thread_id=""))
+        session.commit()
     await plans.create_plan(1, version=1, plan_json={}, is_active=False)
     active_id = await plans.create_plan(1, version=2, plan_json={})
     active = await plans.get_active_plan(1)
@@ -41,12 +56,18 @@ async def test_get_active(session_local: sessionmaker[Session]) -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_and_delete(session_local: sessionmaker[Session]) -> None:
-    plan_id = await plans.create_plan(2, version=1, plan_json={"x": 1})
-    await plans.update_plan(plan_id, plan_json={"x": 2}, is_active=False)
-    updated = await plans.get_plan(plan_id)
+async def test_update_delete_and_list(session_local: sessionmaker[Session]) -> None:
+    with session_local() as session:
+        session.add(db.User(telegram_id=2, thread_id=""))
+        session.commit()
+    plan_id1 = await plans.create_plan(2, version=1, plan_json={"x": 1})
+    plan_id2 = await plans.create_plan(2, version=2, plan_json={"y": 1})
+    await plans.update_plan(plan_id1, plan_json={"x": 2}, is_active=False)
+    updated = await plans.get_plan(plan_id1)
     assert updated is not None
     assert updated.plan_json == {"x": 2}
     assert updated.is_active is False
-    await plans.delete_plan(plan_id)
-    assert await plans.get_plan(plan_id) is None
+    plans_list = await plans.list_plans(2)
+    assert {p.id for p in plans_list} == {plan_id1, plan_id2}
+    await plans.delete_plan(plan_id1)
+    assert await plans.get_plan(plan_id1) is None


### PR DESCRIPTION
## Summary
- use in-memory SQLite for learning plan tests and cover list/update/delete flows
- add assistant memory repository CRUD tests

## Testing
- `ruff check tests/assistant/test_plans_repo.py tests/assistant/test_memory_repo.py`
- `mypy --strict tests/assistant/test_plans_repo.py tests/assistant/test_memory_repo.py tests/assistant/test_progress_repo.py`
- `pytest` *(fails: AttributeError in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bd66ad0148832ab7ca63f1b017c482