### PR TITLE
[handlers] use assistant_state for GPT history

### DIFF
--- a/tests/test_gpt_handlers.py
+++ b/tests/test_gpt_handlers.py
@@ -23,7 +23,7 @@ class DummyMessage:
 @pytest.mark.asyncio
 async def test_chat_with_gpt_replies_and_history() -> None:
     message = DummyMessage("hi")
-    update = cast(Update, SimpleNamespace(message=message))
+    update = cast(Update, SimpleNamespace(message=message, effective_user=None))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
@@ -36,7 +36,7 @@ async def test_chat_with_gpt_replies_and_history() -> None:
 
 @pytest.mark.asyncio
 async def test_chat_with_gpt_no_message() -> None:
-    update = cast(Update, SimpleNamespace(message=None))
+    update = cast(Update, SimpleNamespace(message=None, effective_user=None))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(),
@@ -46,15 +46,15 @@ async def test_chat_with_gpt_no_message() -> None:
 
 @pytest.mark.asyncio
 async def test_chat_with_gpt_trims_history(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(gpt_handlers, "ASSISTANT_MAX_TURNS", 2)
-    monkeypatch.setattr(gpt_handlers, "ASSISTANT_SUMMARY_TRIGGER", 99)
+    monkeypatch.setattr(gpt_handlers.assistant_state, "ASSISTANT_MAX_TURNS", 2)
+    monkeypatch.setattr(gpt_handlers.assistant_state, "ASSISTANT_SUMMARY_TRIGGER", 99)
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
     for i in range(3):
         msg = DummyMessage(str(i))
-        update = cast(Update, SimpleNamespace(message=msg))
+        update = cast(Update, SimpleNamespace(message=msg, effective_user=None))
         await gpt_handlers.chat_with_gpt(update, context)
     history = cast(list[str], context.user_data["assistant_history"])
     assert len(history) == 2
@@ -64,21 +64,22 @@ async def test_chat_with_gpt_trims_history(monkeypatch: pytest.MonkeyPatch) -> N
 
 @pytest.mark.asyncio
 async def test_chat_with_gpt_summarizes_history(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(gpt_handlers, "ASSISTANT_MAX_TURNS", 5)
-    monkeypatch.setattr(gpt_handlers, "ASSISTANT_SUMMARY_TRIGGER", 3)
+    monkeypatch.setattr(gpt_handlers.assistant_state, "ASSISTANT_MAX_TURNS", 2)
+    monkeypatch.setattr(gpt_handlers.assistant_state, "ASSISTANT_SUMMARY_TRIGGER", 3)
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
     for i in range(3):
         msg = DummyMessage(str(i))
-        update = cast(Update, SimpleNamespace(message=msg))
+        update = cast(Update, SimpleNamespace(message=msg, effective_user=None))
         await gpt_handlers.chat_with_gpt(update, context)
     history = cast(list[str], context.user_data["assistant_history"])
     summary = cast(str, context.user_data["assistant_summary"])
-    assert history[0] == summary
-    assert history[1].startswith("user: 1")
-    assert history[2].startswith("user: 2")
+    assert len(history) == 2
+    assert summary.startswith("user: 0")
+    assert history[0].startswith("user: 1")
+    assert history[1].startswith("user: 2")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- refactor GPT chat handler to delegate history trimming/summarization to `assistant_state.add_turn`
- reset GPT history via `assistant_state.reset`
- adjust tests to patch `assistant_state` constants and assert history summary

## Testing
- `pytest tests/test_gpt_handlers.py tests/test_assistant_state.py tests/assistant/test_memory_service.py -q`
- `pytest -q --cov` *(fails: Database engine is not initialized; run init_db() before calling run_db.)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bda43ee988832ab219f4c75be794b1