### PR TITLE
[utils] Ensure asyncio and atexit imports

### DIFF
--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -1,5 +1,5 @@
-import atexit
 import asyncio
+import atexit
 import logging
 import threading
 from collections.abc import AsyncIterator, Iterator


### PR DESCRIPTION
## Summary
- ensure `asyncio` and `atexit` imports are included for OpenAI utilities

## Testing
- `python -m py_compile services/api/app/diabetes/utils/openai_utils.py`
- `pytest -q --cov` *(fails: async def functions are not natively supported, 710 failed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfdf208784832ab2d12477dc6e765f