### PR TITLE
[learning] hydrate profile from repository

### DIFF
--- a/services/api/app/assistant/repositories/learning_profile.py
+++ b/services/api/app/assistant/repositories/learning_profile.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import cast
+
+__all__ = ["get_learning_profile"]
+
+
+async def get_learning_profile(user_id: int) -> dict[str, str | None]:
+    """Return stored learning profile overrides for ``user_id``.
+
+    The default implementation returns an empty mapping and is intended to be
+    patched in tests or extended with real database logic.
+    """
+    return cast(dict[str, str | None], {})


### PR DESCRIPTION
## Summary
- hydrate learning profile from repository when resuming sessions
- skip onboarding when age group and level exist in stored profile
- test that restart resumes without onboarding prompts

## Testing
- `pytest tests/learning/test_flow_autostart.py::test_restart_skips_onboarding -q`
- `mypy --strict services/api/app/assistant/repositories/learning_profile.py services/api/app/diabetes/learning_handlers.py tests/learning/test_flow_autostart.py`
- `ruff check services/api/app/diabetes/learning_handlers.py services/api/app/assistant/repositories/learning_profile.py tests/learning/test_flow_autostart.py`
- `pytest -q --cov` *(fails: Database engine is not initialized; run init_db() before calling run_db.)*

------
https://chatgpt.com/codex/tasks/task_e_68c01b2cc828832aa2415b3c5dcc2f67