### PR TITLE
alembic: merge heads

### DIFF
--- a/services/api/alembic/versions/20251015_merge_heads.py
+++ b/services/api/alembic/versions/20251015_merge_heads.py
@@ -1,0 +1,25 @@
+"""merge heads
+
+Revision ID: 20251015_merge_heads
+Revises: 20251014_user_profile_ondelete_cascade, 20251014_user_role_server_default
+Create Date: 2025-09-07 18:55:13.778752
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "20251015_merge_heads"
+down_revision: Union[str, None] = (
+    "20251014_user_profile_ondelete_cascade",
+    "20251014_user_role_server_default",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- merge current Alembic heads

## Testing
- `PYTHONPATH=services/api alembic -c services/api/alembic.ini merge 20251014_user_profile_ondelete_cascade 20251014_user_role_server_default -m "merge heads"`
- `DATABASE_URL=sqlite:///tmp.db make migrate`
- `venv/bin/black services/api/alembic/versions/20251015_merge_heads.py`
- `venv/bin/ruff check services/api/alembic/versions/20251015_merge_heads.py`
- `venv/bin/pytest -q` *(fails: async def functions are not natively supported)*
- `venv/bin/mypy --strict services/api/alembic/versions/20251015_merge_heads.py` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd4edbb18832a9e21d9e90f241a58