### PR TITLE
[assistant] add stop flush task

### DIFF
--- a/tests/assistant/test_logs.py
+++ b/tests/assistant/test_logs.py
@@ -72,3 +72,14 @@ async def test_logs_queue_and_flush(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert len(inserted) == 3
     assert not logs.pending_logs
+
+
+@pytest.mark.asyncio
+async def test_stop_flush_task_cancels_task() -> None:
+    """stop_flush_task should cancel the background flush task."""
+    await logs.stop_flush_task()  # ensure clean state
+    logs.start_flush_task(0.01)
+    task = logs._flush_task
+    assert task is not None
+    await logs.stop_flush_task()
+    assert task.cancelled()


### PR DESCRIPTION
## Summary
- add async stop_flush_task for background lesson log flushing
- start and stop the periodic log flush during FastAPI lifespan
- test log flush task cancellation

## Testing
- `ruff check services/api/app/assistant/repositories/logs.py services/api/app/main.py tests/assistant/test_logs.py`
- `mypy --strict .`
- `pytest tests/assistant/test_logs.py::test_stop_flush_task_cancels_task -q`
- `pytest -q --cov` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'user'* )

------
https://chatgpt.com/codex/tasks/task_e_68bdb3ae5a68832a93eec3e85e0fe52e