### PR TITLE
[webapp] Read init data from hash

### DIFF
--- a/services/webapp/ui/src/shared/api/onboarding.ts
+++ b/services/webapp/ui/src/shared/api/onboarding.ts
@@ -9,9 +9,10 @@ export function getInitDataRaw(): string | null {
     return initData;
   }
 
-  const urlData = new URLSearchParams(window.location.search).get(
-    'tgWebAppData',
-  );
+  const hash = window.location.hash.startsWith('#')
+    ? window.location.hash.slice(1)
+    : window.location.hash;
+  const urlData = new URLSearchParams(hash).get('tgWebAppData');
 
   return urlData || null;
 }

--- a/services/webapp/ui/src/shared/initData.ts
+++ b/services/webapp/ui/src/shared/initData.ts
@@ -7,9 +7,10 @@ export function hasInitData(): boolean {
     return true;
   }
 
-  const urlData = new URLSearchParams(window.location.search).get(
-    'tgWebAppData',
-  );
+  const hash = window.location.hash.startsWith('#')
+    ? window.location.hash.slice(1)
+    : window.location.hash;
+  const urlData = new URLSearchParams(hash).get('tgWebAppData');
 
   return Boolean(urlData);
 }

--- a/services/webapp/ui/tests/initData.test.ts
+++ b/services/webapp/ui/tests/initData.test.ts
@@ -13,7 +13,7 @@ describe('hasInitData', () => {
   });
 
   it('returns true when tgWebAppData param present', () => {
-    vi.stubGlobal('location', { search: '?tgWebAppData=from-url' } as any);
+    vi.stubGlobal('location', { hash: '#tgWebAppData=from-url' } as any);
     expect(hasInitData()).toBe(true);
   });
 

--- a/services/webapp/ui/tests/onboarding.api.test.ts
+++ b/services/webapp/ui/tests/onboarding.api.test.ts
@@ -3,6 +3,7 @@ import {
   postOnboardingEvent,
   getOnboardingStatus,
 } from '../src/shared/api/onboarding';
+import { setTelegramInitData } from '../src/lib/telegram-auth';
 
 describe('onboarding api', () => {
   afterEach(() => {
@@ -10,6 +11,7 @@ describe('onboarding api', () => {
     vi.unstubAllGlobals();
     delete (window as any).Telegram;
     localStorage.clear();
+    setTelegramInitData('');
   });
 
   it('throws error when postOnboardingEvent request fails', async () => {
@@ -76,7 +78,7 @@ describe('onboarding api', () => {
       .fn()
       .mockResolvedValue(new Response(null, { status: 200 }));
     vi.stubGlobal('fetch', mockFetch);
-    vi.stubGlobal('location', { search: '?tgWebAppData=from-url' } as any);
+    vi.stubGlobal('location', { hash: '#tgWebAppData=from-url' } as any);
 
     await postOnboardingEvent('onboarding_started');
 


### PR DESCRIPTION
## Summary
- read `tgWebAppData` from URL hash instead of search params
- adjust onboarding API to parse hash-based init data
- fix tests and clear stored telegram data between onboarding API tests

## Testing
- `npx tsx -e "import { hasInitData } from './src/shared/initData.ts'; import { getInitDataRaw } from './src/shared/api/onboarding.ts'; import { JSDOM } from 'jsdom'; const dom = new JSDOM('', { url: 'https://example.com/#tgWebAppData=abc' }); global.window = dom.window; console.log('has', hasInitData()); console.log('raw', getInitDataRaw());"`
- `npx vitest run tests/initData.test.ts`
- `npx vitest run tests/onboarding.api.test.ts`
- `npx vitest run --config vitest.config.ts --maxWorkers=2` *(fails: Allocation failed - JavaScript heap out of memory)*
- `pytest -q --cov --cov-fail-under=85` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfbdbb4b7c832a82cbf6b795988ac6