### PR TITLE
[webapp] Validate JSON content type

### DIFF
--- a/services/webapp/ui/src/api/index.ts
+++ b/services/webapp/ui/src/api/index.ts
@@ -1,4 +1,4 @@
-import { httpClient, RequestOptions } from '@/lib/http';
+import { httpClient, RequestOptions } from './http';
 
 export const api = {
   get: <T>(path: string, opts?: RequestOptions) =>

--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -1,5 +1,5 @@
 import { api } from '@/api';
-import { HttpError } from '@/lib/http';
+import { HttpError } from '@/api/http';
 import type { Profile, PatchProfileDto, RapidInsulin, TherapyType } from './types';
 
 export async function getProfile(): Promise<Profile | null> {


### PR DESCRIPTION
## Summary
- add HTTP client to API module with JSON content-type validation
- remove legacy http module and update imports

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter vite_react_shadcn_ts test tests/http.test.ts`
- `pnpm --filter vite_react_shadcn_ts test` *(fails: onboarding.api.test.ts, profile.test.tsx, reminders.default.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68be746625ac832ab501c27154113377