### PR TITLE
[diabetes] Await reset timeout task

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -53,6 +53,10 @@ async def reset_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if user_data.pop("_onb_reset_confirm", False):
         if isinstance(task, asyncio.Task):
             task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
         await _reset_onboarding(update, context)
         return
 


### PR DESCRIPTION
## Summary
- ensure reset_onboarding cancels and awaits timeout task
- test reset_onboarding consumes cancelled task

## Testing
- `pytest -q --cov` *(fails: test_hydration_restores_state, test_dynamic_learn_command_busy, test_learn_command_start_lesson_exception[SQLAlchemyError], test_learn_command_start_lesson_exception[OpenAIError], test_learn_command_start_lesson_exception[HTTPError], test_learn_command_start_lesson_exception[RuntimeError], test_learn_command_next_step_exception[SQLAlchemyError], test_learn_command_next_step_exception[OpenAIError], test_learn_command_next_step_exception[HTTPError], test_learn_command_next_step_exception[RuntimeError], test_lesson_command_start_lesson_exception, test_lesson_command_next_step_exception, test_learn_command_and_callback, test_learn_command_autostarts_when_topics_hidden, test_dynamic_mode_empty_lessons, test_flow_autostart, test_learn_command_stores_plan, test_memory_reset)*
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c013d7d2e8832a8320880c8e3f2005