### PR TITLE
[services] Use per-loop async client locks

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -1,6 +1,7 @@
 # gpt_client.py
 
 import asyncio
+from asyncio import AbstractEventLoop
 import io
 import logging
 import os
@@ -47,7 +48,7 @@ _client: OpenAI | None = None
 _client_lock = threading.Lock()
 
 _async_client: AsyncOpenAI | None = None
-_async_client_lock: asyncio.Lock | None = None
+_async_client_locks: dict[AbstractEventLoop, asyncio.Lock] = {}
 
 _learning_router = LLMRouter()
 
@@ -76,11 +77,9 @@ async def _get_async_client() -> AsyncOpenAI:
     """Return cached AsyncOpenAI client, creating it once in an async-safe manner."""
     global _async_client
     loop = asyncio.get_running_loop()
-    global _async_client_lock
-    if _async_client_lock is None or getattr(_async_client_lock, "_loop", None) is not loop:
-        _async_client_lock = asyncio.Lock()
+    lock = _async_client_locks.setdefault(loop, asyncio.Lock())
     if _async_client is None:
-        async with _async_client_lock:
+        async with lock:
             if _async_client is None:
                 _async_client = get_async_openai_client()
     return _async_client
@@ -93,7 +92,7 @@ async def dispose_openai_clients() -> None:
         if _client is not None:
             _client.close()
             _client = None
-    global _async_client_lock
+
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
@@ -103,16 +102,15 @@ async def dispose_openai_clients() -> None:
         if _async_client is not None:
             asyncio.run(_async_client.close())
             _async_client = None
-        _async_client_lock = None
+        _async_client_locks.clear()
         return
 
-    if _async_client_lock is None or getattr(_async_client_lock, "_loop", None) is not loop:
-        _async_client_lock = asyncio.Lock()
-    async with _async_client_lock:
+    lock = _async_client_locks.setdefault(loop, asyncio.Lock())
+    async with lock:
         if _async_client is not None:
             await _async_client.close()
             _async_client = None
-    _async_client_lock = None
+    _async_client_locks.clear()
 
 
 def format_reply(text: str, *, max_len: int = 800) -> str:


### PR DESCRIPTION
## Summary
- replace single async client lock with per-event-loop locks
- ensure disposal uses per-loop locks
- test async client reuse across loops

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `pytest tests/test_gpt_client.py -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c01a7e058c832ab6aa74dc9814139f