### PR TITLE
[learning] Fallback to dynamic lessons

### DIFF
--- a/tests/assistant/test_e2e_plan_button.py
+++ b/tests/assistant/test_e2e_plan_button.py
@@ -78,6 +78,10 @@ async def test_plan_button_flow(
     monkeypatch.setattr(
         learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
+    monkeypatch.setattr(
+        learning_handlers, "generate_learning_plan", lambda t: [t, "Шаг 2"]
+    )
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     async def fake_generate_step_text(
         _profile: Any, _topic: str, step_idx: int, _prev: str | None

--- a/tests/diabetes/test_curriculum_not_found.py
+++ b/tests/diabetes/test_curriculum_not_found.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any, Mapping
+from typing import Any
 
 import pytest
 
@@ -57,30 +57,25 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(dynamic_handlers, "choose_initial_topic", lambda _p: ("slug", "t"))
     monkeypatch.setattr(dynamic_handlers, "build_main_keyboard", lambda: None)
 
-    async def fail_next_step(
-        user_id: int,
-        lesson_id: int,
-        profile: Mapping[str, str | None],
-        prev_summary: str | None = None,
-    ) -> tuple[str, bool]:
-        raise AssertionError("should not be called")
-
-    monkeypatch.setattr(dynamic_handlers.curriculum_engine, "next_step", fail_next_step)
-
     async def raise_start_lesson(user_id: int, slug: str) -> object:
         raise LessonNotFoundError(slug)
 
     monkeypatch.setattr(dynamic_handlers.curriculum_engine, "start_lesson", raise_start_lesson)
 
-    def fail_generate_learning_plan(_text: str) -> list[str]:
-        raise AssertionError("should not be called")
+    async def fake_generate_step_text(*a: object, **k: object) -> str:
+        return "step1"
 
-    monkeypatch.setattr(dynamic_handlers, "generate_learning_plan", fail_generate_learning_plan)
+    monkeypatch.setattr(
+        dynamic_handlers, "generate_step_text", fake_generate_step_text
+    )
+    monkeypatch.setattr(dynamic_handlers, "generate_learning_plan", lambda _t: ["step1"])
+    monkeypatch.setattr(dynamic_handlers, "format_reply", lambda t: t)
 
-    async def fail_add_log(*args: object, **kwargs: object) -> None:
-        raise AssertionError("should not be called")
+    async def fake_add_log(*args: object, **kwargs: object) -> None:
+        return None
 
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fail_add_log)
+    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(dynamic_handlers, "disclaimer", lambda: "")
 
     msg = DummyMessage()
     update = make_update(message=msg)
@@ -88,8 +83,12 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
 
     await dynamic_handlers.learn_command(update, context)
 
-    assert msg.replies == [dynamic_handlers.LESSON_NOT_FOUND_MESSAGE]
-    assert get_state(context.user_data) is None
+    assert msg.replies == [
+        dynamic_handlers.NO_STATIC_LESSONS_MESSAGE,
+        "step1",
+    ]
+    state = get_state(context.user_data)
+    assert state is not None and state.step == 1
 
 
 @pytest.mark.asyncio
@@ -109,25 +108,19 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setattr(dynamic_handlers.curriculum_engine, "start_lesson", raise_start_lesson)
 
-    async def fail_next_step(
-        user_id: int,
-        lesson_id: int,
-        profile: Mapping[str, str | None],
-        prev_summary: str | None = None,
-    ) -> tuple[str, bool]:
-        raise AssertionError("should not be called")
+    async def fake_generate_step_text2(*a: object, **k: object) -> str:
+        return "step1"
 
-    monkeypatch.setattr(dynamic_handlers.curriculum_engine, "next_step", fail_next_step)
+    monkeypatch.setattr(
+        dynamic_handlers, "generate_step_text", fake_generate_step_text2
+    )
+    monkeypatch.setattr(dynamic_handlers, "generate_learning_plan", lambda _t: ["step1"])
+    monkeypatch.setattr(dynamic_handlers, "format_reply", lambda t: t)
 
-    def fail_generate_learning_plan(_text: str) -> list[str]:
-        raise AssertionError("should not be called")
+    async def fake_add_log2(*args: object, **kwargs: object) -> None:
+        return None
 
-    monkeypatch.setattr(dynamic_handlers, "generate_learning_plan", fail_generate_learning_plan)
-
-    async def fail_add_log(*args: object, **kwargs: object) -> None:
-        raise AssertionError("should not be called")
-
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fail_add_log)
+    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fake_add_log2)
 
     msg = DummyMessage()
     update = make_update(message=msg)
@@ -135,5 +128,9 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
 
     await dynamic_handlers.lesson_command(update, context)
 
-    assert msg.replies == [dynamic_handlers.LESSON_NOT_FOUND_MESSAGE]
-    assert get_state(context.user_data) is None
+    assert msg.replies == [
+        dynamic_handlers.NO_STATIC_LESSONS_MESSAGE,
+        "step1",
+    ]
+    state = get_state(context.user_data)
+    assert state is not None and state.step == 1

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -106,6 +106,10 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
         learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(
+        learning_handlers, "generate_learning_plan", lambda t: [t]
+    )
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     msg = DummyMessage()
     update = make_update(message=msg)
@@ -280,6 +284,7 @@ async def test_learn_command_autostarts_when_topics_hidden(
     monkeypatch.setattr(
         learning_handlers, "choose_initial_topic", lambda _: ("slug", "t")
     )
+    monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
 
     progress = SimpleNamespace(lesson_id=1)
 
@@ -305,6 +310,8 @@ async def test_learn_command_autostarts_when_topics_hidden(
     monkeypatch.setattr(
         learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
+    monkeypatch.setattr(learning_handlers, "generate_learning_plan", lambda t: [t])
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None

--- a/tests/learning/test_flow_autostart.py
+++ b/tests/learning/test_flow_autostart.py
@@ -79,6 +79,11 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
         learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
+    monkeypatch.setattr(
+        learning_handlers, "generate_learning_plan", lambda t: [t]
+    )
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     bot = DummyBot()
     app = Application.builder().bot(bot).build()

--- a/tests/learning/test_plan_handlers.py
+++ b/tests/learning/test_plan_handlers.py
@@ -13,6 +13,7 @@ from services.api.app.diabetes.planner import generate_learning_plan, pretty_pla
 class DummyMessage:
     def __init__(self) -> None:
         self.replies: list[str] = []
+        self.from_user = SimpleNamespace(id=1)
 
     async def reply_text(self, text: str, **kwargs: object) -> None:
         self.replies.append(text)
@@ -55,6 +56,7 @@ async def test_learn_command_stores_plan(monkeypatch: pytest.MonkeyPatch) -> Non
         return True
 
     monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
+    monkeypatch.setattr(learning_handlers.settings, "learning_ui_show_topics", False)
 
     async def fake_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
         return SimpleNamespace(lesson_id=1)
@@ -77,6 +79,9 @@ async def test_learn_command_stores_plan(monkeypatch: pytest.MonkeyPatch) -> Non
         learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
+    monkeypatch.setattr(learning_handlers, "generate_learning_plan", lambda t: [t])
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     message = DummyMessage()
     update = make_update(message=message)


### PR DESCRIPTION
## Summary
- fall back to dynamic lesson generation when static curriculum is missing
- log hint and notify users about dynamic mode
- adjust tests for dynamic fallback and lesson plan flow

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfcd87c1b4832ab0fa776070ee2e7f