### PR TITLE
[handlers] unify Vision failure message

### DIFF
--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -44,9 +44,7 @@ async def photo_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     message = update.message
     if message is None:
         return
-    await message.reply_text(
-        "📸 Пришлите фото блюда для анализа.", reply_markup=build_main_keyboard()
-    )
+    await message.reply_text("📸 Пришлите фото блюда для анализа.", reply_markup=build_main_keyboard())
 
 
 async def photo_handler(
@@ -74,10 +72,7 @@ async def photo_handler(
     flag_ts = user_data.get(WAITING_GPT_TIMESTAMP)
     now = datetime.datetime.now(datetime.timezone.utc)
     if user_data.get(WAITING_GPT_FLAG):
-        if (
-            isinstance(flag_ts, datetime.datetime)
-            and now - flag_ts > WAITING_GPT_TIMEOUT
-        ):
+        if isinstance(flag_ts, datetime.datetime) and now - flag_ts > WAITING_GPT_TIMEOUT:
             _clear_waiting_gpt(user_data)
         else:
             await message.reply_text("⏳ Уже обрабатываю фото, подождите…")
@@ -122,12 +117,8 @@ async def photo_handler(
                     try:
                         commit(session)
                     except CommitError:
-                        logger.exception(
-                            "[PHOTO] Failed to commit user %s", user_id
-                        )
-                        await message.reply_text(
-                            "⚠️ Не удалось сохранить данные пользователя."
-                        )
+                        logger.exception("[PHOTO] Failed to commit user %s", user_id)
+                        await message.reply_text("⚠️ Не удалось сохранить данные пользователя.")
                         return END
             user_data["thread_id"] = thread_id
 
@@ -151,23 +142,17 @@ async def photo_handler(
             )
         except asyncio.TimeoutError:
             logger.warning("[PHOTO] GPT request timed out")
-            await message.reply_text(
-                "⚠️ Превышено время ожидания ответа. Попробуйте ещё раз."
-            )
+            await message.reply_text("⚠️ Превышено время ожидания ответа. Попробуйте ещё раз.")
             _clear_waiting_gpt(user_data)
             return END
-        status_message = await message.reply_text(
-            "🔍 Анализирую фото (это займёт 5‑10 с)…"
-        )
+        status_message = await message.reply_text("🔍 Анализирую фото (это займёт 5‑10 с)…")
         chat_id = getattr(message, "chat_id", None)
 
         async def send_typing_action() -> None:
             if not chat_id:
                 return
             try:
-                await context.bot.send_chat_action(
-                    chat_id=chat_id, action=ChatAction.TYPING
-                )
+                await context.bot.send_chat_action(chat_id=chat_id, action=ChatAction.TYPING)
             except TelegramError as exc:
                 logger.warning(
                     "[PHOTO][TYPING_ACTION] Failed to send typing action: %s",
@@ -210,16 +195,14 @@ async def photo_handler(
                         exc,
                     )
                     raise
-            await message.reply_text(
-                "⚠️ Время ожидания Vision истекло. Попробуйте позже."
-            )
+            await message.reply_text("⚠️ Время ожидания Vision истекло. Попробуйте позже.")
             return END
 
         if run.status != "completed":
             logger.error("[VISION][RUN_FAILED] run.status=%s", run.status)
             if status_message and hasattr(status_message, "edit_text"):
                 try:
-                    await status_message.edit_text("⚠️ Vision не смог обработать фото.")
+                    await status_message.edit_text("⚠️ Vision не смог обработать фото. Попробуйте ещё раз.")
                 except TelegramError as exc:
                     logger.warning(
                         "[PHOTO][RUN_FAILED_EDIT] Failed to send Vision failure notice: %s",
@@ -232,7 +215,7 @@ async def photo_handler(
                     )
                     raise
             else:
-                await message.reply_text("⚠️ Vision не смог обработать фото.")
+                await message.reply_text("⚠️ Vision не смог обработать фото. Попробуйте ещё раз.")
             return END
 
         try:
@@ -335,13 +318,7 @@ async def photo_handler(
             notice = "⚠️ Ответ Vision слишком длинный, полный текст во вложении."
             max_len = max(
                 0,
-                MessageLimit.MAX_TEXT_LENGTH
-                - len(prefix)
-                - len("\n\n")
-                - len(notice)
-                - len("\n\n")
-                - len(suffix)
-                - 3,
+                MessageLimit.MAX_TEXT_LENGTH - len(prefix) - len("\n\n") - len(notice) - len("\n\n") - len(suffix) - 3,
             )
             truncated = vision_text[:max_len] + "..."
             await message.reply_document(
@@ -354,15 +331,11 @@ async def photo_handler(
 
     except OSError as exc:
         logger.exception("[PHOTO] File processing error: %s", exc)
-        await message.reply_text(
-            "⚠️ Ошибка при обработке файла изображения. Попробуйте ещё раз."
-        )
+        await message.reply_text("⚠️ Ошибка при обработке файла изображения. Попробуйте ещё раз.")
         return END
     except OpenAIError as exc:
         logger.exception("[PHOTO] Vision API error: %s", exc)
-        await message.reply_text(
-            "⚠️ Vision не смог обработать фото. Попробуйте ещё раз."
-        )
+        await message.reply_text("⚠️ Vision не смог обработать фото. Попробуйте ещё раз.")
         return END
     except ValueError as exc:
         logger.exception("[PHOTO] Parsing error: %s", exc)

--- a/tests/test_handlers_photo_openai_error.py
+++ b/tests/test_handlers_photo_openai_error.py
@@ -59,13 +59,7 @@ async def test_photo_handler_success(monkeypatch: pytest.MonkeyPatch, tmp_path: 
                         data=[
                             SimpleNamespace(
                                 role="assistant",
-                                content=[
-                                    SimpleNamespace(
-                                        text=SimpleNamespace(
-                                            value="Суп\nУглеводы: 10 г\nХЕ: 1"
-                                        )
-                                    )
-                                ],
+                                content=[SimpleNamespace(text=SimpleNamespace(value="Суп\nУглеводы: 10 г\nХЕ: 1"))],
                             )
                         ]
                     )
@@ -118,4 +112,59 @@ async def test_photo_handler_openai_error(monkeypatch: pytest.MonkeyPatch, tmp_p
 
     assert result == photo_handlers.END
     assert msg.replies[-1] == "⚠️ Vision не смог обработать фото. Попробуйте ещё раз."
+    assert photo_handlers.WAITING_GPT_FLAG not in context.user_data
+
+
+@pytest.mark.asyncio
+async def test_photo_handler_run_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Photo handler informs user when Vision run fails."""
+    monkeypatch.chdir(tmp_path)
+
+    async def fake_send_chat_action(*args: Any, **kwargs: Any) -> None:
+        pass
+
+    class Run:
+        status = "failed"
+        thread_id = "tid"
+        id = "runid"
+
+    async def fake_send_message(**kwargs: Any) -> Run:
+        return Run()
+
+    class DummyStatusMessage:
+        def __init__(self) -> None:
+            self.edits: list[str] = []
+
+        async def edit_text(self, text: str) -> None:
+            self.edits.append(text)
+
+    class DummyMessage:
+        def __init__(self) -> None:
+            self.photo = (DummyPhoto(),)
+            self.replies: list[str] = []
+            self.status: DummyStatusMessage | None = None
+
+        async def reply_text(self, text: str, **kwargs: Any) -> Any:
+            if text.startswith("🔍"):
+                self.status = DummyStatusMessage()
+                return self.status
+            self.replies.append(text)
+            return None
+
+    msg = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=msg, effective_user=SimpleNamespace(id=1)))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(
+            bot=SimpleNamespace(get_file=_fake_get_file, send_chat_action=fake_send_chat_action),
+            user_data={"thread_id": "tid"},
+        ),
+    )
+    monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
+
+    result = await photo_handlers.photo_handler(update, context)
+
+    assert result == photo_handlers.END
+    assert msg.status is not None
+    assert msg.status.edits[-1] == "⚠️ Vision не смог обработать фото. Попробуйте ещё раз."
     assert photo_handlers.WAITING_GPT_FLAG not in context.user_data

--- a/tests/test_photo_handlers_additional.py
+++ b/tests/test_photo_handlers_additional.py
@@ -90,16 +90,11 @@ async def test_photo_handler_commit_failure(
     assert user_data is not None
     assert photo_handlers.WAITING_GPT_FLAG not in user_data
     assert not send_message_mock.called
-    assert any(
-        "[PHOTO] Failed to commit user 1" in r.getMessage()
-        for r in caplog.records
-    )
+    assert any("[PHOTO] Failed to commit user 1" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio
-async def test_photo_handler_run_failure(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_photo_handler_run_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     class StatusMessage:
         def __init__(self) -> None:
             self.edits: list[str] = []
@@ -144,9 +139,7 @@ async def test_photo_handler_run_failure(
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(
-            bot=SimpleNamespace(get_file=fake_get_file), user_data={"thread_id": "tid"}
-        ),
+        SimpleNamespace(bot=SimpleNamespace(get_file=fake_get_file), user_data={"thread_id": "tid"}),
     )
 
     monkeypatch.chdir(tmp_path)
@@ -154,16 +147,14 @@ async def test_photo_handler_run_failure(
 
     assert result == photo_handlers.END
     assert message.status is not None
-    assert message.status.edits == ["⚠️ Vision не смог обработать фото."]
+    assert message.status.edits == ["⚠️ Vision не смог обработать фото. Попробуйте ещё раз."]
     user_data = context.user_data
     assert user_data is not None
     assert photo_handlers.WAITING_GPT_FLAG not in user_data
 
 
 @pytest.mark.asyncio
-async def test_photo_handler_unparsed_response(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_photo_handler_unparsed_response(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     class DummyMessage:
         def __init__(self) -> None:
             self.photo = (DummyPhoto(),)
@@ -199,11 +190,7 @@ async def test_photo_handler_unparsed_response(
         ]
 
     class DummyClient:
-        beta = SimpleNamespace(
-            threads=SimpleNamespace(
-                messages=SimpleNamespace(list=lambda thread_id: Messages())
-            )
-        )
+        beta = SimpleNamespace(threads=SimpleNamespace(messages=SimpleNamespace(list=lambda thread_id: Messages())))
 
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
@@ -220,9 +207,7 @@ async def test_photo_handler_unparsed_response(
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(
-            bot=SimpleNamespace(get_file=fake_get_file), user_data={"thread_id": "tid"}
-        ),
+        SimpleNamespace(bot=SimpleNamespace(get_file=fake_get_file), user_data={"thread_id": "tid"}),
     )
 
     monkeypatch.chdir(tmp_path)
@@ -275,11 +260,7 @@ async def test_photo_handler_unparsed_response_clears_pending_entry(
         ]
 
     class DummyClient:
-        beta = SimpleNamespace(
-            threads=SimpleNamespace(
-                messages=SimpleNamespace(list=lambda thread_id: Messages())
-            )
-        )
+        beta = SimpleNamespace(threads=SimpleNamespace(messages=SimpleNamespace(list=lambda thread_id: Messages())))
 
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
@@ -315,9 +296,7 @@ async def test_photo_handler_unparsed_response_clears_pending_entry(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("mime", [None, "text/plain"])
-async def test_doc_handler_rejects_non_image(
-    monkeypatch: pytest.MonkeyPatch, mime: str | None
-) -> None:
+async def test_doc_handler_rejects_non_image(monkeypatch: pytest.MonkeyPatch, mime: str | None) -> None:
     document = SimpleNamespace(
         mime_type=mime,
         file_name="f.txt",
@@ -406,9 +385,7 @@ async def test_photo_handler_long_vision_text(monkeypatch: pytest.MonkeyPatch, t
         ]
 
     class DummyClient:
-        beta = SimpleNamespace(
-            threads=SimpleNamespace(messages=SimpleNamespace(list=lambda thread_id: Messages()))
-        )
+        beta = SimpleNamespace(threads=SimpleNamespace(messages=SimpleNamespace(list=lambda thread_id: Messages())))
 
     monkeypatch.setattr(photo_handlers, "SessionLocal", lambda: DummySession())
     monkeypatch.setattr(photo_handlers, "create_thread", fake_create_thread)
@@ -439,9 +416,7 @@ async def test_photo_handler_long_vision_text(monkeypatch: pytest.MonkeyPatch, t
 
 
 @pytest.mark.asyncio
-async def test_photo_handler_long_vision_text_parse_fail(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_photo_handler_long_vision_text_parse_fail(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     long_text = "y" * (photo_handlers.MessageLimit.MAX_TEXT_LENGTH + 100)
 
     class DummyMessage:
@@ -504,9 +479,7 @@ async def test_photo_handler_long_vision_text_parse_fail(
         ]
 
     class DummyClient:
-        beta = SimpleNamespace(
-            threads=SimpleNamespace(messages=SimpleNamespace(list=lambda thread_id: Messages()))
-        )
+        beta = SimpleNamespace(threads=SimpleNamespace(messages=SimpleNamespace(list=lambda thread_id: Messages())))
 
     monkeypatch.setattr(photo_handlers, "SessionLocal", lambda: DummySession())
     monkeypatch.setattr(photo_handlers, "create_thread", fake_create_thread)


### PR DESCRIPTION
## Summary
- always tell users to try again when Vision fails
- test photo handler run failure alongside success and OpenAI errors
- update existing tests for new Vision failure wording

## Testing
- `pytest tests/test_handlers_*.py tests/test_photo_handlers_additional.py -q`
- `pytest -q --cov` *(fails: tests/assistant/test_hydration.py::test_hydration_restores_state, tests/diabetes/test_curriculum_busy.py::test_dynamic_learn_command_busy, tests/diabetes/test_curriculum_exceptions.py::test_learn_command_start_lesson_exception[SQLAlchemyError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_start_lesson_exception[OpenAIError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_start_lesson_exception[HTTPError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_start_lesson_exception[RuntimeError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_next_step_exception[SQLAlchemyError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_next_step_exception[OpenAIError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_next_step_exception[HTTPError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_next_step_exception[RuntimeError], tests/diabetes/test_curriculum_exceptions.py::test_lesson_command_start_lesson_exception, tests/diabetes/test_curriculum_exceptions.py::test_lesson_command_next_step_exception, tests/diabetes/test_learning_chat_handlers.py::test_learn_command_and_callback, tests/diabetes/test_learning_chat_handlers.py::test_learn_command_autostarts_when_topics_hidden, tests/learning/test_empty_lessons.py::test_dynamic_mode_empty_lessons, tests/learning/test_flow_autostart.py::test_flow_autostart, tests/learning/test_plan_handlers.py::test_learn_command_stores_plan, tests/test_assistant_memory_integration.py::test_memory_reset, tests/test_photo_handlers_additional.py::test_photo_handler_run_failure)`
- `mypy --strict .` *(fails: Interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c006cb1850832aa89fd4da19b01792