### PR TITLE
[main] Log lesson count errors

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -63,6 +63,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     try:
         static_lessons = await run_db(_count)
     except Exception:  # pragma: no cover - logging only
+        logger.exception("Failed to count lessons")
         static_lessons = 0
     logger.info(
         "startup_env",


### PR DESCRIPTION
## Summary
- log exceptions when counting static lessons fails at startup

## Testing
- `pytest -q --cov` *(fails: async def functions not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfd6e716fc832a8c036d1fc09c8f67