### PR TITLE
[utils] check timezone support before scheduling

### DIFF
--- a/services/api/app/diabetes/utils/jobs.py
+++ b/services/api/app/diabetes/utils/jobs.py
@@ -84,6 +84,7 @@ def schedule_once(
     sig = inspect.signature(job_queue.run_once)
     supports_job_kwargs = "job_kwargs" in sig.parameters
     supports_name = "name" in sig.parameters
+    supports_timezone = "timezone" in sig.parameters
 
     call_kwargs: dict[str, Any] = {"when": when, "data": data}
     jk: dict[str, object] = dict(job_kwargs or {})
@@ -103,9 +104,9 @@ def schedule_once(
         call_kwargs["job_kwargs"] = jk
 
     run_once = cast(Any, job_queue.run_once)
-    try:
+    if supports_timezone:
         result = run_once(callback, timezone=tz, **call_kwargs)
-    except TypeError:
+    else:
         result = run_once(callback, **call_kwargs)
     return cast(Job[CustomContext], result)
 
@@ -142,6 +143,7 @@ def schedule_daily(
     supports_job_kwargs = "job_kwargs" in sig.parameters
     supports_name = "name" in sig.parameters
     supports_days = "days" in sig.parameters
+    supports_timezone = "timezone" in sig.parameters
 
     call_kwargs: dict[str, Any] = {"time": time, "data": data}
     jk: dict[str, object] = dict(job_kwargs or {})
@@ -164,9 +166,9 @@ def schedule_daily(
         call_kwargs["job_kwargs"] = jk
 
     run_daily = cast(Any, job_queue.run_daily)
-    try:
+    if supports_timezone:
         result = run_daily(callback, timezone=tz, **call_kwargs)
-    except TypeError:
+    else:
         result = run_daily(callback, **call_kwargs)
     return cast(Job[CustomContext], result)
 

--- a/tests/test_schedule_daily.py
+++ b/tests/test_schedule_daily.py
@@ -256,3 +256,44 @@ def test_schedule_daily_adds_id_to_job_kwargs(queue_cls: type[object]) -> None:
         assert jq.args.timezone == jq.timezone
     else:
         assert jq.args.timezone is None
+
+
+class QueueDailyTypeError:
+    timezone = ZoneInfo("Europe/Moscow")
+
+    def run_daily(
+        self,
+        callback: Callable[..., object],
+        *,
+        time: dt_time,
+        days: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6),
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+        timezone: ZoneInfo | None = None,
+    ) -> Job:
+        raise TypeError("boom")
+
+
+class QueueDailyNoTimezoneTypeError:
+    def run_daily(
+        self,
+        callback: Callable[..., object],
+        *,
+        time: dt_time,
+        days: tuple[int, ...] = (0, 1, 2, 3, 4, 5, 6),
+        data: dict[str, object] | None = None,
+        name: str | None = None,
+    ) -> Job:
+        raise TypeError("boom")
+
+
+def test_schedule_daily_propagates_internal_type_error() -> None:
+    jq = QueueDailyTypeError()
+    with pytest.raises(TypeError):
+        schedule_daily(jq, dummy_cb, time=dt_time(1, 0))
+
+
+def test_schedule_daily_propagates_internal_type_error_without_timezone() -> None:
+    jq = QueueDailyNoTimezoneTypeError()
+    with pytest.raises(TypeError):
+        schedule_daily(jq, dummy_cb, time=dt_time(1, 0))


### PR DESCRIPTION
## Summary
- inspect JobQueue.run_once/run_daily signatures to detect timezone argument
- avoid masking internal TypeError by only omitting timezone when unsupported
- add tests for internal TypeError propagation in job scheduling helpers

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfaf925a7c832aa4c055a1a3811376