### PR TITLE
[assistant] Add plan deactivation and reset logic

### DIFF
--- a/services/api/app/diabetes/learning_onboarding.py
+++ b/services/api/app/diabetes/learning_onboarding.py
@@ -8,6 +8,8 @@ from typing import Callable, cast
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
 from telegram.ext import ContextTypes
 
+from services.api.app.assistant.repositories import plans
+
 logger = logging.getLogger(__name__)
 
 
@@ -169,6 +171,11 @@ async def learn_reset(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         "learn_onboarding_stage",
     ]:
         user_data.pop(key, None)
+    user = update.effective_user
+    if user is not None:
+        active_plan = await plans.get_active_plan(user.id)
+        if active_plan is not None and active_plan.id is not None:
+            await plans.deactivate_plan(user.id, active_plan.id)
     message = update.message
     if message is not None:
         await message.reply_text("Learning onboarding reset. Отправьте /learn.")


### PR DESCRIPTION
## Summary
- ensure new learning plans deactivate previous active ones
- add repository helper to deactivate plans and use it on /learn_reset
- cover plan deactivation and reset with tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bda9028184832a9d8ccd67e89a0821