### PR TITLE
[assistant] Persist assistant memory summaries

### DIFF
--- a/services/api/alembic/versions/20251013_restore_assistant_memory_summary.py
+++ b/services/api/alembic/versions/20251013_restore_assistant_memory_summary.py
@@ -1,0 +1,27 @@
+"""restore assistant_memory summary_text
+
+Revision ID: 20251013_restore_assistant_memory_summary
+Revises: 20251012_merge_heads
+Create Date: 2025-10-13 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20251013_restore_assistant_memory_summary"
+down_revision: Union[str, Sequence[str], None] = "20251012_merge_heads"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "assistant_memory",
+        sa.Column("summary_text", sa.String(length=1024), nullable=False, server_default=""),
+    )
+    op.alter_column("assistant_memory", "summary_text", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("assistant_memory", "summary_text")

--- a/services/api/app/assistant/models.py
+++ b/services/api/app/assistant/models.py
@@ -24,6 +24,9 @@ class AssistantMemory(Base):
     last_turn_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False
     )
+    summary_text: Mapped[str] = mapped_column(
+        String(1024), nullable=False, default=""
+    )
 
 
 class LessonLog(Base):

--- a/services/api/app/assistant/repositories/memory.py
+++ b/services/api/app/assistant/repositories/memory.py
@@ -21,6 +21,7 @@ def upsert_memory(
     user_id: int,
     turn_count: int,
     last_turn_at: datetime,
+    summary_text: str | None = None,
 ) -> AssistantMemory:
     """Insert or update conversation memory for a user."""
     memory = session.get(AssistantMemory, user_id)
@@ -29,10 +30,13 @@ def upsert_memory(
             user_id=user_id,
             turn_count=turn_count,
             last_turn_at=last_turn_at,
+            summary_text=summary_text or "",
         )
         session.add(memory)
     else:
         memory.turn_count = turn_count
         memory.last_turn_at = last_turn_at
+        if summary_text is not None:
+            memory.summary_text = summary_text
     commit(session)
     return memory

--- a/tests/assistant/test_memory_service.py
+++ b/tests/assistant/test_memory_service.py
@@ -41,16 +41,21 @@ def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
 @pytest.mark.asyncio
 async def test_save_and_get_memory(setup_db: sessionmaker[Session]) -> None:
     now = datetime.now(tz=timezone.utc)
-    await memory_service.save_memory(1, turn_count=1, last_turn_at=now)
+    await memory_service.save_memory(
+        1, turn_count=1, last_turn_at=now, summary_text="hi"
+    )
     mem = await memory_service.get_memory(1)
     assert mem is not None
     assert mem.turn_count == 1
+    assert mem.summary_text == "hi"
 
 
 @pytest.mark.asyncio
 async def test_clear_memory(setup_db: sessionmaker[Session]) -> None:
     now = datetime.now(tz=timezone.utc)
-    await memory_service.save_memory(1, turn_count=1, last_turn_at=now)
+    await memory_service.save_memory(
+        1, turn_count=1, last_turn_at=now, summary_text="x"
+    )
     await memory_service.clear_memory(1)
     assert await memory_service.get_memory(1) is None
 
@@ -58,7 +63,9 @@ async def test_clear_memory(setup_db: sessionmaker[Session]) -> None:
 @pytest.mark.asyncio
 async def test_reset_command_clears_memory(setup_db: sessionmaker[Session]) -> None:
     now = datetime.now(tz=timezone.utc)
-    await memory_service.save_memory(1, turn_count=1, last_turn_at=now)
+    await memory_service.save_memory(
+        1, turn_count=1, last_turn_at=now, summary_text="y"
+    )
 
     class DummyMessage:
         def __init__(self) -> None:
@@ -88,8 +95,12 @@ async def test_reset_command_clears_memory(setup_db: sessionmaker[Session]) -> N
 async def test_cleanup_old_memory(setup_db: sessionmaker[Session]) -> None:
     old = datetime.now(timezone.utc) - timedelta(days=61)
     now = datetime.now(timezone.utc)
-    await memory_service.save_memory(1, turn_count=1, last_turn_at=old)
-    await memory_service.save_memory(2, turn_count=1, last_turn_at=now)
+    await memory_service.save_memory(
+        1, turn_count=1, last_turn_at=old, summary_text="old"
+    )
+    await memory_service.save_memory(
+        2, turn_count=1, last_turn_at=now, summary_text="new"
+    )
 
     await memory_service.cleanup_old_memory(ttl=timedelta(days=60))
 

--- a/tests/assistant/test_memory_summary.py
+++ b/tests/assistant/test_memory_summary.py
@@ -47,3 +47,19 @@ async def test_record_turn_increments(
     assert mem.turn_count == 3
     last = mem.last_turn_at.replace(tzinfo=timezone.utc)
     assert abs(last - (base + timedelta(minutes=2))) < timedelta(seconds=1)
+
+
+@pytest.mark.asyncio
+async def test_record_turn_updates_summary(
+    setup_db: sessionmaker[Session],
+) -> None:
+    now = datetime.now(tz=timezone.utc)
+    await memory_service.record_turn(1, summary_text="hi", now=now)
+    mem = await memory_service.get_memory(1)
+    assert mem is not None
+    assert mem.summary_text == "hi"
+    await memory_service.record_turn(
+        1, summary_text="bye", now=now + timedelta(minutes=1)
+    )
+    mem = await memory_service.get_memory(1)
+    assert mem.summary_text == "bye"

--- a/tests/test_assistant_memory_integration.py
+++ b/tests/test_assistant_memory_integration.py
@@ -33,7 +33,11 @@ async def test_memory_reset(monkeypatch: pytest.MonkeyPatch) -> None:
         assert user_id == 1
         cleared["called"] = True
 
+    async def fake_record_turn(*args: Any, **kwargs: Any) -> None:
+        return None
+
     monkeypatch.setattr(memory_service, "get_memory", fake_get_memory)
+    monkeypatch.setattr(memory_service, "record_turn", fake_record_turn)
     monkeypatch.setattr(commands, "_clear_memory", fake_clear_memory)
 
     message = DummyMessage("hi")


### PR DESCRIPTION
## Summary
- restore `summary_text` column for assistant memory
- store and update conversation summaries when chats reach threshold
- clean memory on `/reset` and retain TTL cleanup

## Testing
- `pytest tests/assistant/test_memory_service.py tests/assistant/test_memory_summary.py -q --import-mode=importlib`
- `pytest tests/test_gpt_handlers.py::test_chat_with_gpt_replies_and_history tests/test_gpt_handlers.py::test_chat_with_gpt_summarizes_history tests/test_assistant_memory_integration.py::test_memory_reset -q --import-mode=importlib`
- `ruff check services/api/app/assistant/models.py services/api/app/assistant/repositories/memory.py services/api/app/assistant/services/memory_service.py services/api/app/diabetes/handlers/gpt_handlers.py tests/assistant/test_memory_service.py tests/assistant/test_memory_summary.py tests/test_assistant_memory_integration.py tests/test_gpt_handlers.py services/api/alembic/versions/20251013_restore_assistant_memory_summary.py`
- `mypy --strict tests/test_gpt_handlers.py tests/test_assistant_memory_integration.py tests/assistant/test_memory_service.py tests/assistant/test_memory_summary.py services/api/app/assistant/models.py services/api/app/assistant/repositories/memory.py services/api/app/assistant/services/memory_service.py services/api/app/diabetes/handlers/gpt_handlers.py services/api/alembic/versions/20251013_restore_assistant_memory_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdb73cc30c832a9c522af84c950ef5