### PR TITLE
[profile] Remove telegramId from getProfile

### DIFF
--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -1,10 +1,10 @@
 import { tgFetch, FetchError } from '@/lib/tgFetch';
 import type { Profile, PatchProfileDto, RapidInsulin } from './types';
 
-export async function getProfile(telegramId: number): Promise<Profile | null> {
+export async function getProfile(): Promise<Profile | null> {
   try {
     return await tgFetch<Profile>(
-      `/profile?telegramId=${telegramId}`,
+      '/profile',
     );
   } catch (error) {
     if (error instanceof FetchError) {

--- a/services/webapp/ui/src/features/profile/hooks.ts
+++ b/services/webapp/ui/src/features/profile/hooks.ts
@@ -11,7 +11,7 @@ export function useDefaultAfterMealMinutes(
   useEffect(() => {
     if (!telegramId) return;
     let cancelled = false;
-    getProfile(telegramId)
+    getProfile()
       .then((profile) => {
         if (cancelled) return;
         const minutes = profile?.afterMealMinutes;

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -327,7 +327,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
 
     let cancelled = false;
 
-    getProfile(telegramId)
+    getProfile()
       .then((data) => {
         if (cancelled) return;
         if (!data) {

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -22,11 +22,11 @@ describe('profile api', () => {
       );
     vi.stubGlobal('fetch', mockFetch);
 
-    await expect(getProfile(1)).rejects.toThrow(
+    await expect(getProfile()).rejects.toThrow(
       'Не удалось получить профиль: boom',
     );
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/profile?telegramId=1',
+      '/api/profile',
       expect.any(Object),
     );
   });
@@ -42,10 +42,10 @@ describe('profile api', () => {
       );
     vi.stubGlobal('fetch', mockFetch);
 
-    const result = await getProfile(1);
+    const result = await getProfile();
     expect(result).toBeNull();
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/profile?telegramId=1',
+      '/api/profile',
       expect.any(Object),
     );
   });
@@ -61,11 +61,11 @@ describe('profile api', () => {
       );
     vi.stubGlobal('fetch', mockFetch);
 
-    await expect(getProfile(1)).rejects.toThrow(
+    await expect(getProfile()).rejects.toThrow(
       'Не удалось получить профиль: Некорректный ответ сервера',
     );
     expect(mockFetch).toHaveBeenCalledWith(
-      '/api/profile?telegramId=1',
+      '/api/profile',
       expect.any(Object),
     );
   });

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -168,7 +168,7 @@ describe('Profile page', () => {
     const { getByLabelText } = renderWithClient(<Profile />);
 
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalledWith(123);
+      expect(getProfile).toHaveBeenCalled();
     });
 
     const options = Array.from(
@@ -213,7 +213,7 @@ describe('Profile page', () => {
     const { queryByLabelText, getByDisplayValue } = renderWithClient(<Profile />);
 
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalledWith(123);
+      expect(getProfile).toHaveBeenCalled();
     });
 
     expect(queryByLabelText('Граммов на 1 ХЕ')).toBeNull();
@@ -363,7 +363,7 @@ describe('Profile page', () => {
       });
       const { queryByLabelText } = renderWithClient(<Profile therapyType={therapy} />);
       await waitFor(() => {
-        expect(getProfile).toHaveBeenCalledWith(123);
+        expect(getProfile).toHaveBeenCalled();
       });
       expect(queryByLabelText(/ICR/)).toBeNull();
       expect(queryByLabelText(/Коэффициент коррекции/)).toBeNull();
@@ -397,7 +397,7 @@ describe('Profile page', () => {
       });
       renderWithClient(<Profile therapyType={therapy} />);
       await waitFor(() => {
-        expect(getProfile).toHaveBeenCalledWith(123);
+        expect(getProfile).toHaveBeenCalled();
       });
       expect(toast).not.toHaveBeenCalled();
     },
@@ -425,7 +425,7 @@ describe('Profile page', () => {
       });
       renderWithClient(<Profile therapyType={therapy} />);
       await waitFor(() => {
-        expect(getProfile).toHaveBeenCalledWith(123);
+        expect(getProfile).toHaveBeenCalled();
       });
       expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -465,7 +465,7 @@ describe('Profile page', () => {
 
     renderWithClient(<Profile />);
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalledWith(123);
+      expect(getProfile).toHaveBeenCalled();
     });
     expect(toast).not.toHaveBeenCalled();
   });
@@ -493,7 +493,7 @@ describe('Profile page', () => {
       });
       renderWithClient(<Profile therapyType={therapy} />);
       await waitFor(() => {
-        expect(getProfile).toHaveBeenCalledWith(123);
+        expect(getProfile).toHaveBeenCalled();
       });
       expect(toast).not.toHaveBeenCalled();
     },
@@ -687,7 +687,7 @@ describe('Profile page', () => {
 
     const { getByPlaceholderText } = renderWithClient(<Profile />);
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalledWith(123);
+      expect(getProfile).toHaveBeenCalled();
     });
     expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('15');
     expect((getByPlaceholderText('2.5') as HTMLInputElement).value).toBe('3');
@@ -712,7 +712,7 @@ describe('Profile page', () => {
 
     const { getByPlaceholderText } = renderWithClient(<Profile />);
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalledWith(123);
+      expect(getProfile).toHaveBeenCalled();
     });
     expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('15');
     expect((getByPlaceholderText('2.5') as HTMLInputElement).value).toBe('3');
@@ -744,7 +744,7 @@ describe('Profile page', () => {
 
     const { getByPlaceholderText } = renderWithClient(<Profile />);
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalledWith(123);
+      expect(getProfile).toHaveBeenCalled();
     });
 
     expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('15');
@@ -798,7 +798,7 @@ describe('Profile page', () => {
 
       renderWithClient(<Profile />);
       await waitFor(() => {
-        expect(getProfile).toHaveBeenCalledWith(123);
+        expect(getProfile).toHaveBeenCalled();
       });
 
       if (shouldToast) {
@@ -821,7 +821,7 @@ describe('Profile page', () => {
 
     const { getByPlaceholderText } = renderWithClient(<Profile />);
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalledWith(123);
+      expect(getProfile).toHaveBeenCalled();
     });
     expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -840,7 +840,7 @@ describe('Profile page', () => {
 
     const { getByPlaceholderText } = renderWithClient(<Profile />);
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalledWith(123);
+      expect(getProfile).toHaveBeenCalled();
     });
     expect(toast).not.toHaveBeenCalled();
     expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('');

--- a/services/webapp/ui/tests/useDefaultAfterMealMinutes.test.ts
+++ b/services/webapp/ui/tests/useDefaultAfterMealMinutes.test.ts
@@ -33,7 +33,7 @@ describe('useDefaultAfterMealMinutes', () => {
     (getProfile as vi.Mock).mockResolvedValue(null);
     const { result } = renderHook(() => useDefaultAfterMealMinutes(1));
     await waitFor(() => {
-      expect(getProfile).toHaveBeenCalledWith(1);
+      expect(getProfile).toHaveBeenCalled();
       expect(result.current).toBe(120);
     });
   });


### PR DESCRIPTION
## Summary
- drop telegramId parameter from getProfile and rely on auth headers
- update profile hooks, page, and tests for new getProfile signature

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: @typescript-eslint/no-empty-object-type and others)*
- `pnpm --filter ./services/webapp/ui test`
- `pnpm --filter ./services/webapp/ui typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68bdfb6d4168832ab7d7598141b6206b