### PR TITLE
[reminders] handle DB errors when loading active reminders

### DIFF
--- a/services/api/app/reminder_events.py
+++ b/services/api/app/reminder_events.py
@@ -6,6 +6,7 @@ import re
 from datetime import timedelta
 
 import sqlalchemy as sa
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker, selectinload
 from telegram.ext import ContextTypes
 
@@ -43,7 +44,11 @@ async def _reminders_gc(_context: ContextTypes.DEFAULT_TYPE) -> None:
                 ).all()
             )
 
-    reminders = await asyncio.to_thread(load_active)
+    try:
+        reminders = await asyncio.to_thread(load_active)
+    except SQLAlchemyError as exc:
+        logger.exception("Failed to load active reminders", exc_info=exc)
+        return
     active_ids = {rem.id for rem in reminders}
 
     for rem in reminders:


### PR DESCRIPTION
## Summary
- log SQLAlchemy errors when loading active reminders

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .` *(fails: process interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfd6ecadc0832aa3ac933d2c8de845