### PR TITLE
[services] Propagate DB errors when ensuring user exists

### DIFF
--- a/services/api/app/diabetes/services/users.py
+++ b/services/api/app/diabetes/services/users.py
@@ -33,5 +33,6 @@ async def ensure_user_exists(user_id: int) -> None:
 
     try:
         await run_db(_ensure, sessionmaker=SessionLocal)
-    except Exception:  # pragma: no cover - logging only
+    except Exception:
         logger.exception("Failed to ensure user %s exists", user_id)
+        raise

--- a/tests/services/test_users.py
+++ b/tests/services/test_users.py
@@ -1,0 +1,21 @@
+import logging
+
+import pytest
+
+from services.api.app.diabetes.services import users
+
+
+@pytest.mark.asyncio
+async def test_ensure_user_exists_db_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    async def failing_run_db(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("db fail")
+
+    monkeypatch.setattr(users, "run_db", failing_run_db)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError):
+            await users.ensure_user_exists(1)
+
+    assert "Failed to ensure user 1 exists" in caplog.text


### PR DESCRIPTION
## Summary
- re-raise database errors in ensure_user_exists after logging
- add regression test for ensure_user_exists DB errors

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: ImportError: cannot import name 'lesson_log')*
- `pytest tests/services/test_users.py -q -o addopts= -p no:cov`


------
https://chatgpt.com/codex/tasks/task_e_68bd7fb9b604832aa2c88aee13482f36