### PR TITLE
[profile] Ensure therapy type always sent

### DIFF
--- a/services/webapp/ui/src/features/profile/api.ts
+++ b/services/webapp/ui/src/features/profile/api.ts
@@ -56,7 +56,7 @@ export async function saveProfile({
   timezoneAuto?: boolean;
   sosContact?: string | null;
   sosAlertsEnabled?: boolean;
-  therapyType?: TherapyType | null;
+  therapyType: TherapyType | null;
 }): Promise<unknown> {
   try {
     const body: Record<string, unknown> = {
@@ -64,6 +64,7 @@ export async function saveProfile({
       target,
       low,
       high,
+      therapyType,
     };
 
     if (icr !== undefined) {
@@ -96,10 +97,6 @@ export async function saveProfile({
 
     if (sosAlertsEnabled !== undefined) {
       body.sosAlertsEnabled = sosAlertsEnabled;
-    }
-
-    if (therapyType !== undefined) {
-      body.therapyType = therapyType;
     }
 
     return await api.post('/profile', body);

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -108,7 +108,15 @@ describe('profile api', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     await expect(
-      saveProfile({ telegramId: 1, icr: 1, cf: 2, target: 5, low: 4, high: 10 }),
+      saveProfile({
+        telegramId: 1,
+        icr: 1,
+        cf: 2,
+        target: 5,
+        low: 4,
+        high: 10,
+        therapyType: 'insulin',
+      }),
     ).rejects.toThrow('Не удалось сохранить профиль: fail');
     expect(mockFetch).toHaveBeenCalledWith(
       '/api/profile',

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -343,6 +343,39 @@ describe('Profile page', () => {
     });
   });
 
+  it('defaults unknown therapyType to none when saving', async () => {
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
+    (getProfile as vi.Mock).mockResolvedValue({
+      ...baseProfile,
+      therapyType: 'unknown',
+    });
+
+    const { getByText, getByPlaceholderText } = renderWithClient(<Profile />);
+
+    await waitFor(() => {
+      expect((getByPlaceholderText('12') as HTMLInputElement).value).toBe('12');
+    });
+
+    fireEvent.click(getByText('Сохранить настройки'));
+
+    await waitFor(() => {
+      expect(saveProfile).toHaveBeenCalledWith({
+        telegramId: 123,
+        target: 6,
+        low: 4,
+        high: 10,
+        timezone: 'Europe/Moscow',
+        timezoneAuto: false,
+        quietStart: '23:00',
+        quietEnd: '07:00',
+        sosAlertsEnabled: true,
+        sosContact: null,
+        therapyType: 'none',
+      });
+      expect(patchProfile).not.toHaveBeenCalled();
+    });
+  });
+
   const nonInsulinTherapies: Array<'none' | 'tablets'> = ['none', 'tablets'];
 
   it.each(nonInsulinTherapies)(


### PR DESCRIPTION
## Summary
- require therapyType when saving profile and always include it in payload
- normalize therapyType from backend to supported enum before saving
- test that unknown therapyType defaults to a supported value

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: multiple lint errors)*
- `pnpm --filter ./services/webapp/ui typecheck`
- `pnpm --filter ./services/webapp/ui test` *(fails: FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*
- `pytest -q --cov` *(fails: 697 failed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfc7fa24c4832aa93424274a0a784e