### PR TITLE
[learning] keep progress index past plan

### DIFF
--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -155,11 +155,7 @@ async def _hydrate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
     prev_summary = cast(str | None, data.get("prev_summary"))
     user_data["learning_module_idx"] = module_idx
     user_data["learning_plan"] = plan
-    if plan is None or not 0 <= step_idx < len(plan):
-        step_idx = 0
-        user_data["learning_plan_index"] = 0
-    else:
-        user_data["learning_plan_index"] = step_idx - 1 if step_idx > 0 else 0
+    user_data["learning_plan_index"] = step_idx - 1 if step_idx > 0 else 0
     if snapshot is None:
         profile = _get_profile(user_data)
         snapshot = await generate_step_text(profile, topic, step_idx, prev_summary)

--- a/tests/assistant/test_e2e_restart.py
+++ b/tests/assistant/test_e2e_restart.py
@@ -67,8 +67,10 @@ async def test_restart_restores_step(
     monkeypatch.setattr(learning_handlers.settings, "learning_content_mode", "dynamic")
 
     await learning_handlers.plan_command(update, context)
-
-    assert context.user_data.get("learning_plan_index") == 0
+    state = learning_handlers.get_state(context.user_data)
+    assert state is not None
+    assert state.step == 2
+    assert context.user_data.get("learning_plan_index") == 1
     assert update.message.sent
     assert "Шаг 2" in update.message.sent[0]
 


### PR DESCRIPTION
## Summary
- retain step progress when it exceeds current learning plan length
- ensure hydration test covers step/plan index restoration

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: 15 failed, 1304 passed)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c01a4a073c832abfe4b6db2e37fe97