### PR TITLE
[handlers] Compile learn button pattern

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -37,11 +37,11 @@ from ..utils.ui import (
 from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
 
 OLD_LEARN_BUTTON_TEXT = "🎓 Обучение"
-LEARN_BUTTON_ALIASES: tuple[str, str] = (
+LEARN_BUTTON_ALIASES: tuple[str, ...] = (
     LEARN_BUTTON_TEXT,
     OLD_LEARN_BUTTON_TEXT,
 )
-LEARN_BUTTON_PATTERN = (
+LEARN_BUTTON_PATTERN: re.Pattern[str] = re.compile(
     r"^(?:" + "|".join(re.escape(text) for text in LEARN_BUTTON_ALIASES) + r")$"
 )
 

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 import json
-import re
 
 import pytest
 from sqlalchemy import create_engine
@@ -220,7 +219,7 @@ async def test_on_learn_button_calls_learn(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_learn_button_texts_match_pattern() -> None:
-    assert re.fullmatch(registration.LEARN_BUTTON_PATTERN, LEARN_BUTTON_TEXT)
-    assert re.fullmatch(
-        registration.LEARN_BUTTON_PATTERN, registration.OLD_LEARN_BUTTON_TEXT
+    assert registration.LEARN_BUTTON_PATTERN.fullmatch(LEARN_BUTTON_TEXT)
+    assert registration.LEARN_BUTTON_PATTERN.fullmatch(
+        registration.OLD_LEARN_BUTTON_TEXT
     )


### PR DESCRIPTION
## Summary
- Compile LEARN_BUTTON_PATTERN to a regex Pattern and include both old and new button texts
- Update learn command tests to use the compiled pattern

## Testing
- `PYTHONPATH=. pytest -q --cov --import-mode=importlib` *(fails: Database engine is not initialized; ModuleNotFoundError: No module named 'trio')*
- `mypy --strict tests/test_learn_command.py services/api/app/diabetes/handlers/registration.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdb9420c80832aadfbbab4d7e91701