### PR TITLE
[docs] document assistant flags

### DIFF
--- a/docs/learn_mode.md
+++ b/docs/learn_mode.md
@@ -14,6 +14,16 @@
 LEARNING_MODE_ENABLED=true
 ```
 
+## Флаги ассистента
+
+| Флаг | Значение по умолчанию | Описание |
+| --- | --- | --- |
+| `ASSISTANT_MODE_ENABLED` | `true` | включает режим ассистента |
+| `LEARNING_PLANNER_MODEL` | `gpt-4o-mini` | модель построения плана урока |
+| `ASSISTANT_MAX_TURNS` | `16` | число сообщений, хранящихся в истории |
+| `ASSISTANT_SUMMARY_TRIGGER` | `12` | после стольких сообщений создаётся сводка |
+| `LEARNING_PROMPT_CACHE_TTL_SEC` | `28800` | время жизни кэша промптов, сек |
+
 ## Подготовка базы данных
 
 ```bash

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -67,18 +67,34 @@ class Settings(BaseSettings):
     openai_assistant_id: Optional[str] = Field(default=None, alias="OPENAI_ASSISTANT_ID")
     openai_command_model: str = Field(default="gpt-4o-mini", alias="OPENAI_COMMAND_MODEL")
     api_key_min_length: int = Field(default=32, alias="API_KEY_MIN_LENGTH")
-    assistant_mode_enabled: bool = Field(default=True, alias="ASSISTANT_MODE_ENABLED")
+    assistant_mode_enabled: bool = Field(
+        default=True,
+        alias="ASSISTANT_MODE_ENABLED",
+        description="Enable assistant mode",
+    )
     learning_mode_enabled: bool = Field(
         default=True,
         alias="LEARNING_MODE_ENABLED",
         validation_alias=AliasChoices("LEARNING_MODE_ENABLED", "LEARNING_ENABLED"),
     )
-    assistant_max_turns: int = Field(default=16, alias="ASSISTANT_MAX_TURNS")
-    assistant_summary_trigger: int = Field(default=12, alias="ASSISTANT_SUMMARY_TRIGGER")
+    assistant_max_turns: int = Field(
+        default=16,
+        alias="ASSISTANT_MAX_TURNS",
+        description="Max turns kept in memory",
+    )
+    assistant_summary_trigger: int = Field(
+        default=12,
+        alias="ASSISTANT_SUMMARY_TRIGGER",
+        description="Turns before conversation is summarized",
+    )
     learning_model_default: str = Field(default="gpt-4o-mini", alias="LEARNING_MODEL_DEFAULT")
     learning_prompt_cache: bool = Field(default=True, alias="LEARNING_PROMPT_CACHE")
     learning_prompt_cache_size: int = Field(default=128, alias="LEARNING_PROMPT_CACHE_SIZE")
-    learning_prompt_cache_ttl_sec: int = Field(default=28800, alias="LEARNING_PROMPT_CACHE_TTL_SEC")
+    learning_prompt_cache_ttl_sec: int = Field(
+        default=28800,
+        alias="LEARNING_PROMPT_CACHE_TTL_SEC",
+        description="TTL of prompt cache in seconds",
+    )
     learning_content_mode: Literal["dynamic", "static"] = Field(default="dynamic", alias="LEARNING_CONTENT_MODE")
     learning_ui_show_topics: bool = Field(default=False, alias="LEARNING_UI_SHOW_TOPICS")
     learning_logging_required: bool = Field(default=False, alias="LEARNING_LOGGING_REQUIRED")
@@ -87,7 +103,11 @@ class Settings(BaseSettings):
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
     learning_assistant_id: Optional[str] = Field(default=None, alias="LEARNING_ASSISTANT_ID")
     learning_command_model: str = Field(default="gpt-4o-mini", alias="LEARNING_COMMAND_MODEL")
-    learning_planner_model: str = Field(default="gpt-4o-mini", alias="LEARNING_PLANNER_MODEL")
+    learning_planner_model: str = Field(
+        default="gpt-4o-mini",
+        alias="LEARNING_PLANNER_MODEL",
+        description="Model used for lesson planning",
+    )
     font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
     onboarding_video_url: Optional[str] = Field(default=None, alias="ONBOARDING_VIDEO_URL")
     telegram_token: Optional[str] = Field(default=None, alias="TELEGRAM_TOKEN")


### PR DESCRIPTION
## Summary
- describe assistant-related environment flags in config
- add table of assistant flags with defaults to learning mode docs

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: async plugin missing)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdbd4fe940832a95e76c07f8ddbfce