### PR TITLE
[api] Register onboarding router

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -54,9 +54,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         init_db()  # создаёт/инициализирует БД
     except (ValueError, SQLAlchemyError) as exc:
         logger.error("Failed to initialize the database: %s", exc)
-        raise RuntimeError(
-            "Database initialization failed. Please check your configuration and try again."
-        ) from exc
+        raise RuntimeError("Database initialization failed. Please check your configuration and try again.") from exc
     jq = cast(DefaultJobQueue | None, getattr(app.state, "job_queue", None))
     reminder_events.register_job_queue(jq)
     if settings.learning_logging_required:
@@ -103,10 +101,10 @@ api_router.include_router(timezones_router)
 api_router.include_router(health_router)
 api_router.include_router(users_router)
 api_router.include_router(history_router)
+api_router.include_router(onboarding_router)
 
 # ────────── include router ──────────
 app.include_router(internal_reminders_router)
-app.include_router(onboarding_router)
 app.include_router(api_router, prefix="/api")
 app.include_router(webapp_router)
 

--- a/services/api/app/routers/onboarding.py
+++ b/services/api/app/routers/onboarding.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 PROFILE, TIMEZONE, REMINDERS = range(3)
 
-router = APIRouter(prefix="/api/onboarding")
+router = APIRouter(prefix="/onboarding")
 
 
 class EventPayload(BaseModel):


### PR DESCRIPTION
## Summary
- expose onboarding routes through the shared `/api` router

## Testing
- `pytest -q --ignore=node_modules` *(fails: async functions not supported)*
- `mypy --strict services/api/app/routers/onboarding.py services/api/app/main.py` *(fails: interrupted)*
- `ruff check services/api/app/main.py services/api/app/routers/onboarding.py`


------
https://chatgpt.com/codex/tasks/task_e_68be7494985c832ab516115cf0b4b0c2