### PR TITLE
[alembic] Prefix merge heads with creation date

### DIFF
--- a/services/api/alembic/versions/20250904_merge_heads.py
+++ b/services/api/alembic/versions/20250904_merge_heads.py
@@ -1,6 +1,6 @@
 """merge heads
 
-Revision ID: 3539fae8f7b6_merge_heads
+Revision ID: 20250904_merge_heads
 Revises: 20250919_onboarding_events_user_fk, 20250920_onboarding_state_ondelete_cascade, 20251001_onboarding_metrics_indexes
 Create Date: 2025-09-04 17:54:48.210001
 
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = "3539fae8f7b6_merge_heads"
+revision: str = "20250904_merge_heads"
 down_revision: Union[str, None] = (
     "20250919_onboarding_events_user_fk",
     "20250920_onboarding_state_ondelete_cascade",

--- a/services/api/alembic/versions/20251002_billing_event_lowercase.py
+++ b/services/api/alembic/versions/20251002_billing_event_lowercase.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 revision: str = "20251002_billing_event_lowercase"
-down_revision: Union[str, Sequence[str], None] = "3539fae8f7b6_merge_heads"
+down_revision: Union[str, Sequence[str], None] = "20250904_merge_heads"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20251002_subscription_plan_values_callable.py
+++ b/services/api/alembic/versions/20251002_subscription_plan_values_callable.py
@@ -1,7 +1,7 @@
 """20251002_subscription_plan_values_callable
 
 Revision ID: 20251002_subscription_plan_values_callable
-Revises: 3539fae8f7b6_merge_heads
+Revises: 20250904_merge_heads
 Create Date: 2025-09-04 19:03:02.753378
 
 """
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "20251002_subscription_plan_values_callable"
-down_revision: Union[str, None] = "3539fae8f7b6_merge_heads"
+down_revision: Union[str, None] = "20250904_merge_heads"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20251003_onboarding_event.py
+++ b/services/api/alembic/versions/20251003_onboarding_event.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 
 
 revision: str = "20251003_onboarding_event"
-down_revision: Union[str, Sequence[str], None] = "3539fae8f7b6_merge_heads"
+down_revision: Union[str, Sequence[str], None] = "20250904_merge_heads"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20251009_lesson_logs_plan_fk.py
+++ b/services/api/alembic/versions/20251009_lesson_logs_plan_fk.py
@@ -4,7 +4,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "20251009_lesson_logs_plan_fk"
-down_revision: Union[str, Sequence[str], None] = "3539fae8f7b6_merge_heads"
+down_revision: Union[str, Sequence[str], None] = "20250904_merge_heads"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- rename 3539fae8f7b6_merge_heads to 20250904_merge_heads and align revision id
- update migrations referencing the renamed merge heads revision

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported; ModuleNotFoundError: No module named 'trio')*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdc5da953c832a93da50965fea6641