### PR TITLE
[tests] add begin method to DummyEngine

### DIFF
--- a/tests/test_db_reinit.py
+++ b/tests/test_db_reinit.py
@@ -1,5 +1,7 @@
-from typing import Any, cast
+from collections.abc import Iterator
+from contextlib import contextmanager
 from types import ModuleType
+from typing import Any, cast
 
 import importlib
 import sys
@@ -20,6 +22,10 @@ class DummyEngine:
 
     def dispose(self) -> None:
         self.disposed = True
+
+    @contextmanager
+    def begin(self) -> Iterator["DummyEngine"]:
+        yield self
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- extend DummyEngine with a begin context manager to mimic sqlalchemy Engine

## Testing
- `pytest tests/test_db_reinit.py -q`
- `mypy --strict tests/test_db_reinit.py`
- `ruff check tests/test_db_reinit.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdb434b458832a9c442e1dd6d5cf38