### PR TITLE
[gpt_command_parser] Require fields only for specific actions

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -64,6 +64,8 @@ API_KEY_RE = re.compile(
     rf"[A-Za-z0-9_-]{{{API_KEY_MIN_LENGTH},}}\b"
 )
 
+ACTIONS_REQUIRE_FIELDS: set[str] = {"add_entry", "update_entry"}
+
 
 def _sanitize_sensitive_data(text: str) -> str:
     """Mask potentially sensitive tokens in *text* before logging."""
@@ -242,7 +244,7 @@ async def parse_command(text: str, timeout: float = 10) -> dict[str, object] | N
         logger.exception("Command validation failed for action=%s", action)
         return None
     cmd_dict = cmd.model_dump(exclude_none=True)
-    if cmd.action != "get_day_summary" and "fields" not in cmd_dict:
+    if cmd.action in ACTIONS_REQUIRE_FIELDS and "fields" not in cmd_dict:
         logger.error("Missing fields for action=%s", cmd.action)
         return None
     return cmd_dict

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -221,6 +221,60 @@ async def test_parse_command_without_fields(
 
 
 @pytest.mark.asyncio
+async def test_parse_command_get_stats_without_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        choices = [
+            type(
+                "Choice",
+                (),
+                {
+                    "message": type(
+                        "Msg", (), {"content": '{"action":"get_stats"}'}
+                    )()
+                },
+            )
+        ]
+
+    async def create(*args: Any, **kwargs: Any) -> Any:
+        return FakeResponse()
+
+    monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)
+
+    result = await gpt_command_parser.parse_command("test")
+
+    assert result == {"action": "get_stats"}
+
+
+@pytest.mark.asyncio
+async def test_parse_command_delete_entry_without_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        choices = [
+            type(
+                "Choice",
+                (),
+                {
+                    "message": type(
+                        "Msg", (), {"content": '{"action":"delete_entry"}'}
+                    )()
+                },
+            )
+        ]
+
+    async def create(*args: Any, **kwargs: Any) -> Any:
+        return FakeResponse()
+
+    monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)
+
+    result = await gpt_command_parser.parse_command("test")
+
+    assert result == {"action": "delete_entry"}
+
+
+@pytest.mark.asyncio
 async def test_parse_command_with_multiple_json_objects(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add explicit list of actions that require fields
- allow get_stats and delete_entry without fields
- test parser for get_stats and delete_entry

## Testing
- `pytest tests/test_gpt_command_parser.py tests/test_gpt_command_parser_errors.py --cov=services.api.app.diabetes.gpt_command_parser -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be80bfe078832a85342738ed1a43ba