### PR TITLE
[webapp] validate profile form fields

### DIFF
--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -49,7 +49,7 @@ export async function saveProfile({
   sosContact?: string | null;
   sosAlertsEnabled?: boolean;
   therapyType?: string | null;
-}): Promise<void> {
+}): Promise<unknown> {
   try {
     const body: Record<string, unknown> = {
       telegramId,
@@ -94,7 +94,7 @@ export async function saveProfile({
       body.therapyType = therapyType;
     }
 
-    await tgFetch('/profile', { method: 'POST', body });
+    return await tgFetch('/profile', { method: 'POST', body });
   } catch (error) {
     console.error('Failed to save profile:', error);
     if (error instanceof Error) {

--- a/services/webapp/ui/src/features/profile/types.ts
+++ b/services/webapp/ui/src/features/profile/types.ts
@@ -5,6 +5,7 @@ import type {
 } from "@sdk";
 
 export type RapidInsulin = "aspart" | "lispro" | "glulisine" | "regular";
+export type TherapyType = "insulin" | "tablets" | "none" | "mixed";
 
 export type Profile = ProfileSchema & ProfileSettingsOut;
 

--- a/services/webapp/ui/src/features/profile/validation.ts
+++ b/services/webapp/ui/src/features/profile/validation.ts
@@ -1,0 +1,173 @@
+import type { RapidInsulin, TherapyType } from './types';
+
+type ProfileForm = {
+  icr: string;
+  cf: string;
+  target: string;
+  low: string;
+  high: string;
+  timezone: string;
+  timezoneAuto: boolean;
+  dia: string;
+  preBolus: string;
+  roundStep: string;
+  carbUnits: 'g' | 'xe';
+  gramsPerXe: string;
+  rapidInsulinType: RapidInsulin;
+  maxBolus: string;
+  afterMealMinutes: string;
+  quietStart: string;
+  quietEnd: string;
+  sosContact: string | null;
+  sosAlertsEnabled: boolean;
+};
+
+type ParsedProfile = {
+  icr?: number;
+  cf?: number;
+  target?: number;
+  low?: number;
+  high?: number;
+  dia?: number;
+  preBolus?: number;
+  roundStep?: number;
+  carbUnits: 'g' | 'xe';
+  gramsPerXe?: number;
+  rapidInsulinType?: RapidInsulin;
+  maxBolus?: number;
+  afterMealMinutes?: number;
+};
+
+type FieldErrors = Partial<Record<keyof ProfileForm, string>>;
+
+export const parseProfile = (
+  profile: ProfileForm,
+  therapyType?: TherapyType,
+): { data: ParsedProfile; errors: FieldErrors } => {
+  const errors: FieldErrors = {};
+  const isNonInsulin = therapyType === 'tablets' || therapyType === 'none';
+
+  const parseNumber = (
+    field: keyof ProfileForm,
+    value: string,
+    {
+      required = true,
+      min,
+      max,
+      allowZero = false,
+    }: {
+      required?: boolean;
+      min?: number;
+      max?: number;
+      allowZero?: boolean;
+    } = {},
+  ): number | undefined => {
+    if (value.trim() === '') {
+      if (required) errors[field] = 'required';
+      return undefined;
+    }
+    const num = Number(value.replace(/,/g, '.'));
+    if (!Number.isFinite(num)) {
+      errors[field] = 'invalid';
+      return undefined;
+    }
+    if (
+      (!allowZero && num <= 0) ||
+      (allowZero && num < 0) ||
+      (min !== undefined && num < min) ||
+      (max !== undefined && num > max)
+    ) {
+      errors[field] = 'out_of_range';
+    }
+    return num;
+  };
+
+  const icr = isNonInsulin ? 0 : parseNumber('icr', profile.icr);
+  const cf = isNonInsulin ? 0 : parseNumber('cf', profile.cf);
+  const target = parseNumber('target', profile.target);
+  const low = parseNumber('low', profile.low);
+  const high = parseNumber('high', profile.high);
+  const dia = isNonInsulin
+    ? 0
+    : parseNumber('dia', profile.dia, { min: 1, max: 24 });
+  const preBolus = isNonInsulin
+    ? 0
+    : parseNumber('preBolus', profile.preBolus, {
+        allowZero: true,
+        max: 60,
+      });
+  const roundStep = parseNumber('roundStep', profile.roundStep);
+
+  const carbUnits = profile.carbUnits;
+  if (carbUnits !== 'g' && carbUnits !== 'xe') {
+    errors.carbUnits = 'invalid';
+  }
+
+  const gramsPerXe = parseNumber('gramsPerXe', profile.gramsPerXe, {
+    required: carbUnits === 'xe',
+  });
+
+  const rapidInsulinType = profile.rapidInsulinType;
+  if (!isNonInsulin && !rapidInsulinType) {
+    errors.rapidInsulinType = 'required';
+  }
+
+  const maxBolus = isNonInsulin ? 0 : parseNumber('maxBolus', profile.maxBolus);
+  const afterMealMinutes = parseNumber(
+    'afterMealMinutes',
+    profile.afterMealMinutes,
+    { allowZero: true, max: 240 },
+  );
+
+  if (
+    low !== undefined &&
+    high !== undefined &&
+    target !== undefined &&
+    (low >= high || low >= target || target >= high)
+  ) {
+    if (!errors.low) errors.low = 'out_of_range';
+    if (!errors.high) errors.high = 'out_of_range';
+    if (!errors.target) errors.target = 'out_of_range';
+  }
+
+  return {
+    data: {
+      icr,
+      cf,
+      target,
+      low,
+      high,
+      dia,
+      preBolus,
+      roundStep,
+      carbUnits,
+      gramsPerXe,
+      rapidInsulinType,
+      maxBolus,
+      afterMealMinutes,
+    },
+    errors,
+  };
+};
+
+export const shouldWarnProfile = (
+  profile: ParsedProfile,
+  original?: ParsedProfile,
+): boolean => {
+  const icrCfWarn =
+    profile.icr !== undefined &&
+    profile.cf !== undefined &&
+    profile.icr > 8 &&
+    profile.cf < 3;
+  const diaWarn = profile.dia !== undefined && profile.dia > 12;
+  const carbUnitsWarn =
+    !!original &&
+    original.carbUnits !== profile.carbUnits &&
+    original.icr === profile.icr &&
+    profile.icr !== undefined &&
+    profile.icr > 0;
+
+  return icrCfWarn || diaWarn || carbUnitsWarn;
+};
+
+export type { ProfileForm, ParsedProfile, FieldErrors };

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -14,14 +14,22 @@ import ProfileHelpSheet from "@/components/ProfileHelpSheet";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useTranslation } from "@/i18n";
 import { saveProfile, getProfile, patchProfile } from "@/features/profile/api";
-import type { PatchProfileDto, RapidInsulin } from "@/features/profile/types";
+import type {
+  PatchProfileDto,
+  RapidInsulin,
+  TherapyType,
+} from "@/features/profile/types";
+import {
+  parseProfile,
+  shouldWarnProfile,
+  type ProfileForm,
+  type ParsedProfile,
+} from "@/features/profile/validation";
 import { getTimezones } from "@/api/timezones";
 import { useTelegram } from "@/hooks/useTelegram";
 import { useTelegramInitData } from "@/hooks/useTelegramInitData";
 import { resolveTelegramId } from "./resolveTelegramId";
 import { postOnboardingEvent } from "@/shared/api/onboarding";
-
-type TherapyType = 'insulin' | 'tablets' | 'none' | 'mixed';
 
 const rapidInsulinTypes: RapidInsulin[] = [
   'aspart',
@@ -29,175 +37,6 @@ const rapidInsulinTypes: RapidInsulin[] = [
   'glulisine',
   'regular',
 ];
-
-type ProfileForm = {
-  icr: string;
-  cf: string;
-  target: string;
-  low: string;
-  high: string;
-  timezone: string;
-  timezoneAuto: boolean;
-  dia: string;
-  preBolus: string;
-  roundStep: string;
-  carbUnits: 'g' | 'xe';
-  gramsPerXe: string;
-  rapidInsulinType: RapidInsulin;
-  maxBolus: string;
-  afterMealMinutes: string;
-  quietStart: string;
-  quietEnd: string;
-  sosContact: string | null;
-  sosAlertsEnabled: boolean;
-};
-
-type ParsedProfile = {
-  icr?: number;
-  cf?: number;
-  target?: number;
-  low?: number;
-  high?: number;
-  dia?: number;
-  preBolus?: number;
-  roundStep?: number;
-  carbUnits: 'g' | 'xe';
-  gramsPerXe?: number;
-  rapidInsulinType?: RapidInsulin;
-  maxBolus?: number;
-  afterMealMinutes?: number;
-};
-type FieldErrors = Partial<Record<keyof ProfileForm, string>>;
-
-export const parseProfile = (
-  profile: ProfileForm,
-  therapyType?: TherapyType,
-): { data: ParsedProfile; errors: FieldErrors } => {
-  const errors: FieldErrors = {};
-  const isNonInsulin = therapyType === 'tablets' || therapyType === 'none';
-
-  const parseNumber = (
-    field: keyof ProfileForm,
-    value: string,
-    {
-      required = true,
-      min,
-      max,
-      allowZero = false,
-    }: {
-      required?: boolean;
-      min?: number;
-      max?: number;
-      allowZero?: boolean;
-    } = {},
-  ): number | undefined => {
-    if (value.trim() === '') {
-      if (required) errors[field] = 'required';
-      return undefined;
-    }
-    const num = Number(value.replace(/,/g, '.'));
-    if (!Number.isFinite(num)) {
-      errors[field] = 'invalid';
-      return undefined;
-    }
-    if (
-      (!allowZero && num <= 0) ||
-      (allowZero && num < 0) ||
-      (min !== undefined && num < min) ||
-      (max !== undefined && num > max)
-    ) {
-      errors[field] = 'out_of_range';
-    }
-    return num;
-  };
-
-  const icr = isNonInsulin ? 0 : parseNumber('icr', profile.icr);
-  const cf = isNonInsulin ? 0 : parseNumber('cf', profile.cf);
-  const target = parseNumber('target', profile.target);
-  const low = parseNumber('low', profile.low);
-  const high = parseNumber('high', profile.high);
-  const dia = isNonInsulin
-    ? 0
-    : parseNumber('dia', profile.dia, { min: 1, max: 24 });
-  const preBolus = isNonInsulin
-    ? 0
-    : parseNumber('preBolus', profile.preBolus, {
-        allowZero: true,
-        max: 60,
-      });
-  const roundStep = parseNumber('roundStep', profile.roundStep);
-
-  const carbUnits = profile.carbUnits;
-  if (carbUnits !== 'g' && carbUnits !== 'xe') {
-    errors.carbUnits = 'invalid';
-  }
-
-  const gramsPerXe = parseNumber('gramsPerXe', profile.gramsPerXe, {
-    required: carbUnits === 'xe',
-  });
-
-  const rapidInsulinType = profile.rapidInsulinType;
-  if (!isNonInsulin && !rapidInsulinType) {
-    errors.rapidInsulinType = 'required';
-  }
-
-  const maxBolus = isNonInsulin ? 0 : parseNumber('maxBolus', profile.maxBolus);
-  const afterMealMinutes = parseNumber(
-    'afterMealMinutes',
-    profile.afterMealMinutes,
-    { allowZero: true, max: 240 },
-  );
-
-  if (
-    low !== undefined &&
-    high !== undefined &&
-    target !== undefined &&
-    (low >= high || low >= target || target >= high)
-  ) {
-    if (!errors.low) errors.low = 'out_of_range';
-    if (!errors.high) errors.high = 'out_of_range';
-    if (!errors.target) errors.target = 'out_of_range';
-  }
-
-  return {
-    data: {
-      icr,
-      cf,
-      target,
-      low,
-      high,
-      dia,
-      preBolus,
-      roundStep,
-      carbUnits,
-      gramsPerXe,
-      rapidInsulinType,
-      maxBolus,
-      afterMealMinutes,
-    },
-    errors,
-  };
-};
-
-export const shouldWarnProfile = (
-  profile: ParsedProfile,
-  original?: ParsedProfile,
-): boolean => {
-  const icrCfWarn =
-    profile.icr !== undefined &&
-    profile.cf !== undefined &&
-    profile.icr > 8 &&
-    profile.cf < 3;
-  const diaWarn = profile.dia !== undefined && profile.dia > 12;
-  const carbUnitsWarn =
-    !!original &&
-    original.carbUnits !== profile.carbUnits &&
-    original.icr === profile.icr &&
-    profile.icr !== undefined &&
-    profile.icr > 0;
-
-  return icrCfWarn || diaWarn || carbUnitsWarn;
-};
 
 interface ProfileFormHeaderProps {
   onBack: () => void;

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseProfile, shouldWarnProfile } from "../src/pages/Profile";
+import { parseProfile, shouldWarnProfile } from "../src/features/profile/validation";
 import type { RapidInsulin } from "../src/features/profile/types";
 
 const makeProfile = (


### PR DESCRIPTION
## Summary
- move profile parsing helpers into feature module
- add TherapyType type and use shared validation utilities in Profile page

## Testing
- `npm test` *(fails: ProfileHelpSheet tests)*
- `pytest -q --cov` *(fails: async functions not supported, many tests failing)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be617123b8832aa32cd7b510d5c20a