### PR TITLE
[auth] handle missing telegram token

### DIFF
--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -80,7 +80,7 @@ def require_tg_user(
     token: str | None = settings.telegram_token
     if not token:
         logger.error("telegram token not configured")
-        raise HTTPException(status_code=500, detail="server misconfigured")
+        raise HTTPException(status_code=503, detail="telegram token not configured")
 
     data: dict[str, object] = parse_and_verify_init_data(init_data, token)
     user_raw = data.get("user")
@@ -98,7 +98,7 @@ def check_token(authorization: str | None = Header(None)) -> UserContext:
     token: str | None = settings.telegram_token
     if not token:
         logger.error("telegram token not configured")
-        raise HTTPException(status_code=500, detail="server misconfigured")
+        raise HTTPException(status_code=503, detail="telegram token not configured")
     data: dict[str, object] = parse_and_verify_init_data(init_data, token)
     user_raw = data.get("user")
     user = user_raw if isinstance(user_raw, dict) else None

--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -106,11 +106,12 @@ def test_require_tg_user_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
         require_tg_user("bad")
 
 
-def test_require_tg_user_empty_token(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_require_tg_user_missing_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Requests fail with a clear error if the bot token is not configured."""
     monkeypatch.setattr(settings, "telegram_token", "")
     with pytest.raises(HTTPException) as exc:
         require_tg_user("whatever")
-    assert exc.value.status_code == 500
+    assert exc.value.status_code == 503
 
 
 def test_parse_and_verify_init_data_expired() -> None:


### PR DESCRIPTION
## Summary
- return 503 when Telegram token is missing
- test missing token error handling

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdfb635d40832aa2e81360de30cb44