### PR TITLE
[tests] remove DATABASE_URL before config reload

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,7 @@ def test_import_config_without_db_password(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_init_db_raises_when_no_password(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DB_PASSWORD", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
     config = cast(Any, _reload("services.api.app.config"))
     db = cast(Any, _reload("services.api.app.diabetes.services.db"))
     assert config.get_db_password() is None


### PR DESCRIPTION
## Summary
- ensure `DATABASE_URL` is unset in `test_init_db_raises_when_no_password`

## Testing
- `pytest tests/test_config.py::test_init_db_raises_when_no_password -q`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be68333678832a86e007fbb161901d