### PR TITLE
[alembic] Remove explicit enum creation

### DIFF
--- a/services/api/alembic/versions/20250807_squashed_initial.py
+++ b/services/api/alembic/versions/20250807_squashed_initial.py
@@ -54,12 +54,6 @@ subscription_status_enum = sa.Enum(
 
 
 def upgrade() -> None:
-    bind = op.get_bind()
-    if bind.dialect.name == "postgresql":
-        subscription_plan_enum.create(bind, checkfirst=True)
-        reminder_type_enum.create(bind, checkfirst=True)
-        schedule_kind_enum.create(bind, checkfirst=True)
-        subscription_status_enum.create(bind, checkfirst=True)
 
     op.create_table(
         "users",


### PR DESCRIPTION
## Summary
- avoid manual Enum.create in initial migration
- ensure subscription_plan_enum reused across tables

## Testing
- `PYTHONPATH=../.. DATABASE_URL=postgresql+psycopg2://postgres:postgres@localhost:5432/saharlight alembic upgrade 20250807_squashed_initial`
- `PYTHONPATH=. pytest -q --cov` *(fails: async def functions are not natively supported)*
- `PYTHONPATH=. mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bde174e3a8832a93e27bfb9a43d572