### PR TITLE
[monitoring] persist alert state via shared metric

### DIFF
--- a/services/api/app/diabetes/metrics.py
+++ b/services/api/app/diabetes/metrics.py
@@ -36,6 +36,11 @@ db_down_seconds: Gauge = Gauge(
 lesson_log_failures: Counter = Counter(
     "lesson_log_failures", "Number of failed lesson log flushes",
 )
+lesson_log_failures_last: Gauge = Gauge(
+    "lesson_log_failures_last",
+    "Previously observed lesson_log_failures count",
+    multiprocess_mode="max",
+)
 
 learning_prompt_cache_hit: Counter = Counter(
     "learning_prompt_cache_hit", "Number of learning prompt cache hits",

--- a/tests/test_monitoring_alerts.py
+++ b/tests/test_monitoring_alerts.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -9,6 +13,7 @@ from services.api.app.diabetes.metrics import (
     db_down_seconds,
     get_metric_value,
     lesson_log_failures,
+    lesson_log_failures_last,
 )
 
 
@@ -16,7 +21,7 @@ def setup_function() -> None:
     """Reset metric state before each test."""
     db_down_seconds.set(0)
     lesson_log_failures._value.set(0)  # type: ignore[attr-defined] # noqa: SLF001
-    monitoring._last_lesson_log_failures = 0.0
+    lesson_log_failures_last.set(0)
 
 
 def test_db_down_triggers_notifications(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -59,3 +64,48 @@ def test_lesson_log_failures_triggers_notifications(monkeypatch: pytest.MonkeyPa
 
     assert email.calls == 1
     assert slack.calls == 1
+
+
+def test_lesson_log_failures_shared_across_processes(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["PROMETHEUS_MULTIPROC_DIR"] = str(tmp_path)
+    env.setdefault("PYTHONPATH", os.getcwd())
+    script1 = (
+        "from services.api.app.diabetes.metrics import lesson_log_failures, lesson_log_failures_last\n"
+        "from services.api.app.diabetes.services import monitoring\n"
+        "lesson_log_failures_last.set(0)\n"
+        "lesson_log_failures.inc()\n"
+        "def se(msg: str) -> None:\n    print('alert')\n"
+        "def ss(msg: str) -> None:\n    pass\n"
+        "monitoring.send_email = se\n"
+        "monitoring.send_slack = ss\n"
+        "monitoring.check_alerts(3)\n"
+    )
+    out1 = subprocess.run(
+        [sys.executable, "-c", script1],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert out1.stdout.strip() == "alert"
+
+    script2 = (
+        "from services.api.app.diabetes.metrics import lesson_log_failures\n"
+        "from services.api.app.diabetes.services import monitoring\n"
+        "def se(msg: str) -> None:\n    print('alert')\n"
+        "def ss(msg: str) -> None:\n    pass\n"
+        "monitoring.send_email = se\n"
+        "monitoring.send_slack = ss\n"
+        "monitoring.check_alerts(3)\n"
+        "lesson_log_failures.inc()\n"
+        "monitoring.check_alerts(3)\n"
+    )
+    out2 = subprocess.run(
+        [sys.executable, "-c", script2],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert out2.stdout.strip() == "alert"


### PR DESCRIPTION
## Summary
- track lesson log failures in a shared Prometheus gauge instead of process memory
- monitor alerts by comparing current and last failure counts from the gauge
- add integration test ensuring alert state survives across processes

## Testing
- `pytest -q --maxfail=1`
- `pytest tests/test_monitoring_alerts.py -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdd4dfe150832a9003de35e9255d9f