### PR TITLE
[tests] Ensure DATABASE_URL unset in config init test

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ def test_import_config_without_db_password(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_init_db_raises_when_no_password(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DB_PASSWORD", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
     config = cast(Any, _reload("services.api.app.config"))
     db = cast(Any, _reload("services.api.app.diabetes.services.db"))
     assert config.get_db_password() is None


### PR DESCRIPTION
## Summary
- ensure test removes DATABASE_URL before reloading config

## Testing
- `ruff check tests/test_config.py`
- `mypy --strict tests/test_config.py`
- `pytest tests/test_config.py::test_init_db_raises_when_no_password -q`


------
https://chatgpt.com/codex/tasks/task_e_68be69a48158832aa39a34a21e830a84