### PR TITLE
[learning] fallback to dynamic lessons

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -118,6 +118,10 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
             continue
 
         i = end
+        if isinstance(obj, list):
+            if len(obj) == 1 and isinstance(obj[0], dict):
+                return obj[0]
+            continue
         queue: deque[object] = deque([obj])
         first_dict: dict[str, object] | None = None
         while queue:

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -538,10 +538,7 @@ def test_extract_first_json_multi_object_array() -> None:
     text = (
         '[{"action":"add_entry","fields":{}},' '{"action":"delete_entry","fields":{}}]'
     )
-    assert gpt_command_parser._extract_first_json(text) == {
-        "action": "add_entry",
-        "fields": {},
-    }
+    assert gpt_command_parser._extract_first_json(text) is None
 
 
 def test_extract_first_json_nested_object_wrapper() -> None:
@@ -554,10 +551,7 @@ def test_extract_first_json_nested_object_wrapper() -> None:
 
 def test_extract_first_json_nested_array_wrapper() -> None:
     text = '[["noise"], [{"action":"add_entry","fields":{}}]]'
-    assert gpt_command_parser._extract_first_json(text) == {
-        "action": "add_entry",
-        "fields": {},
-    }
+    assert gpt_command_parser._extract_first_json(text) is None
 
 
 def test_extract_first_json_multiple_objects() -> None:


### PR DESCRIPTION
## Summary
- generate dynamic lesson content when static lessons are missing
- log missing-lesson condition and remove unused constant
- tighten GPT command parsing for arrays with multiple objects

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q --cov -p pytest_cov -p pytest_asyncio.plugin`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfc3e2f34c832a9e98ae0db230b6f0