### PR TITLE
[utils] Enhance coordinate parsing

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -78,7 +78,7 @@ async def get_coords_and_link(
         return None, None
 
     content_type = resp.headers.get("Content-Type", "")
-    if content_type and "application/json" not in content_type:
+    if content_type and "application/json" not in content_type.lower():
         logger.warning("Unexpected content type: %s", content_type)
         return None, None
 
@@ -89,16 +89,20 @@ async def get_coords_and_link(
         return None, None
 
     loc = data.get("loc")
-    if loc:
+    if isinstance(loc, str):
         try:
-            lat, lon = loc.split(",")
+            lat, lon = (part.strip() for part in loc.split(","))
         except ValueError:
+            logger.warning("Invalid location format: %s", loc)
+            return None, None
+        if not lat or not lon:
             logger.warning("Invalid location format: %s", loc)
             return None, None
         coords = f"{lat},{lon}"
         link = f"https://maps.google.com/?q={lat},{lon}"
         return coords, link
-
+    if loc is not None:
+        logger.warning("Invalid location format: %s", loc)
     return None, None
 
 


### PR DESCRIPTION
## Summary
- normalize Content-Type header before JSON check in coordinate helper
- guard and strip location strings, warning on malformed data
- extend helper tests for header casing and non-standard `loc` values

## Testing
- `pytest tests/test_utils.py -q --cov=services.api.app.diabetes.utils.helpers --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be902c4ea4832abab929b76e0bb203