### PR TITLE
[handlers] store edit message identifiers

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -7,8 +7,6 @@ try:
 except ImportError:  # Python <3.12
     from typing_extensions import TypedDict
 
-from telegram import CallbackQuery
-
 
 class EntryData(TypedDict, total=False):
     """Data used to create or update an :class:`Entry`."""
@@ -26,6 +24,13 @@ class EntryData(TypedDict, total=False):
     photo_path: str | None
 
 
+class EditMessageMeta(TypedDict):
+    """Metadata about the message being edited."""
+
+    chat_id: int
+    message_id: int
+
+
 class UserData(TypedDict, total=False):
     """Mutable mapping used to store per-user state in handlers."""
 
@@ -37,7 +42,7 @@ class UserData(TypedDict, total=False):
     edit_id: int | None
     edit_entry: dict[str, object]
     edit_field: str
-    edit_query: CallbackQuery | None
+    edit_query: EditMessageMeta
     profile_icr: float
     profile_cf: float
     profile_target: float
@@ -49,4 +54,4 @@ class UserData(TypedDict, total=False):
 
 from .dose_calc import _cancel_then  # noqa: E402
 
-__all__ = ["_cancel_then", "EntryData", "UserData"]
+__all__ = ["_cancel_then", "EntryData", "EditMessageMeta", "UserData"]

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -4,10 +4,9 @@ import datetime
 import logging
 import re
 from collections.abc import Awaitable, Callable
-from typing import Protocol, TypedDict, TypeVar, cast
+from typing import Protocol, TypeVar, cast
 
 from telegram import (
-    CallbackQuery,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     Message,
@@ -39,7 +38,7 @@ from services.api.app.assistant.services import memory_service
 from .alert_handlers import check_alert as _check_alert
 from .dose_validation import _sanitize
 from .reporting_handlers import EntryLike, render_entry, send_report
-from . import EntryData, UserData
+from . import EntryData, UserData, EditMessageMeta
 
 commit = _commit
 check_alert = _check_alert
@@ -48,7 +47,9 @@ T = TypeVar("T")
 
 
 class RunDB(Protocol):
-    def __call__(self, fn: Callable[[Session], T], *args: object, **kwargs: object) -> Awaitable[T]: ...
+    def __call__(
+        self, fn: Callable[[Session], T], *args: object, **kwargs: object
+    ) -> Awaitable[T]: ...
 
 
 logger = logging.getLogger(__name__)
@@ -61,13 +62,6 @@ except ImportError:  # pragma: no cover - optional db runner
     run_db = None
 else:
     run_db = cast(RunDB, _run_db)
-
-
-class EditMessageMeta(TypedDict):
-    """Metadata about the message being edited."""
-
-    chat_id: int
-    message_id: int
 
 
 async def _handle_report_request(
@@ -92,7 +86,9 @@ async def _handle_report_request(
         await message.reply_text("📋 Выберите действие:", reply_markup=menu_keyboard)
         return True
     try:
-        date_from = datetime.datetime.strptime(raw_text, "%Y-%m-%d").replace(tzinfo=datetime.timezone.utc)
+        date_from = datetime.datetime.strptime(raw_text, "%Y-%m-%d").replace(
+            tzinfo=datetime.timezone.utc
+        )
     except ValueError:
         await message.reply_text("❗ Некорректная дата. Используйте формат YYYY-MM-DD.")
         return True
@@ -134,7 +130,9 @@ async def _handle_pending_entry(
     *,
     SessionLocal: sessionmaker[Session],
     commit: Callable[[Session], None],
-    check_alert: Callable[[Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]],
+    check_alert: Callable[
+        [Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]
+    ],
     menu_keyboard: ReplyKeyboardMarkup | None,
 ) -> bool:
     """Process numeric input for a pending entry."""
@@ -205,7 +203,10 @@ async def _handle_pending_entry(
         return True
 
     text = raw_text.lower()
-    if re.fullmatch(r"-?\d+(?:[.,]\d+)?", text) and pending_entry.get("sugar_before") is None:
+    if (
+        re.fullmatch(r"-?\d+(?:[.,]\d+)?", text)
+        and pending_entry.get("sugar_before") is None
+    ):
         try:
             sugar = float(text.replace(",", "."))
         except ValueError:
@@ -215,7 +216,10 @@ async def _handle_pending_entry(
             await message.reply_text("Сахар не может быть отрицательным.")
             return True
         pending_entry["sugar_before"] = sugar
-        if pending_entry.get("carbs_g") is not None or pending_entry.get("xe") is not None:
+        if (
+            pending_entry.get("carbs_g") is not None
+            or pending_entry.get("xe") is not None
+        ):
             xe_val = pending_entry.get("xe")
             carbs_g = pending_entry.get("carbs_g")
             if carbs_g is None and xe_val is not None:
@@ -245,7 +249,9 @@ async def _handle_pending_entry(
                 and profile.cf is not None
                 and profile.target_bg is not None
             ):
-                patient = PatientProfile(icr=profile.icr, cf=profile.cf, target_bg=profile.target_bg)
+                patient = PatientProfile(
+                    icr=profile.icr, cf=profile.cf, target_bg=profile.target_bg
+                )
                 dose = calc_bolus(carbs_g, sugar, patient)
                 pending_entry["dose"] = dose
                 await message.reply_text(
@@ -253,7 +259,9 @@ async def _handle_pending_entry(
                     reply_markup=confirm_keyboard(),
                 )
                 return True
-        await message.reply_text("Введите количество углеводов или ХЕ.", reply_markup=menu_keyboard)
+        await message.reply_text(
+            "Введите количество углеводов или ХЕ.", reply_markup=menu_keyboard
+        )
         return True
 
     # not handled here
@@ -273,8 +281,7 @@ async def _handle_edit_entry(
     edit_id = user_data.get("edit_id")
     if edit_id is None:
         return False
-    edit_query_obj = user_data.get("edit_query")
-    edit_query: CallbackQuery | None = edit_query_obj if isinstance(edit_query_obj, CallbackQuery) else None
+    edit_query_raw = user_data.get("edit_query")
     text = raw_text.replace(",", ".")
     try:
         value = float(text)
@@ -311,17 +318,14 @@ async def _handle_edit_entry(
         entry = await run_db(db_edit, sessionmaker=SessionLocal)
     if entry is None:
         await message.reply_text("⚠️ Не удалось сохранить запись.")
-        if edit_query is not None:
-            await edit_query.answer("Не удалось")
         return True
-    edit_info_raw = user_data.get("edit_entry")
-    if not isinstance(edit_info_raw, dict):
+    if not isinstance(edit_query_raw, dict):
         for key in ("edit_id", "edit_field", "edit_entry", "edit_query"):
             user_data.pop(key, None)  # type: ignore[misc]
         return False
-    edit_info = cast(EditMessageMeta, edit_info_raw)
-    chat_id = edit_info["chat_id"]
-    message_id = edit_info["message_id"]
+    edit_query = cast(EditMessageMeta, edit_query_raw)
+    chat_id = edit_query["chat_id"]
+    message_id = edit_query["message_id"]
     markup = InlineKeyboardMarkup(
         [
             [
@@ -338,8 +342,6 @@ async def _handle_edit_entry(
         reply_markup=markup,
         parse_mode="HTML",
     )
-    if edit_query is not None:
-        await edit_query.answer("Изменено")
     for key in ("edit_id", "edit_field", "edit_entry", "edit_query"):
         user_data.pop(key, None)  # type: ignore[misc]
     return True
@@ -350,7 +352,9 @@ def parse_quick_values(
 ) -> tuple[dict[str, float | None], float | None]:
     """Parse quick values (sugar/xe/dose) and carbs."""
     quick = smart_input(raw_text)
-    carbs_match = re.search(r"(?:carbs|углеводов)\s*=\s*(-?\d+(?:[.,]\d+)?)", raw_text, re.I)
+    carbs_match = re.search(
+        r"(?:carbs|углеводов)\s*=\s*(-?\d+(?:[.,]\d+)?)", raw_text, re.I
+    )
     carbs_val = float(carbs_match.group(1).replace(",", ".")) if carbs_match else None
     return quick, carbs_val
 
@@ -366,7 +370,9 @@ async def apply_pending_entry(
     user_id: int,
     SessionLocal: sessionmaker[Session],
     commit: Callable[[Session], None],
-    check_alert: Callable[[Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]],
+    check_alert: Callable[
+        [Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]
+    ],
     menu_keyboard: ReplyKeyboardMarkup | None,
 ) -> bool:
     """Apply quick values to pending entry or create a new one."""
@@ -385,7 +391,9 @@ async def apply_pending_entry(
             pending_entry["carbs_g"] = XE_GRAMS * quick["xe"]
         elif carbs_g is not None:
             if carbs_g < 0:
-                await message.reply_text("Количество углеводов не может быть отрицательным.")
+                await message.reply_text(
+                    "Количество углеводов не может быть отрицательным."
+                )
                 return True
             pending_entry["carbs_g"] = carbs_g
         if quick["dose"] is not None:
@@ -520,9 +528,13 @@ async def parse_via_gpt(
         try:
             hh, mm = map(int, time_obj.split(":"))
             today = datetime.datetime.now(datetime.timezone.utc).date()
-            event_dt = datetime.datetime.combine(today, datetime.time(hh, mm), tzinfo=datetime.timezone.utc)
+            event_dt = datetime.datetime.combine(
+                today, datetime.time(hh, mm), tzinfo=datetime.timezone.utc
+            )
         except (ValueError, TypeError):
-            await message.reply_text("⏰ Неверный формат времени. Использую текущее время.")
+            await message.reply_text(
+                "⏰ Неверный формат времени. Использую текущее время."
+            )
             event_dt = datetime.datetime.now(datetime.timezone.utc)
     else:
         event_dt = datetime.datetime.now(datetime.timezone.utc)
@@ -564,7 +576,9 @@ async def finalize_entry(
     dose_part = f"Инсулин: {dose_val}\u202fед" if dose_val is not None else ""
     sugar_part = f"Сахар: {sugar_val}\u202fммоль/л" if sugar_val is not None else ""
     lines = "  \n- ".join(filter(None, [xe_part or carb_part, dose_part, sugar_part]))
-    reply = f"💉 Расчёт завершён:\n\n{date_str}  \n- {lines}\n\nСохранить это в дневник?"
+    reply = (
+        f"💉 Расчёт завершён:\n\n{date_str}  \n- {lines}\n\nСохранить это в дневник?"
+    )
     await message.reply_text(text=reply, reply_markup=confirm_keyboard())
 
 
@@ -574,7 +588,9 @@ async def freeform_handler(
     *,
     SessionLocal: sessionmaker[Session] | None = None,
     commit: Callable[[Session], None] | None = None,
-    check_alert: (Callable[[Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]] | None) = None,
+    check_alert: (
+        Callable[[Update, ContextTypes.DEFAULT_TYPE, float], Awaitable[object]] | None
+    ) = None,
     menu_keyboard_markup: ReplyKeyboardMarkup | None = None,
     smart_input: Callable[[str], dict[str, float | None]] = smart_input,
     parse_command: Callable[[str], Awaitable[dict[str, object] | None]] = parse_command,

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -187,15 +187,18 @@ async def handle_edit_field(
     user_data = cast(UserData, user_data_raw)
     user_data["edit_id"] = edit_entry_id
     user_data["edit_field"] = field
-    user_data["edit_query"] = query
+    message = query.message
+    if not isinstance(message, Message):
+        return
+    user_data["edit_query"] = {
+        "chat_id": message.chat_id,
+        "message_id": message.message_id,
+    }
     prompt = {
         "sugar": "Введите уровень сахара (ммоль/л).",
         "xe": "Введите количество ХЕ.",
         "dose": "Введите дозу инсулина (ед.).",
     }.get(field, "Введите значение")
-    message = query.message
-    if not isinstance(message, Message):
-        return
     await message.reply_text(prompt, reply_markup=ForceReply(selective=True))
 
 


### PR DESCRIPTION
## Summary
- avoid storing full CallbackQuery in user_data; persist chat_id and message_id instead
- rebuild messages from stored ids when applying edits
- adjust UserData type and tests for new `edit_query` structure

## Testing
- `pytest tests/test_edit_record.py::test_edit_dose tests/test_edit_record.py::test_edit_dose_commit_failure tests/test_handlers_history_edit.py::test_history_view_buttons tests/test_handlers_history_edit.py::test_handle_edit_entry_missing_metadata -q`
- `pytest tests/test_edit_record.py::test_edit_dose tests/test_edit_record.py::test_edit_dose_commit_failure tests/test_handlers_history_edit.py::test_history_view_buttons tests/test_handlers_history_edit.py::test_handle_edit_entry_missing_metadata --cov=services/api/app/diabetes/handlers -q`
- `mypy --strict services/api/app/diabetes/handlers/router.py services/api/app/diabetes/handlers/gpt_handlers.py services/api/app/diabetes/handlers/__init__.py tests/test_edit_record.py tests/test_handlers_history_edit.py`
- `ruff check services/api/app/diabetes/handlers/router.py services/api/app/diabetes/handlers/gpt_handlers.py services/api/app/diabetes/handlers/__init__.py tests/test_edit_record.py tests/test_handlers_history_edit.py`

------
https://chatgpt.com/codex/tasks/task_e_68be90387240832a85f92b48417093d7