### PR TITLE
[learning] Support list-based plan_json

### DIFF
--- a/services/api/app/assistant/repositories/plans.py
+++ b/services/api/app/assistant/repositories/plans.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
@@ -14,7 +14,7 @@ from ...types import SessionProtocol
 async def create_plan(
     user_id: int,
     version: int,
-    plan_json: dict[str, Any],
+    plan_json: list[str],
     *,
     is_active: bool = True,
 ) -> int:
@@ -86,7 +86,7 @@ async def list_plans(user_id: int) -> list[LearningPlan]:
 async def update_plan(
     plan_id: int,
     *,
-    plan_json: dict[str, Any] | None = None,
+    plan_json: list[str] | None = None,
     is_active: bool | None = None,
     version: int | None = None,
 ) -> None:

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -23,7 +23,9 @@ class LearningPlan(Base):
     )
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.true())
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
-    plan_json: Mapped[dict[str, Any]] = mapped_column(sa.JSON().with_variant(JSONB, "postgresql"), nullable=False)
+    plan_json: Mapped[list[str]] = mapped_column(
+        sa.JSON().with_variant(JSONB, "postgresql"), nullable=False
+    )
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False)
     updated_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), onupdate=sa.func.now())
 

--- a/tests/assistant/test_lesson_log_cascade.py
+++ b/tests/assistant/test_lesson_log_cascade.py
@@ -35,7 +35,7 @@ def test_lesson_logs_deleted_with_user(session_factory: sessionmaker[Session]) -
         user = db.User(telegram_id=1, thread_id="")
         session.add(user)
         session.flush()
-        plan = LearningPlan(user_id=1, version=1, plan_json={})
+        plan = LearningPlan(user_id=1, version=1, plan_json=[])
         session.add(plan)
         session.flush()
         session.add(

--- a/tests/assistant/test_lesson_logs.py
+++ b/tests/assistant/test_lesson_logs.py
@@ -45,7 +45,7 @@ async def test_add_and_flush_logs(
     with session_factory() as session:
         session.add(db.User(telegram_id=1, thread_id="t"))
         session.add(
-            LearningPlan(id=1, user_id=1, plan_json={}, is_active=True, version=1)
+            LearningPlan(id=1, user_id=1, plan_json=[], is_active=True, version=1)
         )
         session.commit()
 
@@ -77,7 +77,7 @@ async def test_cleanup_old_logs(session_factory: sessionmaker[Session]) -> None:
     with session_factory() as session:
         session.add(db.User(telegram_id=1, thread_id="t"))
         session.add(
-            LearningPlan(id=1, user_id=1, plan_json={}, is_active=True, version=1)
+            LearningPlan(id=1, user_id=1, plan_json=[], is_active=True, version=1)
         )
         session.flush()
         session.add(

--- a/tests/assistant/test_plans_repo.py
+++ b/tests/assistant/test_plans_repo.py
@@ -34,13 +34,13 @@ async def test_create_and_get(session_local: sessionmaker[Session]) -> None:
     with session_local() as session:
         session.add(db.User(telegram_id=1, thread_id=""))
         session.commit()
-    plan_id = await plans.create_plan(1, version=1, plan_json={"a": 1})
+    plan_id = await plans.create_plan(1, version=1, plan_json=["a"])
     assert plan_id > 0
     fetched = await plans.get_plan(plan_id)
     assert fetched is not None
     assert fetched.user_id == 1
     assert fetched.version == 1
-    assert fetched.plan_json == {"a": 1}
+    assert fetched.plan_json == ["a"]
 
 
 @pytest.mark.asyncio
@@ -48,8 +48,8 @@ async def test_get_active(session_local: sessionmaker[Session]) -> None:
     with session_local() as session:
         session.add(db.User(telegram_id=1, thread_id=""))
         session.commit()
-    await plans.create_plan(1, version=1, plan_json={}, is_active=False)
-    active_id = await plans.create_plan(1, version=2, plan_json={})
+    await plans.create_plan(1, version=1, plan_json=[], is_active=False)
+    active_id = await plans.create_plan(1, version=2, plan_json=[])
     active = await plans.get_active_plan(1)
     assert active is not None
     assert active.id == active_id
@@ -60,12 +60,12 @@ async def test_update_delete_and_list(session_local: sessionmaker[Session]) -> N
     with session_local() as session:
         session.add(db.User(telegram_id=2, thread_id=""))
         session.commit()
-    plan_id1 = await plans.create_plan(2, version=1, plan_json={"x": 1})
-    plan_id2 = await plans.create_plan(2, version=2, plan_json={"y": 1})
-    await plans.update_plan(plan_id1, plan_json={"x": 2}, is_active=False)
+    plan_id1 = await plans.create_plan(2, version=1, plan_json=["x1"])
+    plan_id2 = await plans.create_plan(2, version=2, plan_json=["y1"])
+    await plans.update_plan(plan_id1, plan_json=["x2"], is_active=False)
     updated = await plans.get_plan(plan_id1)
     assert updated is not None
-    assert updated.plan_json == {"x": 2}
+    assert updated.plan_json == ["x2"]
     assert updated.is_active is False
     plans_list = await plans.list_plans(2)
     assert {p.id for p in plans_list} == {plan_id1, plan_id2}
@@ -78,7 +78,7 @@ async def test_deactivate_plan(session_local: sessionmaker[Session]) -> None:
     with session_local() as session:
         session.add(db.User(telegram_id=3, thread_id=""))
         session.commit()
-    plan_id = await plans.create_plan(3, version=1, plan_json={})
+    plan_id = await plans.create_plan(3, version=1, plan_json=[])
     await plans.deactivate_plan(3, plan_id)
     plan = await plans.get_plan(plan_id)
     assert plan is not None
@@ -92,8 +92,8 @@ async def test_create_plan_deactivates_previous_active(
     with session_local() as session:
         session.add(db.User(telegram_id=4, thread_id=""))
         session.commit()
-    first_id = await plans.create_plan(4, version=1, plan_json={})
-    second_id = await plans.create_plan(4, version=2, plan_json={})
+    first_id = await plans.create_plan(4, version=1, plan_json=[])
+    second_id = await plans.create_plan(4, version=2, plan_json=[])
     first = await plans.get_plan(first_id)
     second = await plans.get_plan(second_id)
     assert first is not None and first.is_active is False

--- a/tests/assistant/test_progress_repo.py
+++ b/tests/assistant/test_progress_repo.py
@@ -34,7 +34,7 @@ def session_local(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
 async def test_get_and_upsert(session_local: sessionmaker[Session]) -> None:
     with session_local() as session:
         session.add(db.User(telegram_id=1, thread_id=""))
-        plan = LearningPlan(user_id=1, version=1, plan_json={})
+        plan = LearningPlan(user_id=1, version=1, plan_json=[])
         session.add(plan)
         session.commit()
         plan_id = plan.id

--- a/tests/diabetes/test_learning_onboarding.py
+++ b/tests/diabetes/test_learning_onboarding.py
@@ -248,7 +248,7 @@ async def test_learn_reset_deactivates_plan(
         with SessionLocal() as session:
             session.add(db.User(telegram_id=5, thread_id=""))
             session.commit()
-        plan_id = await plans.create_plan(5, version=1, plan_json={})
+        plan_id = await plans.create_plan(5, version=1, plan_json=[])
         message = DummyMessage()
         update = cast(
             Update,


### PR DESCRIPTION
## Summary
- store learning plans as list-based JSON
- persist plans without unsafe casts
- adjust tests for list-based plans

## Testing
- `python -m pytest -q --cov` *(fails: async def functions are not natively supported, ModuleNotFoundError)*
- `mypy --strict services/api/app/diabetes`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdc695b510832aa9413623721bb4f5