### PR TITLE
[learning] Handle lesson start errors

### DIFF
--- a/tests/diabetes/test_curriculum_busy.py
+++ b/tests/diabetes/test_curriculum_busy.py
@@ -2,6 +2,8 @@ from types import SimpleNamespace
 from typing import Any, Mapping
 
 import pytest
+from openai import OpenAIError
+from sqlalchemy.exc import SQLAlchemyError
 
 from services.api.app.config import settings
 from services.api.app.diabetes import learning_handlers as dynamic_handlers
@@ -104,3 +106,79 @@ async def test_legacy_lesson_command_busy(monkeypatch: pytest.MonkeyPatch) -> No
     assert msg.replies == [BUSY_MESSAGE]
     assert get_state(context.user_data) is None
     assert context.user_data.get("lesson_id") is None
+
+
+@pytest.mark.asyncio
+async def test_learn_command_start_lesson_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+
+    async def fake_ensure_overrides(update: object, context: object) -> bool:
+        return True
+
+    monkeypatch.setattr(dynamic_handlers, "ensure_overrides", fake_ensure_overrides)
+    monkeypatch.setattr(
+        dynamic_handlers, "choose_initial_topic", lambda _profile: ("slug", "t")
+    )
+
+    async def err_start_lesson(user_id: int, slug: str) -> object:
+        raise SQLAlchemyError("db error")
+
+    async def fail_next_step(*args: object, **kwargs: object) -> tuple[str, bool]:
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(
+        dynamic_handlers.curriculum_engine, "start_lesson", err_start_lesson
+    )
+    monkeypatch.setattr(dynamic_handlers.curriculum_engine, "next_step", fail_next_step)
+
+    msg = DummyMessage()
+    update = make_update(message=msg)
+    context = make_context(user_data={})
+
+    await dynamic_handlers.learn_command(update, context)
+
+    assert msg.replies == [BUSY_MESSAGE]
+    assert get_state(context.user_data) is None
+
+
+@pytest.mark.asyncio
+async def test_start_lesson_next_step_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_start_lesson(user_id: int, slug: str) -> object:
+        return SimpleNamespace(lesson_id=1)
+
+    async def err_next_step(
+        user_id: int,
+        lesson_id: int,
+        profile: Mapping[str, str | None],
+        prev_summary: str | None = None,
+    ) -> tuple[str, bool]:
+        raise OpenAIError("llm error")
+
+    monkeypatch.setattr(
+        dynamic_handlers.curriculum_engine, "start_lesson", fake_start_lesson
+    )
+    monkeypatch.setattr(dynamic_handlers.curriculum_engine, "next_step", err_next_step)
+
+    def fail_generate_learning_plan(_text: str) -> list[str]:
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(
+        dynamic_handlers, "generate_learning_plan", fail_generate_learning_plan
+    )
+
+    async def fail_add_log(*args: object, **kwargs: object) -> None:
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fail_add_log)
+
+    msg = DummyMessage()
+    user_data: dict[str, Any] = {}
+
+    await dynamic_handlers._start_lesson(msg, user_data, {}, {}, "slug")
+
+    assert msg.replies == [BUSY_MESSAGE]
+    assert get_state(user_data) is None


### PR DESCRIPTION
## Summary
- guard dynamic lesson start against curriculum or LLM failures
- cover error paths when curriculum `start_lesson` or `next_step` raise

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bdfe6c2408832a8df539c2b0d213f4