### PR TITLE
[learning] hydrate profile on restart

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -190,6 +190,10 @@ async def create_chat_completion(
                 timeout=timeout_param,
                 stream=False,
             )
+        except AttributeError as exc:
+            message = "OpenAI client misconfigured"
+            logger.exception("[OpenAI] %s", message)
+            raise RuntimeError(message) from exc
         except httpx.TimeoutException as exc:
             message = "Chat completion request timed out"
             logger.exception("[OpenAI] %s", message)


### PR DESCRIPTION
## Summary
- pull persistent learning profile into `context.user_data` during hydration
- skip onboarding flow when age group and level already known
- handle misconfigured OpenAI client as runtime error
- add regression test ensuring restart does not re-trigger onboarding

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: test_curriculum_exceptions...)*

------
https://chatgpt.com/codex/tasks/task_e_68c01e43fba8832a9e37bf58d82007cb