### PR TITLE
[ui] map onboarding step

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -35,7 +35,7 @@ import { useTelegram } from "@/hooks/useTelegram";
 import { useTelegramInitData } from "@/hooks/useTelegramInitData";
 import { setTelegramInitData } from "@/lib/telegram-auth";
 import { resolveTelegramId } from "./resolveTelegramId";
-import { postOnboardingEvent } from "@/shared/api/onboarding";
+import { postOnboardingEvent, type OnboardingStep } from "@/shared/api/onboarding";
 
 const rapidInsulinTypes: RapidInsulin[] = [
   'aspart',
@@ -83,7 +83,14 @@ interface ProfileProps {
 const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const onboardingStep = searchParams.get("step") || undefined;
+  const onboardingStepParam = searchParams.get("step");
+  const onboardingStep = (
+    onboardingStepParam === "profile" ||
+    onboardingStepParam === "timezone" ||
+    onboardingStepParam === "reminders"
+  )
+    ? (onboardingStepParam as OnboardingStep)
+    : undefined;
   const isOnboardingFlow = searchParams.get("flow") === "onboarding";
   const { toast } = useToast();
   const { user } = useTelegram();

--- a/services/webapp/ui/src/shared/api/onboarding.ts
+++ b/services/webapp/ui/src/shared/api/onboarding.ts
@@ -1,5 +1,13 @@
 import { getTelegramAuthHeaders, setTelegramInitData } from '@/lib/telegram-auth';
 
+const STEP_MAP = {
+  profile: 0,
+  timezone: 1,
+  reminders: 2,
+} as const;
+
+export type OnboardingStep = keyof typeof STEP_MAP;
+
 export function getInitDataRaw(): string | null {
   const initData =
     (window as unknown as { Telegram?: { WebApp?: { initData?: string } } })
@@ -19,7 +27,7 @@ export function getInitDataRaw(): string | null {
 
 export async function postOnboardingEvent(
   event: string,
-  step?: string,
+  step?: OnboardingStep,
   meta?: any,
 ) {
   const rawInitData = getInitDataRaw();
@@ -35,7 +43,7 @@ export async function postOnboardingEvent(
   const res = await fetch('/api/onboarding/events', {
     method: 'POST',
     headers,
-    body: JSON.stringify({ event, step, meta }),
+    body: JSON.stringify({ event, step: step ? STEP_MAP[step] : null, meta }),
   });
   if (!res.ok) throw new Error('Failed to post onboarding event');
 }

--- a/services/webapp/ui/tests/profile.onboarding.test.tsx
+++ b/services/webapp/ui/tests/profile.onboarding.test.tsx
@@ -85,7 +85,7 @@ describe('Profile onboarding', () => {
   });
 
   it('posts onboarding_started when telegram data is valid', async () => {
-    searchParams = new URLSearchParams('flow=onboarding&step=1');
+    searchParams = new URLSearchParams('flow=onboarding&step=timezone');
     (useTelegramInitData as vi.Mock).mockReturnValue('init');
 
     render(
@@ -97,7 +97,7 @@ describe('Profile onboarding', () => {
     await waitFor(() => {
       expect(postOnboardingEvent).toHaveBeenCalledWith(
         'onboarding_started',
-        '1',
+        'timezone',
       );
     });
   });


### PR DESCRIPTION
## Summary
- map onboarding step strings to numeric values before sending
- validate profile step query param and update onboarding test

## Testing
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfd71297a8832aab770f67acf549fe