### PR TITLE
[reminders] enforce schedule kind check

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_jobs.py
+++ b/services/api/app/diabetes/handlers/reminder_jobs.py
@@ -77,7 +77,8 @@ def schedule_reminder(
             kind = ScheduleKind.at_time
     elif isinstance(kind, str):
         kind = ScheduleKind(kind)
-    assert kind is not None
+    if kind is None:
+        raise RuntimeError("reminder kind is missing")
 
     name = f"{base_name}_after" if kind == ScheduleKind.after_event else base_name
 


### PR DESCRIPTION
## Summary
- ensure `schedule_reminder` raises runtime error when reminder kind is missing

## Testing
- `pytest -q --cov` *(fails: 16 failed, 1285 passed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfd6f11ba0832abc1b686178a83df2