### PR TITLE
[learning] add onboarding callback handler

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -371,6 +371,12 @@ def register_handlers(app: App) -> None:
     app.add_handler(CommandHandler("exit", exit_command))
     app.add_handler(CommandHandler("learn_reset", onboarding.learn_reset))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, onboarding.onboarding_reply))
+    app.add_handler(
+        CallbackQueryHandler(
+            onboarding.onboarding_callback,
+            pattern=f"^{onboarding.CB_PREFIX}",
+        )
+    )
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, quiz_answer_handler, block=False))
     app.add_handler(CallbackQueryHandler(lesson_callback, pattern="^lesson:"))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, lesson_answer_handler, block=False))

--- a/services/api/app/diabetes/handlers/learning_onboarding.py
+++ b/services/api/app/diabetes/handlers/learning_onboarding.py
@@ -22,6 +22,7 @@ __all__ = [
     "onboarding_callback",
     "register_handlers",
     "learn_reset",
+    "CB_PREFIX",
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -149,6 +149,11 @@ def test_register_handlers_attaches_expected_handlers(
         for h in handlers
     )
     assert any(
+        isinstance(h, CallbackQueryHandler)
+        and h.callback is learning_onboarding.onboarding_callback
+        for h in handlers
+    )
+    assert any(
         isinstance(h, MessageHandler)
         and h.callback is learning_handlers.quiz_answer_handler
         for h in handlers


### PR DESCRIPTION
## Summary
- handle learning onboarding callback queries
- test handler registration

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be64a5997c832a9841f06f3addc7f6