### PR TITLE
[assistant] Reorder imports in logs repository

### DIFF
--- a/services/api/app/assistant/repositories/logs.py
+++ b/services/api/app/assistant/repositories/logs.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta, timezone
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone, timedelta
 
 from sqlalchemy.orm import Session
 


### PR DESCRIPTION
## Summary
- Reorder dataclass and datetime imports in assistant logs repository

## Testing
- `pytest -q --cov` *(fails: ImportError: cannot import name 'lesson_log')*
- `mypy --strict .` *(fails: Interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd965bed6c832aa53f6f088380972e