### PR TITLE
[bot] remove Any from telegram payments register

### DIFF
--- a/services/bot/telegram_payments.py
+++ b/services/bot/telegram_payments.py
@@ -7,7 +7,6 @@ import hmac
 import logging
 from dataclasses import dataclass
 from functools import partial
-from typing import Any
 
 import httpx
 from telegram import LabeledPrice, Update
@@ -112,7 +111,7 @@ class TelegramPaymentsAdapter:
 
 
 def register_billing_handlers(
-    app: Application[Any, Any, Any, Any, Any, Any],
+    app: Application,
     adapter: TelegramPaymentsAdapter | None = None,
 ) -> None:
     """Register Telegram Payments handlers with the application."""


### PR DESCRIPTION
## Summary
- remove unused typing.Any import from Telegram payments adapter
- annotate register_billing_handlers app parameter with non-generic Application

## Testing
- `ruff check services/bot/telegram_payments.py`
- `pytest -q` *(fails: openai authentication, database not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe2961dfc832aac98bfd5a35e3324