### PR TITLE
[health] Handle SQLAlchemyError in ping endpoint

### DIFF
--- a/services/api/app/routers/health.py
+++ b/services/api/app/routers/health.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 import sqlalchemy as sa
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from services.api.app.diabetes.services.db import SessionLocal, run_db
@@ -34,7 +35,7 @@ async def ping() -> JSONResponse:
 
     try:
         await run_db(_ping, sessionmaker=SessionLocal)
-    except Exception:
+    except SQLAlchemyError:
         logger.exception("Database ping failed")
         return JSONResponse({"status": "down"}, status_code=503)
 

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import SQLAlchemyError
+
+from services.api.app.main import app
+from services.api.app.routers import health
+
+
+def test_ping_returns_503_when_db_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fail_run_db(*args: object, **kwargs: object) -> None:
+        raise SQLAlchemyError("db down")
+
+    monkeypatch.setattr(health, "run_db", fail_run_db)
+    from services.api.app import main
+    monkeypatch.setattr(main, "init_db", lambda: None)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/health/ping")
+
+    assert resp.status_code == 503
+    assert resp.json() == {"status": "down"}


### PR DESCRIPTION
## Summary
- narrow ping endpoint exception handling to SQLAlchemyError
- add test for health ping returning 503 when DB is unreachable

## Testing
- `ruff check services/api/app/routers/health.py tests/api/test_health.py`
- `mypy --strict services/api/app/routers/health.py tests/api/test_health.py`
- `pytest -q tests/api/test_health.py`


------
https://chatgpt.com/codex/tasks/task_e_68be80c67874832ab34c951899e11ca3