### PR TITLE
[learning] Expose curriculum engine for tests

### DIFF
--- a/services/api/app/diabetes/handlers/learning_handlers.py
+++ b/services/api/app/diabetes/handlers/learning_handlers.py
@@ -20,7 +20,8 @@ from telegram.ext import (
 )
 
 from services.api.app.config import settings
-from services.api.app.diabetes import curriculum_engine
+# Re-export the curriculum engine for tests and other modules.
+from services.api.app.diabetes import curriculum_engine as curriculum_engine
 from services.api.app.diabetes.learning_state import (
     LearnState,
     clear_state,
@@ -386,6 +387,7 @@ def register_handlers(app: App) -> None:
 
 
 __all__ = [
+    "curriculum_engine",
     "cmd_menu",
     "on_learn_button",
     "learn_command",

--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -18,7 +18,9 @@ from ..ui.keyboard import LEARN_BUTTON_TEXT
 from .learning_onboarding import ensure_overrides
 from .learning_state import LearnState, clear_state, get_state, set_state
 from .learning_utils import choose_initial_topic
-from . import curriculum_engine  # noqa: F401
+# Re-export the curriculum engine so tests and callers can patch it easily.
+# Including it in ``__all__`` below marks the import as used for the linter.
+from . import curriculum_engine as curriculum_engine
 from .learning_prompts import build_system_prompt, disclaimer
 from .llm_router import LLMTask
 from .services.gpt_client import (
@@ -605,6 +607,7 @@ async def skip_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
 
 __all__ = [
+    "curriculum_engine",
     "topics_command",
     "learn_command",
     "lesson_command",


### PR DESCRIPTION
## Summary
- re-export curriculum engine in learning handlers for easier patching
- expose curriculum engine in legacy learning handlers

## Testing
- `pytest -q --cov` *(fails: assert [1, 2] == [2]; assert False; etc.)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfc8d52f28832a8c3388b8ec794242