### PR TITLE
handlers: register onboarding callback

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -371,6 +371,11 @@ def register_handlers(app: App) -> None:
     app.add_handler(CommandHandler("exit", exit_command))
     app.add_handler(CommandHandler("learn_reset", onboarding.learn_reset))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, onboarding.onboarding_reply))
+    app.add_handler(
+        CallbackQueryHandler(
+            onboarding.onboarding_callback, pattern=f"^{onboarding.CB_PREFIX}"
+        )
+    )
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, quiz_answer_handler, block=False))
     app.add_handler(CallbackQueryHandler(lesson_callback, pattern="^lesson:"))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, lesson_answer_handler, block=False))

--- a/services/api/app/diabetes/handlers/learning_onboarding.py
+++ b/services/api/app/diabetes/handlers/learning_onboarding.py
@@ -18,6 +18,7 @@ from telegram.ext import (
 from ..learning_onboarding import CB_PREFIX, ensure_overrides, learn_reset
 
 __all__ = [
+    "CB_PREFIX",
     "onboarding_reply",
     "onboarding_callback",
     "register_handlers",

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -149,6 +149,11 @@ def test_register_handlers_attaches_expected_handlers(
         for h in handlers
     )
     assert any(
+        isinstance(h, CallbackQueryHandler)
+        and h.callback is learning_onboarding.onboarding_callback
+        for h in handlers
+    )
+    assert any(
         isinstance(h, MessageHandler)
         and h.callback is learning_handlers.quiz_answer_handler
         for h in handlers
@@ -364,6 +369,11 @@ def test_register_learning_onboarding_handlers() -> None:
     assert any(
         isinstance(h, MessageHandler)
         and h.callback is learning_onboarding.onboarding_reply
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CallbackQueryHandler)
+        and h.callback is learning_onboarding.onboarding_callback
         for h in handlers
     )
 


### PR DESCRIPTION
## Summary
- register onboarding callback query handler in learning handlers
- export CB_PREFIX from learning onboarding module
- test registration of onboarding callback

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be65fb9bc4832ab26a4f92d1ffac51