### PR TITLE
assistant logs: disable session sync during log cleanup

### DIFF
--- a/services/api/app/assistant/repositories/logs.py
+++ b/services/api/app/assistant/repositories/logs.py
@@ -127,7 +127,8 @@ async def cleanup_old_logs(ttl: timedelta | None = None) -> None:
     cutoff = datetime.now(timezone.utc) - ttl
 
     def _cleanup(session: Session) -> int:
-        deleted = session.query(LessonLog).where(LessonLog.created_at < cutoff).delete()
+        query = session.query(LessonLog).where(LessonLog.created_at < cutoff)
+        deleted = query.delete(synchronize_session=False)
         commit(session)
         return deleted
 


### PR DESCRIPTION
## Summary
- avoid in-memory state synchronization when purging old lesson logs by using `synchronize_session=False`

## Testing
- `pytest tests/assistant/test_lesson_log_cascade.py::test_lesson_logs_deleted_with_user -q -Werror::sqlalchemy.exc.SAWarning` *(fails: FOREIGN KEY constraint failed)*
- `mypy --strict services/api/app/assistant/repositories/logs.py`
- `ruff check services/api/app/assistant/repositories/logs.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdb3af39b4832abb02c264df3ffa07