### PR TITLE
[billing] handle trial status errors explicitly

### DIFF
--- a/services/api/app/diabetes/handlers/billing_handlers.py
+++ b/services/api/app/diabetes/handlers/billing_handlers.py
@@ -63,19 +63,19 @@ async def trial_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
                         status_url, params={"user_id": user.id}, timeout=10.0
                     )
                     stat.raise_for_status()
-                    try:
-                        payload = stat.json()
-                    except ValueError:
-                        logger.exception("invalid trial status response")
-                        await message.reply_text("❌ Ошибка сервера.")
-                        return
-                    sub = payload.get("subscription")
-                    if isinstance(sub, dict):
-                        end_raw = sub.get("endDate")
-                        if isinstance(end_raw, str):
-                            end_dt = datetime.fromisoformat(end_raw)
-            except Exception:
+                    payload = stat.json()
+            except httpx.HTTPError:
                 logger.exception("failed to fetch trial status")
+            except ValueError:
+                logger.exception("invalid trial status response")
+                await message.reply_text("❌ Ошибка сервера.")
+                return
+            else:
+                sub = payload.get("subscription")
+                if isinstance(sub, dict):
+                    end_raw = sub.get("endDate")
+                    if isinstance(end_raw, str):
+                        end_dt = datetime.fromisoformat(end_raw)
             if end_dt is not None:
                 end_str = end_dt.strftime("%d.%m.%Y")
                 await message.reply_text(f"🎁 Пробный период уже активен до {end_str}")


### PR DESCRIPTION
## Summary
- handle httpx and JSON errors explicitly when retrieving trial status
- test logging for HTTP errors during trial status lookup

## Testing
- `pytest -q tests/test_billing_commands.py::test_trial_command_status_http_error_logs tests/test_billing_commands.py::test_trial_command_status_parse_error_logs tests/test_billing_commands.py::test_trial_command_json_parse_error tests/test_billing_commands.py::test_trial_command_already_active tests/test_billing_commands.py::test_trial_command_success`
- `ruff check services/api/app/diabetes/handlers/billing_handlers.py tests/test_billing_commands.py`
- `mypy --strict services/api/app/diabetes/handlers/billing_handlers.py tests/test_billing_commands.py` *(failed: Interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c011b17bfc832aacc026ee3fad9dca