### PR TITLE
[payments] add explicit None checks

### DIFF
--- a/services/bot/telegram_payments.py
+++ b/services/bot/telegram_payments.py
@@ -36,7 +36,8 @@ class TelegramPaymentsAdapter:
         """Send an invoice to the user."""
 
         chat = update.effective_chat
-        assert chat is not None
+        if chat is None:
+            raise ValueError("update.effective_chat is required")
         chat_id = chat.id
         prices = [LabeledPrice(label="Subscription", amount=100)]
         await context.bot.send_invoice(
@@ -53,7 +54,8 @@ class TelegramPaymentsAdapter:
         """Confirm pre checkout query."""
 
         query = update.pre_checkout_query
-        assert query is not None
+        if query is None:
+            raise ValueError("update.pre_checkout_query is required")
         await query.answer(ok=True)
 
     async def handle_successful_payment(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -62,7 +64,9 @@ class TelegramPaymentsAdapter:
         msg = update.message
         assert msg is not None
         payment = msg.successful_payment
-        assert payment is not None
+        if payment is None:
+            await msg.reply_text("⚠️ Платёж не найден")
+            return
 
         api_url = settings.api_url or "http://localhost:8000"
         event_id = payment.telegram_payment_charge_id


### PR DESCRIPTION
## Summary
- replace assertions in Telegram payments with explicit ValueErrors or user messages
- test missing chat, pre-checkout query and payment cases

## Testing
- `ruff check services/bot/telegram_payments.py tests`
- `mypy --strict services/bot/telegram_payments.py tests/test_telegram_payments.py` *(fails: hung)
- `pytest -q tests/test_telegram_payments.py`
- `pytest -q` *(fails: 16 failed, 298 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe29a96a8832a9810cdd200fcf7a8