### PR TITLE
[webapp] handle stale telegram auth data

### DIFF
--- a/services/webapp/ui/src/hooks/useTelegramInitData.ts
+++ b/services/webapp/ui/src/hooks/useTelegramInitData.ts
@@ -1,4 +1,8 @@
-import { setTelegramInitData } from '@/lib/telegram-auth';
+import {
+  setTelegramInitData,
+  TELEGRAM_INIT_DATA_KEY,
+  isInitDataFresh,
+} from '@/lib/telegram-auth';
 
 export function useTelegramInitData(): string | null {
   try {
@@ -23,7 +27,19 @@ export function useTelegramInitData(): string | null {
       return tgWebAppData;
     }
 
-    return localStorage.getItem('tg_init_data');
+    try {
+      const saved = localStorage.getItem(TELEGRAM_INIT_DATA_KEY);
+      if (saved) {
+        if (isInitDataFresh(saved)) {
+          return saved;
+        }
+        localStorage.removeItem(TELEGRAM_INIT_DATA_KEY);
+      }
+    } catch {
+      /* ignore */
+    }
+
+    return null;
   } catch {
     return null;
   }

--- a/services/webapp/ui/tests/telegram-auth.test.ts
+++ b/services/webapp/ui/tests/telegram-auth.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getTelegramAuthHeaders,
+  setTelegramInitData,
+  TELEGRAM_INIT_DATA_KEY,
+} from '../src/lib/telegram-auth';
+
+const makeInitData = (authDate: number): string =>
+  new URLSearchParams({ auth_date: String(authDate) }).toString();
+
+describe('getTelegramAuthHeaders auth_date handling', () => {
+  afterEach(() => {
+    setTelegramInitData('');
+    localStorage.clear();
+  });
+
+  it('removes stale auth_date and returns empty headers', () => {
+    const old = makeInitData(Math.floor(Date.now() / 1000) - 60 * 60 * 25);
+    localStorage.setItem(TELEGRAM_INIT_DATA_KEY, old);
+
+    const headers = getTelegramAuthHeaders();
+
+    expect(headers).toEqual({});
+    expect(localStorage.getItem(TELEGRAM_INIT_DATA_KEY)).toBeNull();
+  });
+
+  it('returns Authorization header when auth_date is fresh', () => {
+    const fresh = makeInitData(Math.floor(Date.now() / 1000));
+    localStorage.setItem(TELEGRAM_INIT_DATA_KEY, fresh);
+
+    const headers = getTelegramAuthHeaders();
+
+    expect(headers).toHaveProperty('Authorization', `tg ${fresh}`);
+  });
+});

--- a/services/webapp/ui/tests/useTelegramInitData.authDate.test.ts
+++ b/services/webapp/ui/tests/useTelegramInitData.authDate.test.ts
@@ -1,0 +1,23 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
+import { TELEGRAM_INIT_DATA_KEY } from '../src/lib/telegram-auth';
+
+const makeInitData = (authDate: number): string =>
+  new URLSearchParams({ auth_date: String(authDate) }).toString();
+
+describe('useTelegramInitData auth_date expiry', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('ignores and removes expired init data from localStorage', () => {
+    const old = makeInitData(Math.floor(Date.now() / 1000) - 60 * 60 * 25);
+    localStorage.setItem(TELEGRAM_INIT_DATA_KEY, old);
+
+    const { result } = renderHook(() => useTelegramInitData());
+
+    expect(result.current).toBeNull();
+    expect(localStorage.getItem(TELEGRAM_INIT_DATA_KEY)).toBeNull();
+  });
+});

--- a/services/webapp/ui/tests/useTelegramInitData.hash.test.ts
+++ b/services/webapp/ui/tests/useTelegramInitData.hash.test.ts
@@ -21,31 +21,19 @@ describe('useTelegramInitData tgWebAppData parsing', () => {
   });
 
   it('falls back to localStorage when URL parsing fails', () => {
-    const saved = 'from-ls';
+    const saved = new URLSearchParams({
+      auth_date: String(Math.floor(Date.now() / 1000)),
+    }).toString();
     localStorage.setItem('tg_init_data', saved);
 
-    class ThrowingURLSearchParams {
-      constructor(_: string) {
+    vi.stubGlobal('location', {
+      get hash() {
         throw new Error('boom');
-      }
-      get(): string | null {
-        return null;
-      }
-    }
-    const original = URLSearchParams;
-    Object.defineProperty(globalThis, 'URLSearchParams', {
-      value: ThrowingURLSearchParams,
-      configurable: true,
-    });
-    vi.stubGlobal('location', { hash: '#tgWebAppData=broken' } as any);
+      },
+    } as any);
 
     const { result } = renderHook(() => useTelegramInitData());
 
     expect(result.current).toBe(saved);
-
-    Object.defineProperty(globalThis, 'URLSearchParams', {
-      value: original,
-      configurable: true,
-    });
   });
 });


### PR DESCRIPTION
## Summary
- read tg auth data from URL hash in onboarding tests
- drop expired auth_date from localStorage
- add tests for Telegram init data expiry

## Testing
- `pnpm --filter ./services/webapp/ui test tests/initData.test.ts tests/onboarding.api.test.ts tests/telegram-auth.test.ts tests/useTelegramInitData.authDate.test.ts tests/useTelegramInitData.hash.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bfc316ca20832a9f5601aeff6f7bec