### PR TITLE
[assistant] Cascade delete lesson logs with user

### DIFF
--- a/services/api/alembic/versions/20251009_lesson_logs_user_ondelete_cascade.py
+++ b/services/api/alembic/versions/20251009_lesson_logs_user_ondelete_cascade.py
@@ -1,0 +1,41 @@
+"""lesson_logs.user_id ON DELETE CASCADE"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "20251009_lesson_logs_user_ondelete_cascade"
+down_revision: Union[str, Sequence[str], None] = "20251008_recreate_lesson_logs"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.drop_constraint("lesson_logs_user_id_fkey", "lesson_logs", type_="foreignkey")
+    op.create_foreign_key(
+        "lesson_logs_user_id_fkey",
+        "lesson_logs",
+        "users",
+        ["user_id"],
+        ["telegram_id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.drop_constraint("lesson_logs_user_id_fkey", "lesson_logs", type_="foreignkey")
+    op.create_foreign_key(
+        "lesson_logs_user_id_fkey",
+        "lesson_logs",
+        "users",
+        ["user_id"],
+        ["telegram_id"],
+    )

--- a/services/api/app/assistant/models.py
+++ b/services/api/app/assistant/models.py
@@ -21,7 +21,9 @@ class AssistantMemory(Base):
         index=True,
     )
     turn_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    last_turn_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    last_turn_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
 
 
 class LessonLog(Base):
@@ -31,7 +33,10 @@ class LessonLog(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True
+        BigInteger,
+        ForeignKey("users.telegram_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     plan_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
     module_idx: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/tests/assistant/test_lesson_log_cascade.py
+++ b/tests/assistant/test_lesson_log_cascade.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.assistant.models import LessonLog
+from services.api.app.diabetes.services import db
+
+
+@pytest.fixture()
+def session_factory(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_connection, connection_record) -> None:  # pragma: no cover - setup
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal, raising=False)
+    return SessionLocal
+
+
+def test_lesson_logs_deleted_with_user(session_factory: sessionmaker[Session]) -> None:
+    with session_factory() as session:
+        user = db.User(telegram_id=1, thread_id="")
+        session.add(user)
+        session.flush()
+        session.add(
+            LessonLog(
+                user_id=1,
+                plan_id=1,
+                module_idx=0,
+                step_idx=0,
+                role="assistant",
+                content="hi",
+            )
+        )
+        session.commit()
+
+        assert session.query(LessonLog).count() == 1
+
+        session.delete(user)
+        session.commit()
+
+        assert session.query(LessonLog).count() == 0


### PR DESCRIPTION
## Summary
- cascade delete `lesson_logs` when a user is removed
- add alembic migration to drop and recreate the foreign key with `ON DELETE CASCADE`
- add regression test ensuring `lesson_logs` rows vanish after deleting the parent user

## Testing
- `ruff check .`
- `mypy --strict .`
- `alembic upgrade head` *(fails: Multiple head revisions are present)*
- `pytest tests/assistant/test_lesson_log_cascade.py -q --cov=services.api.app.assistant.models --cov-branch --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68bd9ba5c284832a9a7b20911cd3ede4