### PR TITLE
utils/ui: reload settings for subscription keyboard

### DIFF
--- a/services/api/app/diabetes/utils/ui.py
+++ b/services/api/app/diabetes/utils/ui.py
@@ -128,8 +128,10 @@ def confirm_keyboard(back_cb: str | None = None) -> InlineKeyboardMarkup:
 def subscription_keyboard(trial_available: bool) -> InlineKeyboardMarkup:
     """Build inline keyboard for subscription actions."""
     from services.api.app import config
-
-    settings = config.get_settings()
+    # Ensure settings reflect current environment variables (e.g., SUBSCRIPTION_URL)
+    # since tests and runtime code may mutate os.environ dynamically. Reloading
+    # guarantees we don't use a cached Settings instance with stale values.
+    settings = config.reload_settings()
     buttons: list[InlineKeyboardButton] = []
     if trial_available:
         buttons.append(InlineKeyboardButton("🎁 Trial", callback_data="trial"))

--- a/tests/test_subscription_keyboard_reload.py
+++ b/tests/test_subscription_keyboard_reload.py
@@ -1,0 +1,19 @@
+import pytest
+from telegram import InlineKeyboardButton
+
+from services.api.app.diabetes.utils.ui import subscription_keyboard
+
+
+def test_subscription_keyboard_uses_updated_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SUBSCRIPTION_URL", "https://example.com/sub1")
+    kb1 = subscription_keyboard(False)
+    btn1 = kb1.inline_keyboard[0][0]
+    assert isinstance(btn1, InlineKeyboardButton)
+    assert btn1.web_app and btn1.web_app.url == "https://example.com/sub1"
+
+    monkeypatch.setenv("SUBSCRIPTION_URL", "https://example.com/sub2")
+    kb2 = subscription_keyboard(False)
+    btn2 = kb2.inline_keyboard[0][0]
+    assert btn2.web_app and btn2.web_app.url == "https://example.com/sub2"
+
+    monkeypatch.delenv("SUBSCRIPTION_URL", raising=False)


### PR DESCRIPTION
## Summary
- reload config before building subscription keyboard so env vars are fresh
- test subscription_keyboard picks up updated SUBSCRIPTION_URL automatically

## Testing
- `pytest tests/test_subscription_keyboard_reload.py -q`
- `pytest -q --cov` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'bot', etc.)*
- `mypy --strict tests/test_subscription_keyboard_reload.py`
- `ruff check tests/test_subscription_keyboard_reload.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdb42da930832ab9ed32958e448069