### PR TITLE
[contracts] add therapy type to profile schema

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -916,6 +916,14 @@ components:
           - type: string
           - type: 'null'
           title: Sos Contact
+        therapyType:
+          type: string
+          enum:
+          - insulin
+          - tablets
+          - none
+          - mixed
+          title: Therapy Type
         sosAlertsEnabled:
           type: boolean
           title: Sos Alerts Enabled

--- a/libs/ts-sdk/models/ProfileSchema.ts
+++ b/libs/ts-sdk/models/ProfileSchema.ts
@@ -75,6 +75,12 @@ export interface ProfileSchema {
     sosContact?: string | null;
     /**
      * 
+     * @type {string}
+     * @memberof ProfileSchema
+     */
+    therapyType?: ProfileSchemaTherapyTypeEnum;
+    /**
+     * 
      * @type {boolean}
      * @memberof ProfileSchema
      */
@@ -98,6 +104,19 @@ export interface ProfileSchema {
      */
     orgId?: number | null;
 }
+
+
+/**
+ * @export
+ */
+export const ProfileSchemaTherapyTypeEnum = {
+    Insulin: 'insulin',
+    Tablets: 'tablets',
+    None: 'none',
+    Mixed: 'mixed'
+} as const;
+export type ProfileSchemaTherapyTypeEnum = typeof ProfileSchemaTherapyTypeEnum[keyof typeof ProfileSchemaTherapyTypeEnum];
+
 
 /**
  * Check if a given object implements the ProfileSchema interface.
@@ -129,6 +148,7 @@ export function ProfileSchemaFromJSONTyped(json: any, ignoreDiscriminator: boole
         'quietStart': json['quietStart'] == null ? undefined : json['quietStart'],
         'quietEnd': json['quietEnd'] == null ? undefined : json['quietEnd'],
         'sosContact': json['sosContact'] == null ? undefined : json['sosContact'],
+        'therapyType': json['therapyType'] == null ? undefined : json['therapyType'],
         'sosAlertsEnabled': json['sosAlertsEnabled'] == null ? undefined : json['sosAlertsEnabled'],
         'timezone': json['timezone'] == null ? undefined : json['timezone'],
         'timezoneAuto': json['timezoneAuto'] == null ? undefined : json['timezoneAuto'],
@@ -156,6 +176,7 @@ export function ProfileSchemaToJSONTyped(value?: ProfileSchema | null, ignoreDis
         'quietStart': value['quietStart'],
         'quietEnd': value['quietEnd'],
         'sosContact': value['sosContact'],
+        'therapyType': value['therapyType'],
         'sosAlertsEnabled': value['sosAlertsEnabled'],
         'timezone': value['timezone'],
         'timezoneAuto': value['timezoneAuto'],

--- a/services/webapp/ui/src/components/ProfileHelpSheet.tsx
+++ b/services/webapp/ui/src/components/ProfileHelpSheet.tsx
@@ -17,9 +17,10 @@ import { Button } from '@/components/ui/button';
 import { HelpCircle, X } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useTranslation } from '@/i18n';
+import type { TherapyType } from '@/features/profile/types';
 
 interface ProfileHelpSheetProps {
-  therapyType?: 'insulin' | 'tablets' | 'none' | 'mixed';
+  therapyType?: TherapyType;
 }
 
 interface HelpItem {

--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -1,5 +1,5 @@
 import { tgFetch, FetchError } from '@/lib/tgFetch';
-import type { Profile, PatchProfileDto, RapidInsulin } from './types';
+import type { Profile, PatchProfileDto, RapidInsulin, TherapyType } from './types';
 
 export async function getProfile(): Promise<Profile | null> {
   try {
@@ -48,7 +48,7 @@ export async function saveProfile({
   timezoneAuto?: boolean;
   sosContact?: string | null;
   sosAlertsEnabled?: boolean;
-  therapyType?: string | null;
+  therapyType?: TherapyType | null;
 }): Promise<unknown> {
   try {
     const body: Record<string, unknown> = {


### PR DESCRIPTION
## Summary
- expand ProfileSchema with therapyType enum
- regenerate ts-sdk and update webapp
- consume strong typing for therapyType in UI

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(interrupt: Interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be6954f080832a94d1dbf5a2ba93d1