### PR TITLE
[alembic] fix merge down revision

### DIFF
--- a/services/api/alembic/versions/11eb7c3deda6_merge_onboarding_billing.py
+++ b/services/api/alembic/versions/11eb7c3deda6_merge_onboarding_billing.py
@@ -1,21 +1,18 @@
 """merge onboarding billing
 
 Revision ID: 11eb7c3deda6_merge_onboarding_billing
-Revises: 20250904_merge_heads, 20251003_onboarding_event
+Revises: 11eb7c3deda6, 20251003_onboarding_event
 Create Date: 2025-10-03 00:00:00.000000
 
 """
 
 from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
 revision: str = "11eb7c3deda6_merge_onboarding_billing"
 down_revision: Union[str, Sequence[str], None] = (
-    "20250904_merge_heads",
+    "11eb7c3deda6",
     "20251003_onboarding_event",
 )
 branch_labels: Union[str, Sequence[str], None] = None


### PR DESCRIPTION
## Summary
- fix merge-onboarding-billing migration revision reference

## Testing
- `ruff check services/api/alembic/versions/11eb7c3deda6_merge_onboarding_billing.py`
- `pytest tests/migrations/test_learning_progress_migration.py tests/migrations/test_upgrade.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdd26e3a18832aa288bcb61d552560