### PR TITLE
[webapp] persist Telegram init data on startup

### DIFF
--- a/services/webapp/ui/src/App.tsx
+++ b/services/webapp/ui/src/App.tsx
@@ -5,6 +5,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { BrowserRouter, Routes, Route } from "react-router-dom"
 import { useTelegram } from "@/hooks/useTelegram"
+import { useTelegramInitData } from "@/hooks/useTelegramInitData"
 import { ThemeProvider } from "next-themes"
 import { ToastProvider } from "./shared/toast"
 
@@ -24,6 +25,7 @@ import PaywallGuard from "./features/paywall/PaywallGuard"
 const queryClient = new QueryClient()
 
 const AppContent = () => {
+  useTelegramInitData();
   const { isReady } = useTelegram()
 
   if (!isReady) {

--- a/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersCreate.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useRemindersApi } from "../api/reminders"; // ваш хук, возвращающий DefaultApi
 import { DayOfWeekPicker } from "../components/DayOfWeekPicker";
@@ -8,6 +8,7 @@ import { buildReminderPayload } from "../api/buildPayload";
 import type { ReminderDto, ScheduleKind, ReminderType } from "../types";
 import { validate, hasErrors } from "../logic/validate";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
+import { setTelegramInitData } from "@/lib/telegram-auth";
 import { useTelegram } from "../../../hooks/useTelegram";
 import { getTelegramUserId } from "../../../shared/telegram";
 import { useToast } from "../../../shared/toast";
@@ -34,6 +35,11 @@ const KIND_OPTIONS: { value: ScheduleKind; label: string }[] = [
 export default function RemindersCreate() {
   const api = useRemindersApi();
   const initData = useTelegramInitData();
+  useEffect(() => {
+    if (initData) {
+      setTelegramInitData(initData);
+    }
+  }, [initData]);
   const { sendData, user } = useTelegram();
   const telegramId = useMemo(
     () => getTelegramUserId(initData) || user?.id || 0,

--- a/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
+++ b/services/webapp/ui/src/features/reminders/pages/RemindersEdit.tsx
@@ -9,6 +9,7 @@ import { buildReminderPayload } from "../api/buildPayload";
 import type { ReminderDto, ScheduleKind, ReminderType } from "../types";
 import { validate, hasErrors } from "../logic/validate";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
+import { setTelegramInitData } from "@/lib/telegram-auth";
 import { getTelegramUserId } from "../../../shared/telegram";
 import { useToast } from "../../../shared/toast";
 import { useTelegram } from "@/hooks/useTelegram";
@@ -59,6 +60,11 @@ function mapToForm(reminder: ReminderSchema): ReminderDto {
 export default function RemindersEdit() {
   const api = useRemindersApi();
   const initData = useTelegramInitData();
+  useEffect(() => {
+    if (initData) {
+      setTelegramInitData(initData);
+    }
+  }, [initData]);
   const { sendData, user } = useTelegram();
   const telegramId = useMemo(
     () => getTelegramUserId(initData) || user?.id || 0,

--- a/services/webapp/ui/src/hooks/useTelegramInitData.ts
+++ b/services/webapp/ui/src/hooks/useTelegramInitData.ts
@@ -8,6 +8,7 @@ export function useTelegramInitData(): string | null {
   try {
     const globalData = (window as any)?.Telegram?.WebApp?.initData;
     if (globalData) {
+      setTelegramInitData(globalData);
       return globalData;
     }
 
@@ -31,6 +32,7 @@ export function useTelegramInitData(): string | null {
       const saved = localStorage.getItem(TELEGRAM_INIT_DATA_KEY);
       if (saved) {
         if (isInitDataFresh(saved)) {
+          setTelegramInitData(saved);
           return saved;
         }
         localStorage.removeItem(TELEGRAM_INIT_DATA_KEY);

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -33,6 +33,7 @@ import {
 import { getTimezones } from "@/api/timezones";
 import { useTelegram } from "@/hooks/useTelegram";
 import { useTelegramInitData } from "@/hooks/useTelegramInitData";
+import { setTelegramInitData } from "@/lib/telegram-auth";
 import { resolveTelegramId } from "./resolveTelegramId";
 import { postOnboardingEvent } from "@/shared/api/onboarding";
 
@@ -81,6 +82,11 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
   const { toast } = useToast();
   const { user } = useTelegram();
   const initData = useTelegramInitData();
+  useEffect(() => {
+    if (initData) {
+      setTelegramInitData(initData);
+    }
+  }, [initData]);
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const patchProfileMutation = useMutation({

--- a/services/webapp/ui/src/shared/initData.ts
+++ b/services/webapp/ui/src/shared/initData.ts
@@ -1,9 +1,12 @@
+import { setTelegramInitData } from '@/lib/telegram-auth';
+
 export function hasInitData(): boolean {
   const initData =
     (window as unknown as { Telegram?: { WebApp?: { initData?: string } } })
       .Telegram?.WebApp?.initData;
 
   if (initData) {
+    setTelegramInitData(initData);
     return true;
   }
 
@@ -12,5 +15,10 @@ export function hasInitData(): boolean {
     : window.location.hash;
   const urlData = new URLSearchParams(hash).get('tgWebAppData');
 
-  return Boolean(urlData);
+  if (urlData) {
+    setTelegramInitData(urlData);
+    return true;
+  }
+
+  return false;
 }

--- a/services/webapp/ui/tests/initData.test.ts
+++ b/services/webapp/ui/tests/initData.test.ts
@@ -1,20 +1,26 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { hasInitData } from '../src/shared/initData';
+import * as telegramAuth from '../src/lib/telegram-auth';
 
 describe('hasInitData', () => {
   afterEach(() => {
     delete (window as any).Telegram;
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
-  it('returns true when Telegram initData present', () => {
+  it('returns true and stores when Telegram initData present', () => {
+    const spy = vi.spyOn(telegramAuth, 'setTelegramInitData');
     (window as any).Telegram = { WebApp: { initData: 'init' } };
     expect(hasInitData()).toBe(true);
+    expect(spy).toHaveBeenCalledWith('init');
   });
 
-  it('returns true when tgWebAppData param present', () => {
+  it('returns true and stores when tgWebAppData param present', () => {
+    const spy = vi.spyOn(telegramAuth, 'setTelegramInitData');
     vi.stubGlobal('location', { hash: '#tgWebAppData=from-url' } as any);
     expect(hasInitData()).toBe(true);
+    expect(spy).toHaveBeenCalledWith('from-url');
   });
 
   it('returns false when no init data', () => {

--- a/services/webapp/ui/tests/useTelegramInitData.telegram.test.ts
+++ b/services/webapp/ui/tests/useTelegramInitData.telegram.test.ts
@@ -1,0 +1,22 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useTelegramInitData } from '../src/hooks/useTelegramInitData';
+import * as telegramAuth from '../src/lib/telegram-auth';
+
+describe('useTelegramInitData Telegram context', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('reads initData from Telegram WebApp and stores it', () => {
+    const spy = vi.spyOn(telegramAuth, 'setTelegramInitData');
+    (window as any).Telegram = { WebApp: { initData: 'from-ctx' } };
+
+    const { result } = renderHook(() => useTelegramInitData());
+
+    expect(result.current).toBe('from-ctx');
+    expect(spy).toHaveBeenCalledWith('from-ctx');
+  });
+});


### PR DESCRIPTION
## Summary
- store Telegram init data from WebApp context, URL hash or localStorage in `useTelegramInitData`
- persist Telegram init data on app and page initialization
- test Telegram WebApp init data storage

## Testing
- `pnpm --filter ./services/webapp/ui lint` *(fails: Unexpected any)*
- `pnpm --filter ./services/webapp/ui typecheck`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter ./services/webapp/ui test`
- `pytest -q` *(fails: async def functions not natively supported)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfc7f937cc832a8a6328de834cc9df