### PR TITLE
[devops] Use dynamic PYTHONPATH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ALEMBIC=$(PY) -m alembic -c services/api/alembic.ini
 DB_NAME?=diabetes_bot
 DB_URL?=postgresql://postgres@localhost/$(DB_NAME)
 RUN_AS_POSTGRES?=sudo -u postgres
-PYTHONPATH?=PYTHONPATH=/opt/saharlight-ux
+PYTHONPATH?=PYTHONPATH=$(PWD)
 
 # === VENV ===
 


### PR DESCRIPTION
## Summary
- use project root for PYTHONPATH instead of hardcoded path

## Testing
- `make show` *(fails: venv/bin/python not found)*
- `pytest -q --cov` *(fails: ImportError: cannot import name 'lesson_log')*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bda1c6f484832abefe021557279c24