### PR TITLE
[profile] pass DB session factory explicitly

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -254,8 +254,9 @@ async def profile_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         getattr(profile, field, None) is None for field in ("target", "low", "high")
     ):
         try:
-            profile_service.db.SessionLocal = SessionLocal
-            profile = await profile_service.get_profile(user_id)
+            profile = await profile_service.get_profile(
+                user_id, sessionmaker=SessionLocal
+            )
         except HTTPException as exc:
             if exc.status_code != 404:
                 logger.exception("failed to fetch profile from DB for %s", user_id)
@@ -423,7 +424,10 @@ async def profile_webapp_save(
     if settings is not None or device_tz is not None:
         try:
             await profile_service.patch_user_settings(
-                user_id, settings or ProfileSettingsIn(), device_tz
+                user_id,
+                settings or ProfileSettingsIn(),
+                device_tz,
+                sessionmaker=SessionLocal,
             )
         except HTTPException:
             await eff_msg.reply_text(
@@ -459,7 +463,9 @@ async def profile_back(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     message = cast(Message, query.message)
     await query.answer()
     await message.delete()
-    await message.reply_text("📋 Выберите действие:", reply_markup=build_main_keyboard())
+    await message.reply_text(
+        "📋 Выберите действие:", reply_markup=build_main_keyboard()
+    )
 
 
 async def profile_timezone(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:


### PR DESCRIPTION
## Summary
- inject session factory into profile service functions
- remove global SessionLocal assignment in profile conversation handler

## Testing
- `pytest -q --cov` *(fails: test_gpt_client.py::test_upload_image_file, test_gpt_client.py::test_validate_image_path, test_gpt_command_parser.py::test_extract_first_json_malformed_input, test_gpt_command_parser.py::test_parse_command_with_malformed_json, test_health_ping.py::test_ping_down)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bea0115244832ab4af8dbb626838f1