### PR TITLE
[bot] derive invoice price from settings

### DIFF
--- a/services/api/app/billing/config.py
+++ b/services/api/app/billing/config.py
@@ -29,24 +29,37 @@ class BillingSettings(BaseSettings):
 
     billing_enabled: bool = Field(default=False, alias="BILLING_ENABLED")
     billing_test_mode: bool = Field(default=True, alias="BILLING_TEST_MODE")
-    billing_provider: BillingProvider = Field(default=BillingProvider.DUMMY, alias="BILLING_PROVIDER")
+    billing_provider: BillingProvider = Field(
+        default=BillingProvider.DUMMY, alias="BILLING_PROVIDER"
+    )
     paywall_mode: PaywallMode = Field(default=PaywallMode.SOFT, alias="PAYWALL_MODE")
     billing_admin_token: str | None = Field(default=None, alias="BILLING_ADMIN_TOKEN")
-    billing_webhook_secret: str | None = Field(default=None, alias="BILLING_WEBHOOK_SECRET")
+    billing_webhook_secret: str | None = Field(
+        default=None, alias="BILLING_WEBHOOK_SECRET"
+    )
     billing_webhook_ips_raw: str = Field(default="", alias="BILLING_WEBHOOK_IPS")
     billing_webhook_timeout: float = Field(default=5.0, alias="BILLING_WEBHOOK_TIMEOUT")
+    billing_currency: str = Field(default="RUB", alias="BILLING_CURRENCY")
+    billing_plan_prices: dict[str, int] = Field(
+        default_factory=dict, alias="BILLING_PLAN_PRICES"
+    )
 
     @model_validator(mode="after")
     def _require_admin_token(self) -> "BillingSettings":
         """Ensure real providers have an admin token configured."""
-        if self.billing_provider is not BillingProvider.DUMMY and not self.billing_admin_token:
+        if (
+            self.billing_provider is not BillingProvider.DUMMY
+            and not self.billing_admin_token
+        ):
             raise ValueError("BILLING_ADMIN_TOKEN is required for non-dummy providers")
         return self
 
     @property
     def billing_webhook_ips(self) -> list[str]:
         """List of allowed source IPs for billing webhooks."""
-        return [ip.strip() for ip in self.billing_webhook_ips_raw.split(",") if ip.strip()]
+        return [
+            ip.strip() for ip in self.billing_webhook_ips_raw.split(",") if ip.strip()
+        ]
 
 
 billing_settings = BillingSettings()

--- a/services/bot/telegram_payments.py
+++ b/services/bot/telegram_payments.py
@@ -32,31 +32,41 @@ class TelegramPaymentsAdapter:
 
     provider_token: str = settings.telegram_payments_provider_token or ""
 
-    async def create_invoice(self, update: Update, context: ContextTypes.DEFAULT_TYPE, plan: str) -> None:
+    async def create_invoice(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE, plan: str
+    ) -> None:
         """Send an invoice to the user."""
 
         chat = update.effective_chat
         assert chat is not None
         chat_id = chat.id
-        prices = [LabeledPrice(label="Subscription", amount=100)]
+        settings = BillingSettings()
+        amount = settings.billing_plan_prices.get(plan)
+        if amount is None:
+            raise ValueError(f"unknown plan: {plan}")
+        prices = [LabeledPrice(label="Subscription", amount=amount)]
         await context.bot.send_invoice(
             chat_id=chat_id,
             title="Subscription",
             description="Monthly subscription",
             payload=plan,
             provider_token=self.provider_token,
-            currency="RUB",
+            currency=settings.billing_currency,
             prices=prices,
         )
 
-    async def handle_pre_checkout_query(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def handle_pre_checkout_query(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Confirm pre checkout query."""
 
         query = update.pre_checkout_query
         assert query is not None
         await query.answer(ok=True)
 
-    async def handle_successful_payment(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    async def handle_successful_payment(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ) -> None:
         """Notify backend about successful payment."""
 
         msg = update.message
@@ -119,6 +129,10 @@ def register_billing_handlers(
 
     if adapter is None:
         adapter = TelegramPaymentsAdapter()
-    app.add_handler(CommandHandler("subscribe", partial(adapter.create_invoice, plan="pro")))
+    app.add_handler(
+        CommandHandler("subscribe", partial(adapter.create_invoice, plan="pro"))
+    )
     app.add_handler(PreCheckoutQueryHandler(adapter.handle_pre_checkout_query))
-    app.add_handler(MessageHandler(filters.SUCCESSFUL_PAYMENT, adapter.handle_successful_payment))
+    app.add_handler(
+        MessageHandler(filters.SUCCESSFUL_PAYMENT, adapter.handle_successful_payment)
+    )


### PR DESCRIPTION
## Summary
- derive Telegram invoice price and currency from BillingSettings
- expose currency and plan price mapping in BillingSettings
- test invoice uses configured plan pricing

## Testing
- `ruff check services/bot/telegram_payments.py tests`
- `pytest -q` *(fails: openai.AuthenticationError and assertion mismatches in unrelated modules)*
- `pytest tests/test_telegram_payments.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfe2979698832aa3fdfc73eb660fa2