### PR TITLE
[learning] log profile fetch errors and test

### DIFF
--- a/services/api/app/diabetes/learning_onboarding.py
+++ b/services/api/app/diabetes/learning_onboarding.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Callable, cast
 
+import httpx
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
 from telegram.ext import ContextTypes
 
@@ -153,7 +154,8 @@ async def ensure_overrides(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if user is not None:
         try:
             profile = await profiles.get_profile_for_user(user.id, context)
-        except Exception:
+        except (httpx.HTTPError, RuntimeError):
+            logger.exception("Failed to get profile for user %s", user.id)
             profile = {}
         diabetes_type = profile.get("diabetes_type")
         if (


### PR DESCRIPTION
## Summary
- handle httpx and runtime errors when fetching profile during learning onboarding
- log profile retrieval failures
- test that profile fetch errors log and unexpected errors propagate

## Testing
- `pytest -q --cov --cov-fail-under=85` (fails: async def functions are not natively supported)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfc1c0677c832a9734c603a97bac74