### PR TITLE
[alembic] merge onboarding and billing revisions

### DIFF
--- a/services/api/alembic/versions/11eb7c3deda6_merge_onboarding_billing.py
+++ b/services/api/alembic/versions/11eb7c3deda6_merge_onboarding_billing.py
@@ -1,0 +1,30 @@
+"""merge onboarding billing
+
+Revision ID: 11eb7c3deda6_merge_onboarding_billing
+Revises: 20250904_merge_heads, 20251003_onboarding_event
+Create Date: 2025-10-03 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "11eb7c3deda6_merge_onboarding_billing"
+down_revision: Union[str, Sequence[str], None] = (
+    "20250904_merge_heads",
+    "20251003_onboarding_event",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/services/api/alembic/versions/20251004_lesson_logs.py
+++ b/services/api/alembic/versions/20251004_lesson_logs.py
@@ -1,7 +1,7 @@
 """lesson logs table
 
 Revision ID: 20251004_lesson_logs
-Revises: 20251003_onboarding_event
+Revises: 11eb7c3deda6_merge_onboarding_billing
 Create Date: 2025-10-04
 """
 from typing import Sequence, Union
@@ -10,7 +10,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "20251004_lesson_logs"
-down_revision: Union[str, Sequence[str], None] = "20251003_onboarding_event"
+down_revision: Union[str, Sequence[str], None] = "11eb7c3deda6_merge_onboarding_billing"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- add merge revision bridging billing and onboarding heads
- point later migrations to new merge revision

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: Returning Any and missing imports)*
- `DATABASE_URL=sqlite+pysqlite:///:memory: alembic -c services/api/alembic.ini upgrade heads`
- `pytest tests/migrations/ -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdce3f490c832ab365c81e98405de2