### PR TITLE
[webapp] init telegram auth headers

### DIFF
--- a/services/webapp/ui/src/api/index.auth.test.ts
+++ b/services/webapp/ui/src/api/index.auth.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Ensures that api.ts attaches Telegram auth headers to requests
+
+describe('api client telegram auth', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('sends Authorization header from getTelegramAuthHeaders', async () => {
+    vi.doMock('@/lib/telegram-auth', () => ({
+      getTelegramAuthHeaders: () => ({ Authorization: 'tg test' }),
+    }));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response('{}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const { api } = await import('./index');
+    await api.get('/foo');
+    const headers = fetchMock.mock.calls[0][1]?.headers as Headers;
+    expect(headers.get('Authorization')).toBe('tg test');
+  });
+});

--- a/services/webapp/ui/src/lib/telegram-auth.startup.test.ts
+++ b/services/webapp/ui/src/lib/telegram-auth.startup.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// This test verifies that the module initializes Telegram auth data on load
+// using the global Telegram object.
+describe('telegram-auth startup', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it('loads init data from Telegram global object', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    vi.stubGlobal('Telegram', { WebApp: { initData: `auth_date=${now}` } });
+    const mod = await import('./telegram-auth?startup');
+    expect(mod.getTelegramAuthHeaders()).toEqual({
+      Authorization: `tg auth_date=${now}`,
+    });
+  });
+});

--- a/services/webapp/ui/src/lib/telegram-auth.ts
+++ b/services/webapp/ui/src/lib/telegram-auth.ts
@@ -73,3 +73,32 @@ export function getTelegramAuthHeaders(): Record<string, string> {
 }
 
 export { LS_KEY as TELEGRAM_INIT_DATA_KEY };
+
+// Initialize stored init data on module load so that API calls can immediately
+// include the Telegram authentication header. In a real Telegram WebApp the
+// init data may be provided either via the global `Telegram.WebApp.initData`
+// object or through the `tgWebAppData` hash parameter. We try both sources and
+// silently ignore any errors (for example when running in non-browser
+// environments).
+try {
+  if (typeof window !== 'undefined') {
+    const globalData = (window as any)?.Telegram?.WebApp?.initData;
+    if (globalData) {
+      setTelegramInitData(globalData);
+    } else {
+      try {
+        const hash = window.location.hash.startsWith('#')
+          ? window.location.hash.slice(1)
+          : window.location.hash;
+        const tgWebAppData = new URLSearchParams(hash).get('tgWebAppData');
+        if (tgWebAppData) {
+          setTelegramInitData(tgWebAppData);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+} catch {
+  /* ignore */
+}


### PR DESCRIPTION
## Summary
- initialize Telegram auth data on startup so `getTelegramAuthHeaders` immediately returns `Authorization`
- add tests ensuring API client includes Telegram auth headers

## Testing
- `pytest -q --cov` *(fails: 17 failed, 1274 passed)*
- `mypy --strict .`
- `ruff check .`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(crashes: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd0960aec832a920b4b6da9a02d1f