### PR TITLE
[alembic] Fix merge heads revision references

### DIFF
--- a/services/api/alembic/versions/11eb7c3deda6_merge_heads.py
+++ b/services/api/alembic/versions/11eb7c3deda6_merge_heads.py
@@ -1,6 +1,6 @@
 """merge heads
 
-Revision ID: 11eb7c3deda6
+Revision ID: 11eb7c3deda6_merge_heads
 Revises: 20251002_billing_event_lowercase, 20251002_subscription_plan_values_callable
 Create Date: 2025-09-04 19:44:43.266143
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '11eb7c3deda6'
+revision: str = '11eb7c3deda6_merge_heads'
 down_revision: Union[str, None] = ('20251002_billing_event_lowercase', '20251002_subscription_plan_values_callable')
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/services/api/alembic/versions/11eb7c3deda6_merge_onboarding_billing.py
+++ b/services/api/alembic/versions/11eb7c3deda6_merge_onboarding_billing.py
@@ -1,7 +1,7 @@
 """merge onboarding billing
 
 Revision ID: 11eb7c3deda6_merge_onboarding_billing
-Revises: 11eb7c3deda6, 20251003_onboarding_event
+Revises: 11eb7c3deda6_merge_heads, 20251003_onboarding_event
 Create Date: 2025-10-03 00:00:00.000000
 
 """
@@ -12,7 +12,7 @@ from typing import Sequence, Union
 # revision identifiers, used by Alembic.
 revision: str = "11eb7c3deda6_merge_onboarding_billing"
 down_revision: Union[str, Sequence[str], None] = (
-    "11eb7c3deda6",
+    "11eb7c3deda6_merge_heads",
     "20251003_onboarding_event",
 )
 branch_labels: Union[str, Sequence[str], None] = None

--- a/services/api/alembic/versions/20251011_merge_heads.py
+++ b/services/api/alembic/versions/20251011_merge_heads.py
@@ -1,7 +1,7 @@
 """merge heads
 
 Revision ID: 20251011_merge_heads
-Revises: 11eb7c3deda6, 20251010_lesson_logs_user_plan_index
+Revises: 11eb7c3deda6_merge_heads, 20251010_lesson_logs_user_plan_index
 Create Date: 2025-09-07 15:17:50.994294
 
 """
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 # revision identifiers, used by Alembic.
 revision: str = "20251011_merge_heads"
 down_revision: Union[str, None] = (
-    "11eb7c3deda6",
+    "11eb7c3deda6_merge_heads",
     "20251010_lesson_logs_user_plan_index",
 )
 branch_labels: Union[str, Sequence[str], None] = None


### PR DESCRIPTION
## Summary
- ensure merge heads revision ID matches filename
- update migrations to reference new merge head revision

## Testing
- `alembic -c services/api/alembic.ini heads`
- `pytest -q --cov` *(fails: async def functions are not natively supported; ModuleNotFoundError: No module named 'trio')*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bde2c7138c832aa52c2cd9171f4647