### PR TITLE
[assistant] use greatest for progress step

### DIFF
--- a/services/api/app/assistant/services/progress_service.py
+++ b/services/api/app/assistant/services/progress_service.py
@@ -54,7 +54,7 @@ async def upsert_progress(user_id: int, lesson: str, step: int) -> None:
             stmt.on_conflict_do_update(
                 index_elements=[Progress.user_id, Progress.lesson],
                 set_={
-                    "step": sa.func.max(Progress.step, stmt.excluded.step),
+                    "step": sa.func.greatest(Progress.step, stmt.excluded.step),
                     "updated_at": func.now(),
                 },
             )


### PR DESCRIPTION
## Summary
- ensure progress upsert keeps the higher step with `sa.func.greatest`
- test concurrent upserts keep max step and register SQLite `greatest`

## Testing
- `pytest tests/assistant/test_progress_service.py -q --cov=services.api.app.assistant.services.progress_service --cov-fail-under=85`
- `mypy --strict services/api/app/assistant/services/progress_service.py tests/assistant/test_progress_service.py`
- `ruff check services/api/app/assistant/services/progress_service.py tests/assistant/test_progress_service.py`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68be5c08dcb0832aa43e3ac1ac253259