### PR TITLE
[learning] Map 'продвинутый' to expert

### DIFF
--- a/services/api/app/diabetes/learning_onboarding.py
+++ b/services/api/app/diabetes/learning_onboarding.py
@@ -56,7 +56,7 @@ def _norm_level(text: str) -> str | None:
         "новичок": "novice",
         "intermediate": "intermediate",
         "средний": "intermediate",
-        "продвинутый": "intermediate",
+        "продвинутый": "expert",
         "advanced": "expert",
         "expert": "expert",
         "эксперт": "expert",
@@ -118,7 +118,9 @@ _ORDER: list[
                     InlineKeyboardButton(
                         "Средний", callback_data=f"{CB_PREFIX}intermediate"
                     ),
-                    InlineKeyboardButton("Эксперт", callback_data=f"{CB_PREFIX}expert"),
+                    InlineKeyboardButton(
+                        "Продвинутый", callback_data=f"{CB_PREFIX}expert"
+                    ),
                 ]
             ]
         ),

--- a/tests/learning/test_onboarding_normalization.py
+++ b/tests/learning/test_onboarding_normalization.py
@@ -17,3 +17,7 @@ def test_norm_diabetes_type_numeric() -> None:
 
 def test_norm_level_numeric() -> None:
     assert _norm_level("0") == "novice"
+
+
+def test_norm_level_russian_advanced() -> None:
+    assert _norm_level("продвинутый") == "expert"


### PR DESCRIPTION
## Summary
- map Russian "продвинутый" learning level to expert
- show "Продвинутый" label in onboarding keyboard
- cover normalization and ensure_overrides with tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdc6aff1b4832ab45309f8ff5a7cc9