### PR TITLE
[gpt_client] Handle missing OpenAI key before creating client

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -3,6 +3,7 @@
 import asyncio
 import io
 import logging
+import os
 import re
 import threading
 import time
@@ -149,6 +150,11 @@ async def create_chat_completion(
     timeout: float | httpx.Timeout | None = None,
 ) -> ChatCompletion:
     """Create a chat completion with typed return value."""
+    settings = config.get_settings()
+    api_key = settings.openai_api_key or os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        logger.warning("[OpenAI] OPENAI_API_KEY is not set")
+        return _static_completion(model)
     try:
         client: AsyncOpenAI = await _get_async_client()
     except RuntimeError as exc:


### PR DESCRIPTION
## Summary
- avoid calling OpenAI client when no API key is configured
- support OPENAI_API_KEY from environment
- cover missing/available key cases with tests

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: sqlalchemy.exc.OperationalError no such table: users, AttributeError: SimpleNamespace object has no attribute 'effective_user', etc.)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdb43074e4832a8598bdb715e043c2