### PR TITLE
[services] Handle missing chat interface in GPT client

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -77,7 +77,10 @@ async def _get_async_client() -> AsyncOpenAI:
     global _async_client
     loop = asyncio.get_running_loop()
     global _async_client_lock
-    if _async_client_lock is None or getattr(_async_client_lock, "_loop", None) is not loop:
+    if (
+        _async_client_lock is None
+        or getattr(_async_client_lock, "_loop", None) is not loop
+    ):
         _async_client_lock = asyncio.Lock()
     if _async_client is None:
         async with _async_client_lock:
@@ -106,7 +109,10 @@ async def dispose_openai_clients() -> None:
         _async_client_lock = None
         return
 
-    if _async_client_lock is None or getattr(_async_client_lock, "_loop", None) is not loop:
+    if (
+        _async_client_lock is None
+        or getattr(_async_client_lock, "_loop", None) is not loop
+    ):
         _async_client_lock = asyncio.Lock()
     async with _async_client_lock:
         if _async_client is not None:
@@ -130,7 +136,11 @@ def format_reply(text: str, *, max_len: int = 800) -> str:
     str
         Formatted text with paragraphs truncated and separated by blank lines.
     """
-    paragraphs = [part.strip()[:max_len] for part in re.split(r"\n\s*\n", text.strip()) if part.strip()]
+    paragraphs = [
+        part.strip()[:max_len]
+        for part in re.split(r"\n\s*\n", text.strip())
+        if part.strip()
+    ]
     return "\n\n".join(paragraphs)
 
 
@@ -193,6 +203,11 @@ async def create_chat_completion(
                 timeout=timeout_param,
                 stream=False,
             )
+        except AttributeError:
+            logger.warning(
+                "[OpenAI] client does not support chat completions",
+            )
+            return _static_completion(model)
         except httpx.TimeoutException as exc:
             message = "Chat completion request timed out"
             logger.exception("[OpenAI] %s", message)
@@ -201,7 +216,10 @@ async def create_chat_completion(
             status_code = getattr(exc, "status_code", None)
             if isinstance(exc, httpx.HTTPStatusError):
                 status_code = exc.response.status_code
-            if status_code in {429, 500, 502, 503, 504} and attempt < CHAT_COMPLETION_MAX_RETRIES:
+            if (
+                status_code in {429, 500, 502, 503, 504}
+                and attempt < CHAT_COMPLETION_MAX_RETRIES
+            ):
                 backoff = 2**attempt
                 logger.warning(
                     "[OpenAI] transient error (status %s), retrying in %s s",
@@ -265,9 +283,7 @@ async def create_learning_chat_completion(
     message = getattr(first_choice, "message", None)
     raw_content = getattr(message, "content", None)
     if not raw_content:
-        logger.error(
-            "[OpenAI] completion choice has empty content: %s", first_choice
-        )
+        logger.error("[OpenAI] completion choice has empty content: %s", first_choice)
         raise ValueError("OpenAI completion choice has empty content")
     content = cast(str, raw_content)
     reply = format_reply(content)
@@ -351,7 +367,9 @@ async def _upload_image_file(client: OpenAI, image_path: str) -> FileObject:
             with open(safe_path, "rb") as f:
                 return client.files.create(file=f, purpose="vision")
 
-        file = await asyncio.wait_for(asyncio.to_thread(_upload), timeout=FILE_UPLOAD_TIMEOUT)
+        file = await asyncio.wait_for(
+            asyncio.to_thread(_upload), timeout=FILE_UPLOAD_TIMEOUT
+        )
     except asyncio.TimeoutError:
         logger.exception("[OpenAI] Timeout while uploading %s", safe_path)
         raise RuntimeError("Timed out while uploading image")
@@ -374,7 +392,9 @@ async def _upload_image_bytes(client: OpenAI, image_bytes: bytes) -> FileObject:
             with io.BytesIO(image_bytes) as buffer:
                 return client.files.create(file=("image.jpg", buffer), purpose="vision")
 
-        file = await asyncio.wait_for(asyncio.to_thread(_upload_bytes), timeout=FILE_UPLOAD_TIMEOUT)
+        file = await asyncio.wait_for(
+            asyncio.to_thread(_upload_bytes), timeout=FILE_UPLOAD_TIMEOUT
+        )
     except asyncio.TimeoutError:
         logger.exception("[OpenAI] Timeout while uploading bytes")
         raise RuntimeError("Timed out while uploading image")
@@ -437,7 +457,9 @@ async def send_message(
         "type": "text",
         "text": content if content is not None else "Что изображено на фото?",
     }
-    message_content: Iterable[ImageFileContentBlockParam | ImageURLContentBlockParam | TextContentBlockParam]
+    message_content: Iterable[
+        ImageFileContentBlockParam | ImageURLContentBlockParam | TextContentBlockParam
+    ]
     if image_path:
         file = await _upload_image_file(client, image_path)
         image_block: ImageFileContentBlockParam = {


### PR DESCRIPTION
## Summary
- Fallback to static completion when OpenAI client lacks `chat` interface
- Test chat completion fallback for clients without `chat`

## Testing
- `ruff check services/api/app/diabetes/services/gpt_client.py tests/test_gpt_client.py`
- `mypy --strict .`
- `pytest -q --cov` *(fails: tests/assistant/test_hydration.py::test_hydration_restores_state, tests/diabetes/test_curriculum_busy.py::test_dynamic_learn_command_busy, tests/diabetes/test_curriculum_exceptions.py::test_learn_command_start_lesson_exception[SQLAlchemyError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_start_lesson_exception[OpenAIError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_start_lesson_exception[HTTPError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_start_lesson_exception[RuntimeError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_next_step_exception[SQLAlchemyError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_next_step_exception[OpenAIError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_next_step_exception[HTTPError], tests/diabetes/test_curriculum_exceptions.py::test_learn_command_next_step_exception[RuntimeError], tests/diabetes/test_curriculum_exceptions.py::test_lesson_command_start_lesson_exception, tests/diabetes/test_curriculum_exceptions.py::test_lesson_command_next_step_exception, tests/diabetes/test_learning_chat_handlers.py::test_learn_command_and_callback, tests/diabetes/test_learning_chat_handlers.py::test_learn_command_autostarts_when_topics_hidden, tests/learning/test_empty_lessons.py::test_dynamic_mode_empty_lessons, tests/learning/test_flow_autostart.py::test_flow_autostart, tests/learning/test_plan_handlers.py::test_learn_command_stores_plan)*
- `pytest tests/test_gpt_client.py::test_create_chat_completion_missing_chat -q`


------
https://chatgpt.com/codex/tasks/task_e_68c01a4c3f4c832ab9c05f8c2e381269