### PR TITLE
[services] Narrow transactional exception handling

### DIFF
--- a/services/api/app/diabetes/services/repository.py
+++ b/services/api/app/diabetes/services/repository.py
@@ -41,7 +41,11 @@ def transactional(session: Session) -> Iterator[Session]:
     try:
         yield session
         session.commit()
-    except Exception as exc:  # pragma: no cover - logging only
+    except SQLAlchemyError as exc:  # pragma: no cover - logging only
         session.rollback()
         logger.exception("DB transaction failed: %s", exc.__class__.__name__)
+        raise
+    except Exception:  # pragma: no cover - logging only
+        session.rollback()
+        logger.exception("Unexpected DB transaction error")
         raise


### PR DESCRIPTION
## Summary
- refine transactional session handling to catch SQLAlchemy errors and log/re-raise unexpected ones

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bea01ae198832a8d9a63bebf388b7a