### PR TITLE
[config] Refresh TELEGRAM_TOKEN during validation

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 from typing import Iterable
 
-from services.api.app.config import settings
+from services.api.app.config import get_settings, reload_settings, settings
 
 # Expose commonly used environment variables so importing modules can
 # reference them directly if needed.  Values default to ``None`` when not
@@ -50,9 +50,13 @@ def validate_tokens(required: Iterable[str] | None = None) -> None:
 
     required_vars = list(required or [])
     missing = []
+
+    if "TELEGRAM_TOKEN" in required_vars:
+        reload_settings()
+
     for var in required_vars:
         if var == "TELEGRAM_TOKEN":
-            if not settings.telegram_token:
+            if not get_settings().telegram_token:
                 missing.append(var)
         elif not os.getenv(var):
             missing.append(var)

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -34,3 +34,18 @@ def test_validate_tokens_env_not_declared(monkeypatch: pytest.MonkeyPatch) -> No
     assert not hasattr(config, "UNDECLARED_TOKEN")
 
     config.validate_tokens(["UNDECLARED_TOKEN"])
+
+
+def test_validate_tokens_reflects_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``validate_tokens`` checks the current ``TELEGRAM_TOKEN`` value."""
+
+    monkeypatch.setenv("TELEGRAM_TOKEN", "initial")
+    config = _reload("config")
+    config.validate_tokens(["TELEGRAM_TOKEN"])
+
+    monkeypatch.delenv("TELEGRAM_TOKEN", raising=False)
+    with pytest.raises(RuntimeError):
+        config.validate_tokens(["TELEGRAM_TOKEN"])
+
+    monkeypatch.setenv("TELEGRAM_TOKEN", "updated")
+    config.validate_tokens(["TELEGRAM_TOKEN"])


### PR DESCRIPTION
## Summary
- reload settings to use current TELEGRAM_TOKEN in `validate_tokens`
- test runtime updates to TELEGRAM_TOKEN

## Testing
- `pytest -q --cov` (fails: 16 failed, 1289 passed)
- `pytest tests/test_root_config.py -q --cov=config`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bfdf26b5b4832aba77e51280a25c7f