### PR TITLE
[alembic] Rename merge heads revision file

### DIFF
--- a/services/api/alembic/versions/20250904_merge_heads.py
+++ b/services/api/alembic/versions/20250904_merge_heads.py
@@ -1,10 +1,11 @@
 """merge heads
 
-Revision ID: 11eb7c3deda6
+Revision ID: 20250904_merge_heads
 Revises: 20251002_billing_event_lowercase, 20251002_subscription_plan_values_callable
 Create Date: 2025-09-04 19:44:43.266143
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -12,8 +13,11 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '11eb7c3deda6'
-down_revision: Union[str, None] = ('20251002_billing_event_lowercase', '20251002_subscription_plan_values_callable')
+revision: str = "20250904_merge_heads"
+down_revision: Union[str, None] = (
+    "20251002_billing_event_lowercase",
+    "20251002_subscription_plan_values_callable",
+)
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20251011_merge_heads.py
+++ b/services/api/alembic/versions/20251011_merge_heads.py
@@ -1,10 +1,11 @@
 """merge heads
 
 Revision ID: 20251011_merge_heads
-Revises: 11eb7c3deda6, 20251010_lesson_logs_user_plan_index
+Revises: 20250904_merge_heads, 20251010_lesson_logs_user_plan_index
 Create Date: 2025-09-07 15:17:50.994294
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -12,8 +13,11 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '20251011_merge_heads'
-down_revision: Union[str, None] = ('11eb7c3deda6', '20251010_lesson_logs_user_plan_index')
+revision: str = "20251011_merge_heads"
+down_revision: Union[str, None] = (
+    "20250904_merge_heads",
+    "20251010_lesson_logs_user_plan_index",
+)
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- rename Alembic merge-heads file to date-based name
- update revision id and downstream migration references

## Testing
- `ruff check .`
- `mypy --strict .` *(interrupted)*
- `mypy --strict services/api/alembic/versions/20250904_merge_heads.py services/api/alembic/versions/20251011_merge_heads.py`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc5d831bc832aa68d343a9c8a35e5