### PR TITLE
[alembic] Align revision IDs with filenames

### DIFF
--- a/services/api/alembic/versions/20251002_billing_event_lowercase.py
+++ b/services/api/alembic/versions/20251002_billing_event_lowercase.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 revision: str = "20251002_billing_event_lowercase"
-down_revision: Union[str, Sequence[str], None] = "3539fae8f7b6"
+down_revision: Union[str, Sequence[str], None] = "3539fae8f7b6_merge_heads"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -60,4 +60,3 @@ def downgrade() -> None:
         op.execute("ALTER TYPE billing_event_old RENAME TO billing_event")
     else:
         return
-

--- a/services/api/alembic/versions/20251002_subscription_plan_values_callable.py
+++ b/services/api/alembic/versions/20251002_subscription_plan_values_callable.py
@@ -1,7 +1,7 @@
 """20251002_subscription_plan_values_callable
 
 Revision ID: 20251002_subscription_plan_values_callable
-Revises: 3539fae8f7b6
+Revises: 3539fae8f7b6_merge_heads
 Create Date: 2025-09-04 19:03:02.753378
 
 """
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "20251002_subscription_plan_values_callable"
-down_revision: Union[str, None] = "3539fae8f7b6"
+down_revision: Union[str, None] = "3539fae8f7b6_merge_heads"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20251003_onboarding_event.py
+++ b/services/api/alembic/versions/20251003_onboarding_event.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 
 
 revision: str = "20251003_onboarding_event"
-down_revision: Union[str, Sequence[str], None] = "3539fae8f7b6"
+down_revision: Union[str, Sequence[str], None] = "3539fae8f7b6_merge_heads"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20251009_lesson_logs_plan_fk.py
+++ b/services/api/alembic/versions/20251009_lesson_logs_plan_fk.py
@@ -4,7 +4,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "20251009_lesson_logs_plan_fk"
-down_revision: Union[str, Sequence[str], None] = "3539fae8f7b6"
+down_revision: Union[str, Sequence[str], None] = "3539fae8f7b6_merge_heads"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/3539fae8f7b6_merge_heads.py
+++ b/services/api/alembic/versions/3539fae8f7b6_merge_heads.py
@@ -1,10 +1,11 @@
 """merge heads
 
-Revision ID: 3539fae8f7b6
+Revision ID: 3539fae8f7b6_merge_heads
 Revises: 20250919_onboarding_events_user_fk, 20250920_onboarding_state_ondelete_cascade, 20251001_onboarding_metrics_indexes
 Create Date: 2025-09-04 17:54:48.210001
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -12,8 +13,12 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '3539fae8f7b6'
-down_revision: Union[str, None] = ('20250919_onboarding_events_user_fk', '20250920_onboarding_state_ondelete_cascade', '20251001_onboarding_metrics_indexes')
+revision: str = "3539fae8f7b6_merge_heads"
+down_revision: Union[str, None] = (
+    "20250919_onboarding_events_user_fk",
+    "20250920_onboarding_state_ondelete_cascade",
+    "20251001_onboarding_metrics_indexes",
+)
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- sync merge heads migration revision with filename
- update down_revision references in later migrations

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: imported module `test_lesson_logs` conflicts between `tests/assistant` and `tests/learning`)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb61208c0832aafac095ed2791ee6