### PR TITLE
[learning] tighten novice level detection

### DIFF
--- a/services/api/app/diabetes/learning_utils.py
+++ b/services/api/app/diabetes/learning_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Mapping
 
-NOVICE_LEVELS = {"novice", "beginner", "a"}
+NOVICE_LEVELS = {"novice", "beginner"}
 INSULIN_THERAPIES = {"insulin", "mixed"}
 
 __all__ = ["choose_initial_topic"]

--- a/tests/learning/test_choose_initial_topic.py
+++ b/tests/learning/test_choose_initial_topic.py
@@ -13,6 +13,11 @@ def test_choose_initial_topic_novice_non_insulin() -> None:
     assert choose_initial_topic(profile) == ("basics-of-diabetes", "Основы диабета")
 
 
+def test_choose_initial_topic_beginner_insulin() -> None:
+    profile = {"learning_level": "beginner", "therapyType": "insulin"}
+    assert choose_initial_topic(profile) == ("insulin-usage", "Инсулин")
+
+
 def test_choose_initial_topic_non_novice_insulin() -> None:
     profile = {"learning_level": "expert", "therapyType": "insulin"}
     assert choose_initial_topic(profile) == ("xe_basics", "Хлебные единицы")
@@ -21,3 +26,8 @@ def test_choose_initial_topic_non_novice_insulin() -> None:
 def test_choose_initial_topic_non_novice_non_insulin() -> None:
     profile = {"learning_level": "expert", "therapyType": "none"}
     assert choose_initial_topic(profile) == ("healthy-eating", "Здоровое питание")
+
+
+def test_choose_initial_topic_invalid_novice_level() -> None:
+    profile = {"learning_level": "a", "therapyType": "insulin"}
+    assert choose_initial_topic(profile) == ("xe_basics", "Хлебные единицы")


### PR DESCRIPTION
## Summary
- remove stray `"a"` value from `NOVICE_LEVELS`
- ensure `choose_initial_topic` treats only `novice` and `beginner` as novice levels

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/learning/test_choose_initial_topic.py --cov=services.api.app.diabetes.learning_utils --cov-fail-under=85 -q`
- `pytest --cov --cov-fail-under=85` *(fails: async fixtures and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc6a8d3ac832aa17c18ca20ef4471