### PR TITLE
[handlers] allow photo button without emoji

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -31,7 +31,7 @@ from services.api.app.diabetes.utils.functions import (
 from services.api.app.diabetes.utils.ui import (
     confirm_keyboard,
     dose_keyboard,
-    PHOTO_BUTTON_TEXT,
+    PHOTO_BUTTON_PATTERN,
     SUGAR_BUTTON_TEXT,
     DOSE_BUTTON_TEXT,
     HISTORY_BUTTON_TEXT,
@@ -365,7 +365,7 @@ dose_conv = ConversationHandler(
         MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), dose_cancel),
         CommandHandler("menu", cast(object, _cancel_then(menu_command))),
         MessageHandler(
-            filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"),
+            filters.Regex(PHOTO_BUTTON_PATTERN),
             cast(object, _cancel_then(photo_prompt)),
         ),
         MessageHandler(

--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -44,7 +44,7 @@ from services.api.app.services.profile import save_timezone
 from services.api.app.types import SessionProtocol
 from sqlalchemy.orm import Session
 from services.api.app.diabetes.utils.ui import (
-    PHOTO_BUTTON_TEXT,
+    PHOTO_BUTTON_PATTERN,
     build_timezone_webapp_button,
 )
 from services.api.app.ui.keyboard import build_main_keyboard
@@ -663,7 +663,7 @@ onboarding_conv = ConversationHandler(
         REMINDERS: [CallbackQueryHandler(reminders_chosen)],
     },
     fallbacks=[
-        MessageHandler(filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), _photo_fallback)
+        MessageHandler(filters.Regex(PHOTO_BUTTON_PATTERN), _photo_fallback)
     ],
 )
 __all__ = [

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -36,7 +36,7 @@ from services.api.app.diabetes.services.db import (
     Reminder,
     User,
 )
-from services.api.app.diabetes.utils.ui import BACK_BUTTON_TEXT, PHOTO_BUTTON_TEXT
+from services.api.app.diabetes.utils.ui import BACK_BUTTON_TEXT, PHOTO_BUTTON_PATTERN
 
 logger = logging.getLogger(__name__)
 
@@ -1026,7 +1026,7 @@ profile_conv = ConversationHandler(
     fallbacks=[
         MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), profile_cancel),
         CommandHandler("cancel", profile_cancel),
-        MessageHandler(filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), _photo_fallback),
+        MessageHandler(filters.Regex(PHOTO_BUTTON_PATTERN), _photo_fallback),
     ],
     # Subsequent steps depend on ``MessageHandler`` for text inputs. Enabling
     # ``per_message=True`` would store state per message and reset the

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -28,7 +28,7 @@ from ..utils.ui import (
     REMINDERS_BUTTON_TEXT,
     REPORT_BUTTON_TEXT,
     HISTORY_BUTTON_TEXT,
-    PHOTO_BUTTON_TEXT,
+    PHOTO_BUTTON_PATTERN,
     QUICK_INPUT_BUTTON_TEXT,
     HELP_BUTTON_TEXT,
     SOS_BUTTON_TEXT,
@@ -215,7 +215,7 @@ def register_handlers(
     )
     app.add_handler(
         MessageHandlerT(
-            filters.Regex(re.escape(PHOTO_BUTTON_TEXT)), photo_handlers.photo_prompt
+            filters.Regex(PHOTO_BUTTON_PATTERN), photo_handlers.photo_prompt
         )
     )
     app.add_handler(

--- a/services/api/app/diabetes/handlers/sos_handlers.py
+++ b/services/api/app/diabetes/handlers/sos_handlers.py
@@ -17,7 +17,7 @@ from services.api.app.diabetes.services.db import SessionLocal, Profile
 
 from services.api.app.diabetes.utils.ui import (
     BACK_BUTTON_TEXT,
-    PHOTO_BUTTON_TEXT,
+    PHOTO_BUTTON_PATTERN,
     back_keyboard,
 )
 from services.api.app.ui.keyboard import build_main_keyboard
@@ -115,7 +115,7 @@ sos_contact_conv = ConversationHandler(
         MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), sos_contact_cancel),
         CommandHandler("cancel", sos_contact_cancel),
         MessageHandler(
-            filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"),
+            filters.Regex(PHOTO_BUTTON_PATTERN),
             _cancel_then(dose_calc.photo_prompt),
         ),
     ],

--- a/services/api/app/diabetes/handlers/sugar_handlers.py
+++ b/services/api/app/diabetes/handlers/sugar_handlers.py
@@ -20,7 +20,7 @@ from services.api.app.diabetes.utils.ui import (
     sugar_keyboard,
     SUGAR_BUTTON_TEXT,
     BACK_BUTTON_TEXT,
-    PHOTO_BUTTON_TEXT,
+    PHOTO_BUTTON_PATTERN,
 )
 from services.api.app.ui.keyboard import build_main_keyboard
 
@@ -150,7 +150,7 @@ sugar_conv = ConversationHandler(
         MessageHandler(filters.Regex(f"^{BACK_BUTTON_TEXT}$"), dose_cancel),
         CommandHandler("menu", cast(object, _cancel_then(menu_command))),
         MessageHandler(
-            filters.Regex(f"^{PHOTO_BUTTON_TEXT}$"), cast(object, _cancel_then(photo_prompt))
+            filters.Regex(PHOTO_BUTTON_PATTERN), cast(object, _cancel_then(photo_prompt))
         ),
     ],
 )

--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -7,6 +7,8 @@ UI-компоненты бота «Diabet Buddy».
     from services.api.app.diabetes.utils.ui import menu_keyboard, dose_keyboard, confirm_keyboard
 """
 
+import re
+
 from telegram import (
     InlineKeyboardMarkup,
     InlineKeyboardButton,
@@ -18,6 +20,7 @@ from telegram import (
 PROFILE_BUTTON_TEXT = "📄 Мой профиль"
 REMINDERS_BUTTON_TEXT = "⏰ Напоминания"
 PHOTO_BUTTON_TEXT = "📷 Фото еды"
+PHOTO_BUTTON_PATTERN = re.compile(r"^\s*📷?\s*Фото еды$", re.IGNORECASE)
 SUGAR_BUTTON_TEXT = "🩸 Уровень сахара"
 DOSE_BUTTON_TEXT = "💉 Доза инсулина"
 HISTORY_BUTTON_TEXT = "📊 История"
@@ -40,6 +43,7 @@ __all__ = (
     "PROFILE_BUTTON_TEXT",
     "REMINDERS_BUTTON_TEXT",
     "PHOTO_BUTTON_TEXT",
+    "PHOTO_BUTTON_PATTERN",
     "SUGAR_BUTTON_TEXT",
     "DOSE_BUTTON_TEXT",
     "HISTORY_BUTTON_TEXT",

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -13,7 +13,10 @@ os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import dose_calc
-from services.api.app.diabetes.utils.ui import PHOTO_BUTTON_TEXT
+from services.api.app.diabetes.utils.ui import (
+    PHOTO_BUTTON_PATTERN,
+    PHOTO_BUTTON_TEXT,
+)
 
 
 def _find_handler(
@@ -50,7 +53,7 @@ class DummyMessage:
 
 @pytest.mark.asyncio
 async def test_photo_button_cancels_and_prompts_photo() -> None:
-    handler = _find_handler(dose_calc.dose_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$")
+    handler = _find_handler(dose_calc.dose_conv.fallbacks, PHOTO_BUTTON_PATTERN.pattern)
     message = DummyMessage(PHOTO_BUTTON_TEXT)
     update = cast(
         Update,

--- a/tests/test_photo_button_regex.py
+++ b/tests/test_photo_button_regex.py
@@ -1,0 +1,46 @@
+import os
+import re
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import ApplicationBuilder, MessageHandler, ContextTypes, filters
+
+import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
+import services.api.app.diabetes.handlers.registration as handlers
+
+
+class DummyMessage:
+    def __init__(self, text: str) -> None:
+        self.text: str = text
+        self.replies: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.replies.append(text)
+        self.kwargs.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_photo_button_without_emoji_triggers_prompt() -> None:
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
+    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
+
+    app = ApplicationBuilder().token("TESTTOKEN").build()
+    handlers.register_handlers(app)
+    photo_handler = next(
+        h
+        for h in app.handlers[0]
+        if isinstance(h, MessageHandler) and h.callback is photo_handlers.photo_prompt
+    )
+    pattern = cast(filters.Regex, photo_handler.filters).pattern.pattern
+    assert re.fullmatch(pattern, "Фото еды")
+
+    message = DummyMessage("Фото еды")
+    update = cast(Update, SimpleNamespace(message=message))
+    context = cast(ContextTypes.DEFAULT_TYPE, SimpleNamespace())
+    result = await photo_handler.callback(update, context)
+    assert result is None
+    assert message.replies == ["📸 Пришлите фото блюда для анализа."]

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -5,9 +5,8 @@ from re import Pattern
 from types import SimpleNamespace
 from typing import Any, Iterable, cast
 
-from telegram import Update
-
 import pytest
+from telegram import Update
 from telegram.ext import BaseHandler, CallbackContext, MessageHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
@@ -19,7 +18,10 @@ from services.api.app.diabetes.handlers import (
     onboarding_handlers,
     sos_handlers,
 )
-from services.api.app.diabetes.utils.ui import PHOTO_BUTTON_TEXT
+from services.api.app.diabetes.utils.ui import (
+    PHOTO_BUTTON_PATTERN,
+    PHOTO_BUTTON_TEXT,
+)
 
 
 def _find_handler(
@@ -79,21 +81,21 @@ async def _exercise(
 @pytest.mark.asyncio
 async def test_profile_conv_photo_fallback() -> None:
     handler = _find_handler(
-        profile_handlers.profile_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$"
+        profile_handlers.profile_conv.fallbacks, PHOTO_BUTTON_PATTERN.pattern
     )
     await _exercise(handler)
 
 
 @pytest.mark.asyncio
 async def test_sugar_conv_photo_fallback() -> None:
-    handler = _find_handler(dose_calc.sugar_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$")
+    handler = _find_handler(dose_calc.sugar_conv.fallbacks, PHOTO_BUTTON_PATTERN.pattern)
     await _exercise(handler)
 
 
 @pytest.mark.asyncio
 async def test_onboarding_conv_photo_fallback() -> None:
     handler = _find_handler(
-        onboarding_handlers.onboarding_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$"
+        onboarding_handlers.onboarding_conv.fallbacks, PHOTO_BUTTON_PATTERN.pattern
     )
     await _exercise(handler)
 
@@ -101,6 +103,6 @@ async def test_onboarding_conv_photo_fallback() -> None:
 @pytest.mark.asyncio
 async def test_sos_contact_conv_photo_fallback() -> None:
     handler = _find_handler(
-        sos_handlers.sos_contact_conv.fallbacks, f"^{PHOTO_BUTTON_TEXT}$"
+        sos_handlers.sos_contact_conv.fallbacks, PHOTO_BUTTON_PATTERN.pattern
     )
     await _exercise(handler)


### PR DESCRIPTION
## Summary
- allow photo button regex to match text without camera emoji
- add tests for photo button fallbacks
- cover text-only "Фото еды" button

## Testing
- `pytest -q --cov` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'effective_user', OperationalError: no such table: users, AuthenticationError: Incorrect API key provided)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bda3db417c832a930ebe36cbb9037b