### PR TITLE
[utils] make get_coords_and_link use dynamic GEO_DATA_URL

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -59,15 +59,12 @@ def parse_time_interval(value: str) -> time | timedelta:
         raise ValueError(INVALID_TIME_MSG)
 
 
-GEO_DATA_URL = os.getenv("GEO_DATA_URL", "https://ipinfo.io/json")
-
-
 async def get_coords_and_link(
     source_url: str | None = None,
 ) -> tuple[str | None, str | None]:
     """Return approximate coordinates and Google Maps link based on IP."""
 
-    url = source_url or GEO_DATA_URL
+    url = source_url or os.getenv("GEO_DATA_URL") or "https://ipinfo.io/json"
 
     try:
         async with httpx.AsyncClient() as client:


### PR DESCRIPTION
## Summary
- retrieve GEO_DATA_URL from environment in `get_coords_and_link` instead of global constant
- add regression test for environment variable changes

## Testing
- `pytest tests/test_utils.py -q`
- `pytest tests/test_utils.py::test_get_coords_and_link_env_change -q --cov=services.api.app.diabetes.utils.helpers`
- `ruff check services/api/app/diabetes/utils/helpers.py tests/test_utils.py`
- `mypy --strict services/api/app/diabetes/utils/helpers.py tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68be903fd484832a85b7b88cd5cc59fd