### PR TITLE
feat(api): adjust onboarding router registration

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -54,7 +54,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         init_db()  # создаёт/инициализирует БД
     except (ValueError, SQLAlchemyError) as exc:
         logger.error("Failed to initialize the database: %s", exc)
-        raise RuntimeError("Database initialization failed. Please check your configuration and try again.") from exc
+        raise RuntimeError(
+            "Database initialization failed. Please check your configuration and try again."
+        ) from exc
     jq = cast(DefaultJobQueue | None, getattr(app.state, "job_queue", None))
     reminder_events.register_job_queue(jq)
     if settings.learning_logging_required:
@@ -101,11 +103,11 @@ api_router.include_router(timezones_router)
 api_router.include_router(health_router)
 api_router.include_router(users_router)
 api_router.include_router(history_router)
+api_router.include_router(onboarding_router)
 
 # ────────── include router ──────────
 app.include_router(internal_reminders_router)
 app.include_router(metrics.router)
-app.include_router(onboarding_router)
 app.include_router(api_router, prefix="/api")
 app.include_router(webapp_router)
 


### PR DESCRIPTION
## Summary
- refactor onboarding router to use '/onboarding' prefix
- register onboarding endpoints via main API router

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be71abb450832a99805822eff9d9d7