### PR TITLE
[migrations] merge heads

### DIFF
--- a/services/api/alembic/versions/20251012_merge_heads.py
+++ b/services/api/alembic/versions/20251012_merge_heads.py
@@ -1,0 +1,26 @@
+"""merge heads
+
+Revision ID: 20251012_merge_heads
+Revises: 20251011_merge_heads
+Create Date: 2025-09-07 15:34:50.033001
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '20251012_merge_heads'
+down_revision: Union[str, None] = '20251011_merge_heads'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- merge outstanding Alembic head revisions

## Testing
- `alembic -c services/api/alembic.ini heads`
- `alembic -c services/api/alembic.ini upgrade head` *(fails: connection refused)*
- `pytest -q` *(fails: async def functions are not natively supported, 638 failed)*
- `mypy --strict services/api/alembic/versions/20251012_merge_heads.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bda5c537ec832ab08c25a5d5e5e539