### PR TITLE
[webapp] ensure Telegram auth before requests

### DIFF
--- a/services/webapp/ui/src/api/history.ts
+++ b/services/webapp/ui/src/api/history.ts
@@ -1,12 +1,13 @@
 import { Configuration } from '@sdk/runtime.ts';
 import { HistoryApi } from '@sdk/apis';
 import type { HistoryRecordSchemaInput, HistoryRecordSchemaOutput } from '@sdk/models';
-import { getTelegramAuthHeaders } from '@/lib/telegram-auth';
+import { buildHeaders } from './http';
 
 function makeApi(): HistoryApi {
+  const hdrs = buildHeaders({ headers: {} }, true);
   const cfg = new Configuration({
     basePath: '/api',
-    headers: getTelegramAuthHeaders(),
+    headers: Object.fromEntries(hdrs.entries()),
   });
   return new HistoryApi(cfg);
 }

--- a/services/webapp/ui/src/api/index.auth.test.ts
+++ b/services/webapp/ui/src/api/index.auth.test.ts
@@ -12,6 +12,7 @@ describe('api client telegram auth', () => {
   it('sends Authorization header from getTelegramAuthHeaders', async () => {
     vi.doMock('@/lib/telegram-auth', () => ({
       getTelegramAuthHeaders: () => ({ Authorization: 'tg test' }),
+      setTelegramInitData: vi.fn(),
     }));
     const fetchMock = vi
       .fn()

--- a/services/webapp/ui/src/api/stats.test.ts
+++ b/services/webapp/ui/src/api/stats.test.ts
@@ -18,6 +18,7 @@ vi.mock('@sdk/apis', () => ({
 
 vi.mock('@/lib/telegram-auth', () => ({
   getTelegramAuthHeaders: vi.fn(() => ({ Authorization: 'tg test' })),
+  setTelegramInitData: vi.fn(),
 }));
 
 import { fetchAnalytics, fetchDayStats } from './stats';

--- a/services/webapp/ui/src/api/stats.ts
+++ b/services/webapp/ui/src/api/stats.ts
@@ -1,12 +1,13 @@
 import { Configuration } from '@sdk/runtime.ts';
 import { DefaultApi } from '@sdk/apis';
 import type { AnalyticsPoint, DayStats } from '@sdk/models';
-import { getTelegramAuthHeaders } from '@/lib/telegram-auth';
+import { buildHeaders } from './http';
 
 function makeApi(): DefaultApi {
+  const hdrs = buildHeaders({ headers: {} }, true);
   const cfg = new Configuration({
     basePath: '/api',
-    headers: getTelegramAuthHeaders(),
+    headers: Object.fromEntries(hdrs.entries()),
   });
   return new DefaultApi(cfg);
 }

--- a/services/webapp/ui/src/features/reminders/api/reminders.ts
+++ b/services/webapp/ui/src/features/reminders/api/reminders.ts
@@ -2,12 +2,14 @@ import { useEffect, useMemo } from "react";
 import { Configuration } from "@sdk/runtime.ts";
 import { RemindersApi } from "@sdk/apis";
 import { useTelegramInitData } from "../../../hooks/useTelegramInitData";
-import { getTelegramAuthHeaders, setTelegramInitData } from "@/lib/telegram-auth";
+import { setTelegramInitData } from "@/lib/telegram-auth";
+import { buildHeaders } from "@/api/http";
 
 export function makeRemindersApi() {
+  const hdrs = buildHeaders({ headers: {} }, true);
   const cfg = new Configuration({
     basePath: "/api",
-    headers: getTelegramAuthHeaders(),
+    headers: Object.fromEntries(hdrs.entries()),
   });
   return new RemindersApi(cfg);
 }

--- a/services/webapp/ui/src/main.tsx
+++ b/services/webapp/ui/src/main.tsx
@@ -2,6 +2,28 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 import './index.css'
+import { setTelegramInitData } from '@/lib/telegram-auth'
+
+function initTelegram(): void {
+  try {
+    const globalData = (window as any)?.Telegram?.WebApp?.initData
+    if (globalData) {
+      setTelegramInitData(globalData)
+      return
+    }
+    const hash = window.location.hash.startsWith('#')
+      ? window.location.hash.slice(1)
+      : window.location.hash
+    const tgWebAppData = new URLSearchParams(hash).get('tgWebAppData')
+    if (tgWebAppData) {
+      setTelegramInitData(tgWebAppData)
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+initTelegram()
 
 if (import.meta.env.DEV) {
   import('./api/mock-server')

--- a/services/webapp/ui/src/shared/api/onboarding.ts
+++ b/services/webapp/ui/src/shared/api/onboarding.ts
@@ -1,4 +1,5 @@
-import { getTelegramAuthHeaders, setTelegramInitData } from '@/lib/telegram-auth';
+import { setTelegramInitData } from '@/lib/telegram-auth';
+import { buildHeaders } from '@/api/http';
 
 export function getInitDataRaw(): string | null {
   const initData =
@@ -26,16 +27,12 @@ export async function postOnboardingEvent(
   if (rawInitData) {
     setTelegramInitData(rawInitData);
   }
-  const headers = getTelegramAuthHeaders();
-  if (!headers.Authorization) {
-    return;
-  }
-  headers['Content-Type'] = 'application/json';
-
+  const body = JSON.stringify({ event, step, meta });
+  const headers = buildHeaders({ headers: {}, body }, true);
   const res = await fetch('/api/onboarding/events', {
     method: 'POST',
     headers,
-    body: JSON.stringify({ event, step, meta }),
+    body,
   });
   if (!res.ok) throw new Error('Failed to post onboarding event');
 }
@@ -45,10 +42,7 @@ export async function getOnboardingStatus() {
   if (rawInitData) {
     setTelegramInitData(rawInitData);
   }
-  const headers = getTelegramAuthHeaders();
-  if (!headers.Authorization) {
-    return;
-  }
+  const headers = buildHeaders({ headers: {} }, true);
   const res = await fetch('/api/onboarding/status', { headers });
   if (!res.ok) throw new Error('Failed to get onboarding status');
   return res.json();

--- a/services/webapp/ui/tests/http.test.ts
+++ b/services/webapp/ui/tests/http.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/lib/telegram-auth', () => ({
   getTelegramAuthHeaders: () => ({}),
+  setTelegramInitData: vi.fn(),
 }));
 
 const makeJsonResponse = () =>

--- a/services/webapp/ui/tests/profile.api.test.ts
+++ b/services/webapp/ui/tests/profile.api.test.ts
@@ -7,7 +7,8 @@ import {
 } from '../src/features/profile/api';
 
 vi.mock('@/lib/telegram-auth', () => ({
-  getTelegramAuthHeaders: () => ({}),
+  getTelegramAuthHeaders: () => ({ Authorization: 'tg test' }),
+  setTelegramInitData: vi.fn(),
 }));
 
 describe('profile api', () => {

--- a/services/webapp/ui/tests/timezones.api.test.ts
+++ b/services/webapp/ui/tests/timezones.api.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@/lib/telegram-auth', () => ({
+  getTelegramAuthHeaders: () => ({ Authorization: 'tg test' }),
+  setTelegramInitData: vi.fn(),
+}));
+
 const makeResponse = () =>
   new Response(JSON.stringify(['UTC']), {
     status: 200,


### PR DESCRIPTION
## Summary
- initialize Telegram auth data on webapp startup
- validate Telegram headers before API calls and redirect when missing
- update tests for new auth checks

## Testing
- `pnpm --filter ./services/webapp/ui test -- src/api/billing.auth.test.ts tests/onboarding.api.test.ts tests/profile.api.test.ts tests/timezones.api.test.ts`
- `pytest -q` *(fails: many tests failing early)*
- `mypy --strict .` *(terminated: took too long)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfd7106e50832a924ecc298322303d