### PR TITLE
[api] enforce auth for user roles

### DIFF
--- a/services/api/app/routers/users.py
+++ b/services/api/app/routers/users.py
@@ -43,7 +43,10 @@ async def create_user(
 
 
 @router.get("/user/{user_id}/role")
-async def get_role(user_id: int) -> RoleSchema:
+async def get_role(
+    user_id: int,
+    _: UserContext = Depends(require_tg_user),
+) -> RoleSchema:
     """Return user role."""
 
     role = await get_user_role(user_id)
@@ -51,8 +54,16 @@ async def get_role(user_id: int) -> RoleSchema:
 
 
 @router.put("/user/{user_id}/role")
-async def put_role(user_id: int, data: RoleSchema) -> RoleSchema:
+async def put_role(
+    user_id: int,
+    data: RoleSchema,
+    user: UserContext = Depends(require_tg_user),
+) -> RoleSchema:
     """Set user role."""
+
+    caller_role = await get_user_role(user["id"])
+    if caller_role != "superadmin":
+        raise HTTPException(status_code=403, detail="forbidden")
 
     await set_user_role(user_id, data.role)
     return RoleSchema(role=data.role)

--- a/tests/test_user_roles.py
+++ b/tests/test_user_roles.py
@@ -5,10 +5,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-import services.api.app.main as server
 from services.api.app.diabetes.services import db
 from services.api.app.middleware.auth import AuthMiddleware
+from services.api.app.routers import users
 from services.api.app.services import user_roles
+from services.api.app.telegram_auth import require_tg_user
 
 
 def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
@@ -25,21 +26,57 @@ def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
 
 def test_role_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
     SessionLocal = setup_db(monkeypatch)
-    with TestClient(server.app) as client:
+    with SessionLocal() as session:
+        session.add(db.UserRole(user_id=1, role="superadmin"))
+        session.commit()
+
+    app = FastAPI()
+    app.include_router(users.router, prefix="/api")
+    app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
+
+    with TestClient(app) as client:
         resp = client.get("/api/user/1/role")
         assert resp.status_code == 200
-        assert resp.json() == {"role": "patient"}
-        resp = client.put("/api/user/1/role", json={"role": "clinician"})
+        assert resp.json() == {"role": "superadmin"}
+
+        resp = client.put("/api/user/2/role", json={"role": "clinician"})
         assert resp.status_code == 200
         assert resp.json() == {"role": "clinician"}
-        resp = client.get("/api/user/1/role")
+
+        resp = client.get("/api/user/2/role")
         assert resp.status_code == 200
         assert resp.json() == {"role": "clinician"}
 
     with SessionLocal() as session:
-        obj = session.get(db.UserRole, 1)
+        obj = session.get(db.UserRole, 2)
         assert obj is not None
         assert obj.role == "clinician"
+
+
+def test_get_role_requires_token() -> None:
+    app = FastAPI()
+    app.include_router(users.router, prefix="/api")
+    with TestClient(app) as client:
+        resp = client.get("/api/user/1/role")
+    assert resp.status_code == 401
+
+
+def test_put_role_requires_token() -> None:
+    app = FastAPI()
+    app.include_router(users.router, prefix="/api")
+    with TestClient(app) as client:
+        resp = client.put("/api/user/1/role", json={"role": "clinician"})
+    assert resp.status_code == 401
+
+
+def test_put_role_forbidden(monkeypatch: pytest.MonkeyPatch) -> None:
+    setup_db(monkeypatch)
+    app = FastAPI()
+    app.include_router(users.router, prefix="/api")
+    app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
+    with TestClient(app) as client:
+        resp = client.put("/api/user/2/role", json={"role": "clinician"})
+    assert resp.status_code == 403
 
 
 def test_middleware_reads_role(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- require Telegram user auth on role endpoints
- restrict role updates to superadmins
- add tests for token and permission checks

## Testing
- `pytest tests/test_user_roles.py -q`
- `pytest -q --cov` *(fails: numerous failing tests)*
- `mypy --strict services/api/app/routers/users.py tests/test_user_roles.py` *(hung)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be9efb2170832aa96d3056b2137856