### PR TITLE
[db] cascade delete for user-related data

### DIFF
--- a/services/api/alembic/versions/20251014_user_profile_ondelete_cascade.py
+++ b/services/api/alembic/versions/20251014_user_profile_ondelete_cascade.py
@@ -1,0 +1,77 @@
+"""user_roles.user_id and profiles.telegram_id ON DELETE CASCADE"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "20251014_user_profile_ondelete_cascade"
+down_revision: Union[str, Sequence[str], None] = (
+    "20251013_restore_assistant_memory_summary"
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.drop_constraint(
+        "user_roles_user_id_fkey",
+        "user_roles",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "user_roles_user_id_fkey",
+        "user_roles",
+        "users",
+        ["user_id"],
+        ["telegram_id"],
+        ondelete="CASCADE",
+    )
+    op.drop_constraint(
+        "profiles_telegram_id_fkey",
+        "profiles",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "profiles_telegram_id_fkey",
+        "profiles",
+        "users",
+        ["telegram_id"],
+        ["telegram_id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.drop_constraint(
+        "user_roles_user_id_fkey",
+        "user_roles",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "user_roles_user_id_fkey",
+        "user_roles",
+        "users",
+        ["user_id"],
+        ["telegram_id"],
+    )
+    op.drop_constraint(
+        "profiles_telegram_id_fkey",
+        "profiles",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "profiles_telegram_id_fkey",
+        "profiles",
+        "users",
+        ["telegram_id"],
+        ["telegram_id"],
+    )

--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -194,7 +194,9 @@ class User(Base):
 class UserRole(Base):
     __tablename__ = "user_roles"
     user_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
+        BigInteger,
+        ForeignKey("users.telegram_id", ondelete="CASCADE"),
+        primary_key=True,
     )
     role: Mapped[str] = mapped_column(String, nullable=False, default="patient")
 
@@ -202,7 +204,9 @@ class UserRole(Base):
 class Profile(Base):
     __tablename__ = "profiles"
     telegram_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("users.telegram_id"), primary_key=True
+        BigInteger,
+        ForeignKey("users.telegram_id", ondelete="CASCADE"),
+        primary_key=True,
     )
     icr: Mapped[Optional[float]] = mapped_column(Float)
     cf: Mapped[Optional[float]] = mapped_column(Float)


### PR DESCRIPTION
## Summary
- cascade delete user roles and profiles when a user is removed
- add migration to apply CASCADE to user_roles and profiles foreign keys

## Testing
- `alembic upgrade head`
- `psql -U diabetes_user -h localhost -d diabetes_bot <<'SQL'
INSERT INTO users (telegram_id) VALUES (1);
INSERT INTO user_roles (user_id, role) VALUES (1, 'patient');
INSERT INTO profiles (telegram_id) VALUES (1);
DELETE FROM users WHERE telegram_id = 1;
SELECT * FROM user_roles;
SELECT * FROM profiles;
SQL`
- `pytest tests/test_services_reminders.py::test_delete_reminder -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdcb0a40d4832a896f480583849f00