### PR TITLE
[learning] Handle specific errors in lesson logging

### DIFF
--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping, MutableMapping, cast
 
 import httpx
 from openai import OpenAIError
+from sqlalchemy.exc import SQLAlchemyError
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
 from telegram.ext import ApplicationHandlerStop, ContextTypes
 
@@ -328,8 +329,8 @@ async def lesson_answer_handler(update: Update, context: ContextTypes.DEFAULT_TY
                 "user",
                 "",
             )
-        except Exception:
-            logger.exception("lesson log failed")
+        except (SQLAlchemyError, httpx.HTTPError, RuntimeError) as exc:
+            logger.exception("lesson log failed: %s", exc)
             await message.reply_text(BUSY_MESSAGE, reply_markup=build_main_keyboard())
             state.awaiting = True
             set_state(user_data, state)
@@ -356,8 +357,8 @@ async def lesson_answer_handler(update: Update, context: ContextTypes.DEFAULT_TY
                     "assistant",
                     "",
                 )
-            except Exception:
-                logger.exception("lesson log failed")
+            except (SQLAlchemyError, httpx.HTTPError, RuntimeError) as exc:
+                logger.exception("lesson log failed: %s", exc)
                 await message.reply_text(BUSY_MESSAGE, reply_markup=build_main_keyboard())
                 return
         next_text = await generate_step_text(profile, state.topic, state.step + 1, feedback)
@@ -376,8 +377,8 @@ async def lesson_answer_handler(update: Update, context: ContextTypes.DEFAULT_TY
                     "assistant",
                     "",
                 )
-            except Exception:
-                logger.exception("lesson log failed")
+            except (SQLAlchemyError, httpx.HTTPError, RuntimeError) as exc:
+                logger.exception("lesson log failed: %s", exc)
                 await message.reply_text(BUSY_MESSAGE, reply_markup=build_main_keyboard())
                 return
         state.step += 1

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -3,6 +3,7 @@ from typing import Any, Mapping, cast
 
 import asyncio
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 from telegram import InlineKeyboardMarkup, ReplyKeyboardMarkup
 
 from services.api.app.config import settings
@@ -366,7 +367,7 @@ async def test_lesson_answer_handler_add_log_failure(
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
     async def fail_add_log(*args: object, **kwargs: object) -> None:
-        raise RuntimeError("db error")
+        raise SQLAlchemyError("db error")
 
     async def fail_check_user_answer(*args: object, **kwargs: object) -> tuple[bool, str]:
         raise AssertionError("should not be called")


### PR DESCRIPTION
## Summary
- handle SQLAlchemy and network errors when logging learning steps
- adjust test to simulate database failure with SQLAlchemyError

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'lesson_log')*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd7fb44934832ab7ae49971ce72a31