### PR TITLE
[gpt_client] Add TTL and metrics for learning prompt cache

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -85,6 +85,9 @@ class Settings(BaseSettings):
     learning_prompt_cache_size: int = Field(
         default=128, alias="LEARNING_PROMPT_CACHE_SIZE"
     )
+    learning_prompt_cache_ttl: int = Field(
+        default=3600, alias="LEARNING_PROMPT_CACHE_TTL"
+    )
     learning_content_mode: Literal["dynamic", "static"] = Field(
         default="dynamic", alias="LEARNING_CONTENT_MODE"
     )

--- a/services/api/app/diabetes/metrics.py
+++ b/services/api/app/diabetes/metrics.py
@@ -20,9 +20,8 @@ def get_metric_value(metric: MetricWrapperBase, suffix: str | None = None) -> fl
                 return float(sample.value)
     return 0.0
 
-lessons_started: Counter = Counter(
-    "lessons_started", "Total number of lessons started"
-)
+
+lessons_started: Counter = Counter("lessons_started", "Total number of lessons started")
 lessons_completed: Counter = Counter(
     "lessons_completed", "Total number of lessons completed"
 )
@@ -35,4 +34,10 @@ db_down_seconds: Gauge = Gauge(
 )
 lesson_log_failures: Counter = Counter(
     "lesson_log_failures", "Number of failed lesson log flushes"
+)
+learning_cache_hit: Counter = Counter(
+    "learning_cache_hit", "Number of learning prompt cache hits"
+)
+learning_cache_miss: Counter = Counter(
+    "learning_cache_miss", "Number of learning prompt cache misses"
 )


### PR DESCRIPTION
## Summary
- add configurable TTL for learning prompt cache
- track cache hits/misses with Prometheus counters and logs
- test cache TTL expiry and metric increments

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/test_learning_prompt_cache.py -q --cov`
- `pytest -q --cov` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bdac2bf5ac832aab91cde8073b07bb