### PR TITLE
[webapp/ui] Render chart styles without unsafe HTML

### DIFF
--- a/services/webapp/ui/src/components/ui/chart.tsx
+++ b/services/webapp/ui/src/components/ui/chart.tsx
@@ -81,30 +81,25 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
     return null
   }
 
-  return (
-    <style
-      dangerouslySetInnerHTML={{
-        __html: Object.entries(THEMES)
-          .map(
-            ([theme, prefix]) => `
-${prefix} [data-chart=${id}] {
-${colorConfig
-  .map(([key, itemConfig]) => {
-    const color =
-      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
-      itemConfig.color
-    return color && isValidColor(color)
-      ? `  --color-${key}: ${color};`
-      : null
-  })
-  .join("\n")}
-}
-`
-          )
-          .join("\n"),
-      }}
-    />
-  )
+  const css = Object.entries(THEMES)
+    .map(([theme, prefix]) => {
+      const declarations = colorConfig
+        .map(([key, itemConfig]) => {
+          const colorValue =
+            itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+            itemConfig.color
+          const color = colorValue?.trim()
+          return color && isValidColor(color)
+            ? `  --color-${key}: ${color};`
+            : null
+        })
+        .filter(Boolean)
+        .join("\n")
+      return `${prefix} [data-chart=${id}] {\n${declarations}\n}`
+    })
+    .join("\n")
+
+  return <style>{css}</style>
 }
 
 const ChartTooltip = RechartsPrimitive.Tooltip


### PR DESCRIPTION
## Summary
- generate chart CSS with React `<style>` instead of `dangerouslySetInnerHTML`
- trim and validate chart colors to allow only safe values

## Testing
- `pnpm --filter ./services/webapp/ui test src/components/ui/chart.test.tsx`
- `ruff check .`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict` *(fails: command interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_68be8ffeeed0832aa1b35b1a1fc76776