### PR TITLE
tests: fix async patch in double click test

### DIFF
--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -358,7 +358,10 @@ async def test_lesson_answer_double_click(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(
         learning_handlers, "generate_step_text", fake_generate_step_text
     )
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", lambda *a, **k: None)
+    async def fake_add_log(*args: object, **kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     user_data: dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- fix lesson answer double-click test by replacing sync lambda patch with async stub

## Testing
- `pytest tests/diabetes/test_learning_chat_handlers.py::test_lesson_answer_double_click -q`
- `pytest -q --cov --maxfail=1` *(fails: sqlalchemy.exc.IntegrityError: FOREIGN KEY constraint failed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdbede88c4832a807e385b8a02cb5e