### PR TITLE
[handlers] expand learn button pattern

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -41,18 +41,15 @@ from services.api.app.ui.keyboard import (
 
 OLD_LEARN_BUTTON_TEXT = "🎓 Обучение"
 LEARN_BUTTON_PATTERN = (
-    rf"^(?:{re.escape(LEARN_BUTTON_TEXT)}|{re.escape(OLD_LEARN_BUTTON_TEXT)})$"
+    rf"^(?:{re.escape(LEARN_BUTTON_TEXT)}|{re.escape(OLD_LEARN_BUTTON_TEXT)}|{re.escape(ASSISTANT_AI_BUTTON_TEXT)})$"
 )
-ASSISTANT_AI_BUTTON_PATTERN = rf"^{re.escape(ASSISTANT_AI_BUTTON_TEXT)}$"
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     CommandHandlerT: TypeAlias = CommandHandler[ContextTypes.DEFAULT_TYPE, object]
     MessageHandlerT: TypeAlias = MessageHandler[ContextTypes.DEFAULT_TYPE, object]
-    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[
-        ContextTypes.DEFAULT_TYPE, object
-    ]
+    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, object]
 else:
     CommandHandlerT = CommandHandler
     MessageHandlerT = MessageHandler
@@ -75,17 +72,9 @@ def register_profile_handlers(
 
     app.add_handler(profile.profile_conv)
     app.add_handler(profile.profile_webapp_handler)
-    app.add_handler(
-        MessageHandlerT(
-            filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandlerT(profile.profile_security, pattern="^profile_security")
-    )
-    app.add_handler(
-        CallbackQueryHandlerT(profile.profile_back, pattern="^profile_back$")
-    )
+    app.add_handler(MessageHandlerT(filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view))
+    app.add_handler(CallbackQueryHandlerT(profile.profile_security, pattern="^profile_security"))
+    app.add_handler(CallbackQueryHandlerT(profile.profile_back, pattern="^profile_back$"))
 
 
 def register_reminder_handlers(
@@ -113,9 +102,7 @@ def register_reminder_handlers(
             reminder_handlers.reminders_list,
         )
     )
-    app.add_handler(
-        CallbackQueryHandlerT(reminder_handlers.reminder_callback, pattern="^remind_")
-    )
+    app.add_handler(CallbackQueryHandlerT(reminder_handlers.reminder_callback, pattern="^remind_"))
 
     # --- DEBUG HANDLERS ---
     try:
@@ -182,12 +169,6 @@ def register_handlers(
             learning_handlers.on_learn_button,
         )
     )
-    app.add_handler(
-        MessageHandlerT(
-            filters.TEXT & filters.Regex(ASSISTANT_AI_BUTTON_PATTERN),
-            dynamic_learning_handlers.learn_command,
-        )
-    )
     app.add_handler(CommandHandlerT("report", reporting_handlers.report_request))
     app.add_handler(CommandHandlerT("history", reporting_handlers.history_view))
     app.add_handler(dose_calc.dose_conv)
@@ -205,9 +186,7 @@ def register_handlers(
     app.add_handler(CommandHandlerT("reset", bot_commands.reset_command))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))
-    app.add_handler(
-        CallbackQueryHandlerT(billing_handlers.trial_command, pattern="^trial$")
-    )
+    app.add_handler(CallbackQueryHandlerT(billing_handlers.trial_command, pattern="^trial$"))
     register_reminder_handlers(app)
     app.add_handler(CommandHandlerT("alertstats", alert_handlers.alert_stats))
     app.add_handler(CommandHandlerT("hypoalert", security_handlers.hypo_alert_faq))
@@ -223,19 +202,9 @@ def register_handlers(
             reporting_handlers.history_view,
         )
     )
-    app.add_handler(
-        MessageHandlerT(
-            filters.Regex(PHOTO_BUTTON_PATTERN), photo_handlers.photo_prompt
-        )
-    )
-    app.add_handler(
-        MessageHandlerT(
-            filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help
-        )
-    )
-    app.add_handler(
-        MessageHandlerT(filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command)
-    )
+    app.add_handler(MessageHandlerT(filters.Regex(PHOTO_BUTTON_PATTERN), photo_handlers.photo_prompt))
+    app.add_handler(MessageHandlerT(filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help))
+    app.add_handler(MessageHandlerT(filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command))
     app.add_handler(
         MessageHandlerT(
             filters.Regex(re.escape(SUBSCRIPTION_BUTTON_TEXT)),
@@ -256,21 +225,11 @@ def register_handlers(
         ),
         group=0,
     )
-    app.add_handler(
-        MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler)
-    )
+    app.add_handler(MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler))
     app.add_handler(MessageHandlerT(filters.PHOTO, photo_handlers.photo_handler))
     app.add_handler(MessageHandlerT(filters.Document.IMAGE, photo_handlers.doc_handler))
-    app.add_handler(
-        CallbackQueryHandlerT(
-            reporting_handlers.report_period_callback, pattern="^report_back$"
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandlerT(
-            reporting_handlers.report_period_callback, pattern="^report_period:"
-        )
-    )
+    app.add_handler(CallbackQueryHandlerT(reporting_handlers.report_period_callback, pattern="^report_back$"))
+    app.add_handler(CallbackQueryHandlerT(reporting_handlers.report_period_callback, pattern="^report_period:"))
     app.add_handler(CallbackQueryHandlerT(callback_router))
 
     async def _clear_waiting_flags(context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -62,9 +62,7 @@ async def test_learn_command_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     message = DummyMessage()
     update = cast(
         Update,
-        SimpleNamespace(
-            message=message, effective_message=message, effective_user=None
-        ),
+        SimpleNamespace(message=message, effective_message=message, effective_user=None),
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -114,9 +112,7 @@ async def test_learn_command_no_lessons(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 @pytest.mark.asyncio
-async def test_learn_command_lists_lessons(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_learn_command_lists_lessons(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """After loading fixtures /learn should show at least one button."""
 
     sample = [
@@ -176,9 +172,7 @@ async def test_cmd_menu_shows_keyboard() -> None:
     message = DummyMessage()
     update = cast(
         Update,
-        SimpleNamespace(
-            message=message, effective_message=message, effective_user=None
-        ),
+        SimpleNamespace(message=message, effective_message=message, effective_user=None),
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -194,11 +188,7 @@ async def test_cmd_menu_shows_keyboard() -> None:
     expected_layout.append((KeyboardButton(LEARN_BUTTON_TEXT),))
     expected_layout.append((KeyboardButton(ASSISTANT_AI_BUTTON_TEXT),))
     assert list(keyboard.keyboard) == expected_layout
-    assert not any(
-        button.text == registration.OLD_LEARN_BUTTON_TEXT
-        for row in keyboard.keyboard
-        for button in row
-    )
+    assert not any(button.text == registration.OLD_LEARN_BUTTON_TEXT for row in keyboard.keyboard for button in row)
 
 
 @pytest.mark.asyncio
@@ -224,6 +214,8 @@ async def test_on_learn_button_calls_learn(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_old_learn_button_text_matches_pattern() -> None:
-    assert re.fullmatch(
-        registration.LEARN_BUTTON_PATTERN, registration.OLD_LEARN_BUTTON_TEXT
-    )
+    assert re.fullmatch(registration.LEARN_BUTTON_PATTERN, registration.OLD_LEARN_BUTTON_TEXT)
+
+
+def test_assistant_button_text_matches_pattern() -> None:
+    assert re.fullmatch(registration.LEARN_BUTTON_PATTERN, ASSISTANT_AI_BUTTON_TEXT)


### PR DESCRIPTION
## Summary
- expand `LEARN_BUTTON_PATTERN` to include "🤖 Ассистент_AI"
- ensure assistant button uses the same learning handler
- test regex compatibility for both button captions

## Testing
- `pytest -q --cov` *(fails: AttributeError and OperationalError in multiple tests)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdac4dcdbc832aad8ac2d37a64f7a2