### PR TITLE
[assistant] Disable session sync in memory cleanup

### DIFF
--- a/services/api/app/assistant/services/memory_service.py
+++ b/services/api/app/assistant/services/memory_service.py
@@ -108,7 +108,7 @@ async def cleanup_old_memory(ttl: timedelta | None = None) -> None:
         deleted = (
             session.query(AssistantMemory)
             .where(AssistantMemory.last_turn_at < cutoff)
-            .delete()
+            .delete(synchronize_session=False)
         )
         commit(session)
         return deleted


### PR DESCRIPTION
## Summary
- avoid ORM session synchronization when purging expired assistant memories

## Testing
- `pytest tests/assistant/test_memory_service.py -q`
- `mypy --strict services/api/app/assistant/services/memory_service.py tests/assistant/test_memory_service.py`
- `ruff check services/api/app/assistant/services/memory_service.py tests/assistant/test_memory_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68be5c0c3bfc832ab6e916134598d779