### PR TITLE
tests: stub OpenAI clients

### DIFF
--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -9,6 +9,17 @@ import pytest
 from services.api.app import config
 from services.api.app.diabetes.utils import openai_utils
 
+_original_get_openai_client = openai_utils.get_openai_client
+_original_get_async_openai_client = openai_utils.get_async_openai_client
+
+
+@pytest.fixture(autouse=True)
+def _restore_openai_utils(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(openai_utils, "get_openai_client", _original_get_openai_client)
+    monkeypatch.setattr(
+        openai_utils, "get_async_openai_client", _original_get_async_openai_client
+    )
+
 
 def test_get_openai_client_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(openai_utils, "_http_client", None)


### PR DESCRIPTION
## Summary
- stub out OpenAI client getters for test suite
- ensure OpenAI-related environment variables are set to dummy values
- restore original OpenAI helpers in openai_utils tests

## Testing
- `pytest -q --cov` (failed: 18 failed, 1294 passed)
- `mypy --strict .` (failed: Missing type parameters for generic type "Application")
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bffabacd34832a9e8a1c0fb909a623