### PR TITLE
[registration] Support legacy learn button text

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -37,8 +37,12 @@ from ..utils.ui import (
 from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
 
 OLD_LEARN_BUTTON_TEXT = "🎓 Обучение"
+LEARN_BUTTON_ALIASES: tuple[str, str] = (
+    LEARN_BUTTON_TEXT,
+    OLD_LEARN_BUTTON_TEXT,
+)
 LEARN_BUTTON_PATTERN = (
-    rf"^(?:{re.escape(LEARN_BUTTON_TEXT)}|{re.escape(OLD_LEARN_BUTTON_TEXT)})$"
+    r"^(?:" + "|".join(re.escape(text) for text in LEARN_BUTTON_ALIASES) + r")$"
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -219,7 +219,8 @@ async def test_on_learn_button_calls_learn(monkeypatch: pytest.MonkeyPatch) -> N
     assert called["v"] is True
 
 
-def test_old_learn_button_text_matches_pattern() -> None:
+def test_learn_button_texts_match_pattern() -> None:
+    assert re.fullmatch(registration.LEARN_BUTTON_PATTERN, LEARN_BUTTON_TEXT)
     assert re.fullmatch(
         registration.LEARN_BUTTON_PATTERN, registration.OLD_LEARN_BUTTON_TEXT
     )

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -90,7 +90,7 @@ def test_register_handlers_attaches_expected_handlers(
     )
     assert any(
         isinstance(h, MessageHandler)
-        and h.callback is learning_handlers.on_learn_button
+        and h.callback is dynamic_learning_handlers.learn_command
         for h in handlers
     )
     assert any(


### PR DESCRIPTION
## Summary
- Allow both 🤖 Ассистент_AI and 🎓 Обучение buttons to trigger learning flow
- Verify dynamic learning handler registration
- Cover both button texts with pattern test

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/test_register_handlers.py::test_register_handlers_attaches_expected_handlers -q`
- `pytest tests/test_learn_command.py::test_learn_button_texts_match_pattern -q`
- `pytest -q --cov --cov-fail-under=85` *(fails: Database engine is not initialized, 28 failed tests)*


------
https://chatgpt.com/codex/tasks/task_e_68bdafed2250832a92123592fdb5a85f