### PR TITLE
[tests] conditionally enable pytest-cov

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from argparse import Namespace
+
+import pytest
+from _pytest.config import Config
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: Config) -> None:
+    if not config.pluginmanager.hasplugin("pytest_cov"):
+        return
+    option: Namespace = config.option
+    if getattr(option, "cov", None) is None:
+        setattr(option, "cov", ["services.api.app.diabetes"])
+    if getattr(option, "cov_report", None) is None:
+        setattr(option, "cov_report", ["term-missing"])
+    if getattr(option, "cov_fail_under", None) is None:
+        setattr(option, "cov_fail_under", 85)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,6 @@
 [pytest]
 asyncio_mode = auto
-addopts =
-    --cov=services.api.app.diabetes
-    --cov-report=term-missing
-    --cov-fail-under=85
+# Coverage options are set in conftest.py if pytest-cov is available
 markers =
     asyncio: mark a coroutine test
 filterwarnings =

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 -r services/api/app/requirements.txt
+pytest-cov
 # Optional local Python SDK (generated from OpenAPI)
 # To use it, generate `libs/py-sdk` and install its dependencies manually:
 #   pip install -r libs/py-sdk/requirements.txt


### PR DESCRIPTION
## Summary
- ensure pytest-cov is installed
- configure coverage options only when plugin is present

## Testing
- `pytest -q --cov=services.api.app.diabetes --ignore=tests/assistant/test_integration.py` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute ...)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd7faf65dc832abbf58fd76bb80051