### PR TITLE
[handlers] drop summary DB lookups

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -24,7 +24,6 @@ from services.api.app.diabetes.utils.calc_bolus import (
     calc_bolus,
 )
 from .. import assistant_state
-from ...assistant.services import memory_service
 from services.api.app.diabetes.utils.functions import smart_input
 from services.api.app.diabetes.gpt_command_parser import (
     ParserTimeoutError,
@@ -71,21 +70,13 @@ else:
 
 
 async def _ensure_summary_loaded(
-    user_id: int, user_data: MutableMapping[str, object]
+    _user_id: int, user_data: MutableMapping[str, object]
 ) -> None:
     """Populate ``assistant_summary`` from DB if missing."""
 
     if assistant_state.SUMMARY_KEY in user_data:
         return
-    try:
-        memory = await memory_service.get_memory(user_id)
-    except Exception:  # pragma: no cover - DB issues
-        return
-    if memory is None:
-        return
-    summary = getattr(memory, "summary_text", None) or getattr(memory, "summary", None)
-    if summary:
-        user_data[assistant_state.SUMMARY_KEY] = summary
+    # Summary persistence has been removed; this stub is kept for compatibility.
 
 
 class EditMessageMeta(TypedDict):

--- a/tests/test_assistant_memory_integration.py
+++ b/tests/test_assistant_memory_integration.py
@@ -20,10 +20,12 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_memory_loaded_and_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_memory_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, bool] = {"called": False}
+
     async def fake_get_memory(user_id: int) -> Any:
-        assert user_id == 1
-        return SimpleNamespace(summary_text="prev")
+        called["called"] = True
+        return SimpleNamespace()
 
     cleared: dict[str, bool] = {"called": False}
 
@@ -43,7 +45,8 @@ async def test_memory_loaded_and_reset(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     await gpt_handlers.chat_with_gpt(update, context)
-    assert context.user_data.get("assistant_summary") == "prev"
+    assert not called["called"]
+    assert "assistant_summary" not in context.user_data
 
     reset_update = cast(Update, SimpleNamespace(effective_message=DummyMessage(), effective_user=user))
     reset_context = cast(


### PR DESCRIPTION
## Summary
- stop reading summary_text from AssistantMemory
- adjust memory reset integration test

## Testing
- `pytest -q --cov` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute ... and others)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bda4342dd0832aa5aff9e927df124d