### PR TITLE
[config] reload TELEGRAM_TOKEN from env

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 from typing import Iterable
 
-from services.api.app.config import get_settings, reload_settings, settings
+from services.api.app.config import reload_settings, settings
 
 # Expose commonly used environment variables so importing modules can
 # reference them directly if needed.  Values default to ``None`` when not
@@ -56,7 +56,7 @@ def validate_tokens(required: Iterable[str] | None = None) -> None:
 
     for var in required_vars:
         if var == "TELEGRAM_TOKEN":
-            if not get_settings().telegram_token:
+            if not os.getenv("TELEGRAM_TOKEN"):
                 missing.append(var)
         elif not os.getenv(var):
             missing.append(var)

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -49,3 +49,17 @@ def test_validate_tokens_reflects_runtime_env(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setenv("TELEGRAM_TOKEN", "updated")
     config.validate_tokens(["TELEGRAM_TOKEN"])
+
+
+def test_validate_tokens_missing_telegram_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deleting ``TELEGRAM_TOKEN`` causes validation to fail."""
+
+    monkeypatch.setenv("TELEGRAM_TOKEN", "present")
+    config = _reload("config")
+    config.validate_tokens(["TELEGRAM_TOKEN"])
+
+    monkeypatch.delenv("TELEGRAM_TOKEN", raising=False)
+    with pytest.raises(RuntimeError):
+        config.validate_tokens(["TELEGRAM_TOKEN"])


### PR DESCRIPTION
## Summary
- revalidate TELEGRAM_TOKEN using environment after reload
- add regression test for missing TELEGRAM_TOKEN

## Testing
- `pytest -q --cov` *(fails: tests failing in other modules)*
- `pytest tests/test_root_config.py::test_validate_tokens_missing_telegram_token -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c01a4fdc74832aac54016716d7aa26