### PR TITLE
[webapp] Map onboarding step to index

### DIFF
--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -35,7 +35,11 @@ import { useTelegram } from "@/hooks/useTelegram";
 import { useTelegramInitData } from "@/hooks/useTelegramInitData";
 import { setTelegramInitData } from "@/lib/telegram-auth";
 import { resolveTelegramId } from "./resolveTelegramId";
-import { postOnboardingEvent } from "@/shared/api/onboarding";
+import {
+  postOnboardingEvent,
+  type OnboardingStep,
+  isValidOnboardingStep,
+} from "@/shared/api/onboarding";
 
 const rapidInsulinTypes: RapidInsulin[] = [
   'aspart',
@@ -83,7 +87,9 @@ interface ProfileProps {
 const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const onboardingStep = searchParams.get("step") || undefined;
+  const onboardingStepParam = searchParams.get("step");
+  const onboardingStep: OnboardingStep | undefined =
+    isValidOnboardingStep(onboardingStepParam) ? onboardingStepParam : undefined;
   const isOnboardingFlow = searchParams.get("flow") === "onboarding";
   const { toast } = useToast();
   const { user } = useTelegram();

--- a/services/webapp/ui/tests/profile.onboarding.test.tsx
+++ b/services/webapp/ui/tests/profile.onboarding.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../src/hooks/useTelegramInitData', () => ({
 
 vi.mock('@/shared/api/onboarding', () => ({
   postOnboardingEvent: vi.fn().mockResolvedValue(undefined),
+  isValidOnboardingStep: (step: string | null) => step !== null,
 }));
 
 let searchParams = new URLSearchParams();
@@ -40,11 +41,9 @@ vi.mock('../src/features/profile/api', async () => {
     ...actual,
     saveProfile: vi.fn(),
     patchProfile: vi.fn(),
-    getProfile: vi
-      .fn()
-      .mockRejectedValue(
-        new actual.ProfileNotRegisteredError('missing'),
-      ),
+    getProfile: vi.fn(
+      () => Promise.reject(new actual.ProfileNotRegisteredError('missing')),
+    ),
   };
 });
 
@@ -85,7 +84,7 @@ describe('Profile onboarding', () => {
   });
 
   it('posts onboarding_started when telegram data is valid', async () => {
-    searchParams = new URLSearchParams('flow=onboarding&step=1');
+    searchParams = new URLSearchParams('flow=onboarding&step=profile');
     (useTelegramInitData as vi.Mock).mockReturnValue('init');
 
     render(
@@ -97,7 +96,7 @@ describe('Profile onboarding', () => {
     await waitFor(() => {
       expect(postOnboardingEvent).toHaveBeenCalledWith(
         'onboarding_started',
-        '1',
+        'profile',
       );
     });
   });

--- a/services/webapp/ui/tests/profile.test.tsx
+++ b/services/webapp/ui/tests/profile.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../src/hooks/useTelegramInitData', () => ({
 
 vi.mock('@/shared/api/onboarding', () => ({
   postOnboardingEvent: vi.fn().mockResolvedValue(undefined),
+  isValidOnboardingStep: (step: string | null) => step !== null,
 }));
 
 vi.mock('react-router-dom', () => ({

--- a/tests/ui/test_onboarding_flow.spec.ts
+++ b/tests/ui/test_onboarding_flow.spec.ts
@@ -56,6 +56,7 @@ vi.mock('../../services/webapp/ui/src/pages/resolveTelegramId', () => ({
 const postEventProfile = vi.fn();
 vi.mock('../../services/webapp/ui/src/shared/api/onboarding', () => ({
   postOnboardingEvent: postEventProfile,
+  isValidOnboardingStep: (step: string | null) => step !== null,
 }));
 
 import Profile from '../../services/webapp/ui/src/pages/Profile';


### PR DESCRIPTION
## Summary
- map onboarding steps to numeric indices and expose step validation
- validate onboarding step query param before posting events
- align onboarding tests with named step usage

## Testing
- `pnpm --filter ./services/webapp/ui test` *(fails: Cannot read properties of undefined (reading 'then') in Profile onboarding test)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfdde3f870832aa83722522fc52b5f