### PR TITLE
[ui] parse tgWebAppData hash

### DIFF
--- a/services/webapp/ui/src/hooks/useTelegramInitData.ts
+++ b/services/webapp/ui/src/hooks/useTelegramInitData.ts
@@ -1,7 +1,29 @@
+import { setTelegramInitData } from '@/lib/telegram-auth';
+
 export function useTelegramInitData(): string | null {
   try {
     const globalData = (window as any)?.Telegram?.WebApp?.initData;
-    return globalData || localStorage.getItem("tg_init_data");
+    if (globalData) {
+      return globalData;
+    }
+
+    let tgWebAppData: string | null = null;
+
+    try {
+      const hash = window.location.hash.startsWith('#')
+        ? window.location.hash.slice(1)
+        : window.location.hash;
+      tgWebAppData = new URLSearchParams(hash).get('tgWebAppData');
+    } catch {
+      tgWebAppData = null;
+    }
+
+    if (tgWebAppData) {
+      setTelegramInitData(tgWebAppData);
+      return tgWebAppData;
+    }
+
+    return localStorage.getItem('tg_init_data');
   } catch {
     return null;
   }

--- a/services/webapp/ui/tests/useTelegramInitData.hash.test.ts
+++ b/services/webapp/ui/tests/useTelegramInitData.hash.test.ts
@@ -1,0 +1,51 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
+import * as telegramAuth from '../src/lib/telegram-auth';
+
+describe('useTelegramInitData tgWebAppData parsing', () => {
+  afterEach((): void => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('reads tgWebAppData from location hash and stores it', () => {
+    const spy = vi.spyOn(telegramAuth, 'setTelegramInitData');
+    vi.stubGlobal('location', { hash: '#tgWebAppData=from-hash' } as any);
+
+    const { result } = renderHook(() => useTelegramInitData());
+
+    expect(result.current).toBe('from-hash');
+    expect(spy).toHaveBeenCalledWith('from-hash');
+  });
+
+  it('falls back to localStorage when URL parsing fails', () => {
+    const saved = 'from-ls';
+    localStorage.setItem('tg_init_data', saved);
+
+    class ThrowingURLSearchParams {
+      constructor(_: string) {
+        throw new Error('boom');
+      }
+      get(): string | null {
+        return null;
+      }
+    }
+    const original = URLSearchParams;
+    Object.defineProperty(globalThis, 'URLSearchParams', {
+      value: ThrowingURLSearchParams,
+      configurable: true,
+    });
+    vi.stubGlobal('location', { hash: '#tgWebAppData=broken' } as any);
+
+    const { result } = renderHook(() => useTelegramInitData());
+
+    expect(result.current).toBe(saved);
+
+    Object.defineProperty(globalThis, 'URLSearchParams', {
+      value: original,
+      configurable: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- parse `tgWebAppData` from URL hash in `useTelegramInitData`
- store parsed hash data in local storage via `setTelegramInitData`
- add tests for hash parsing and error handling

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`
- `pnpm --filter ./services/webapp/ui lint` *(fails: many @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbdc01eec832a8c1931accb50c452