### PR TITLE
[webapp] Fix billing auth test indentation

### DIFF
--- a/services/webapp/ui/src/api/billing.auth.test.ts
+++ b/services/webapp/ui/src/api/billing.auth.test.ts
@@ -48,7 +48,7 @@ describe('billing auth', () => {
       );
     vi.stubGlobal('fetch', fetchMock);
     const { getBillingStatus } = await import('./billing');
-      await expect(getBillingStatus('1')).rejects.toThrow('unauthorized');
-    });
+    await expect(getBillingStatus('1')).rejects.toThrow('unauthorized');
   });
+});
 


### PR DESCRIPTION
## Summary
- fix indentation and close test blocks in billing auth tests

## Testing
- `pnpm --filter ./services/webapp/ui exec eslint -f json src/api/billing.auth.test.ts`
- `pnpm --filter ./services/webapp/ui test src/api/billing.auth.test.ts`
- `ruff check services/api/app`
- `pytest -q` *(fails: 619 failed, 407 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68be71b03c58832aa7423529b2d1af6c