### PR TITLE
[learning] add step timing and onboarding logs

### DIFF
--- a/services/api/app/diabetes/learning_state.py
+++ b/services/api/app/diabetes/learning_state.py
@@ -15,6 +15,7 @@ class LearnState:
     last_step_text: str | None = None
     prev_summary: str | None = None
     awaiting: bool = True
+    last_step_at: float = 0.0
 
 
 def get_state(data: MutableMapping[str, object]) -> LearnState | None:


### PR DESCRIPTION
## Summary
- track last lesson step timestamp and accept answers for a grace period
- log onboarding data and reasons for questions
- set awaiting state and timestamp after each sent step

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c01b3392f0832a9d9728ef838033b5