### PR TITLE
tests: namespace assistant and learning packages

### DIFF
--- a/tests/assistant/__init__.py
+++ b/tests/assistant/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for assistant tests."""

--- a/tests/learning/__init__.py
+++ b/tests/learning/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for learning tests."""


### PR DESCRIPTION
## Summary
- mark `tests.assistant` and `tests.learning` as packages to avoid test name collisions

## Testing
- `pytest --collect-only`
- `pytest -q --cov` *(fails: async def functions are not natively supported; ModuleNotFoundError for trio)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdba082ed0832aae66c20c44415011