### PR TITLE
[bot] Add type parameter for Application

### DIFF
--- a/services/bot/telegram_payments.py
+++ b/services/bot/telegram_payments.py
@@ -7,6 +7,7 @@ import hmac
 import logging
 from dataclasses import dataclass
 from functools import partial
+from typing import TYPE_CHECKING, TypeAlias
 
 import httpx
 from telegram import LabeledPrice, Update
@@ -14,6 +15,8 @@ from telegram.ext import (
     Application,
     CommandHandler,
     ContextTypes,
+    ExtBot,
+    JobQueue,
     MessageHandler,
     PreCheckoutQueryHandler,
     filters,
@@ -23,6 +26,19 @@ from services.api.app.config import settings
 from services.api.app.billing.config import BillingSettings
 
 logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    App: TypeAlias = Application[
+        ExtBot[None],
+        ContextTypes.DEFAULT_TYPE,
+        dict[str, object],
+        dict[str, object],
+        dict[str, object],
+        JobQueue[ContextTypes.DEFAULT_TYPE],
+    ]
+else:
+    App = Application
 
 
 @dataclass
@@ -125,7 +141,7 @@ class TelegramPaymentsAdapter:
 
 
 def register_billing_handlers(
-    app: Application,
+    app: App,
     adapter: TelegramPaymentsAdapter | None = None,
 ) -> None:
     """Register Telegram Payments handlers with the application."""


### PR DESCRIPTION
## Summary
- specify full Application type parameters for Telegram payment handlers

## Testing
- `pytest -q --cov` *(fails: test_hydration_restores_state and others)*
- `mypy --strict services/bot/telegram_payments.py`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68bffabd3124832a8122c6e4b7973085