### PR TITLE
tests: use timezone aware datetime

### DIFF
--- a/scripts/diag_reminders.sh
+++ b/scripts/diag_reminders.sh
@@ -113,7 +113,7 @@ BOT_TOKEN="${BOT_TOKEN:-${TELEGRAM_BOT_TOKEN:-}}"
 if [ -n "$BOT_TOKEN" ]; then
   "$PY" - <<PY
 import asyncio, os, sys
-from datetime import datetime
+from datetime import datetime, UTC
 try:
     from telegram import Bot
 except Exception as e:
@@ -123,7 +123,7 @@ token=os.environ.get("BOT_TOKEN") or os.environ.get("TELEGRAM_BOT_TOKEN")
 chat_id=int("${TG_ID}")
 async def main():
     bot=Bot(token=token)
-    txt=f"Диагностика: бот доступен ✅ (UTC={datetime.utcnow():%Y-%m-%d %H:%M:%S})"
+    txt=f"Диагностика: бот доступен ✅ (UTC={datetime.now(UTC):%Y-%m-%d %H:%M:%S})"
     await bot.send_message(chat_id=chat_id, text=txt)
 asyncio.run(main())
 print(">> Сообщение диагностики отправлено (если токен и чат корректны).")

--- a/tests/test_entry_indexes.py
+++ b/tests/test_entry_indexes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Any
 
 import sqlalchemy as sa
@@ -35,7 +35,7 @@ def test_entry_indexes_usage() -> None:
     with SessionLocal() as session:
         session.add(db.User(telegram_id=1, thread_id="t"))
         session.flush()
-        session.add(db.Entry(telegram_id=1, event_time=datetime.utcnow()))
+        session.add(db.Entry(telegram_id=1, event_time=datetime.now(UTC)))
         session.commit()
 
         plan_tg = session.execute(

--- a/tests/test_onboarding_metrics_indexes.py
+++ b/tests/test_onboarding_metrics_indexes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, UTC
 from typing import Any
 
 import sqlalchemy as sa
@@ -40,7 +40,7 @@ def test_onboarding_events_metrics_index_exists() -> None:
             OnboardingMetricEvent(
                 variant="v1",
                 step="s1",
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(UTC),
             )
         )
         session.commit()


### PR DESCRIPTION
## Summary
- use timezone-aware datetime.now(UTC) in index tests
- adjust diagnostic reminder script to UTC aware datetime

## Testing
- `pytest -q tests/test_entry_indexes.py tests/test_onboarding_metrics_indexes.py --cov=tests.test_entry_indexes --cov=tests.test_onboarding_metrics_indexes --cov-fail-under=85`
- `mypy --strict tests/test_entry_indexes.py tests/test_onboarding_metrics_indexes.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdc5b9976c832a90c022385d77782e