### PR TITLE
[migrations] merge heads

### DIFF
--- a/services/api/alembic/versions/20251011_merge_heads.py
+++ b/services/api/alembic/versions/20251011_merge_heads.py
@@ -1,0 +1,26 @@
+"""merge heads
+
+Revision ID: 20251011_merge_heads
+Revises: 11eb7c3deda6, 20251010_lesson_logs_user_plan_index
+Create Date: 2025-09-07 15:17:50.994294
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '20251011_merge_heads'
+down_revision: Union[str, None] = ('11eb7c3deda6', '20251010_lesson_logs_user_plan_index')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- merge alembic heads `11eb7c3deda6` and `20251010_lesson_logs_user_plan_index`

## Testing
- `PYTHONPATH=/workspace/saharlight-ux venv/bin/python -m alembic -c services/api/alembic.ini heads`
- `make PYTHONPATH="PYTHONPATH=/workspace/saharlight-ux" migrate` *(fails: connection refused)*
- `pytest -q --cov` *(fails: ImportError: cannot import name 'lesson_log')*
- `mypy --strict .` *(interrupted)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68bda1bb8b94832a867fb04348976df2