### PR TITLE
[tests] clear DATABASE_URL before db init

### DIFF
--- a/tests/test_db_reinit.py
+++ b/tests/test_db_reinit.py
@@ -38,6 +38,7 @@ class DummyEngine:
 def test_init_db_recreates_engine_on_url_change(
     monkeypatch: pytest.MonkeyPatch, attr: Any, orig: Any, new: Any, url_attr: Any
 ) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.setenv("DB_PASSWORD", "pwd")
     _reload("services.api.app.config")
     db = cast(Any, _reload("services.api.app.diabetes.services.db"))


### PR DESCRIPTION
## Summary
- ensure DB reinit test rebuilds default URL by clearing DATABASE_URL

## Testing
- `pytest tests/test_db_reinit.py::test_init_db_recreates_engine_on_url_change -q`
- `pytest tests/test_db_reinit.py::test_init_db_recreates_engine_on_url_change --cov -q`
- `mypy --strict tests/test_db_reinit.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be68368bcc832abd15d09341669cc4