### PR TITLE
[webapp] enforce profile numeric fields

### DIFF
--- a/services/webapp/ui/src/features/profile/validation.ts
+++ b/services/webapp/ui/src/features/profile/validation.ts
@@ -46,6 +46,7 @@ export const parseProfile = (
 ): { data: ParsedProfile; errors: FieldErrors } => {
   const errors: FieldErrors = {};
   const isNonInsulin = therapyType === 'tablets' || therapyType === 'none';
+  const isInsulinTherapy = therapyType === 'insulin' || therapyType === 'mixed';
 
   const parseNumber = (
     field: keyof ProfileForm,
@@ -82,8 +83,8 @@ export const parseProfile = (
     return num;
   };
 
-  const icr = isNonInsulin ? 0 : parseNumber('icr', profile.icr);
-  const cf = isNonInsulin ? 0 : parseNumber('cf', profile.cf);
+  const icr = isInsulinTherapy ? parseNumber('icr', profile.icr) : 0;
+  const cf = isInsulinTherapy ? parseNumber('cf', profile.cf) : 0;
   const target = parseNumber('target', profile.target);
   const low = parseNumber('low', profile.low);
   const high = parseNumber('high', profile.high);
@@ -125,6 +126,14 @@ export const parseProfile = (
     !/^\d+$/.test(profile.sosContact)
   ) {
     errors.sosContact = 'invalid';
+  }
+
+  if (target === undefined && !errors.target) errors.target = 'required';
+  if (low === undefined && !errors.low) errors.low = 'required';
+  if (high === undefined && !errors.high) errors.high = 'required';
+  if (isInsulinTherapy) {
+    if (icr === undefined && !errors.icr) errors.icr = 'required';
+    if (cf === undefined && !errors.cf) errors.cf = 'required';
   }
 
   if (

--- a/services/webapp/ui/tests/parseProfile.test.ts
+++ b/services/webapp/ui/tests/parseProfile.test.ts
@@ -86,6 +86,24 @@ describe("parseProfile", () => {
     expect(result.data.icr).toBeUndefined();
   });
 
+  it("requires target, low and high values", () => {
+    const result = parseProfile(
+      makeProfile({ target: "", low: "", high: "" }),
+    );
+    expect(result.errors.target).toBe("required");
+    expect(result.errors.low).toBe("required");
+    expect(result.errors.high).toBe("required");
+  });
+
+  it("requires icr and cf for mixed therapy", () => {
+    const result = parseProfile(
+      makeProfile({ icr: "", cf: "" }),
+      "mixed",
+    );
+    expect(result.errors.icr).toBe("required");
+    expect(result.errors.cf).toBe("required");
+  });
+
   it("validates target range", () => {
     const result = parseProfile(makeProfile({ target: "12" }));
     expect(result.errors.target).toBe("out_of_range");

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -219,6 +219,24 @@ describe('Profile page', () => {
     expect(getByText('Обязательное поле')).toBeTruthy();
   });
 
+  it('requires target, low and high values', () => {
+    (resolveTelegramId as vi.Mock).mockReturnValue(123);
+    const { getByText, getByPlaceholderText, getAllByText } =
+      renderWithClient(<Profile />);
+    const targetInput = getByPlaceholderText('6.0');
+    const lowInput = getByPlaceholderText('4.0');
+    const highInput = getByPlaceholderText('10.0');
+    fireEvent.change(targetInput, { target: { value: '' } });
+    fireEvent.change(lowInput, { target: { value: '' } });
+    fireEvent.change(highInput, { target: { value: '' } });
+    fireEvent.click(getByText('Сохранить настройки'));
+    expect(saveProfile).not.toHaveBeenCalled();
+    expect(targetInput).toHaveAttribute('aria-invalid', 'true');
+    expect(lowInput).toHaveAttribute('aria-invalid', 'true');
+    expect(highInput).toHaveAttribute('aria-invalid', 'true');
+    expect(getAllByText('Обязательное поле')).toHaveLength(3);
+  });
+
   it('toggles grams per XE input with carb unit', async () => {
     (resolveTelegramId as vi.Mock).mockReturnValue(123);
     const { queryByLabelText, getByDisplayValue } = renderWithClient(<Profile />);


### PR DESCRIPTION
## Summary
- ensure insulin and mixed therapies require numeric ICR/CF
- validate numeric target, low and high values
- cover profile validation and UI errors in tests

## Testing
- `npm test` *(fails: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfd0a1883c832aacd23f02cc1461f5