### PR TITLE
[gpt_parser] Improve logging for command validation

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -238,10 +238,11 @@ async def parse_command(text: str, timeout: float = 10) -> dict[str, object] | N
     try:
         cmd = CommandSchema.model_validate(parsed)
     except ValidationError:
-        logger.exception("Invalid command structure")
+        action = parsed.get("action") if isinstance(parsed, dict) else None
+        logger.exception("Command validation failed for action=%s", action)
         return None
     cmd_dict = cmd.model_dump(exclude_none=True)
     if cmd.action != "get_day_summary" and "fields" not in cmd_dict:
-        logger.error("Invalid command structure")
+        logger.error("Missing fields for action=%s", cmd.action)
         return None
     return cmd_dict

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -379,7 +379,7 @@ async def test_parse_command_with_invalid_schema(
         result = await gpt_command_parser.parse_command("test")
 
     assert result is None
-    assert "Invalid command structure" in caplog.text
+    assert "Command validation failed for action=123" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -620,8 +620,7 @@ def test_extract_first_json_with_escaped_chars() -> None:
 
 def test_extract_first_json_braces_inside_string_field() -> None:
     text = (
-        'prefix {"action":"add_entry","fields":{"note":"use {curly} braces"}} '
-        "suffix"
+        'prefix {"action":"add_entry","fields":{"note":"use {curly} braces"}} ' "suffix"
     )
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
@@ -630,9 +629,7 @@ def test_extract_first_json_braces_inside_string_field() -> None:
 
 
 def test_extract_first_json_braces_and_quotes_inside_string_field() -> None:
-    text = (
-        '{"action":"add_entry","fields":{"note":"{\\"inner\\":1} end"}}'
-    )
+    text = '{"action":"add_entry","fields":{"note":"{\\"inner\\":1} end"}}'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {"note": '{"inner":1} end'},

--- a/tests/test_gpt_command_parser_errors.py
+++ b/tests/test_gpt_command_parser_errors.py
@@ -198,7 +198,7 @@ async def test_parse_command_json_invalid_structure(
         result = await gpt_command_parser.parse_command("test")
 
     assert result is None
-    assert "Invalid command structure" in caplog.text
+    assert "Missing fields for action=add_entry" in caplog.text
 
 
 def test_sanitize_sensitive_data_masks_token() -> None:


### PR DESCRIPTION
## Summary
- log action-specific context when command validation fails
- clarify error when command is missing required fields

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'db', sqlite3.OperationalError: no such table: reminders, openai.AuthenticationError)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb3b89e28832a9f41cc0bf524b559