### PR TITLE
[assistant] Use shared assistant_state and clean up tests

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 import re
 from collections.abc import Awaitable, Callable
-from typing import MutableMapping, Protocol, TypedDict, TypeVar, cast
+from typing import Protocol, TypedDict, TypeVar, cast
 
 from telegram import (
     CallbackQuery,
@@ -61,16 +61,6 @@ except ImportError:  # pragma: no cover - optional db runner
     run_db = None
 else:
     run_db = cast(RunDB, _run_db)
-
-
-async def _ensure_summary_loaded(
-    _user_id: int, user_data: MutableMapping[str, object]
-) -> None:
-    """Populate ``assistant_summary`` from DB if missing."""
-
-    if assistant_state.SUMMARY_KEY in user_data:
-        return
-    # Summary persistence has been removed; this stub is kept for compatibility.
 
 
 class EditMessageMeta(TypedDict):
@@ -644,7 +634,6 @@ async def freeform_handler(
     user = update.effective_user
     if user is None:
         return
-    await _ensure_summary_loaded(user.id, user_data)
     raw_text = text.strip()
     user_id = user.id
     logger.info("FREEFORM raw='%s'  user=%s", _sanitize(raw_text), user_id)
@@ -725,13 +714,10 @@ async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     """Chat handler that records conversation history."""
 
     message = update.message
-    user = update.effective_user
     if message is None or message.text is None:
         return
 
     user_data = cast(dict[str, object], context.user_data)
-    if user is not None:
-        await _ensure_summary_loaded(user.id, user_data)
     user_text = message.text
 
     try:

--- a/tests/assistant/test_memory_service.py
+++ b/tests/assistant/test_memory_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from services.api.app.assistant.services import memory_service
-from services.api.app.diabetes import commands
+from services.api.app.diabetes import assistant_state, commands
 from services.api.app.diabetes.services import db
 
 
@@ -72,7 +72,10 @@ async def test_reset_command_clears_memory(setup_db: sessionmaker[Session]) -> N
         effective_user=SimpleNamespace(id=1),
     )
     context = SimpleNamespace(
-        user_data={"assistant_history": ["x"], "assistant_summary": "y"}
+        user_data={
+            assistant_state.HISTORY_KEY: ["x"],
+            assistant_state.SUMMARY_KEY: "y",
+        }
     )
 
     await commands.reset_command(update, context)

--- a/tests/test_assistant_memory_integration.py
+++ b/tests/test_assistant_memory_integration.py
@@ -5,7 +5,7 @@ import pytest
 from telegram import Update
 from telegram.ext import CallbackContext
 
-from services.api.app.diabetes import commands
+from services.api.app.diabetes import assistant_state, commands
 from services.api.app.diabetes.handlers import gpt_handlers
 from services.api.app.assistant.services import memory_service
 
@@ -46,7 +46,7 @@ async def test_memory_reset(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await gpt_handlers.chat_with_gpt(update, context)
     assert not called["called"]
-    assert "assistant_summary" not in context.user_data
+    assert assistant_state.SUMMARY_KEY not in context.user_data
 
     reset_update = cast(Update, SimpleNamespace(effective_message=DummyMessage(), effective_user=user))
     reset_context = cast(

--- a/tests/test_gpt_handlers.py
+++ b/tests/test_gpt_handlers.py
@@ -136,7 +136,12 @@ async def test_chat_with_gpt_summarizes_history(monkeypatch: pytest.MonkeyPatch)
 async def test_reset_command_clears_history() -> None:
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={"assistant_history": ["turn"], "assistant_summary": "s"}),
+        SimpleNamespace(
+            user_data={
+                assistant_state.HISTORY_KEY: ["turn"],
+                assistant_state.SUMMARY_KEY: "s",
+            }
+        ),
     )
     message = DummyMessage()
     update = cast(Update, SimpleNamespace(message=message))


### PR DESCRIPTION
## Summary
- drop legacy summary loader from GPT handlers and rely on `assistant_state.add_turn`
- update tests to use assistant_state constants for history and summary

## Testing
- `pytest --cov=services.api.app.diabetes.assistant_state --cov=services.api.app.diabetes.handlers.gpt_handlers tests/test_assistant_state.py tests/test_gpt_handlers.py tests/test_assistant_memory_integration.py tests/assistant/test_memory_service.py -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bda74f3d28832ab5c7a82ef7db9834