### PR TITLE
[routers] add token auth for internal reminders

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -112,6 +112,7 @@ class Settings(BaseSettings):
     onboarding_video_url: Optional[str] = Field(default=None, alias="ONBOARDING_VIDEO_URL")
     telegram_token: Optional[str] = Field(default=None, alias="TELEGRAM_TOKEN")
     telegram_payments_provider_token: Optional[str] = Field(default=None, alias="TELEGRAM_PAYMENTS_PROVIDER_TOKEN")
+    internal_api_key: Optional[str] = Field(default=None, alias="INTERNAL_API_KEY")
     admin_id: Optional[int] = Field(default=None, alias="ADMIN_ID")
 
     @field_validator("log_level", mode="before")

--- a/services/api/app/routers/internal_reminders.py
+++ b/services/api/app/routers/internal_reminders.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
 
 from .. import reminder_events
+from ..config import settings
+
+
+def _require_internal_token(
+    token: str | None = Header(None, alias="X-Internal-API-Key"),
+) -> None:
+    if not token or token != settings.internal_api_key:
+        raise HTTPException(status_code=401, detail="invalid token")
 
 
 class ReminderId(BaseModel):
@@ -14,12 +22,16 @@ router = APIRouter(prefix="/internal/reminders")
 
 
 @router.post("/saved")
-async def reminder_saved(data: ReminderId) -> dict[str, str]:
+async def reminder_saved(
+    data: ReminderId, _: None = Depends(_require_internal_token)
+) -> dict[str, str]:
     await reminder_events.notify_reminder_saved(data.id)
     return {"status": "ok"}
 
 
 @router.post("/deleted")
-async def reminder_deleted(data: ReminderId) -> dict[str, str]:
+async def reminder_deleted(
+    data: ReminderId, _: None = Depends(_require_internal_token)
+) -> dict[str, str]:
     reminder_events.notify_reminder_deleted(data.id)
     return {"status": "ok"}

--- a/tests/test_internal_reminders_router.py
+++ b/tests/test_internal_reminders_router.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 import pytest
 
 from services.api.app import reminder_events
+from services.api.app.config import settings
 from services.api.app.routers.internal_reminders import router
 
 
@@ -12,11 +13,16 @@ def test_saved_notifies(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_notify(rid: int) -> None:
         called.append(rid)
 
+    monkeypatch.setattr(settings, "internal_api_key", "token")
     monkeypatch.setattr(reminder_events, "notify_reminder_saved", fake_notify)
     app = FastAPI()
     app.include_router(router)
     with TestClient(app) as client:
-        resp = client.post("/internal/reminders/saved", json={"id": 1})
+        resp = client.post(
+            "/internal/reminders/saved",
+            json={"id": 1},
+            headers={"X-Internal-API-Key": "token"},
+        )
     assert resp.status_code == 200
     assert called == [1]
 
@@ -27,10 +33,27 @@ def test_deleted_notifies(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_notify(rid: int) -> None:
         called.append(rid)
 
+    monkeypatch.setattr(settings, "internal_api_key", "token")
     monkeypatch.setattr(reminder_events, "notify_reminder_deleted", fake_notify)
     app = FastAPI()
     app.include_router(router)
     with TestClient(app) as client:
-        resp = client.post("/internal/reminders/deleted", json={"id": 2})
+        resp = client.post(
+            "/internal/reminders/deleted",
+            json={"id": 2},
+            headers={"X-Internal-API-Key": "token"},
+        )
     assert resp.status_code == 200
     assert called == [2]
+
+
+@pytest.mark.parametrize("path", ["/internal/reminders/saved", "/internal/reminders/deleted"])
+def test_requires_token(monkeypatch: pytest.MonkeyPatch, path: str) -> None:
+    monkeypatch.setattr(settings, "internal_api_key", "token")
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as client:
+        resp = client.post(path, json={"id": 1})
+        assert resp.status_code == 401
+        resp = client.post(path, json={"id": 1}, headers={"X-Internal-API-Key": "wrong"})
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- require internal API key header for `/internal/reminders` routes
- add `internal_api_key` setting
- test reminders endpoints for missing or invalid token

## Testing
- `pytest -q --cov` (fails: tests/test_gpt_client.py::test_upload_image_file, tests/test_gpt_client.py::test_validate_image_path, tests/test_gpt_command_parser.py::test_extract_first_json_malformed_input, tests/test_gpt_command_parser.py::test_parse_command_with_malformed_json, tests/test_health_ping.py::test_ping_down)
- `pytest tests/test_internal_reminders_router.py -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68be9f0f62d0832a84615b5c80b93b27