### PR TITLE
[telegram_auth] reject future auth dates

### DIFF
--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -55,6 +55,8 @@ def parse_and_verify_init_data(init_data: str, token: str) -> dict[str, object]:
         auth_date = int(auth_date_raw)
     except ValueError as exc:
         raise HTTPException(status_code=401, detail="invalid auth date") from exc
+    if auth_date > time.time() + 60:
+        raise HTTPException(status_code=401, detail="invalid auth date")
     if time.time() - auth_date > AUTH_DATE_MAX_AGE:
         raise HTTPException(status_code=401, detail="expired auth data")
     params["auth_date"] = auth_date

--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -123,6 +123,15 @@ def test_parse_and_verify_init_data_expired() -> None:
     assert exc.value.detail == "expired auth data"
 
 
+def test_parse_and_verify_init_data_future() -> None:
+    future = int(time.time()) + 61
+    init_data = build_init_data(auth_date=future)
+    with pytest.raises(HTTPException) as exc:
+        parse_and_verify_init_data(init_data, TOKEN)
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "invalid auth date"
+
+
 def test_require_tg_user_expired(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
     past = int(time.time()) - (AUTH_DATE_MAX_AGE + 1)
@@ -131,3 +140,13 @@ def test_require_tg_user_expired(monkeypatch: pytest.MonkeyPatch) -> None:
         require_tg_user(init_data)
     assert exc.value.status_code == 401
     assert exc.value.detail == "expired auth data"
+
+
+def test_require_tg_user_future(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    future = int(time.time()) + 61
+    init_data = build_init_data(auth_date=future)
+    with pytest.raises(HTTPException) as exc:
+        require_tg_user(init_data)
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "invalid auth date"


### PR DESCRIPTION
## Summary
- reject auth dates more than a minute in the future
- test future auth_date validation in parse_and_verify_init_data and require_tg_user

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `pytest tests/test_telegram_auth.py -q --cov=services.api.app.telegram_auth`


------
https://chatgpt.com/codex/tasks/task_e_68bfbdcfce3c832abcee817c5d5254d1