### PR TITLE
[commands] Log Telegram errors in onboarding reset timeout

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from typing import cast
 
+import telegram
 from telegram import Update
 from telegram.ext import ContextTypes
 
@@ -63,8 +64,11 @@ async def reset_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             await message.reply_text(
                 "⏱ Сброс онбординга не подтверждён. Отправьте /reset_onboarding снова.",
             )
-        except Exception:
-            pass
+        except telegram.error.TelegramError as exc:
+            logger.exception(
+                "Failed to notify about onboarding reset timeout: %s",
+                exc,
+            )
 
     user_data["_onb_reset_confirm"] = True
     user_data["_onb_reset_task"] = asyncio.create_task(_reset_timeout())

--- a/tests/diabetes/test_commands.py
+++ b/tests/diabetes/test_commands.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import asyncio
+import logging
+
 import pytest
+import telegram
 from telegram import Update
 from telegram.ext import CallbackContext
 
@@ -105,3 +108,52 @@ async def test_reset_onboarding_timeout(monkeypatch: pytest.MonkeyPatch) -> None
     assert "_onb_reset_confirm" not in context.user_data
     assert "_onb_reset_task" not in context.user_data
     assert any("не подтвержд" in r.lower() for r in message.replies)
+
+
+@pytest.mark.asyncio
+async def test_reset_onboarding_timeout_telegram_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class FailingMessage:
+        def __init__(self) -> None:
+            self.replies: list[str] = []
+            self.calls = 0
+
+        async def reply_text(self, text: str) -> None:
+            self.calls += 1
+            if self.calls > 1:
+                raise telegram.error.TelegramError("fail")
+            self.replies.append(text)
+
+    message = FailingMessage()
+    user = SimpleNamespace(id=1)
+    update = cast(
+        Update,
+        SimpleNamespace(effective_message=message, message=message, effective_user=user),
+    )
+    app = DummyApp()
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(application=app, user_data={}),
+    )
+
+    async def fast_sleep(_: float) -> None:
+        return
+
+    monkeypatch.setattr(commands.asyncio, "sleep", fast_sleep)
+
+    with caplog.at_level(logging.ERROR):
+        await commands.reset_onboarding(update, context)
+        task = context.user_data.get("_onb_reset_task")
+        assert isinstance(task, asyncio.Task)
+        await task
+        assert any(
+            "Failed to notify about onboarding reset timeout" in r.message
+            for r in caplog.records
+        )
+
+    assert task.exception() is None
+    assert len(message.replies) == 1
+    assert "_onb_reset_confirm" not in context.user_data
+    assert "_onb_reset_task" not in context.user_data


### PR DESCRIPTION
## Summary
- log Telegram API failures during onboarding reset timeout
- test reset timeout logs errors without aborting task

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/diabetes/test_commands.py::test_reset_onboarding_timeout_telegram_error -q`
- `pytest -q --maxfail=1` *(fails: AssertionError: assert 0 == 3)*

------
https://chatgpt.com/codex/tasks/task_e_68c011aa664c832a9a1329d12a9b510a