### PR TITLE
[bot] Refine billing handlers app type

### DIFF
--- a/services/bot/telegram_payments.py
+++ b/services/bot/telegram_payments.py
@@ -7,7 +7,6 @@ import hmac
 import logging
 from dataclasses import dataclass
 from functools import partial
-from typing import Any
 
 import httpx
 from telegram import LabeledPrice, Update
@@ -112,7 +111,7 @@ class TelegramPaymentsAdapter:
 
 
 def register_billing_handlers(
-    app: Application[Any, Any, Any, Any, Any, Any],
+    app: Application,
     adapter: TelegramPaymentsAdapter | None = None,
 ) -> None:
     """Register Telegram Payments handlers with the application."""


### PR DESCRIPTION
## Summary
- drop unused Any import in Telegram payments
- narrow register_billing_handlers to Application

## Testing
- `ruff check services/bot/telegram_payments.py`
- `pytest -q` *(fails: 16 failed, 1291 passed, 9 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe859a9cc832a90014acd15acc409