### PR TITLE
[monitoring] use public Prometheus accessor

### DIFF
--- a/services/api/app/diabetes/metrics.py
+++ b/services/api/app/diabetes/metrics.py
@@ -3,6 +3,22 @@
 from __future__ import annotations
 
 from prometheus_client import Counter, Gauge, Summary
+from prometheus_client.metrics import MetricWrapperBase
+
+
+def get_metric_value(metric: MetricWrapperBase, suffix: str | None = None) -> float:
+    """Return current value of *metric* using only public APIs."""
+    for metric_family in metric.collect():
+        base_name = metric_family.name
+        target = f"{base_name}_{suffix}" if suffix else None
+        for sample in metric_family.samples:
+            name = sample.name
+            if target:
+                if name == target:
+                    return float(sample.value)
+            elif name in {base_name, f"{base_name}_total"}:
+                return float(sample.value)
+    return 0.0
 
 lessons_started: Counter = Counter(
     "lessons_started", "Total number of lessons started"

--- a/services/api/app/diabetes/services/monitoring.py
+++ b/services/api/app/diabetes/services/monitoring.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from ..metrics import db_down_seconds, lesson_log_failures
+from ..metrics import get_metric_value, db_down_seconds, lesson_log_failures
 from .db import SessionLocal, run_db
 
 logger = logging.getLogger(__name__)
@@ -40,10 +40,11 @@ async def ping_db() -> None:
 
 def check_alerts(db_threshold: int) -> None:
     """Check metrics and notify if alerts trigger."""
-    if db_down_seconds._value.get() > db_threshold:
-        notify(f"db_down for {db_down_seconds._value.get()} sec")
+    db_value = get_metric_value(db_down_seconds)
+    if db_value > db_threshold:
+        notify(f"db_down for {db_value} sec")
     global _last_lesson_log_failures
-    current = lesson_log_failures._value.get()
+    current = get_metric_value(lesson_log_failures)
     if current > _last_lesson_log_failures:
         notify("lesson_log_failures increased")
     _last_lesson_log_failures = current

--- a/tests/test_monitoring_alerts.py
+++ b/tests/test_monitoring_alerts.py
@@ -5,7 +5,11 @@ from types import SimpleNamespace
 import pytest
 
 from services.api.app.diabetes.services import monitoring
-from services.api.app.diabetes.metrics import db_down_seconds, lesson_log_failures
+from services.api.app.diabetes.metrics import (
+    db_down_seconds,
+    get_metric_value,
+    lesson_log_failures,
+)
 
 
 def setup_function() -> None:
@@ -17,6 +21,7 @@ def setup_function() -> None:
 
 def test_db_down_triggers_notifications(monkeypatch: pytest.MonkeyPatch) -> None:
     db_down_seconds.set(5)
+    assert get_metric_value(db_down_seconds) == 5
     email = SimpleNamespace(calls=0)
     slack = SimpleNamespace(calls=0)
 
@@ -37,6 +42,7 @@ def test_db_down_triggers_notifications(monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_lesson_log_failures_triggers_notifications(monkeypatch: pytest.MonkeyPatch) -> None:
     lesson_log_failures.inc()
+    assert get_metric_value(lesson_log_failures) == 1
     email = SimpleNamespace(calls=0)
     slack = SimpleNamespace(calls=0)
 


### PR DESCRIPTION
## Summary
- use a helper for fetching metric values instead of accessing `_value`
- update monitoring alerts to use new metric accessor
- adjust tests to read metrics via helper

## Testing
- `pytest -q --cov` *(fails: ImportError: cannot import name 'lesson_log')*
- `pytest tests/test_monitoring_alerts.py tests/learning/test_curriculum_engine.py -q --cov=services/api/app/diabetes --cov-fail-under=85` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bda0d12c48832aab16f0c151433464