### PR TITLE
[learning] fallback to dynamic when lesson missing

### DIFF
--- a/tests/diabetes/test_curriculum_not_found.py
+++ b/tests/diabetes/test_curriculum_not_found.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any, Mapping
 
+import logging
 import pytest
 
 from services.api.app.config import settings
@@ -47,7 +48,9 @@ async def test_start_lesson_unknown_slug(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.mark.asyncio
-async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_learn_command_lesson_not_found(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
     async def fake_ensure_overrides(update: object, context: object) -> bool:
@@ -56,6 +59,7 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(dynamic_handlers, "ensure_overrides", fake_ensure_overrides)
     monkeypatch.setattr(dynamic_handlers, "choose_initial_topic", lambda _p: ("slug", "t"))
     monkeypatch.setattr(dynamic_handlers, "build_main_keyboard", lambda: None)
+    monkeypatch.setattr(dynamic_handlers, "disclaimer", lambda: "")
 
     async def fail_next_step(
         user_id: int,
@@ -72,28 +76,38 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(dynamic_handlers.curriculum_engine, "start_lesson", raise_start_lesson)
 
-    def fail_generate_learning_plan(_text: str) -> list[str]:
-        raise AssertionError("should not be called")
+    async def fake_generate_step_text(*_a: object, **_k: object) -> str:
+        return "step1"
 
-    monkeypatch.setattr(dynamic_handlers, "generate_learning_plan", fail_generate_learning_plan)
+    monkeypatch.setattr(dynamic_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(dynamic_handlers, "generate_learning_plan", lambda _t: ["step1"])
+    monkeypatch.setattr(dynamic_handlers, "format_reply", lambda x: x)
 
-    async def fail_add_log(*args: object, **kwargs: object) -> None:
-        raise AssertionError("should not be called")
+    async def fake_add_log(*args: object, **kwargs: object) -> None:
+        return None
 
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fail_add_log)
+    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fake_add_log)
 
     msg = DummyMessage()
     update = make_update(message=msg)
     context = make_context(user_data={})
 
-    await dynamic_handlers.learn_command(update, context)
+    with caplog.at_level(logging.WARNING):
+        await dynamic_handlers.learn_command(update, context)
 
-    assert msg.replies == [dynamic_handlers.LESSON_NOT_FOUND_MESSAGE]
-    assert get_state(context.user_data) is None
+    assert msg.replies == [
+        "Не нашёл учебные записи, пробую динамический режим…",
+        "step1",
+    ]
+    state = get_state(context.user_data)
+    assert state is not None and state.last_step_text == "step1"
+    assert any("no_static_lessons" in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio
-async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_lesson_command_lesson_not_found(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
     async def fake_ensure_overrides(update: object, context: object) -> bool:
@@ -119,21 +133,29 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setattr(dynamic_handlers.curriculum_engine, "next_step", fail_next_step)
 
-    def fail_generate_learning_plan(_text: str) -> list[str]:
-        raise AssertionError("should not be called")
+    async def fake_generate_step_text(*_a: object, **_k: object) -> str:
+        return "step1"
 
-    monkeypatch.setattr(dynamic_handlers, "generate_learning_plan", fail_generate_learning_plan)
+    monkeypatch.setattr(dynamic_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(dynamic_handlers, "generate_learning_plan", lambda _t: ["step1"])
+    monkeypatch.setattr(dynamic_handlers, "format_reply", lambda x: x)
 
-    async def fail_add_log(*args: object, **kwargs: object) -> None:
-        raise AssertionError("should not be called")
+    async def fake_add_log(*args: object, **kwargs: object) -> None:
+        return None
 
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fail_add_log)
+    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fake_add_log)
 
     msg = DummyMessage()
     update = make_update(message=msg)
     context = make_context(user_data={}, args=["slug"])
 
-    await dynamic_handlers.lesson_command(update, context)
+    with caplog.at_level(logging.WARNING):
+        await dynamic_handlers.lesson_command(update, context)
 
-    assert msg.replies == [dynamic_handlers.LESSON_NOT_FOUND_MESSAGE]
-    assert get_state(context.user_data) is None
+    assert msg.replies == [
+        "Не нашёл учебные записи, пробую динамический режим…",
+        "step1",
+    ]
+    state = get_state(context.user_data)
+    assert state is not None and state.last_step_text == "step1"
+    assert any("no_static_lessons" in r.message for r in caplog.records)

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -94,7 +94,7 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
         profile: Mapping[str, str | None],
         prev_summary: str | None = None,
     ) -> tuple[str, bool]:
-        return "step1?", False
+        return f"{disclaimer()}\n\nstep1?", False
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -168,7 +168,7 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
         profile: Mapping[str, str | None],
         prev_summary: str | None = None,
     ) -> tuple[str, bool]:
-        return "step1?", False
+        return f"{disclaimer()}\n\nstep1?", False
 
     monkeypatch.setattr(
         learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson


### PR DESCRIPTION
## Summary
- Fall back to dynamic lessons when static content is missing, notifying user and logging a warning
- Remove unused `LESSON_NOT_FOUND_MESSAGE`
- Update tests for dynamic fallback behaviour

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfc96ea014832abc4a6a9dc09323d8