### PR TITLE
[handlers] Route assistant button to learn command

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -34,12 +34,16 @@ from ..utils.ui import (
     SOS_BUTTON_TEXT,
     SUBSCRIPTION_BUTTON_TEXT,
 )
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import (
+    ASSISTANT_AI_BUTTON_TEXT,
+    LEARN_BUTTON_TEXT,
+)
 
 OLD_LEARN_BUTTON_TEXT = "🎓 Обучение"
 LEARN_BUTTON_PATTERN = (
     rf"^(?:{re.escape(LEARN_BUTTON_TEXT)}|{re.escape(OLD_LEARN_BUTTON_TEXT)})$"
 )
+ASSISTANT_AI_BUTTON_PATTERN = rf"^{re.escape(ASSISTANT_AI_BUTTON_TEXT)}$"
 
 logger = logging.getLogger(__name__)
 
@@ -176,6 +180,12 @@ def register_handlers(
         MessageHandlerT(
             filters.TEXT & filters.Regex(LEARN_BUTTON_PATTERN),
             learning_handlers.on_learn_button,
+        )
+    )
+    app.add_handler(
+        MessageHandlerT(
+            filters.TEXT & filters.Regex(ASSISTANT_AI_BUTTON_PATTERN),
+            dynamic_learning_handlers.learn_command,
         )
     )
     app.add_handler(CommandHandlerT("report", reporting_handlers.report_request))


### PR DESCRIPTION
## Summary
- route 🤖 Ассистент_AI button to learning flow
- add test for assistant button routing

## Testing
- `pytest -q --cov` *(fails: no such table: users, missing user context etc)*
- `mypy --strict services/api/app/diabetes/handlers/registration.py tests/learning/test_handlers_e2e.py` *(process hung, aborted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bda8df5a00832abbfb948085974336