### PR TITLE
[learning] Fix cascade delete and rate limit test context

### DIFF
--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -16,7 +16,11 @@ class LearningPlan(Base):
     __table_args__ = (sa.Index("ix_learning_plans_user_id_is_active", "user_id", "is_active"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), nullable=False)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.telegram_id", ondelete="CASCADE"),
+        nullable=False,
+    )
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.true())
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     plan_json: Mapped[dict[str, Any]] = mapped_column(sa.JSON().with_variant(JSONB, "postgresql"), nullable=False)

--- a/tests/utils/telegram.py
+++ b/tests/utils/telegram.py
@@ -13,4 +13,8 @@ def make_context(
     *, user_data: dict[str, object] | None = None, **kwargs: Any
 ) -> object:
     """Create context stub with mandatory bot_data."""
-    return SimpleNamespace(user_data=user_data or {}, bot_data={}, **kwargs)
+    return SimpleNamespace(
+        user_data=user_data if user_data is not None else {},
+        bot_data={},
+        **kwargs,
+    )


### PR DESCRIPTION
## Summary
- cascade delete learning plans on user removal
- fix test context helper to retain provided user_data

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdc23efa78832ab926712cb57c47a7