### PR TITLE
[tests] add helpers for telegram stubs

### DIFF
--- a/tests/diabetes/test_curriculum_busy.py
+++ b/tests/diabetes/test_curriculum_busy.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from typing import Any, Mapping, cast
+from typing import Any, Mapping
 
 import pytest
 
@@ -8,6 +8,7 @@ from services.api.app.diabetes import learning_handlers as dynamic_handlers
 from services.api.app.diabetes.dynamic_tutor import BUSY_MESSAGE
 from services.api.app.diabetes.handlers import learning_handlers as legacy_handlers
 from services.api.app.diabetes.learning_state import get_state
+from tests.utils.telegram import make_context, make_update
 
 
 class DummyMessage:
@@ -65,10 +66,8 @@ async def test_dynamic_learn_command_busy(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fail_add_log)
 
     msg = DummyMessage()
-    update = cast(
-        object, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=7))
-    )
-    context = SimpleNamespace(user_data={})
+    update = make_update(message=msg)
+    context = make_context(user_data={})
 
     await dynamic_handlers.learn_command(update, context)
 
@@ -97,10 +96,8 @@ async def test_legacy_lesson_command_busy(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(legacy_handlers, "ensure_overrides", fake_ensure_overrides)
 
     msg = DummyMessage()
-    update = cast(
-        object, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=7))
-    )
-    context = SimpleNamespace(user_data={}, args=["slug"])
+    update = make_update(message=msg)
+    context = make_context(user_data={}, args=["slug"])
 
     await legacy_handlers.lesson_command(update, context)
 

--- a/tests/learning/test_handlers_rate_limit.py
+++ b/tests/learning/test_handlers_rate_limit.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
 import pytest
 
 from services.api.app.config import settings
 from services.api.app.diabetes import learning_handlers
 from services.api.app.diabetes.learning_state import LearnState
+from tests.utils.telegram import make_context, make_update
 
 
 class DummyMessage:
@@ -16,7 +17,9 @@ class DummyMessage:
         self.replies: list[str] = []
         self.from_user = SimpleNamespace(id=1)
 
-    async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - helper
+    async def reply_text(
+        self, text: str, **kwargs: Any
+    ) -> None:  # pragma: no cover - helper
         self.replies.append(text)
 
 
@@ -34,20 +37,30 @@ class DummyCallback:
 async def test_lesson_callback_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
-    async def fake_generate_step_text(profile: object, topic: str, step_idx: int, prev: object) -> str:
+    async def fake_generate_step_text(
+        profile: object, topic: str, step_idx: int, prev: object
+    ) -> str:
         return "step1"
 
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fake_generate_step_text
+    )
     monkeypatch.setattr(learning_handlers, "TOPICS_RU", {"slug": "Topic"})
 
     async def fake_start_lesson(user_id: int, topic_slug: str) -> object:
         return SimpleNamespace(lesson_id=1)
 
-    async def fake_next_step(user_id: int, lesson_id: int, profile: object) -> tuple[str, object | None]:
+    async def fake_next_step(
+        user_id: int, lesson_id: int, profile: object
+    ) -> tuple[str, object | None]:
         return "step1", None
 
-    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
-    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
+    )
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "next_step", fake_next_step
+    )
     monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
 
     times = iter([0.0, 1.0])
@@ -64,15 +77,15 @@ async def test_lesson_callback_rate_limit(monkeypatch: pytest.MonkeyPatch) -> No
 
     msg1 = DummyMessage()
     callback1 = DummyCallback(msg1, "lesson:slug")
-    update1 = cast(object, SimpleNamespace(callback_query=callback1))
-    context1 = SimpleNamespace(user_data=user_data)
+    update1 = make_update(callback_query=callback1)
+    context1 = make_context(user_data=user_data)
     await learning_handlers.lesson_callback(update1, context1)
     assert msg1.replies == ["step1"]
 
     msg2 = DummyMessage()
     callback2 = DummyCallback(msg2, "lesson:slug")
-    update2 = cast(object, SimpleNamespace(callback_query=callback2))
-    context2 = SimpleNamespace(user_data=user_data)
+    update2 = make_update(callback_query=callback2)
+    context2 = make_context(user_data=user_data)
     await learning_handlers.lesson_callback(update2, context2)
     assert msg2.replies == [learning_handlers.RATE_LIMIT_MESSAGE]
 
@@ -81,14 +94,20 @@ async def test_lesson_callback_rate_limit(monkeypatch: pytest.MonkeyPatch) -> No
 async def test_lesson_answer_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
-    async def fake_check_user_answer(profile: object, topic: str, answer: str, last: str) -> tuple[bool, str]:
+    async def fake_check_user_answer(
+        profile: object, topic: str, answer: str, last: str
+    ) -> tuple[bool, str]:
         return True, "feedback"
 
-    async def fake_generate_step_text(profile: object, topic: str, step_idx: int, prev: object) -> str:
+    async def fake_generate_step_text(
+        profile: object, topic: str, step_idx: int, prev: object
+    ) -> str:
         return "next"
 
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fake_generate_step_text
+    )
 
     times = iter([0.0, 1.0])
 
@@ -103,11 +122,17 @@ async def test_lesson_answer_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None
     async def fake_start_lesson2(user_id: int, topic_slug: str) -> object:
         return SimpleNamespace(lesson_id=1)
 
-    async def fake_next_step2(user_id: int, lesson_id: int, profile: object) -> tuple[str, object | None]:
+    async def fake_next_step2(
+        user_id: int, lesson_id: int, profile: object
+    ) -> tuple[str, object | None]:
         return "next", None
 
-    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson2)
-    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step2)
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson2
+    )
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "next_step", fake_next_step2
+    )
     monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
 
     user_data: dict[str, object] = {}
@@ -117,13 +142,13 @@ async def test_lesson_answer_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None
     )
 
     msg1 = DummyMessage(text="a1")
-    update1 = cast(object, SimpleNamespace(message=msg1))
-    context1 = SimpleNamespace(user_data=user_data)
+    update1 = make_update(message=msg1)
+    context1 = make_context(user_data=user_data)
     await learning_handlers.lesson_answer_handler(update1, context1)
     assert msg1.replies == ["feedback", "next"]
 
     msg2 = DummyMessage(text="a2")
-    update2 = cast(object, SimpleNamespace(message=msg2))
-    context2 = SimpleNamespace(user_data=user_data)
+    update2 = make_update(message=msg2)
+    context2 = make_context(user_data=user_data)
     await learning_handlers.lesson_answer_handler(update2, context2)
     assert msg2.replies == [learning_handlers.RATE_LIMIT_MESSAGE]

--- a/tests/learning/test_on_any_text.py
+++ b/tests/learning/test_on_any_text.py
@@ -2,6 +2,8 @@ import pytest
 from types import SimpleNamespace
 from typing import Any, Mapping
 
+from tests.utils.telegram import make_context, make_update
+
 from services.api.app.config import settings
 from services.api.app.diabetes import learning_handlers
 from services.api.app.diabetes.learning_state import LearnState, set_state
@@ -22,7 +24,9 @@ class DummyMessage:
 async def test_on_any_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
     user_data: dict[str, object] = {}
-    set_state(user_data, LearnState(topic="t", step=1, awaiting=True, last_step_text="q"))
+    set_state(
+        user_data, LearnState(topic="t", step=1, awaiting=True, last_step_text="q")
+    )
     called = False
 
     async def fake_check_user_answer(
@@ -40,7 +44,9 @@ async def test_on_any_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
         return "next"
 
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fake_generate_step_text
+    )
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -49,8 +55,8 @@ async def test_on_any_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     msg = DummyMessage("ans")
-    update = SimpleNamespace(message=msg)
-    context = SimpleNamespace(user_data=user_data)
+    update = make_update(message=msg)
+    context = make_context(user_data=user_data)
 
     with pytest.raises(ApplicationHandlerStop):
         await learning_handlers.on_any_text(update, context)
@@ -80,21 +86,25 @@ async def test_on_any_text_idontknow(monkeypatch: pytest.MonkeyPatch) -> None:
         assert prev == "fb"
         return "next"
 
-    async def fake_check_user_answer(*args: object, **kwargs: object) -> tuple[bool, str]:
+    async def fake_check_user_answer(
+        *args: object, **kwargs: object
+    ) -> tuple[bool, str]:
         raise AssertionError("should not be called")
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 
     monkeypatch.setattr(learning_handlers, "assistant_chat", fake_assistant_chat)
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fake_generate_step_text
+    )
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     msg = DummyMessage("Не знаю")
-    update = SimpleNamespace(message=msg)
-    context = SimpleNamespace(user_data=user_data)
+    update = make_update(message=msg)
+    context = make_context(user_data=user_data)
 
     with pytest.raises(ApplicationHandlerStop):
         await learning_handlers.on_any_text(update, context)
@@ -114,7 +124,9 @@ async def test_on_any_text_general(monkeypatch: pytest.MonkeyPatch) -> None:
         assert text == "hello"
         return "reply"
 
-    async def fake_check_user_answer(*args: object, **kwargs: object) -> tuple[bool, str]:
+    async def fake_check_user_answer(
+        *args: object, **kwargs: object
+    ) -> tuple[bool, str]:
         raise AssertionError("should not be called")
 
     monkeypatch.setattr(learning_handlers, "assistant_chat", fake_assistant_chat)
@@ -122,8 +134,8 @@ async def test_on_any_text_general(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     msg = DummyMessage("hello")
-    update = SimpleNamespace(message=msg)
-    context = SimpleNamespace(user_data=user_data)
+    update = make_update(message=msg)
+    context = make_context(user_data=user_data)
 
     with pytest.raises(ApplicationHandlerStop):
         await learning_handlers.on_any_text(update, context)

--- a/tests/utils/telegram.py
+++ b/tests/utils/telegram.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+
+def make_update(**kwargs: Any) -> object:
+    """Create update stub with mandatory effective_user."""
+    return cast(object, SimpleNamespace(effective_user=SimpleNamespace(id=1), **kwargs))
+
+
+def make_context(
+    *, user_data: dict[str, object] | None = None, **kwargs: Any
+) -> object:
+    """Create context stub with mandatory bot_data."""
+    return SimpleNamespace(user_data=user_data or {}, bot_data={}, **kwargs)


### PR DESCRIPTION
## Summary
- add `make_update` and `make_context` helpers for tests
- refactor learning and curriculum tests to use helpers instead of `SimpleNamespace`

## Testing
- `pytest tests/diabetes/test_curriculum_busy.py tests/learning/test_handlers_rate_limit.py tests/learning/test_on_any_text.py -q` *(fails: async def functions are not natively supported)*
- `ruff check .`
- `mypy --strict .`


------
https://chatgpt.com/codex/tasks/task_e_68bdbedd1a68832a83c43536c5e65fe2