### PR TITLE
[api] refine profiles_get error handling

### DIFF
--- a/services/api/app/legacy.py
+++ b/services/api/app/legacy.py
@@ -69,9 +69,12 @@ async def profiles_get(
     except (ConnectionError, sqlalchemy_exc.OperationalError) as exc:
         logger.exception("failed to fetch profile %s", tid)
         raise HTTPException(status_code=503, detail="database temporarily unavailable") from exc
-    except Exception as exc:
+    except sqlalchemy_exc.SQLAlchemyError as exc:
         logger.exception("failed to fetch profile %s", tid)
-        raise HTTPException(status_code=500, detail="database connection failed") from exc
+        raise HTTPException(status_code=500, detail="database error") from exc
+    except Exception:
+        logger.exception("failed to fetch profile %s", tid)
+        raise
 
     tz = profile.timezone if profile.timezone else "UTC"
     tz_auto = profile.timezone_auto if profile.timezone_auto is not None else True


### PR DESCRIPTION
## Summary
- avoid swallowing unexpected exceptions in legacy profiles_get
- ensure legacy profiles_get re-raises unexpected errors

## Testing
- `pytest -q --cov` *(fails: test_parse_command_with_array_multiple_objects, test_extract_first_json_array_with_many_objects)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfc1b95154832a82adce0fc73cf25b