### PR TITLE
[ui] Rename learn button to assistant

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -34,16 +34,12 @@ from ..utils.ui import (
     SOS_BUTTON_TEXT,
     SUBSCRIPTION_BUTTON_TEXT,
 )
-from services.api.app.ui.keyboard import (
-    ASSISTANT_AI_BUTTON_TEXT,
-    LEARN_BUTTON_TEXT,
-)
+from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
 
 OLD_LEARN_BUTTON_TEXT = "🎓 Обучение"
 LEARN_BUTTON_PATTERN = (
     rf"^(?:{re.escape(LEARN_BUTTON_TEXT)}|{re.escape(OLD_LEARN_BUTTON_TEXT)})$"
 )
-ASSISTANT_AI_BUTTON_PATTERN = rf"^{re.escape(ASSISTANT_AI_BUTTON_TEXT)}$"
 
 logger = logging.getLogger(__name__)
 
@@ -179,12 +175,6 @@ def register_handlers(
     app.add_handler(
         MessageHandlerT(
             filters.TEXT & filters.Regex(LEARN_BUTTON_PATTERN),
-            learning_handlers.on_learn_button,
-        )
-    )
-    app.add_handler(
-        MessageHandlerT(
-            filters.TEXT & filters.Regex(ASSISTANT_AI_BUTTON_PATTERN),
             dynamic_learning_handlers.learn_command,
         )
     )

--- a/services/api/app/ui/keyboard.py
+++ b/services/api/app/ui/keyboard.py
@@ -2,16 +2,14 @@ from telegram import ReplyKeyboardMarkup, KeyboardButton
 
 from services.api.app.diabetes.utils.ui import menu_keyboard
 
-LEARN_BUTTON_TEXT = "🎓 Учебный режим"
-ASSISTANT_AI_BUTTON_TEXT = "🤖 Ассистент_AI"
+LEARN_BUTTON_TEXT = "🤖 Ассистент_AI"
 
 
 def build_main_keyboard() -> ReplyKeyboardMarkup:
-    """Build main menu keyboard with extra learning and assistant buttons."""
+    """Build main menu keyboard with extra assistant button."""
     menu = menu_keyboard()
     layout = [row[:] for row in menu.keyboard]
     layout.append((KeyboardButton(LEARN_BUTTON_TEXT),))
-    layout.append((KeyboardButton(ASSISTANT_AI_BUTTON_TEXT),))
     return ReplyKeyboardMarkup(
         keyboard=layout,
         resize_keyboard=True,
@@ -23,6 +21,5 @@ def build_main_keyboard() -> ReplyKeyboardMarkup:
 
 __all__ = [
     "LEARN_BUTTON_TEXT",
-    "ASSISTANT_AI_BUTTON_TEXT",
     "build_main_keyboard",
 ]

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -19,10 +19,7 @@ from services.api.app.config import Settings
 from services.api.app.diabetes.learning_fixtures import load_lessons
 from services.api.app.diabetes.services import db
 from services.api.app.diabetes.utils.ui import menu_keyboard
-from services.api.app.ui.keyboard import (
-    ASSISTANT_AI_BUTTON_TEXT,
-    LEARN_BUTTON_TEXT,
-)
+from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
 
 
 class DummyMessage:
@@ -192,7 +189,6 @@ async def test_cmd_menu_shows_keyboard() -> None:
     assert keyboard is not None
     expected_layout = list(menu_keyboard().keyboard)
     expected_layout.append((KeyboardButton(LEARN_BUTTON_TEXT),))
-    expected_layout.append((KeyboardButton(ASSISTANT_AI_BUTTON_TEXT),))
     assert list(keyboard.keyboard) == expected_layout
     assert not any(
         button.text == registration.OLD_LEARN_BUTTON_TEXT

--- a/tests/test_menu_keyboard.py
+++ b/tests/test_menu_keyboard.py
@@ -12,5 +12,4 @@ def test_menu_keyboard_layout() -> None:
         [ui.QUICK_INPUT_BUTTON_TEXT, ui.HELP_BUTTON_TEXT],
         [ui.SOS_BUTTON_TEXT],
         [kb.LEARN_BUTTON_TEXT],
-        [kb.ASSISTANT_AI_BUTTON_TEXT],
     ]

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -12,5 +12,4 @@ def test_menu_keyboard_webapp_layout() -> None:
         [ui.QUICK_INPUT_BUTTON_TEXT, ui.HELP_BUTTON_TEXT],
         [ui.SOS_BUTTON_TEXT],
         [kb.LEARN_BUTTON_TEXT],
-        [kb.ASSISTANT_AI_BUTTON_TEXT],
     ]

--- a/tests/ui/test_keyboard_regression.py
+++ b/tests/ui/test_keyboard_regression.py
@@ -12,7 +12,6 @@ def test_main_keyboard_preserves_buttons() -> None:
         [ui.QUICK_INPUT_BUTTON_TEXT, ui.HELP_BUTTON_TEXT],
         [ui.SOS_BUTTON_TEXT],
         [kb.LEARN_BUTTON_TEXT],
-        [kb.ASSISTANT_AI_BUTTON_TEXT],
     ]
 
 


### PR DESCRIPTION
## Summary
- rename learn mode button to 🤖 Ассистент_AI
- simplify registration handler to match new and legacy button texts
- update keyboard tests for single assistant button

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict services/api/app/ui/keyboard.py services/api/app/diabetes/handlers/registration.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdaba55cac832aab2a8aecf7b8057a