### PR TITLE
[migrations] restore 11eb7c3deda6 merge revision

### DIFF
--- a/services/api/alembic/versions/11eb7c3deda6_merge_heads.py
+++ b/services/api/alembic/versions/11eb7c3deda6_merge_heads.py
@@ -1,11 +1,10 @@
 """merge heads
 
-Revision ID: 20250904_merge_heads
+Revision ID: 11eb7c3deda6
 Revises: 20251002_billing_event_lowercase, 20251002_subscription_plan_values_callable
 Create Date: 2025-09-04 19:44:43.266143
 
 """
-
 from typing import Sequence, Union
 
 from alembic import op
@@ -13,11 +12,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = "20250904_merge_heads"
-down_revision: Union[str, None] = (
-    "20251002_billing_event_lowercase",
-    "20251002_subscription_plan_values_callable",
-)
+revision: str = '11eb7c3deda6'
+down_revision: Union[str, None] = ('20251002_billing_event_lowercase', '20251002_subscription_plan_values_callable')
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/api/alembic/versions/20251011_merge_heads.py
+++ b/services/api/alembic/versions/20251011_merge_heads.py
@@ -1,7 +1,7 @@
 """merge heads
 
 Revision ID: 20251011_merge_heads
-Revises: 20250904_merge_heads, 20251010_lesson_logs_user_plan_index
+Revises: 11eb7c3deda6, 20251010_lesson_logs_user_plan_index
 Create Date: 2025-09-07 15:17:50.994294
 
 """
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 # revision identifiers, used by Alembic.
 revision: str = "20251011_merge_heads"
 down_revision: Union[str, None] = (
-    "20250904_merge_heads",
+    "11eb7c3deda6",
     "20251010_lesson_logs_user_plan_index",
 )
 branch_labels: Union[str, Sequence[str], None] = None


### PR DESCRIPTION
## Summary
- restore missing merge revision 11eb7c3deda6
- point 20251011_merge_heads to the restored revision

## Testing
- `make migrate` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdce11c800832a99058d55e9f9853c