### PR TITLE
[diabetes] import assistant and learning models

### DIFF
--- a/services/api/app/diabetes/models.py
+++ b/services/api/app/diabetes/models.py
@@ -4,6 +4,8 @@ from services.api.app.models.onboarding_metrics import (  # noqa: F401
     OnboardingMetricEvent,
     OnboardingMetricDaily,
 )
+from services.api.app.assistant import models as assistant_models  # noqa: F401
+from services.api.app.diabetes import models_learning  # noqa: F401
 from .services.db import Base
 
 metadata = Base.metadata


### PR DESCRIPTION
## Summary
- import assistant models and learning models for metadata registration

## Testing
- `pytest -q` (fails: ImportError: cannot import name 'lesson_log')
- `mypy --strict .`
- `ruff check .`
- `PYTHONPATH=/workspace/saharlight-ux DATABASE_URL=sqlite:///tmp.db python -m alembic -c alembic.ini revision --autogenerate -m "tmp" --head 11eb7c3deda6`

------
https://chatgpt.com/codex/tasks/task_e_68bd9bb3acf8832aaf6f43ddfe2a9c07