### PR TITLE
[handlers] use build_main_keyboard in main menu

### DIFF
--- a/services/api/app/diabetes/handlers/common_handlers.py
+++ b/services/api/app/diabetes/handlers/common_handlers.py
@@ -5,15 +5,17 @@ from __future__ import annotations
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.ui.keyboard import build_main_keyboard
 from .learning_handlers import learn_command
 
 
 async def menu_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Display the main menu keyboard using ``menu_keyboard``."""
+    """Display the main menu keyboard using ``build_main_keyboard``."""
     message = update.message
     if message:
-        await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
+        await message.reply_text(
+            "📋 Выберите действие:", reply_markup=build_main_keyboard()
+        )
 
 
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -60,7 +62,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     )
     message = update.message
     if message:
-        await message.reply_text(text, reply_markup=menu_keyboard())
+        await message.reply_text(text, reply_markup=build_main_keyboard())
 
 
 async def smart_input_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -77,7 +79,6 @@ async def smart_input_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
 
 __all__ = [
-    "menu_keyboard",
     "menu_command",
     "help_command",
     "smart_input_help",

--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -31,7 +31,6 @@ from services.api.app.diabetes.utils.functions import (
 from services.api.app.diabetes.utils.ui import (
     confirm_keyboard,
     dose_keyboard,
-    menu_keyboard,
     PHOTO_BUTTON_TEXT,
     SUGAR_BUTTON_TEXT,
     DOSE_BUTTON_TEXT,
@@ -40,6 +39,7 @@ from services.api.app.diabetes.utils.ui import (
     PROFILE_BUTTON_TEXT,
     BACK_BUTTON_TEXT,
 )
+from services.api.app.ui.keyboard import build_main_keyboard
 
 from . import EntryData, UserData
 from .alert_handlers import check_alert
@@ -220,7 +220,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     if carbs_g is None and xe is None:
         await message.reply_text(
             "Не указаны углеводы или ХЕ. Расчёт невозможен.",
-            reply_markup=menu_keyboard(),
+            reply_markup=build_main_keyboard(),
         )
         user_data.pop("pending_entry", None)
         return END
@@ -241,7 +241,7 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     if profile is None or profile.icr is None or profile.cf is None or profile.target_bg is None:
         await message.reply_text(
             "Профиль не настроен. Установите коэффициенты через /profile.",
-            reply_markup=menu_keyboard(),
+            reply_markup=build_main_keyboard(),
         )
         user_data.pop("pending_entry", None)
         return END
@@ -279,7 +279,7 @@ async def dose_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
     message = update.message
     if message is None:
         return END
-    await message.reply_text("Отменено.", reply_markup=menu_keyboard())
+    await message.reply_text("Отменено.", reply_markup=build_main_keyboard())
     user_data.pop("pending_entry", None)
     user_data.pop("dose_method", None)
     chat_data = getattr(context, "chat_data", None)
@@ -326,7 +326,7 @@ async def freeform_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         SessionLocal=SessionLocal,
         commit=commit,
         check_alert=check_alert,
-        menu_keyboard_markup=menu_keyboard(),
+        menu_keyboard_markup=build_main_keyboard(),
         smart_input=smart_input,
         parse_command=parse_command,
         send_report=send_report,

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -31,10 +31,8 @@ from services.api.app.diabetes.gpt_command_parser import (
     parse_command,
 )
 from services.api.app.diabetes.utils.constants import XE_GRAMS
-from services.api.app.diabetes.utils.ui import (
-    confirm_keyboard,
-    menu_keyboard as menu_keyboard_fn,
-)
+from services.api.app.diabetes.utils.ui import confirm_keyboard
+from services.api.app.ui.keyboard import build_main_keyboard
 
 from .alert_handlers import check_alert as _check_alert
 from .dose_validation import _sanitize
@@ -644,7 +642,7 @@ async def freeform_handler(
     SessionLocal = SessionLocal or globals()["SessionLocal"]
     commit = commit or globals()["commit"]
     check_alert = check_alert or globals()["check_alert"]
-    menu_keyboard_markup = menu_keyboard_markup or menu_keyboard_fn()
+    menu_keyboard_markup = menu_keyboard_markup or build_main_keyboard()
     assert SessionLocal is not None
     assert commit is not None
     assert check_alert is not None

--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -30,7 +30,6 @@ from services.api.app.diabetes.learning_state import (
 from services.api.app.diabetes.models_learning import Lesson, LessonProgress
 from services.api.app.diabetes.services.db import SessionLocal, run_db
 from services.api.app.diabetes.services.repository import commit
-from services.api.app.diabetes.utils.ui import menu_keyboard
 from ...ui.keyboard import build_main_keyboard
 from ..learning_onboarding import ensure_overrides
 from ..dynamic_tutor import BUSY_MESSAGE
@@ -336,7 +335,7 @@ async def exit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
         await run_db(_complete, user.id, lesson_id, sessionmaker=SessionLocal)
 
-    await message.reply_text("Учебная сессия завершена.", reply_markup=menu_keyboard())
+    await message.reply_text("Учебная сессия завершена.", reply_markup=build_main_keyboard())
     logger.info(
         "exit_command_complete",
         extra={"user_id": user.id, "lesson_id": lesson_id},

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -46,8 +46,8 @@ from sqlalchemy.orm import Session
 from services.api.app.diabetes.utils.ui import (
     PHOTO_BUTTON_TEXT,
     build_timezone_webapp_button,
-    menu_keyboard,
 )
+from services.api.app.ui.keyboard import build_main_keyboard
 from services.api.app.utils import choose_variant
 import services.bot.main as bot_main
 from .reminder_jobs import DefaultJobQueue
@@ -500,7 +500,7 @@ async def onboarding_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     await onboarding_state.complete_state(user.id)
     await _mark_user_complete(user.id)
     await _log_event(user.id, "onboarding_finished", 3, variant)
-    await message.reply_text("Пропущено", reply_markup=menu_keyboard())
+    await message.reply_text("Пропущено", reply_markup=build_main_keyboard())
     bot = cast(ExtBot[None], message.get_bot())
     try:
         await bot.set_my_commands(bot_main.commands)
@@ -565,7 +565,7 @@ async def _finish(
         await message.reply_text("Созданы напоминания:\n" + "\n".join(reminders))
     await _log_event(user_id, "step_completed_3", 3, variant)
     await message.reply_text(
-        "🎉 Готово! Настройка завершена.", reply_markup=menu_keyboard()
+        "🎉 Готово! Настройка завершена.", reply_markup=build_main_keyboard()
     )
     await _log_event(user_id, "onboarding_finished", 3, variant)
     bot = cast(ExtBot[None], message.get_bot())

--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -20,7 +20,7 @@ from services.api.app.diabetes.services.gpt_client import (
 )
 from services.api.app.diabetes.services.repository import CommitError, commit
 from services.api.app.diabetes.utils.functions import extract_nutrition_info
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.ui.keyboard import build_main_keyboard
 
 from . import EntryData, UserData
 
@@ -44,7 +44,7 @@ async def photo_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if message is None:
         return
     await message.reply_text(
-        "📸 Пришлите фото блюда для анализа.", reply_markup=menu_keyboard()
+        "📸 Пришлите фото блюда для анализа.", reply_markup=build_main_keyboard()
     )
 
 
@@ -270,7 +270,7 @@ async def photo_handler(
                 f"Вот полный ответ Vision:\n<pre>{html.escape(vision_text)}</pre>\n"
                 "Введите /dose и укажите их вручную.",
                 parse_mode="HTML",
-                reply_markup=menu_keyboard(),
+                reply_markup=build_main_keyboard(),
             )
             user_data.pop("pending_entry", None)
             return END
@@ -311,7 +311,7 @@ async def photo_handler(
                 raise
         await message.reply_text(
             f"🍽️ На фото:\n{vision_text}\n\nВведите текущий сахар (ммоль/л) — и я рассчитаю дозу инсулина.",
-            reply_markup=menu_keyboard(),
+            reply_markup=build_main_keyboard(),
         )
         return PHOTO_SUGAR
 

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -59,8 +59,8 @@ from services.api.app.diabetes.handlers.callbackquery_no_warn_handler import (  
 from services.api.app.diabetes.utils.ui import (  # noqa: E402
     build_timezone_webapp_button,
     back_keyboard as _back_keyboard,
-    menu_keyboard,
 )
+from services.api.app.ui.keyboard import build_main_keyboard
 from services.api.app.diabetes.services.repository import (  # noqa: E402
     CommitError,
     commit,
@@ -223,7 +223,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     if not db_ok:
         await message.reply_text(
             "⚠️ Не удалось сохранить профиль.",
-            reply_markup=menu_keyboard(),
+            reply_markup=build_main_keyboard(),
         )
         return END
     await message.reply_text(
@@ -234,7 +234,7 @@ async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         f"• Низкий порог: {low} ммоль/л\n"
         f"• Высокий порог: {high} ммоль/л"
         f"{warning_msg}",
-        reply_markup=menu_keyboard(),
+        reply_markup=build_main_keyboard(),
     )
     return END
 
@@ -261,7 +261,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 logger.exception("failed to fetch profile from DB for %s", user_id)
                 await message.reply_text(
                     "⚠️ Не удалось загрузить профиль из локальной базы.",
-                    reply_markup=menu_keyboard(),
+                    reply_markup=build_main_keyboard(),
                 )
                 return
             profile = None
@@ -271,7 +271,7 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             logger.exception("failed to fetch profile from DB for %s", user_id)
             await message.reply_text(
                 "⚠️ Не удалось загрузить профиль из локальной базы.",
-                reply_markup=menu_keyboard(),
+                reply_markup=build_main_keyboard(),
             )
             return
         if profile is not None:
@@ -316,13 +316,13 @@ async def profile_webapp_save(
     web_app = getattr(eff_msg, "web_app_data", None)
     error_msg = "⚠️ Некорректные данные из WebApp."
     if web_app is None:
-        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
+        await eff_msg.reply_text(error_msg, reply_markup=build_main_keyboard())
         return
     raw = web_app.data
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
-        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
+        await eff_msg.reply_text(error_msg, reply_markup=build_main_keyboard())
         return
     if {
         "icr",
@@ -331,13 +331,13 @@ async def profile_webapp_save(
         "low",
         "high",
     } - data.keys():
-        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
+        await eff_msg.reply_text(error_msg, reply_markup=build_main_keyboard())
         return
     try:
         icr, cf, target, low, high = parse_profile_values(data)
     except ValueError as exc:
         await eff_msg.reply_text(
-            exc.args[0] if exc.args else error_msg, reply_markup=menu_keyboard()
+            exc.args[0] if exc.args else error_msg, reply_markup=build_main_keyboard()
         )
         return
 
@@ -369,12 +369,12 @@ async def profile_webapp_save(
         except ValidationError:
             await eff_msg.reply_text(
                 "Некорректные данные настроек профиля",
-                reply_markup=menu_keyboard(),
+                reply_markup=build_main_keyboard(),
             )
             return
     user = update.effective_user
     if user is None:
-        await eff_msg.reply_text(error_msg, reply_markup=menu_keyboard())
+        await eff_msg.reply_text(error_msg, reply_markup=build_main_keyboard())
         return
     user_id = user.id
     ok, err = post_profile(
@@ -391,7 +391,7 @@ async def profile_webapp_save(
     if not ok:
         await eff_msg.reply_text(
             err or "⚠️ Не удалось сохранить профиль.",
-            reply_markup=menu_keyboard(),
+            reply_markup=build_main_keyboard(),
         )
         return
 
@@ -416,7 +416,7 @@ async def profile_webapp_save(
     if not db_ok:
         await eff_msg.reply_text(
             "⚠️ Не удалось сохранить профиль.",
-            reply_markup=menu_keyboard(),
+            reply_markup=build_main_keyboard(),
         )
         return
 
@@ -428,7 +428,7 @@ async def profile_webapp_save(
         except HTTPException:
             await eff_msg.reply_text(
                 "⚠️ Не удалось сохранить настройки",
-                reply_markup=menu_keyboard(),
+                reply_markup=build_main_keyboard(),
             )
             return
 
@@ -439,7 +439,7 @@ async def profile_webapp_save(
         f"• Целевой сахар: {target} ммоль/л\n"
         f"• Низкий порог: {low} ммоль/л\n"
         f"• Высокий порог: {high} ммоль/л",
-        reply_markup=menu_keyboard(),
+        reply_markup=build_main_keyboard(),
     )
 
 
@@ -447,7 +447,7 @@ async def profile_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     """Cancel profile creation conversation."""
     message = update.message
     if message is not None:
-        await message.reply_text("Отменено.", reply_markup=menu_keyboard())
+        await message.reply_text("Отменено.", reply_markup=build_main_keyboard())
     return END
 
 
@@ -459,7 +459,7 @@ async def profile_back(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     message = cast(Message, query.message)
     await query.answer()
     await message.delete()
-    await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
+    await message.reply_text("📋 Выберите действие:", reply_markup=build_main_keyboard())
 
 
 async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -539,7 +539,7 @@ async def profile_timezone_save(
     if not ok:
         await message.reply_text(
             "⚠️ Не удалось обновить часовой пояс.",
-            reply_markup=menu_keyboard(),
+            reply_markup=build_main_keyboard(),
         )
         return END
 
@@ -575,7 +575,7 @@ async def profile_timezone_save(
     if not existed:
         text = "✅ Профиль создан. Часовой пояс сохранён."
 
-    await message.reply_text(text, reply_markup=menu_keyboard())
+    await message.reply_text(text, reply_markup=build_main_keyboard())
     return END
 
 
@@ -693,7 +693,7 @@ async def profile_security(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if not result.get("commit_ok", True):
         await message.reply_text(
             "⚠️ Не удалось сохранить настройки.",
-            reply_markup=menu_keyboard(),
+            reply_markup=build_main_keyboard(),
         )
         return
     alert_sugar = result.get("alert_sugar")
@@ -974,7 +974,7 @@ async def profile_high(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         f"• Низкий порог: {low} ммоль/л\n"
         f"• Высокий порог: {high} ммоль/л"
         f"{warning_msg}",
-        reply_markup=menu_keyboard(),
+        reply_markup=build_main_keyboard(),
     )
     return END
 

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -48,7 +48,7 @@ from services.api.app.diabetes.utils.helpers import (
     parse_time_interval,
 )
 from services.api.app.diabetes.utils.jobs import _remove_jobs, schedule_once
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.ui.keyboard import build_main_keyboard
 from services.api.app.diabetes.schemas.reminders import ScheduleKind
 from .reminder_jobs import DefaultJobQueue, schedule_reminder
 from .alert_handlers import check_alert as _check_alert
@@ -453,7 +453,9 @@ async def reminders_list(
         return
 
     if show_menu:
-        await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
+        await message.reply_text(
+            "📋 Выберите действие:", reply_markup=build_main_keyboard()
+        )
 
     if keyboard is not None:
         await message.reply_text(text, parse_mode="HTML", reply_markup=keyboard)

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -42,7 +42,8 @@ from services.api.app.diabetes.services.reporting import (
     make_sugar_plot,
     generate_pdf_report,
 )
-from services.api.app.diabetes.utils.ui import menu_keyboard, BACK_BUTTON_TEXT
+from services.api.app.diabetes.utils.ui import BACK_BUTTON_TEXT
+from services.api.app.ui.keyboard import build_main_keyboard
 from . import UserData
 
 logger = logging.getLogger(__name__)
@@ -224,7 +225,9 @@ async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_T
     if query.data == "report_back":
         await query.answer()
         await message.delete()
-        await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
+        await message.reply_text(
+            "📋 Выберите действие:", reply_markup=build_main_keyboard()
+        )
         return
     if ":" not in query.data:
         await query.answer("Некорректный формат данных", show_alert=True)

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -13,7 +13,7 @@ from telegram.ext import ContextTypes
 from typing import Awaitable, Callable, cast
 
 from services.api.app.diabetes.services.db import Entry, SessionLocal
-from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.ui.keyboard import build_main_keyboard
 
 from services.api.app.diabetes.services.repository import CommitError, commit
 from . import EntryData, UserData
@@ -100,7 +100,9 @@ async def handle_cancel_entry(
     message = query.message
     if not isinstance(message, Message):
         return
-    await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard())
+    await message.reply_text(
+        "📋 Выберите действие:", reply_markup=build_main_keyboard()
+    )
 
 
 async def handle_edit_or_delete(

--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -19,8 +19,8 @@ from services.api.app.diabetes.utils.ui import (
     BACK_BUTTON_TEXT,
     PHOTO_BUTTON_TEXT,
     back_keyboard,
-    menu_keyboard,
 )
+from services.api.app.ui.keyboard import build_main_keyboard
 from services.api.app.diabetes.services.repository import CommitError, commit
 
 from . import dose_calc, _cancel_then
@@ -85,13 +85,13 @@ async def sos_contact_save(
         except CommitError:
             await message.reply_text(
                 "⚠️ Не удалось сохранить контакт.",
-                reply_markup=menu_keyboard(),
+                reply_markup=build_main_keyboard(),
             )
             return ConversationHandler.END
 
     await message.reply_text(
         "✅ Контакт для SOS сохранён.",
-        reply_markup=menu_keyboard(),
+        reply_markup=build_main_keyboard(),
     )
     return ConversationHandler.END
 
@@ -104,7 +104,7 @@ async def sos_contact_cancel(
     if message is None:
         return ConversationHandler.END
     assert message is not None
-    await message.reply_text("Отменено.", reply_markup=menu_keyboard())
+    await message.reply_text("Отменено.", reply_markup=build_main_keyboard())
     return ConversationHandler.END
 
 

--- a/services/api/app/diabetes/handlers/sugar_handlers.py
+++ b/services/api/app/diabetes/handlers/sugar_handlers.py
@@ -17,12 +17,12 @@ from services.api.app.diabetes.services.db import Entry, SessionLocal
 from services.api.app.diabetes.services.repository import CommitError, commit
 from services.api.app.diabetes.utils.functions import _safe_float
 from services.api.app.diabetes.utils.ui import (
-    menu_keyboard,
     sugar_keyboard,
     SUGAR_BUTTON_TEXT,
     BACK_BUTTON_TEXT,
     PHOTO_BUTTON_TEXT,
 )
+from services.api.app.ui.keyboard import build_main_keyboard
 
 from . import EntryData, UserData
 from .alert_handlers import check_alert
@@ -129,7 +129,7 @@ async def sugar_val(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     await check_alert(update, context, sugar)
     await message.reply_text(
         f"✅ Уровень сахара {sugar} ммоль/л сохранён.",
-        reply_markup=menu_keyboard(),
+        reply_markup=build_main_keyboard(),
     )
     if chat_data is not None:
         chat_data.pop("sugar_active", None)

--- a/tests/handlers/test_wizard_navigation.py
+++ b/tests/handlers/test_wizard_navigation.py
@@ -140,7 +140,7 @@ async def test_variant_b_starts_with_timezone(
 async def test_profile_back_returns_menu(monkeypatch: pytest.MonkeyPatch) -> None:
     import services.api.app.diabetes.handlers.profile as profile
 
-    monkeypatch.setattr(profile, "menu_keyboard", lambda: "MK")
+    monkeypatch.setattr(profile, "build_main_keyboard", lambda: "MK")
     message = DummyMessage()
     query = DummyQuery(message, "profile_back")
     update = cast(Update, SimpleNamespace(callback_query=query))
@@ -169,7 +169,7 @@ async def test_onboarding_skip_sends_final(
 
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
     monkeypatch.setattr(onboarding, "commit", lambda s: None)
-    monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
+    monkeypatch.setattr(onboarding, "build_main_keyboard", lambda: "MK")
     async def run_db(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         sessionmaker = kwargs.get("sessionmaker", TestSession)
         with sessionmaker() as session:
@@ -202,7 +202,7 @@ async def test_onboarding_skip_sends_final(
 async def test_profile_cancel_outputs_text(monkeypatch: pytest.MonkeyPatch) -> None:
     import services.api.app.diabetes.handlers.profile as profile
 
-    monkeypatch.setattr(profile, "menu_keyboard", lambda: "MK")
+    monkeypatch.setattr(profile, "build_main_keyboard", lambda: "MK")
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message))
     context = cast(
@@ -230,7 +230,7 @@ async def test_onboarding_completion_message(
 
     monkeypatch.setattr(onboarding, "SessionLocal", TestSession)
     monkeypatch.setattr(onboarding, "commit", lambda s: None)
-    monkeypatch.setattr(onboarding, "menu_keyboard", lambda: "MK")
+    monkeypatch.setattr(onboarding, "build_main_keyboard", lambda: "MK")
     async def run_db(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         sessionmaker = kwargs.get("sessionmaker", TestSession)
         with sessionmaker() as session:

--- a/tests/test_dose_calc_unit.py
+++ b/tests/test_dose_calc_unit.py
@@ -162,7 +162,7 @@ async def test_dose_sugar_profile_required(monkeypatch: pytest.MonkeyPatch) -> N
     context.user_data["pending_entry"] = {"carbs_g": 10}
 
     monkeypatch.setattr(dose_calc, "SessionLocal", lambda: DummySession(None))
-    monkeypatch.setattr(dose_calc, "menu_keyboard", lambda: "menu")
+    monkeypatch.setattr(dose_calc, "build_main_keyboard", lambda: "menu")
 
     result = await dose_calc.dose_sugar(
         cast(Update, update),

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -90,7 +90,7 @@ async def test_entry_without_dose_has_no_unit(
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: None)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
-    monkeypatch.setattr(dose_handlers, "menu_keyboard", lambda: None)
+    monkeypatch.setattr(dose_handlers, "build_main_keyboard", lambda: None)
 
     monkeypatch.setattr(gpt_handlers, "run_db", None)
 
@@ -145,7 +145,7 @@ async def test_entry_without_sugar_has_placeholder(
     monkeypatch.setattr(dose_handlers, "SessionLocal", session_factory)
     monkeypatch.setattr(dose_handlers, "commit", lambda session: None)
     monkeypatch.setattr(dose_handlers, "check_alert", noop)
-    monkeypatch.setattr(dose_handlers, "menu_keyboard", lambda: None)
+    monkeypatch.setattr(dose_handlers, "build_main_keyboard", lambda: None)
 
     monkeypatch.setattr(gpt_handlers, "run_db", None)
 

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 import pytest
 from telegram import Chat, Message, Update
 from telegram.ext import CallbackContext
+import services.api.app.ui.keyboard as kb
 
 
 class DummyMessage(Message):
@@ -48,7 +49,6 @@ async def test_callback_router_cancel_entry_sends_menu(
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
-    from services.api.app.diabetes.handlers import common_handlers
 
     query = DummyQuery(DummyMessage(), "cancel_entry")
     update = cast(Update, SimpleNamespace(callback_query=query))
@@ -67,7 +67,7 @@ async def test_callback_router_cancel_entry_sends_menu(
     assert query.message.kwargs
     kwargs = query.message.kwargs[0]
     markup = kwargs.get("reply_markup")
-    assert markup and markup.keyboard == common_handlers.menu_keyboard().keyboard
+    assert markup and markup.keyboard == kb.build_main_keyboard().keyboard
     assert context.user_data is not None
     user_data = context.user_data
     assert "pending_entry" not in user_data

--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -336,7 +336,7 @@ async def test_photo_handler_sends_bytes(
         "extract_nutrition_info",
         lambda text: functions.NutritionInfo(carbs_g=10.0, xe=1.0),
     )
-    monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
+    monkeypatch.setattr(photo_handlers, "build_main_keyboard", lambda: None)
 
     result = await photo_handlers.photo_handler(update, context)
 
@@ -390,7 +390,7 @@ async def test_photo_then_freeform_calculates_dose(
         "extract_nutrition_info",
         lambda text: functions.NutritionInfo(carbs_g=10.0, xe=1.0),
     )
-    monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
+    monkeypatch.setattr(photo_handlers, "build_main_keyboard", lambda: None)
     monkeypatch.setattr(gpt_handlers, "confirm_keyboard", lambda: None)
 
     photo_msg = DummyMessage(photo=(DummyPhoto(),))

--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -87,7 +87,7 @@ async def test_photo_flow_saves_entry(
         return {"action": "add_entry", "fields": {}, "entry_date": None, "time": None}
 
     monkeypatch.setattr(gpt_handlers, "confirm_keyboard", lambda: None)
-    monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
+    monkeypatch.setattr(photo_handlers, "build_main_keyboard", lambda: None)
 
     msg_start = DummyMessage("/dose")
     update_start = cast(
@@ -236,7 +236,7 @@ async def test_photo_flow_saves_entry(
 async def test_photo_handler_removes_file_on_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
+    monkeypatch.setattr(photo_handlers, "build_main_keyboard", lambda: None)
 
     async def fake_get_file(file_id: str) -> Any:
         class File:

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 from telegram import InlineKeyboardMarkup, Update
 from telegram.ext import CallbackContext
 
-from services.api.app.diabetes.utils.ui import menu_keyboard
+import services.api.app.ui.keyboard as kb
 
 from services.api.app.diabetes.services.db import Base, User, Profile, dispose_engine
 from tests.utils.profile_factory import make_profile
@@ -123,7 +123,7 @@ async def test_profile_command_and_view(
         await handlers.profile_view(update2, context2)
         dispose_engine(engine)
 
-    assert message.markups[0].keyboard == menu_keyboard().keyboard
+    assert message.markups[0].keyboard == kb.build_main_keyboard().keyboard
     assert f"• ИКХ: {expected_icr} г/ед." in message.texts[0]
     assert f"• КЧ: {expected_cf} ммоль/л" in message.texts[0]
     assert f"• Целевой сахар: {expected_target} ммоль/л" in message.texts[0]

--- a/tests/test_handlers_vision_prompt.py
+++ b/tests/test_handlers_vision_prompt.py
@@ -88,7 +88,7 @@ async def test_photo_prompt_includes_dish_name(
 
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
-    monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
+    monkeypatch.setattr(photo_handlers, "build_main_keyboard", lambda: None)
 
     msg_photo = DummyMessage(photo=[DummyPhoto()])
     update = cast(

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -6,6 +6,7 @@ from telegram import Update
 from telegram.ext import CallbackContext
 
 import services.api.app.diabetes.handlers.common_handlers as handlers
+import services.api.app.ui.keyboard as kb
 
 
 class DummyMessage:
@@ -32,7 +33,8 @@ async def test_help_includes_new_features() -> None:
     await handlers.help_command(update, context)
 
     assert (
-        message.kwargs[0]["reply_markup"].keyboard == handlers.menu_keyboard().keyboard
+        message.kwargs[0]["reply_markup"].keyboard
+        == kb.build_main_keyboard().keyboard
     )
     text = message.replies[0]
     assert "🆕 Новые возможности:\n" in text

--- a/tests/test_menu_keyboard.py
+++ b/tests/test_menu_keyboard.py
@@ -1,11 +1,16 @@
 import services.api.app.diabetes.utils.ui as ui
+import services.api.app.ui.keyboard as kb
 
 
 def test_menu_keyboard_layout() -> None:
-    keyboard_texts = [[btn.text for btn in row] for row in ui.menu_keyboard().keyboard]
+    keyboard_texts = [
+        [btn.text for btn in row] for row in kb.build_main_keyboard().keyboard
+    ]
     assert keyboard_texts == [
         [ui.PHOTO_BUTTON_TEXT, ui.SUGAR_BUTTON_TEXT],
         [ui.DOSE_BUTTON_TEXT, ui.REPORT_BUTTON_TEXT],
         [ui.QUICK_INPUT_BUTTON_TEXT, ui.HELP_BUTTON_TEXT],
         [ui.SOS_BUTTON_TEXT],
+        [kb.LEARN_BUTTON_TEXT],
+        [kb.ASSISTANT_AI_BUTTON_TEXT],
     ]

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -1,12 +1,16 @@
-import services.api.app.diabetes.handlers.common_handlers as handlers
 import services.api.app.diabetes.utils.ui as ui
+import services.api.app.ui.keyboard as kb
 
 
 def test_menu_keyboard_webapp_layout() -> None:
-    keyboard_texts = [[btn.text for btn in row] for row in handlers.menu_keyboard().keyboard]
+    keyboard_texts = [
+        [btn.text for btn in row] for row in kb.build_main_keyboard().keyboard
+    ]
     assert keyboard_texts == [
         [ui.PHOTO_BUTTON_TEXT, ui.SUGAR_BUTTON_TEXT],
         [ui.DOSE_BUTTON_TEXT, ui.REPORT_BUTTON_TEXT],
         [ui.QUICK_INPUT_BUTTON_TEXT, ui.HELP_BUTTON_TEXT],
         [ui.SOS_BUTTON_TEXT],
+        [kb.LEARN_BUTTON_TEXT],
+        [kb.ASSISTANT_AI_BUTTON_TEXT],
     ]

--- a/tests/test_photo_handler_run_filter.py
+++ b/tests/test_photo_handler_run_filter.py
@@ -105,7 +105,7 @@ async def test_photo_handler_ignores_previous_runs(
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: dummy_client)
     monkeypatch.setattr(photo_handlers, "extract_nutrition_info", fake_extract)
-    monkeypatch.setattr(photo_handlers, "menu_keyboard", lambda: None)
+    monkeypatch.setattr(photo_handlers, "build_main_keyboard", lambda: None)
 
     await photo_handlers.photo_handler(update, context)
 

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -1068,7 +1068,7 @@ async def test_reminders_list_shows_menu_keyboard(
     monkeypatch.setattr(handlers, "_render_reminders", fake_render)
 
     sentinel_markup = ReplyKeyboardMarkup([[]])
-    monkeypatch.setattr(handlers, "menu_keyboard", lambda: sentinel_markup)
+    monkeypatch.setattr(handlers, "build_main_keyboard", lambda: sentinel_markup)
 
     captured: list[tuple[str, dict[str, Any]]] = []
 

--- a/tests/ui/test_keyboard_regression.py
+++ b/tests/ui/test_keyboard_regression.py
@@ -3,11 +3,14 @@ import services.api.app.ui.keyboard as kb
 
 
 def test_main_keyboard_preserves_buttons() -> None:
-    menu_layout = [[btn.text for btn in row] for row in ui.menu_keyboard().keyboard]
     keyboard_layout = [
         [btn.text for btn in row] for row in kb.build_main_keyboard().keyboard
     ]
-    assert keyboard_layout == menu_layout + [
+    assert keyboard_layout == [
+        [ui.PHOTO_BUTTON_TEXT, ui.SUGAR_BUTTON_TEXT],
+        [ui.DOSE_BUTTON_TEXT, ui.REPORT_BUTTON_TEXT],
+        [ui.QUICK_INPUT_BUTTON_TEXT, ui.HELP_BUTTON_TEXT],
+        [ui.SOS_BUTTON_TEXT],
         [kb.LEARN_BUTTON_TEXT],
         [kb.ASSISTANT_AI_BUTTON_TEXT],
     ]


### PR DESCRIPTION
## Summary
- use extended `build_main_keyboard` in all handlers
- update keyboard tests for new buttons

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'lesson_log' and missing async plugin)*
- `pytest tests/test_menu_keyboard.py tests/ui/test_keyboard_regression.py -q`
- `ruff check .`
- `mypy --strict .`


------
https://chatgpt.com/codex/tasks/task_e_68bd9a28695c832ab946688fd203c1a3