### PR TITLE
[bot] Ensure user creation and restrict profile access

### DIFF
--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -60,7 +60,9 @@ async def patch_user_settings(
         try:
             ZoneInfo(device_tz)
         except ZoneInfoNotFoundError as exc:  # pragma: no cover - validation
-            raise HTTPException(status_code=400, detail="invalid device timezone") from exc
+            raise HTTPException(
+                status_code=400, detail="invalid device timezone"
+            ) from exc
 
     def _patch(session: SessionProtocol) -> ProfileSchema:
         user = cast(User | None, session.get(User, telegram_id))
@@ -115,7 +117,12 @@ async def patch_user_settings(
         if data.afterMealMinutes is not None:
             profile.postmeal_check_min = data.afterMealMinutes
 
-        if profile.timezone_auto and device_tz and data.timezone is None and profile.timezone != device_tz:
+        if (
+            profile.timezone_auto
+            and device_tz
+            and data.timezone is None
+            and profile.timezone != device_tz
+        ):
             profile.timezone = device_tz
 
         try:
@@ -137,13 +144,17 @@ async def patch_user_settings(
             sosAlertsEnabled=profile.sos_alerts_enabled,
             timezone=profile.timezone,
             timezoneAuto=profile.timezone_auto,
-            therapyType=(TherapyType(profile.therapy_type) if profile.therapy_type else None),
+            therapyType=(
+                TherapyType(profile.therapy_type) if profile.therapy_type else None
+            ),
             dia=profile.dia,
             roundStep=profile.round_step,
             carbUnits=CarbUnits(profile.carb_units),
             gramsPerXe=profile.grams_per_xe,
             glucoseUnits=GlucoseUnits(profile.glucose_units),
-            rapidInsulinType=(RapidInsulinType(profile.insulin_type) if profile.insulin_type else None),
+            rapidInsulinType=(
+                RapidInsulinType(profile.insulin_type) if profile.insulin_type else None
+            ),
             maxBolus=profile.max_bolus,
             preBolus=profile.prebolus_min,
             afterMealMinutes=profile.postmeal_check_min,
@@ -169,13 +180,17 @@ async def get_profile_settings(telegram_id: int) -> ProfileSchema:
         sosAlertsEnabled=profile.sos_alerts_enabled,
         timezone=profile.timezone,
         timezoneAuto=profile.timezone_auto,
-        therapyType=(TherapyType(profile.therapy_type) if profile.therapy_type else None),
+        therapyType=(
+            TherapyType(profile.therapy_type) if profile.therapy_type else None
+        ),
         dia=profile.dia,
         roundStep=profile.round_step,
         carbUnits=CarbUnits(profile.carb_units),
         gramsPerXe=profile.grams_per_xe,
         glucoseUnits=GlucoseUnits(profile.glucose_units),
-        rapidInsulinType=(RapidInsulinType(profile.insulin_type) if profile.insulin_type else None),
+        rapidInsulinType=(
+            RapidInsulinType(profile.insulin_type) if profile.insulin_type else None
+        ),
         maxBolus=profile.max_bolus,
         preBolus=profile.prebolus_min,
         afterMealMinutes=profile.postmeal_check_min,
@@ -267,7 +282,11 @@ async def save_profile(data: ProfileUpdateSchema | ProfileSchema) -> None:
                     profile_data[column] = value
 
         stmt = insert(Profile).values(**profile_data)
-        update_values = {key: getattr(stmt.excluded, key) for key in profile_data.keys() if key != "telegram_id"}
+        update_values = {
+            key: getattr(stmt.excluded, key)
+            for key in profile_data.keys()
+            if key != "telegram_id"
+        }
         session.execute(
             stmt.on_conflict_do_update(
                 index_elements=[Profile.telegram_id],
@@ -292,7 +311,9 @@ async def save_profile(data: ProfileUpdateSchema | ProfileSchema) -> None:
     except HTTPException as exc:
         if exc.status_code == 500:
             logger.exception("save_profile failed for %s", data.telegramId)
-            raise HTTPException(status_code=503, detail="временные проблемы с БД") from exc
+            raise HTTPException(
+                status_code=503, detail="временные проблемы с БД"
+            ) from exc
         raise
 
 
@@ -307,7 +328,9 @@ async def get_profile(telegram_id: int) -> Profile:
         profile = await db.run_db(_get, sessionmaker=db.SessionLocal)
     except (OperationalError, ConnectionError) as exc:
         logger.exception("failed to fetch profile %s", telegram_id)
-        raise HTTPException(status_code=503, detail="database temporarily unavailable") from exc
+        raise HTTPException(
+            status_code=503, detail="database temporarily unavailable"
+        ) from exc
     except SQLAlchemyError as exc:
         logger.exception("sqlalchemy error while fetching profile %s", telegram_id)
         raise HTTPException(status_code=500, detail="database error") from exc

--- a/tests/test_profile_requires_onboarding.py
+++ b/tests/test_profile_requires_onboarding.py
@@ -1,0 +1,70 @@
+import hashlib
+import hmac
+import json
+import time
+import urllib.parse
+from typing import Any, Callable
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import services.api.app.main as server
+from services.api.app.config import settings
+from services.api.app.diabetes.services import db
+from services.api.app.telegram_auth import TG_INIT_DATA_HEADER
+
+TOKEN = "test-token"
+
+
+def build_init_data(user_id: int = 1) -> str:
+    user = json.dumps({"id": user_id, "first_name": "A"}, separators=(",", ":"))
+    params = {"auth_date": str(int(time.time())), "query_id": "abc", "user": user}
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
+    secret = hmac.new(b"WebAppData", TOKEN.encode(), hashlib.sha256).digest()
+    params["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return urllib.parse.urlencode(params)
+
+
+@pytest.fixture
+def auth_headers(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    return {TG_INIT_DATA_HEADER: build_init_data()}
+
+
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+
+    original_run_db = db.run_db
+
+    async def run_db_wrapper(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        kwargs["sessionmaker"] = SessionLocal
+        return await original_run_db(fn, *args, **kwargs)
+
+    monkeypatch.setattr(server, "run_db", run_db_wrapper)
+    import services.api.app.routers.profile as profile_router
+
+    monkeypatch.setattr(profile_router.db_module, "run_db", run_db_wrapper)
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal, raising=False)
+    return SessionLocal
+
+
+def test_profile_get_requires_onboarding(
+    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
+) -> None:
+    SessionLocal = setup_db(monkeypatch)
+    with SessionLocal() as session:
+        session.add(db.User(telegram_id=1, thread_id="t", onboarding_complete=False))
+        session.add(db.Profile(telegram_id=1))
+        session.commit()
+    with TestClient(server.app) as client:
+        resp = client.get("/api/profile", headers=auth_headers)
+    assert resp.status_code == 422

--- a/tests/test_profile_webapp_save_flow.py
+++ b/tests/test_profile_webapp_save_flow.py
@@ -243,6 +243,10 @@ async def test_webapp_save_persists_settings(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(handlers, "get_api", lambda: (None, None, None))
     monkeypatch.setattr(handlers, "post_profile", lambda *a, **kw: (True, None))
 
+    with TestSession() as session:
+        session.add(User(telegram_id=1, thread_id="t", onboarding_complete=True))
+        session.commit()
+
     msg = DummyMessage()
     payload = {
         "icr": 8,

--- a/tests/test_users_api.py
+++ b/tests/test_users_api.py
@@ -1,0 +1,64 @@
+import hashlib
+import hmac
+import json
+import time
+import urllib.parse
+from typing import Any, Callable
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import services.api.app.main as server
+from services.api.app.config import settings
+from services.api.app.diabetes.services import db
+from services.api.app.telegram_auth import TG_INIT_DATA_HEADER
+
+TOKEN = "test-token"
+
+
+def build_init_data(user_id: int = 1) -> str:
+    user = json.dumps({"id": user_id, "first_name": "A"}, separators=(",", ":"))
+    params = {"auth_date": str(int(time.time())), "query_id": "abc", "user": user}
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
+    secret = hmac.new(b"WebAppData", TOKEN.encode(), hashlib.sha256).digest()
+    params["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return urllib.parse.urlencode(params)
+
+
+@pytest.fixture
+def auth_headers(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    return {TG_INIT_DATA_HEADER: build_init_data()}
+
+
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+
+    async def run_db_wrapper(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        return await db.run_db(fn, *args, sessionmaker=SessionLocal, **kwargs)
+
+    monkeypatch.setattr(server, "run_db", run_db_wrapper)
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal, raising=False)
+    return SessionLocal
+
+
+def test_post_users_creates_record(
+    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
+) -> None:
+    SessionLocal = setup_db(monkeypatch)
+    with TestClient(server.app) as client:
+        resp = client.post("/api/users", json={"telegramId": 1}, headers=auth_headers)
+    assert resp.status_code == 200
+    with SessionLocal() as session:
+        user = session.get(db.User, 1)
+        assert user is not None
+        assert user.thread_id == "webapp"


### PR DESCRIPTION
## Summary
- ensure user rows exist by factoring user creation logic and exposing `/users`
- block `/profile` access until onboarding is complete
- add tests for user creation endpoint and onboarding guard

## Testing
- `ruff check .`
- `mypy --strict services/api/app/routers/users.py services/api/app/routers/profile.py services/api/app/services/profile.py tests/test_users_api.py tests/test_profile_requires_onboarding.py tests/test_profile_patch_endpoint.py tests/test_profile_webapp_save_flow.py`
- `pytest -q --cov` *(fails: tests/diabetes/test_curriculum_exceptions.py::test_learn_command_start_lesson_exception[OpenAIError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_start_lesson_exception[HTTPError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_start_lesson_exception[RuntimeError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_next_step_exception[SQLAlchemyError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_next_step_exception[OpenAIError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_next_step_exception[HTTPError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_next_step_exception[RuntimeError], tests/diabetes/test_curriculum_exceptions.py::test_lesson_command_start_lesson_exception, tests/diabetes/test_curriculum_exceptions.py::test_lesson_command_next_step_exception, tests/diabetes/test_curriculum_not_found.py::test_learn_command_lesson_not_found, tests/diabetes/test_curriculum_not_found.py::test_lesson_command_lesson_not_found, tests/diabetes/test_learning_chat_handlers.py::test_learn_command_and_callback, tests/diabetes/test_learning_chat_handlers.py::test_learn_command_autostarts_when_topics_hidden, tests/learning/test_flow_autostart.py::test_flow_autostart, tests/learning/test_plan_handlers.py::test_learn_command_stores_plan, tests/assistant/test_e2e_restart.py::test_hydrate_generates_snapshot_and_persists)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd09c84dc832abea0b3e5add5307d