### PR TITLE
[services] Reset async OpenAI client lock for new event loops

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -75,17 +75,11 @@ def _get_client() -> OpenAI:
 async def _get_async_client() -> AsyncOpenAI:
     """Return cached AsyncOpenAI client, creating it once in an async-safe manner."""
     global _async_client
+    loop = asyncio.get_running_loop()
+    global _async_client_lock
+    if _async_client_lock is None or getattr(_async_client_lock, "_loop", None) is not loop:
+        _async_client_lock = asyncio.Lock()
     if _async_client is None:
-        global _async_client_lock
-        if _async_client_lock is None:
-            try:
-                asyncio.get_running_loop()
-            except RuntimeError:
-                pass
-            else:
-                _async_client_lock = asyncio.Lock()
-        if _async_client_lock is None:
-            raise RuntimeError("No running event loop")
         async with _async_client_lock:
             if _async_client is None:
                 _async_client = get_async_openai_client()


### PR DESCRIPTION
## Summary
- ensure _get_async_client uses the current event loop and recreates its lock when the loop changes
- add regression test covering multiple event loops

## Testing
- `pytest tests/test_gpt_client.py::test_get_async_client_multiple_loops -q`
- `pytest -q --cov --maxfail=1` *(fails: tests/assistant/test_hydration.py::test_hydration_restores_state)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfdf23152c832a8db7fa7f8e138619