### PR TITLE
[learning] Localize age groups

### DIFF
--- a/services/api/app/diabetes/learning_onboarding.py
+++ b/services/api/app/diabetes/learning_onboarding.py
@@ -26,7 +26,9 @@ def _norm_age_group(text: str) -> str | None:
         return "adult"
     mapping = {
         "teen": "teen",
+        "подросток": "teen",
         "adult": "adult",
+        "взрослый": "adult",
         "60+": "60+",
     }
     return mapping.get(t)
@@ -87,8 +89,8 @@ _ORDER: list[
         InlineKeyboardMarkup(
             [
                 [
-                    InlineKeyboardButton("teen", callback_data=f"{CB_PREFIX}teen"),
-                    InlineKeyboardButton("adult", callback_data=f"{CB_PREFIX}adult"),
+                    InlineKeyboardButton("Подросток", callback_data=f"{CB_PREFIX}teen"),
+                    InlineKeyboardButton("Взрослый", callback_data=f"{CB_PREFIX}adult"),
                     InlineKeyboardButton("60+", callback_data=f"{CB_PREFIX}60+"),
                 ]
             ]

--- a/tests/diabetes/test_learning_onboarding.py
+++ b/tests/diabetes/test_learning_onboarding.py
@@ -84,8 +84,15 @@ async def test_learning_onboarding_flow(
 
         await learning_handlers.learn_command(update1, context)
         assert message1.replies == [onboarding_utils.AGE_PROMPT]
+        markup = message1.markups[0]
+        assert isinstance(markup, InlineKeyboardMarkup)
+        assert [b.text for b in markup.inline_keyboard[0]] == [
+            "Подросток",
+            "Взрослый",
+            "60+",
+        ]
 
-        message2 = DummyMessage("adult")
+        message2 = DummyMessage("взрослый")
         update2 = cast(Update, SimpleNamespace(message=message2, effective_user=None))
         await learning_onboarding.onboarding_reply(update2, context)
         assert message2.replies == [onboarding_utils.DIABETES_TYPE_PROMPT]

--- a/tests/learning/test_onboarding_normalization.py
+++ b/tests/learning/test_onboarding_normalization.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from services.api.app.diabetes.learning_onboarding import (
     _norm_age_group,
     _norm_diabetes_type,
@@ -9,6 +11,14 @@ from services.api.app.diabetes.learning_onboarding import (
 
 def test_norm_age_group_numeric() -> None:
     assert _norm_age_group("49") == "adult"
+
+
+@pytest.mark.parametrize(
+    ("text", "code"),
+    [("подросток", "teen"), ("взрослый", "adult"), ("60+", "60+")],
+)
+def test_norm_age_group_russian(text: str, code: str) -> None:
+    assert _norm_age_group(text) == code
 
 
 def test_norm_diabetes_type_numeric() -> None:


### PR DESCRIPTION
## Summary
- map Russian age group inputs to internal codes
- display age group buttons in Russian during learning onboarding
- test onboarding normalization with Russian labels

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdf90d50bc832a8b13c18ba9eabe27