### PR TITLE
[services] expose lesson log repository

### DIFF
--- a/services/api/app/diabetes/services/__init__.py
+++ b/services/api/app/diabetes/services/__init__.py
@@ -1,3 +1,4 @@
+from services.api.app.assistant.repositories import logs as lesson_log
 from .user_profile import save_timezone
 
-__all__ = ["save_timezone"]
+__all__ = ["save_timezone", "lesson_log"]


### PR DESCRIPTION
## Summary
- re-export lesson log repository from diabetes services

## Testing
- `black services/api/app/diabetes/services/__init__.py`
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68bda0cd8bf8832ab3aa3c948617b428