### PR TITLE
[webapp] Validate response content-type before JSON parsing

### DIFF
--- a/services/webapp/ui/src/api/http.ts
+++ b/services/webapp/ui/src/api/http.ts
@@ -30,10 +30,14 @@ export async function request<T>(
       return null;
     }
 
-    // Check if response is HTML (backend not available) - do this BEFORE parsing JSON
+    // Validate content type before parsing
     const contentType = res.headers.get('content-type');
     if (contentType?.includes('text/html')) {
       throw new Error('Backend returned HTML instead of JSON');
+    }
+    if (!contentType?.includes('application/json')) {
+      const type = contentType ?? 'unknown';
+      throw new Error(`Unexpected content-type: ${type}`);
     }
 
     const data = (await res.json()) as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- ensure http client validates `content-type` before JSON parsing

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: KeyboardInterrupt)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`
- `pnpm --filter ./services/webapp/ui lint` *(fails: 28 errors, 10 warnings)*
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test` *(fails: 4 failed, 21 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68be71a59a14832abc0b50d2dfadade7