### PR TITLE
[services] Handle SQLAlchemy errors in profile

### DIFF
--- a/tests/test_profile_errors.py
+++ b/tests/test_profile_errors.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi import HTTPException
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 
 from services.api.app.diabetes.services.db import Profile
 from services.api.app.services import profile as profile_service
@@ -30,8 +30,21 @@ async def test_get_profile_unexpected_error(
         raise RuntimeError("boom")
 
     monkeypatch.setattr(profile_service.db, "run_db", _run_db)
+    with pytest.raises(RuntimeError):
+        await profile_service.get_profile(1)
+
+
+@pytest.mark.asyncio
+async def test_get_profile_sqlalchemy_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run_db(*args: object, **kwargs: object) -> Profile | None:
+        raise SQLAlchemyError("boom")
+
+    monkeypatch.setattr(profile_service.db, "run_db", _run_db)
 
     with pytest.raises(HTTPException) as excinfo:
         await profile_service.get_profile(1)
 
     assert excinfo.value.status_code == 500
+    assert excinfo.value.detail == "database error"


### PR DESCRIPTION
## Summary
- catch `SQLAlchemyError` in profile service
- log SQLAlchemy-specific failures and return database error
- test SQLAlchemyError handling and unexpected exception propagation

## Testing
- `ruff check services/api/app/services/profile.py tests/test_profile_errors.py`
- `mypy --strict services/api/app/services/profile.py tests/test_profile_errors.py`
- `pytest -q tests/test_profile_errors.py --cov=services.api.app.services.profile --cov-report=term`


------
https://chatgpt.com/codex/tasks/task_e_68be80cf5dbc832a8fde414c47c9c450