### PR TITLE
auth: ensure user record exists for new telegram ids

### DIFF
--- a/services/api/app/diabetes/services/users.py
+++ b/services/api/app/diabetes/services/users.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import cast
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
 from .db import SessionLocal, User, run_db
 from .repository import CommitError, commit
@@ -13,22 +13,33 @@ logger = logging.getLogger(__name__)
 __all__ = ["ensure_user_exists"]
 
 
-async def ensure_user_exists(user_id: int) -> None:
+async def ensure_user_exists(
+    user_id: int,
+    thread_id: str = "",
+    session_factory: sessionmaker[Session] | None = None,
+) -> None:
     """Ensure that a user row exists for ``user_id``.
 
     If no :class:`~services.api.app.diabetes.services.db.User` exists with the given
-    ``telegram_id``, a new one is inserted with an empty ``thread_id``.
+    ``telegram_id``, a new one is inserted with ``thread_id``. Creation and duplicate
+    situations are logged.
     """
 
     def _ensure(session: Session) -> None:
         user = cast(User | None, session.get(User, user_id))
         if user is not None:
+            logger.info("User %s already exists", user_id)
             return
-        session.add(User(telegram_id=user_id, thread_id=""))
+        session.add(User(telegram_id=user_id, thread_id=thread_id))
         try:
             commit(session)
         except CommitError:  # pragma: no cover - logging only
+            existing = cast(User | None, session.get(User, user_id))
+            if existing is not None:
+                logger.info("User %s already exists (race)", user_id)
+                return
             logger.exception("Failed to create user %s", user_id)
             raise
+        logger.info("Created user %s", user_id)
 
-    await run_db(_ensure, sessionmaker=SessionLocal)
+    await run_db(_ensure, sessionmaker=session_factory or SessionLocal)

--- a/services/bot/handlers/start_webapp.py
+++ b/services/bot/handlers/start_webapp.py
@@ -7,6 +7,8 @@ from typing import TypeAlias
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, WebAppInfo
 from telegram.ext import CommandHandler, ContextTypes
 
+from services.api.app.diabetes.services.users import ensure_user_exists
+
 logger = logging.getLogger(__name__)
 
 CommandHandlerT: TypeAlias = CommandHandler[ContextTypes.DEFAULT_TYPE, object]
@@ -21,6 +23,9 @@ def build_start_handler() -> CommandHandlerT:
         ui_base_url = f"{public_origin.rstrip('/')}{ui_base_url}"
 
     async def _start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        user = getattr(update, "effective_user", None)
+        if user is not None:
+            await ensure_user_exists(user.id)
         profile_url = f"{ui_base_url.rstrip('/')}/profile?flow=onboarding&step=profile"
         reminders_url = f"{ui_base_url.rstrip('/')}/reminders?flow=onboarding&step=reminders"
 


### PR DESCRIPTION
## Summary
- create or fetch user on `/start` webapp handler
- ensure API user creation uses shared helper and logs creation
- add logging and duplicate handling to `ensure_user_exists`
- test user creation and duplicate scenarios

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be74d965b0832a82ba9ace4969da61