### PR TITLE
[ui] Handle profile fetch errors

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -459,7 +459,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
         }
 
       })
-      .catch((error) => {
+      .catch((error: unknown) => {
         if (cancelled) return;
         const message = error instanceof Error ? error.message : String(error);
         toast({

--- a/services/webapp/ui/tests/profile.onboarding.test.tsx
+++ b/services/webapp/ui/tests/profile.onboarding.test.tsx
@@ -48,6 +48,7 @@ import Profile from '../src/pages/Profile';
 import { resolveTelegramId } from '../src/pages/resolveTelegramId';
 import { postOnboardingEvent } from '../src/shared/api/onboarding';
 import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
+import { getProfile } from '../src/features/profile/api';
 
 const originalSupportedValuesOf = (Intl as any).supportedValuesOf;
 
@@ -114,6 +115,7 @@ describe('Profile onboarding', () => {
   });
 
   it('renders empty form when profile is missing (404)', async () => {
+    (getProfile as vi.Mock).mockResolvedValueOnce(null);
     const { getByPlaceholderText } = render(
       <QueryClientProvider client={new QueryClient()}>
         <Profile />
@@ -122,6 +124,21 @@ describe('Profile onboarding', () => {
 
     await waitFor(() => {
       expect(toast).not.toHaveBeenCalled();
+    });
+
+    expect((getByPlaceholderText('6.0') as HTMLInputElement).value).toBe('');
+  });
+
+  it('shows error toast on profile load failure', async () => {
+    (getProfile as vi.Mock).mockRejectedValueOnce(new Error('network'));
+    const { getByPlaceholderText } = render(
+      <QueryClientProvider client={new QueryClient()}>
+        <Profile />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalled();
     });
 
     expect((getByPlaceholderText('6.0') as HTMLInputElement).value).toBe('');


### PR DESCRIPTION
## Summary
- handle getProfile failures on profile page
- test onboarding profile fetch errors and 404s

## Testing
- `pnpm --filter ./services/webapp/ui test -- tests/profile.onboarding.test.tsx`
- `pnpm --filter ./services/webapp/ui test` *(fails: JS heap out of memory)*
- `pytest -q --cov` *(fails: ImportError: lesson_log)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd7fc0423c832aaabe73c25fdced41