### PR TITLE
[assistant] validate user before learning plan creation

### DIFF
--- a/services/api/app/assistant/repositories/plans.py
+++ b/services/api/app/assistant/repositories/plans.py
@@ -6,7 +6,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 from ...diabetes.models_learning import LearningPlan
-from ...diabetes.services.db import SessionLocal, run_db
+from ...diabetes.services.db import SessionLocal, run_db, User
 from ...diabetes.services.repository import commit
 from ...types import SessionProtocol
 
@@ -20,6 +20,8 @@ async def create_plan(
 ) -> int:
     def _create(session: SessionProtocol) -> int:
         sess = cast(Session, session)
+        if sess.get(User, user_id) is None:
+            raise RuntimeError("User is not registered. Please register.")
         if is_active:
             stmt = (
                 sa.update(LearningPlan)

--- a/tests/assistant/test_plans_repo.py
+++ b/tests/assistant/test_plans_repo.py
@@ -98,3 +98,9 @@ async def test_create_plan_deactivates_previous_active(
     second = await plans.get_plan(second_id)
     assert first is not None and first.is_active is False
     assert second is not None and second.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_create_plan_without_user(session_local: sessionmaker[Session]) -> None:
+    with pytest.raises(RuntimeError, match="not registered"):
+        await plans.create_plan(5, version=1, plan_json=[])


### PR DESCRIPTION
## Summary
- ensure learning plans are only created for existing users
- cover missing-user case in repository tests

## Testing
- `black services/api/app/assistant/repositories/plans.py tests/assistant/test_plans_repo.py`
- `ruff check .`
- `mypy --strict .` *(fails: Missing type parameters for generic type "Application" in services/bot/telegram_payments.py)*
- `pytest -q --cov` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68bfef9fddfc832aa37b58e2ec4f2cd4