### PR TITLE
[learning] warn when diabetes type unknown

### DIFF
--- a/services/api/app/diabetes/learning_prompts.py
+++ b/services/api/app/diabetes/learning_prompts.py
@@ -57,25 +57,26 @@ def build_system_prompt(p: Mapping[str, str | None]) -> str:
         "adult": "ясно и по делу",
         "60+": "очень простыми фразами, поддерживающе",
     }.get(p.get("age_group") or "", "ясно и просто")
+    diabetes_type = p.get("diabetes_type") or "unknown"
     prompt = dedent(
         f"""
         Ты — персональный тьютор по диабету. Подстраивайся под пользователя.
-        Профиль: тип диабета={p.get('diabetes_type', 'unknown')},
-        терапия={p.get('therapyType', 'unknown')},
-        уровень={p.get('learning_level', 'novice')},
-        углеводы={p.get('carbUnits', 'XE')}. Тон: {tone}.
+        Профиль: тип диабета={diabetes_type},
+        терапия={p.get("therapyType", "unknown")},
+        уровень={p.get("learning_level", "novice")},
+        углеводы={p.get("carbUnits", "XE")}. Тон: {tone}.
         Пиши коротко (2–4 предложения). Каждый шаг заканчивай ОДНИМ
         вопросом-проверкой.
         Не назначай лечение/дозировки; при сомнениях — советуй обсудить
         с врачом.
         """
     ).strip()
+    if diabetes_type == "unknown":
+        prompt += " Тип диабета не определён — избегай тип-специфичных рекомендаций."
     return _trim(prompt)
 
 
-def build_user_prompt_step(
-    topic_slug: str, step_idx: int, prev_summary: str | None
-) -> str:
+def build_user_prompt_step(topic_slug: str, step_idx: int, prev_summary: str | None) -> str:
     """Build a user-level prompt for a learning step."""
 
     goals = {

--- a/tests/test_learning_prompts.py
+++ b/tests/test_learning_prompts.py
@@ -40,9 +40,7 @@ def test_system_tutor_contains_disclaimer() -> None:
         ),
     ],
 )
-def test_builder_functions_without_disclaimer(
-    builder: object, kwargs: dict[str, object]
-) -> None:
+def test_builder_functions_without_disclaimer(builder: object, kwargs: dict[str, object]) -> None:
     """Builders should return non-empty text without the disclaimer."""
 
     text = builder(**kwargs)  # type: ignore[arg-type]
@@ -80,3 +78,9 @@ def test_build_user_prompt_step_trims_and_ends_with_instruction() -> None:
     assert len(prompt) <= 1_500
     assert prompt.endswith("Ответ не показывай.")
 
+
+def test_build_system_prompt_warns_on_unknown_type() -> None:
+    """Include warning when diabetes type is unknown."""
+
+    prompt = build_system_prompt({"diabetes_type": "unknown"})
+    assert "Тип диабета не определён — избегай тип-специфичных рекомендаций." in prompt


### PR DESCRIPTION
## Summary
- warn tutor when diabetes type is unknown
- add unit test for unknown diabetes type warning

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/test_learning_prompts.py --cov=services.api.app.diabetes.learning_prompts --cov-fail-under=85 -q`


------
https://chatgpt.com/codex/tasks/task_e_68c01b303b60832a8e24ad1b202c4c0d