### PR TITLE
[profile] add glucose units to profile settings

### DIFF
--- a/libs/contracts/openapi.yaml
+++ b/libs/contracts/openapi.yaml
@@ -822,6 +822,12 @@ components:
         gramsPerXe:
           type: number
           title: Grams Per Xe
+        glucoseUnits:
+          type: string
+          enum:
+          - mmol/L
+          - mg/dL
+          title: Glucose Units
         therapyType:
           type: string
           enum:
@@ -870,6 +876,7 @@ components:
       - roundStep
       - carbUnits
       - gramsPerXe
+      - glucoseUnits
       - sosAlertsEnabled
       - therapyType
       - maxBolus

--- a/libs/ts-sdk/models/ProfileSettingsIn.ts
+++ b/libs/ts-sdk/models/ProfileSettingsIn.ts
@@ -60,6 +60,12 @@ export interface ProfileSettingsIn {
      * @type {string}
      * @memberof ProfileSettingsIn
      */
+    glucoseUnits?: ProfileSettingsInGlucoseUnitsEnum;
+    /**
+     * 
+     * @type {string}
+     * @memberof ProfileSettingsIn
+     */
     therapyType?: ProfileSettingsInTherapyTypeEnum;
     /**
      * 
@@ -112,6 +118,15 @@ export type ProfileSettingsInCarbUnitsEnum = typeof ProfileSettingsInCarbUnitsEn
 /**
  * @export
  */
+export const ProfileSettingsInGlucoseUnitsEnum = {
+    MmolL: 'mmol/L',
+    MgDL: 'mg/dL'
+} as const;
+export type ProfileSettingsInGlucoseUnitsEnum = typeof ProfileSettingsInGlucoseUnitsEnum[keyof typeof ProfileSettingsInGlucoseUnitsEnum];
+
+/**
+ * @export
+ */
 export const ProfileSettingsInTherapyTypeEnum = {
     Insulin: 'insulin',
     Tablets: 'tablets',
@@ -155,6 +170,7 @@ export function ProfileSettingsInFromJSONTyped(json: any, ignoreDiscriminator: b
         'roundStep': json['roundStep'] == null ? undefined : json['roundStep'],
         'carbUnits': json['carbUnits'] == null ? undefined : json['carbUnits'],
         'gramsPerXe': json['gramsPerXe'] == null ? undefined : json['gramsPerXe'],
+        'glucoseUnits': json['glucoseUnits'] == null ? undefined : json['glucoseUnits'],
         'therapyType': json['therapyType'] == null ? undefined : json['therapyType'],
         'sosContact': json['sosContact'] == null ? undefined : json['sosContact'],
         'sosAlertsEnabled': json['sosAlertsEnabled'] == null ? undefined : json['sosAlertsEnabled'],
@@ -182,6 +198,7 @@ export function ProfileSettingsInToJSONTyped(value?: ProfileSettingsIn | null, i
         'roundStep': value['roundStep'],
         'carbUnits': value['carbUnits'],
         'gramsPerXe': value['gramsPerXe'],
+        'glucoseUnits': value['glucoseUnits'],
         'therapyType': value['therapyType'],
         'sosContact': value['sosContact'],
         'sosAlertsEnabled': value['sosAlertsEnabled'],

--- a/libs/ts-sdk/models/ProfileSettingsOut.ts
+++ b/libs/ts-sdk/models/ProfileSettingsOut.ts
@@ -60,6 +60,12 @@ export interface ProfileSettingsOut {
      * @type {string}
      * @memberof ProfileSettingsOut
      */
+    glucoseUnits: ProfileSettingsOutGlucoseUnitsEnum;
+    /**
+     * 
+     * @type {string}
+     * @memberof ProfileSettingsOut
+     */
     therapyType: ProfileSettingsOutTherapyTypeEnum;
     /**
      * 
@@ -112,6 +118,15 @@ export type ProfileSettingsOutCarbUnitsEnum = typeof ProfileSettingsOutCarbUnits
 /**
  * @export
  */
+export const ProfileSettingsOutGlucoseUnitsEnum = {
+    MmolL: 'mmol/L',
+    MgDL: 'mg/dL'
+} as const;
+export type ProfileSettingsOutGlucoseUnitsEnum = typeof ProfileSettingsOutGlucoseUnitsEnum[keyof typeof ProfileSettingsOutGlucoseUnitsEnum];
+
+/**
+ * @export
+ */
 export const ProfileSettingsOutTherapyTypeEnum = {
     Insulin: 'insulin',
     Tablets: 'tablets',
@@ -142,6 +157,7 @@ export function instanceOfProfileSettingsOut(value: object): value is ProfileSet
     if (!('roundStep' in value) || value['roundStep'] === undefined) return false;
     if (!('carbUnits' in value) || value['carbUnits'] === undefined) return false;
     if (!('gramsPerXe' in value) || value['gramsPerXe'] === undefined) return false;
+    if (!('glucoseUnits' in value) || value['glucoseUnits'] === undefined) return false;
     if (!('therapyType' in value) || value['therapyType'] === undefined) return false;
     if (!('sosAlertsEnabled' in value) || value['sosAlertsEnabled'] === undefined) return false;
     if (!('maxBolus' in value) || value['maxBolus'] === undefined) return false;
@@ -166,6 +182,7 @@ export function ProfileSettingsOutFromJSONTyped(json: any, ignoreDiscriminator: 
         'roundStep': json['roundStep'],
         'carbUnits': json['carbUnits'],
         'gramsPerXe': json['gramsPerXe'],
+        'glucoseUnits': json['glucoseUnits'],
         'therapyType': json['therapyType'],
         'sosContact': json['sosContact'] == null ? undefined : json['sosContact'],
         'sosAlertsEnabled': json['sosAlertsEnabled'],
@@ -193,6 +210,7 @@ export function ProfileSettingsOutToJSONTyped(value?: ProfileSettingsOut | null,
         'roundStep': value['roundStep'],
         'carbUnits': value['carbUnits'],
         'gramsPerXe': value['gramsPerXe'],
+        'glucoseUnits': value['glucoseUnits'],
         'therapyType': value['therapyType'],
         'sosContact': value['sosContact'],
         'sosAlertsEnabled': value['sosAlertsEnabled'],

--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -35,6 +35,7 @@ export async function saveProfile({
   sosContact,
   sosAlertsEnabled,
   therapyType,
+  glucoseUnits,
 }: {
   telegramId: number;
   target: number;
@@ -49,6 +50,7 @@ export async function saveProfile({
   sosContact?: string | null;
   sosAlertsEnabled?: boolean;
   therapyType?: string | null;
+  glucoseUnits?: 'mmol/L' | 'mg/dL';
 }): Promise<unknown> {
   try {
     const body: Record<string, unknown> = {
@@ -92,6 +94,10 @@ export async function saveProfile({
 
     if (therapyType !== undefined) {
       body.therapyType = therapyType;
+    }
+
+    if (glucoseUnits !== undefined) {
+      body.glucoseUnits = glucoseUnits;
     }
 
     return await tgFetch('/profile', { method: 'POST', body });

--- a/services/webapp/ui/src/features/profile/types.ts
+++ b/services/webapp/ui/src/features/profile/types.ts
@@ -23,6 +23,7 @@ export type PatchProfileDto = Partial<
     | "roundStep"
     | "carbUnits"
     | "gramsPerXe"
+    | "glucoseUnits"
     | "rapidInsulinType"
     | "maxBolus"
     | "afterMealMinutes"

--- a/services/webapp/ui/src/features/profile/validation.ts
+++ b/services/webapp/ui/src/features/profile/validation.ts
@@ -13,6 +13,7 @@ type ProfileForm = {
   roundStep: string;
   carbUnits: 'g' | 'xe';
   gramsPerXe: string;
+  glucoseUnits: 'mmol/L' | 'mg/dL';
   rapidInsulinType: RapidInsulin;
   maxBolus: string;
   afterMealMinutes: string;
@@ -33,6 +34,7 @@ type ParsedProfile = {
   roundStep?: number;
   carbUnits: 'g' | 'xe';
   gramsPerXe?: number;
+  glucoseUnits?: 'mmol/L' | 'mg/dL';
   rapidInsulinType?: RapidInsulin;
   maxBolus?: number;
   afterMealMinutes?: number;
@@ -107,6 +109,11 @@ export const parseProfile = (
     required: carbUnits === 'xe',
   });
 
+  const glucoseUnits = profile.glucoseUnits;
+  if (glucoseUnits !== 'mmol/L' && glucoseUnits !== 'mg/dL') {
+    errors.glucoseUnits = 'invalid';
+  }
+
   const rapidInsulinType = profile.rapidInsulinType;
   if (!isNonInsulin && !rapidInsulinType) {
     errors.rapidInsulinType = 'required';
@@ -142,6 +149,7 @@ export const parseProfile = (
       roundStep,
       carbUnits,
       gramsPerXe,
+      glucoseUnits,
       rapidInsulinType,
       maxBolus,
       afterMealMinutes,

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -98,6 +98,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
     roundStep: "",
     carbUnits: 'g',
     gramsPerXe: "",
+    glucoseUnits: 'mmol/L',
     rapidInsulinType: 'aspart',
     maxBolus: "",
     afterMealMinutes: "",
@@ -247,6 +248,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
           roundStep,
           carbUnits,
           gramsPerXe,
+          glucoseUnits: data.glucoseUnits === 'mg/dL' ? 'mg/dL' : 'mmol/L',
           rapidInsulinType,
           maxBolus,
           afterMealMinutes,
@@ -376,6 +378,8 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
       parsed.gramsPerXe !== undefined
     )
       patch.gramsPerXe = parsed.gramsPerXe;
+    if (profile.glucoseUnits !== original.glucoseUnits && parsed.glucoseUnits)
+      patch.glucoseUnits = parsed.glucoseUnits;
     if (
       profile.rapidInsulinType !== original.rapidInsulinType &&
       parsed.rapidInsulinType !== undefined
@@ -413,6 +417,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
         sosContact: string | null;
         sosAlertsEnabled: boolean;
         therapyType: TherapyType;
+        glucoseUnits: 'mmol/L' | 'mg/dL';
       } = {
         telegramId: data.telegramId,
         target: data.target!,
@@ -425,6 +430,7 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
         sosContact: profile.sosContact,
         sosAlertsEnabled: profile.sosAlertsEnabled,
         therapyType: data.therapyType ?? originalTherapyType,
+        glucoseUnits: parsed.glucoseUnits!,
       };
 
       if (data.therapyType !== 'tablets' && data.therapyType !== 'none') {


### PR DESCRIPTION
## Summary
- add glucoseUnits to ProfileSettings schemas and regenerate TypeScript SDK
- include glucoseUnits in profile types, validation and API calls
- handle glucoseUnits in profile page state and patch logic

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be6958d990832a873012c6211ff06e