### PR TITLE
[assistant] Link lesson logs to learning plans

### DIFF
--- a/services/api/alembic/versions/20251009_lesson_logs_plan_fk.py
+++ b/services/api/alembic/versions/20251009_lesson_logs_plan_fk.py
@@ -1,0 +1,24 @@
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20251009_lesson_logs_plan_fk"
+down_revision: Union[str, Sequence[str], None] = "3539fae8f7b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_foreign_key(
+        "lesson_logs_plan_id_fkey",
+        "lesson_logs",
+        "learning_plans",
+        ["plan_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("lesson_logs_plan_id_fkey", "lesson_logs", type_="foreignkey")

--- a/services/api/app/assistant/models.py
+++ b/services/api/app/assistant/models.py
@@ -33,7 +33,9 @@ class LessonLog(Base):
     user_id: Mapped[int] = mapped_column(
         BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True
     )
-    plan_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    plan_id: Mapped[int] = mapped_column(
+        ForeignKey("learning_plans.id", ondelete="CASCADE"), nullable=False, index=True
+    )
     module_idx: Mapped[int] = mapped_column(Integer, nullable=False)
     step_idx: Mapped[int] = mapped_column(Integer, nullable=False)
     role: Mapped[str] = mapped_column(String, nullable=False)


### PR DESCRIPTION
## Summary
- enforce cascade delete from learning plans to lesson logs via `plan_id`
- add Alembic migration adding `lesson_logs_plan_id_fkey`

## Testing
- `alembic -c services/api/alembic.ini upgrade heads` *(fails: No support for ALTER of constraints in SQLite dialect)*
- `pytest -q --cov` *(fails: ImportError: cannot import name 'lesson_log' from 'services.api.app.diabetes.services')*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bd9ba2f518832aa820577dc3d85461