### PR TITLE
[learning] add learning user profile

### DIFF
--- a/services/api/alembic/versions/20250909_learning_user_profile.py
+++ b/services/api/alembic/versions/20250909_learning_user_profile.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20250909_learning_user_profile"
+down_revision: Union[str, Sequence[str], None] = "5fbcb2a13695"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "learning_user_profile",
+        sa.Column(
+            "user_id",
+            sa.BigInteger(),
+            sa.ForeignKey("users.telegram_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("age_group", sa.String(), nullable=True),
+        sa.Column("learning_level", sa.String(), nullable=True),
+        sa.Column("diabetes_type", sa.String(), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("user_id"),
+        sa.UniqueConstraint("user_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("learning_user_profile")

--- a/services/api/app/assistant/repositories/learning_profile.py
+++ b/services/api/app/assistant/repositories/learning_profile.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import cast
+
+from sqlalchemy.orm import Session
+
+from ...diabetes.models_learning import LearningUserProfile
+from ...diabetes.services.db import SessionLocal, run_db, User
+from ...diabetes.services.repository import commit
+from ...types import SessionProtocol
+
+__all__ = ["get_learning_profile", "upsert_learning_profile"]
+
+
+async def get_learning_profile(user_id: int) -> LearningUserProfile | None:
+    def _get(session: SessionProtocol) -> LearningUserProfile | None:
+        return cast(LearningUserProfile | None, session.get(LearningUserProfile, user_id))
+
+    return await run_db(_get, sessionmaker=SessionLocal)
+
+
+async def upsert_learning_profile(
+    user_id: int,
+    *,
+    age_group: str | None = None,
+    learning_level: str | None = None,
+    diabetes_type: str | None = None,
+) -> None:
+    def _upsert(session: SessionProtocol) -> None:
+        sess = cast(Session, session)
+        profile = cast(LearningUserProfile | None, sess.get(LearningUserProfile, user_id))
+        if profile is None:
+            if sess.get(User, user_id) is None:
+                raise RuntimeError("User is not registered. Please register.")
+            profile = LearningUserProfile(
+                user_id=user_id,
+                age_group=age_group,
+                learning_level=learning_level,
+                diabetes_type=diabetes_type,
+            )
+            sess.add(profile)
+        else:
+            if age_group is not None:
+                profile.age_group = age_group
+            if learning_level is not None:
+                profile.learning_level = learning_level
+            if diabetes_type is not None:
+                profile.diabetes_type = diabetes_type
+        commit(sess)
+
+    await run_db(_upsert, sessionmaker=SessionLocal)

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -124,3 +124,25 @@ class LessonProgress(Base):
     lesson: Mapped[Lesson] = relationship("Lesson", back_populates="progresses")
 
 
+
+
+class LearningUserProfile(Base):
+    __tablename__ = "learning_user_profile"
+    __table_args__ = (sa.UniqueConstraint("user_id"),)
+
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.telegram_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    age_group: Mapped[str | None] = mapped_column(String)
+    learning_level: Mapped[str | None] = mapped_column(String)
+    diabetes_type: Mapped[str | None] = mapped_column(String)
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+        nullable=False,
+    )
+
+    user: Mapped[User] = relationship("User")

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -37,6 +37,7 @@ from .routers import metrics
 from .routers.billing import router as billing_router
 from .routers.health import router as health_router
 from .routers.history import router as history_router
+from .routers.learning_profile import router as learning_profile_router
 from .routers.internal_reminders import router as internal_reminders_router
 from .routers.onboarding import router as onboarding_router
 from .routers.profile import router as profile_router
@@ -114,6 +115,7 @@ api_router.include_router(stats_router)
 api_router.include_router(legacy_router)
 api_router.include_router(metrics.router)  # metrics available under /api/metrics
 api_router.include_router(billing_router)
+api_router.include_router(learning_profile_router)
 api_router.include_router(profile_router)
 api_router.include_router(timezones_router)
 api_router.include_router(health_router)

--- a/services/api/app/profiles.py
+++ b/services/api/app/profiles.py
@@ -11,11 +11,12 @@ async def get_profile_for_user(
     _: int, ctx: ContextTypes.DEFAULT_TYPE
 ) -> dict[str, object]:
     base = await get_json("/profile/self")
+    db_profile = await get_json("/learning-profile")
     user_data = ctx.user_data or {}
     overrides = cast(
         dict[str, object], user_data.get("learn_profile_overrides", {})
     )
-    profile = {**base, **overrides}
+    profile = {**base, **db_profile, **overrides}
     profile.setdefault("age_group", "adult")
     profile.setdefault("diabetes_type", "unknown")
     profile.setdefault("learning_level", "novice")

--- a/services/api/app/routers/learning_profile.py
+++ b/services/api/app/routers/learning_profile.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ..assistant.repositories.learning_profile import (
+    get_learning_profile,
+    upsert_learning_profile,
+)
+from ..schemas.learning_profile import LearningProfileSchema
+from ..schemas.user import UserContext
+from ..telegram_auth import check_token
+
+router = APIRouter()
+
+
+@router.get(
+    "/learning-profile",
+    response_model=LearningProfileSchema,
+    response_model_exclude_none=True,
+)
+async def learning_profile_get(
+    user: UserContext = Depends(check_token),
+) -> LearningProfileSchema:
+    profile = await get_learning_profile(user["id"])
+    if profile is None:
+        return LearningProfileSchema()
+    return LearningProfileSchema.model_validate(profile)
+
+
+@router.patch(
+    "/learning-profile",
+    response_model=LearningProfileSchema,
+    response_model_exclude_none=True,
+)
+async def learning_profile_patch(
+    data: LearningProfileSchema,
+    user: UserContext = Depends(check_token),
+) -> LearningProfileSchema:
+    await upsert_learning_profile(
+        user["id"],
+        age_group=data.age_group,
+        learning_level=data.learning_level,
+        diabetes_type=data.diabetes_type,
+    )
+    profile = await get_learning_profile(user["id"])
+    if profile is None:
+        return LearningProfileSchema()
+    return LearningProfileSchema.model_validate(profile)

--- a/services/api/app/routers/profile.py
+++ b/services/api/app/routers/profile.py
@@ -19,6 +19,7 @@ from ..services.profile import (
     save_profile,
 )
 from ..telegram_auth import check_token
+from ..assistant.repositories.learning_profile import get_learning_profile
 
 
 logger = logging.getLogger(__name__)
@@ -28,8 +29,16 @@ router = APIRouter()
 
 @router.get("/profile/self")
 async def profile_self(user: UserContext = Depends(check_token)) -> UserContext:
-    """Return current user context."""
+    """Return current user context including learning profile fields."""
 
+    profile = await get_learning_profile(user["id"])
+    if profile is not None:
+        user = {
+            **user,
+            "age_group": profile.age_group,
+            "learning_level": profile.learning_level,
+            "diabetes_type": profile.diabetes_type,
+        }
     return user
 
 

--- a/services/api/app/schemas/learning_profile.py
+++ b/services/api/app/schemas/learning_profile.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class LearningProfileSchema(BaseModel):
+    age_group: str | None = None
+    learning_level: str | None = None
+    diabetes_type: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/services/api/app/schemas/user.py
+++ b/services/api/app/schemas/user.py
@@ -12,3 +12,6 @@ class UserContext(TypedDict):
     username: NotRequired[str]
     language_code: NotRequired[str]
     is_premium: NotRequired[bool]
+    age_group: NotRequired[str | None]
+    learning_level: NotRequired[str | None]
+    diabetes_type: NotRequired[str | None]

--- a/services/api/tests/test_learning_profile_repository.py
+++ b/services/api/tests/test_learning_profile_repository.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+from typing import Any, Callable
+
+from services.api.app.assistant.repositories import learning_profile
+from services.api.app.diabetes.services import db
+
+
+def setup_db() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    return SessionLocal
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_get(monkeypatch: pytest.MonkeyPatch) -> None:
+    SessionLocal = setup_db()
+
+    async def run_db(
+        fn: Callable[..., Any],
+        *args: Any,
+        sessionmaker: sessionmaker[Session] = SessionLocal,
+        **kwargs: Any,
+    ) -> Any:
+        with sessionmaker() as session:
+            return fn(session, *args, **kwargs)
+
+    monkeypatch.setattr(learning_profile, "run_db", run_db, raising=False)
+    monkeypatch.setattr(learning_profile, "SessionLocal", SessionLocal, raising=False)
+
+    with SessionLocal() as session:
+        session.add(db.User(telegram_id=1, thread_id="t1"))
+        session.commit()
+
+    await learning_profile.upsert_learning_profile(
+        1, age_group="adult", learning_level="novice", diabetes_type="T1"
+    )
+    profile = await learning_profile.get_learning_profile(1)
+    assert profile is not None
+    assert profile.age_group == "adult"
+
+    await learning_profile.upsert_learning_profile(1, learning_level="expert")
+    profile = await learning_profile.get_learning_profile(1)
+    assert profile is not None
+    assert profile.learning_level == "expert"
+    assert profile.diabetes_type == "T1"

--- a/tests/test_learning_profile_router.py
+++ b/tests/test_learning_profile_router.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.main import app
+from services.api.app.diabetes.services.db import Base, User
+from services.api.app.diabetes.models_learning import LearningUserProfile
+from services.api.app.telegram_auth import check_token
+import services.api.app.assistant.repositories.learning_profile as repo
+
+
+def setup_db() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    Base.metadata.create_all(engine, tables=[User.__table__, LearningUserProfile.__table__])
+    return sessionmaker(bind=engine, class_=Session)
+
+
+def make_client(
+    monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]
+) -> TestClient:
+    async def run_db(fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs):
+        with sessionmaker() as session:
+            return fn(session, *args, **kwargs)
+
+    monkeypatch.setattr(repo, "run_db", run_db, raising=False)
+    monkeypatch.setattr(repo, "SessionLocal", session_local, raising=False)
+    app.dependency_overrides[check_token] = lambda: {"id": 1}
+    return TestClient(app)
+
+
+def teardown_client() -> None:
+    app.dependency_overrides.clear()
+
+
+def add_user(session_local: sessionmaker[Session]) -> None:
+    with session_local() as session:
+        session.add(User(telegram_id=1, thread_id="t"))
+        session.commit()
+
+
+@pytest.mark.asyncio
+async def test_get_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    add_user(session_local)
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.get("/api/learning-profile")
+    assert resp.status_code == 200
+    assert resp.json() == {}
+    teardown_client()
+
+
+@pytest.mark.asyncio
+async def test_patch_and_get(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_local = setup_db()
+    add_user(session_local)
+    client = make_client(monkeypatch, session_local)
+    with client:
+        resp = client.patch(
+            "/api/learning-profile",
+            json={
+                "age_group": "adult",
+                "learning_level": "novice",
+                "diabetes_type": "T1",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "age_group": "adult",
+            "learning_level": "novice",
+            "diabetes_type": "T1",
+        }
+        resp2 = client.get("/api/learning-profile")
+    assert resp2.json() == {
+        "age_group": "adult",
+        "learning_level": "novice",
+        "diabetes_type": "T1",
+    }
+    teardown_client()

--- a/tests/test_profiles_overrides.py
+++ b/tests/test_profiles_overrides.py
@@ -10,11 +10,17 @@ class DummyCtx:
 @pytest.mark.asyncio
 async def test_get_profile_for_user_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_get_json(path: str) -> dict[str, object]:
-        assert path == "/profile/self"
+        if path == "/profile/self":
+            return {
+                "therapyType": "bolus",
+                "rapidInsulinType": "aspart",
+                "carbUnits": "grams",
+            }
+        assert path == "/learning-profile"
         return {
-            "therapyType": "bolus",
-            "rapidInsulinType": "aspart",
-            "carbUnits": "grams",
+            "age_group": "child",
+            "diabetes_type": "T1",
+            "learning_level": "novice",
         }
 
     monkeypatch.setattr(profiles, "get_json", fake_get_json)
@@ -26,7 +32,7 @@ async def test_get_profile_for_user_overrides(monkeypatch: pytest.MonkeyPatch) -
         "therapyType": "bolus",
         "rapidInsulinType": "aspart",
         "carbUnits": "units",
-        "age_group": "adult",
-        "diabetes_type": "unknown",
+        "age_group": "child",
+        "diabetes_type": "T1",
         "learning_level": "expert",
     }


### PR DESCRIPTION
## Summary
- add `learning_user_profile` table and ORM model
- expose learning profile via `/learning-profile` API and augment `/profile/self`
- merge DB learning profile with overrides when building profile

## Testing
- `pytest services/api/tests/test_learning_profile_repository.py tests/test_learning_profile_router.py tests/test_profiles_overrides.py -q`
- `mypy --strict .`
- `ruff check .`
- `make migrate` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c01a652b4c832aad7a53e8712507c7