### PR TITLE
[assistant] Define composite PK in progress service

### DIFF
--- a/services/api/app/assistant/services/progress_service.py
+++ b/services/api/app/assistant/services/progress_service.py
@@ -20,10 +20,9 @@ class Progress(Base):
     """Store learning progress for a user and a lesson."""
 
     __tablename__ = "assistant_progress"
-    __table_args__ = (sa.PrimaryKeyConstraint("user_id", "lesson"),)
 
-    user_id: Mapped[int] = mapped_column(BigInteger)
-    lesson: Mapped[str] = mapped_column(String)
+    user_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    lesson: Mapped[str] = mapped_column(String, primary_key=True)
     step: Mapped[int] = mapped_column(Integer, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False


### PR DESCRIPTION
## Summary
- define `user_id` and `lesson` as composite primary key in assistant progress model

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdb3b56288832a8082e956164c22be