### PR TITLE
[tests] add dynamic/static learning fallback tests

### DIFF
--- a/services/api/app/diabetes/handlers/learning_onboarding.py
+++ b/services/api/app/diabetes/handlers/learning_onboarding.py
@@ -15,6 +15,7 @@ from telegram.ext import (
     filters,
 )
 
+from .. import learning_handlers
 from ..learning_onboarding import CB_PREFIX, ensure_overrides, learn_reset
 
 __all__ = [
@@ -56,7 +57,8 @@ async def onboarding_reply(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     overrides[stage] = message.text.strip()
     user_data.pop("learn_onboarding_stage", None)
     if await ensure_overrides(update, context):
-        await message.reply_text("Ответы сохранены. Отправьте /learn чтобы продолжить.")
+        await learning_handlers.learn_command(update, context)
+        await learning_handlers.plan_command(update, context)
 
 
 async def onboarding_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -77,11 +79,8 @@ async def onboarding_callback(update: Update, context: ContextTypes.DEFAULT_TYPE
     overrides[stage] = data
     user_data.pop("learn_onboarding_stage", None)
     if await ensure_overrides(update, context):
-        message = cast("Message | None", query.message)
-        if message is not None:
-            await message.reply_text(
-                "Ответы сохранены. Отправьте /learn чтобы продолжить."
-            )
+        await learning_handlers.learn_command(update, context)
+        await learning_handlers.plan_command(update, context)
 
 
 def register_handlers(app: App) -> None:

--- a/tests/diabetes/test_learning_onboarding.py
+++ b/tests/diabetes/test_learning_onboarding.py
@@ -76,6 +76,7 @@ async def test_learning_onboarding_flow(
     SessionLocal, engine = setup_db()
     await load_lessons(path, sessionmaker=SessionLocal)
     monkeypatch.setattr(learning_handlers, "SessionLocal", SessionLocal)
+    monkeypatch.setattr(learning_handlers, "plan_command", lambda *a, **k: None)
 
     try:
         message1 = DummyMessage()
@@ -108,9 +109,9 @@ async def test_learning_onboarding_flow(
         message4 = DummyMessage("новичок")
         update4 = cast(Update, SimpleNamespace(message=message4, effective_user=None))
         await learning_onboarding.onboarding_reply(update4, context)
-        assert message4.replies == [
-            "Ответы сохранены. Отправьте /learn чтобы продолжить."
-        ]
+        assert any(
+            LEARN_BUTTON_TEXT in text or "Урок" in text for text in message4.replies
+        )
         assert context.user_data["learn_profile_overrides"] == {
             "age_group": "adult",
             "diabetes_type": "T1",
@@ -157,6 +158,7 @@ async def test_learning_onboarding_callback_flow(
     SessionLocal, engine = setup_db()
     await load_lessons(path, sessionmaker=SessionLocal)
     monkeypatch.setattr(learning_handlers, "SessionLocal", SessionLocal)
+    monkeypatch.setattr(learning_handlers, "plan_command", lambda *a, **k: None)
 
     try:
         msg1 = DummyMessage()
@@ -201,9 +203,7 @@ async def test_learning_onboarding_callback_flow(
             SimpleNamespace(callback_query=q3, message=None, effective_user=None),
         )
         await learning_onboarding.onboarding_callback(upd_cb3, ctx)
-        assert q3_msg.replies == [
-            "Ответы сохранены. Отправьте /learn чтобы продолжить.",
-        ]
+        assert any(LEARN_BUTTON_TEXT in text or "Урок" in text for text in q3_msg.replies)
         assert ctx.user_data["learn_profile_overrides"] == {
             "age_group": "adult",
             "diabetes_type": "T1",

--- a/tests/learning/test_empty_lessons.py
+++ b/tests/learning/test_empty_lessons.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Mapping
+
+import pytest
+
+from services.api.app.config import settings
+from services.api.app.diabetes import learning_handlers
+from services.api.app.diabetes.curriculum_engine import LessonNotFoundError
+from tests.utils.telegram import make_context, make_update
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **_: Any) -> None:  # pragma: no cover - helper
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio()
+async def test_learn_dynamic_empty_lessons(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dynamic mode should fall back when lessons table is empty."""
+
+    monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+
+    async def raise_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
+        raise LessonNotFoundError(slug)
+
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "start_lesson", raise_start_lesson
+    )
+    monkeypatch.setattr(learning_handlers, "build_main_keyboard", lambda: None)
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", lambda *a, **k: None)
+    monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
+    monkeypatch.setattr(learning_handlers, "choose_initial_topic", lambda _p: ("s", "t"))
+    monkeypatch.setattr(learning_handlers, "generate_learning_plan", lambda text: [text])
+
+    async def fake_step(
+        profile: Mapping[str, str | None],
+        slug: str,
+        step_idx: int,
+        prev_summary: str | None,
+    ) -> str:
+        return "step1"
+
+    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_step)
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", lambda *_: True)
+
+    msg = DummyMessage()
+    update = make_update(message=msg)
+    context = make_context(user_data={})
+
+    await learning_handlers.learn_command(update, context)
+
+    assert msg.replies == ["step1"]
+
+
+@pytest.mark.asyncio()
+async def test_learn_static_empty_lessons_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Static mode should automatically fall back to dynamic when no lessons."""
+
+    monkeypatch.setattr(settings, "learning_content_mode", "static")
+
+    async def fake_run_db(fn, *args: object, **kwargs: object) -> bool:
+        return False
+
+    monkeypatch.setattr(learning_handlers.db, "run_db", fake_run_db)
+
+    async def raise_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
+        raise LessonNotFoundError(slug)
+
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "start_lesson", raise_start_lesson
+    )
+    monkeypatch.setattr(learning_handlers, "build_main_keyboard", lambda: None)
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", lambda *a, **k: None)
+    monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
+    monkeypatch.setattr(learning_handlers, "choose_initial_topic", lambda _p: ("s", "t"))
+    monkeypatch.setattr(learning_handlers, "generate_learning_plan", lambda text: [text])
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", lambda *_: True)
+
+    async def fake_step(
+        profile: Mapping[str, str | None],
+        slug: str,
+        step_idx: int,
+        prev_summary: str | None,
+    ) -> str:
+        return "step1"
+
+    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_step)
+
+    msg = DummyMessage()
+    update = make_update(message=msg)
+    context = make_context(user_data={})
+
+    await learning_handlers.learn_command(update, context)
+
+    assert msg.replies == ["step1"]

--- a/tests/learning/test_flow_autostart.py
+++ b/tests/learning/test_flow_autostart.py
@@ -79,6 +79,11 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
         learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(
+        learning_handlers,
+        "plan_command",
+        lambda update, ctx: bot.send_message(chat_id=1, text="plan"),
+    )
 
     bot = DummyBot()
     app = Application.builder().bot(bot).build()
@@ -118,15 +123,7 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
     await app.process_update(Update(update_id=3, message=_msg(3, "2")))
     await app.process_update(Update(update_id=4, message=_msg(4, "0")))
 
-    # call /learn again - should autostart first topic
-    await app.process_update(
-        Update(
-            update_id=5,
-            message=_msg(5, "/learn", entities=[MessageEntity("bot_command", 0, 6)]),
-        )
-    )
-
-    assert bot.sent[-1] == "шаг1"
+    assert bot.sent[-2:] == ["шаг1", "plan"]
     assert all(
         title not in s
         and "Выберите тему" not in s


### PR DESCRIPTION
## Summary
- handle empty lessons by falling back to dynamic content
- auto-start learning after onboarding completion
- test dynamic/static lesson fallbacks and onboarding autostart

## Testing
- `pytest -q --cov` *(fails: FixtureDef object has no attribute 'unittest')*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfc3e8e200832abb423a2bd2d7194c