### PR TITLE
[billing] enforce TG user authorization

### DIFF
--- a/tests/billing/test_billing_router.py
+++ b/tests/billing/test_billing_router.py
@@ -4,13 +4,16 @@ from fastapi.testclient import TestClient
 
 from services.api.app.billing import reload_billing_settings
 from services.api.app.main import app
+from services.api.app.telegram_auth import require_tg_user
 
 
 def test_billing_disabled(monkeypatch) -> None:
     monkeypatch.setenv("BILLING_ENABLED", "false")
     reload_billing_settings()
     with TestClient(app) as client:
-        response = client.post("/api/billing/pay")
+        client.app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
+        response = client.post("/api/billing/pay", params={"user_id": 1})
+        client.app.dependency_overrides.clear()
     assert response.status_code == 503
 
 
@@ -20,7 +23,8 @@ def test_dummy_provider(monkeypatch) -> None:
     monkeypatch.setenv("BILLING_TEST_MODE", "true")
     reload_billing_settings()
     with TestClient(app) as client:
-        response = client.post("/api/billing/pay")
+        client.app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
+        response = client.post("/api/billing/pay", params={"user_id": 1})
+        client.app.dependency_overrides.clear()
     assert response.status_code == 200
     assert response.json() == {"status": "ok", "test_mode": True}
-

--- a/tests/test_billing_auth.py
+++ b/tests/test_billing_auth.py
@@ -1,0 +1,99 @@
+"""Authorization tests for billing endpoints."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+import urllib.parse
+from collections.abc import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.api.app.config import settings
+from services.api.app.main import app
+from services.api.app.routers import billing
+from services.api.app.telegram_auth import TG_INIT_DATA_HEADER
+from services.api.app.billing.config import BillingSettings
+
+
+TOKEN = "test-token"
+
+
+def build_init_data(token: str = TOKEN, user_id: int = 1) -> str:
+    """Create signed init data for Telegram WebApp."""
+
+    user = json.dumps({"id": user_id}, separators=(",", ":"))
+    params = {"auth_date": str(int(time.time())), "user": user}
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
+    secret = hmac.new(b"WebAppData", token.encode(), hashlib.sha256).digest()
+    params["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return urllib.parse.urlencode(params)
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+    """Test client with billing enabled."""
+
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    with TestClient(app) as test_client:
+        test_client.app.dependency_overrides.clear()
+        test_client.app.dependency_overrides[billing._require_billing_enabled] = (
+            lambda: BillingSettings(
+                billing_enabled=True,
+                billing_test_mode=True,
+                billing_provider="dummy",
+                paywall_mode="soft",
+            )
+        )
+        try:
+            yield test_client
+        finally:
+            test_client.app.dependency_overrides.clear()
+
+
+def test_pay_requires_auth(client: TestClient) -> None:
+    resp = client.post("/api/billing/pay", params={"user_id": 1})
+    assert resp.status_code == 401
+
+
+def test_pay_id_mismatch(client: TestClient) -> None:
+    init_data = build_init_data()
+    resp = client.post(
+        "/api/billing/pay",
+        params={"user_id": 2},
+        headers={TG_INIT_DATA_HEADER: init_data},
+    )
+    assert resp.status_code == 403
+
+
+def test_trial_id_mismatch(client: TestClient) -> None:
+    init_data = build_init_data()
+    resp = client.post(
+        "/api/billing/trial",
+        params={"user_id": 2},
+        headers={TG_INIT_DATA_HEADER: init_data},
+    )
+    assert resp.status_code == 403
+
+
+def test_trial_requires_auth(client: TestClient) -> None:
+    resp = client.post("/api/billing/trial", params={"user_id": 1})
+    assert resp.status_code == 401
+
+
+def test_subscribe_id_mismatch(client: TestClient) -> None:
+    init_data = build_init_data()
+    resp = client.post(
+        "/api/billing/subscribe",
+        params={"user_id": 2, "plan": "pro"},
+        headers={TG_INIT_DATA_HEADER: init_data},
+    )
+    assert resp.status_code == 403
+
+
+def test_subscribe_requires_auth(client: TestClient) -> None:
+    resp = client.post("/api/billing/subscribe", params={"user_id": 1, "plan": "pro"})
+    assert resp.status_code == 401

--- a/tests/test_billing_trial.py
+++ b/tests/test_billing_trial.py
@@ -23,6 +23,7 @@ from services.api.app.diabetes.services.db import (
     SubStatus,
 )
 from services.api.app.billing.log import BillingEvent, BillingLog
+from services.api.app.telegram_auth import require_tg_user
 
 
 def parse_iso(dt: str) -> datetime:
@@ -38,14 +39,20 @@ def setup_db() -> sessionmaker[Session]:
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-    Base.metadata.create_all(engine, tables=[Subscription.__table__, BillingLog.__table__])
+    Base.metadata.create_all(
+        engine, tables=[Subscription.__table__, BillingLog.__table__]
+    )
     return sessionmaker(bind=engine, expire_on_commit=False)
 
 
-def make_client(monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]) -> TestClient:
+def make_client(
+    monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]
+) -> TestClient:
     from services.api.app.billing.config import BillingSettings
 
-    async def run_db(fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs):
+    async def run_db(
+        fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs
+    ):
         with sessionmaker() as session:
             return fn(session, *args, **kwargs)
 
@@ -54,14 +61,30 @@ def make_client(monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Ses
 
     from services.api.app.main import app
 
-    app.dependency_overrides[billing._require_billing_enabled] = lambda: BillingSettings(
-        billing_enabled=True,
-        billing_test_mode=True,
-        billing_provider="dummy",
-        paywall_mode="soft",
+    app.dependency_overrides[billing._require_billing_enabled] = (
+        lambda: BillingSettings(
+            billing_enabled=True,
+            billing_test_mode=True,
+            billing_provider="dummy",
+            paywall_mode="soft",
+        )
     )
 
-    return TestClient(app)
+    app.dependency_overrides[require_tg_user] = lambda: {"id": 1}
+
+    client = TestClient(app)
+    orig_exit = client.__exit__
+
+    def _exit(
+        exc_type: object, exc: object, tb: object
+    ) -> bool:  # pragma: no cover - cleanup
+        try:
+            return orig_exit(exc_type, exc, tb)
+        finally:
+            client.app.dependency_overrides.clear()
+
+    client.__exit__ = _exit  # type: ignore[method-assign]
+    return client
 
 
 # --- tests --------------------------------------------------------------------
@@ -177,7 +200,9 @@ def test_trial_repeat_call_after_expiration(
     assert count == 1
 
 
-def test_trial_integrity_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+def test_trial_integrity_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     session_local = setup_db()
     client = make_client(monkeypatch, session_local)
     calls: dict[str, int] = {"n": 0}
@@ -210,7 +235,9 @@ def test_trial_integrity_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.L
     }
 
 
-def test_trial_invalid_enum(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+def test_trial_invalid_enum(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     session_local = setup_db()
     client = make_client(monkeypatch, session_local)
     calls: dict[str, int] = {"n": 0}
@@ -254,14 +281,18 @@ async def test_trial_parallel_requests(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(billing, "SessionLocal", session_local, raising=False)
     from services.api.app.main import app
 
-    app.dependency_overrides[billing._require_billing_enabled] = lambda: BillingSettings(
-        billing_enabled=True,
-        billing_test_mode=True,
-        billing_provider="dummy",
-        paywall_mode="soft",
+    app.dependency_overrides[billing._require_billing_enabled] = (
+        lambda: BillingSettings(
+            billing_enabled=True,
+            billing_test_mode=True,
+            billing_provider="dummy",
+            paywall_mode="soft",
+        )
     )
 
-    async with AsyncClient(transport=ASGITransport(app=cast(Any, app)), base_url="http://test") as ac:
+    async with AsyncClient(
+        transport=ASGITransport(app=cast(Any, app)), base_url="http://test"
+    ) as ac:
         resp1, resp2 = await asyncio.gather(
             ac.post("/api/billing/trial", params={"user_id": 1}),
             ac.post("/api/billing/trial", params={"user_id": 1}),


### PR DESCRIPTION
## Summary
- require Telegram user context for billing endpoints
- validate user id matches authenticated user
- add tests for unauthorized or spoofed billing requests

## Testing
- `pytest tests/test_billing_auth.py tests/billing/test_billing_router.py tests/test_billing_trial.py tests/test_billing_trial_response.py tests/billing/test_billing_subscribe.py tests/billing/test_billing_webhook.py tests/test_legacy_reminders_auth.py -q`
- `mypy --strict services/api/app/routers/billing.py tests/test_billing_auth.py tests/billing/test_billing_router.py tests/test_billing_trial.py tests/billing/test_billing_subscribe.py tests/billing/test_billing_webhook.py tests/test_legacy_reminders_auth.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be9f0722f0832a849ce990df33e5ce