### PR TITLE
tests: add learning profile repository coverage and onboarding flow

### DIFF
--- a/tests/assistant/test_e2e_learning_onboarding.py
+++ b/tests/assistant/test_e2e_learning_onboarding.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app import profiles
+from services.api.app.assistant.repositories import plans as plans_repo
+from services.api.app.assistant.services import progress_service as progress_repo
+from services.api.app.diabetes import learning_handlers, learning_onboarding
+from services.api.app.diabetes.handlers import (
+    learning_onboarding as onboarding_handlers,
+)
+from services.api.app.diabetes.services import db
+
+
+class DummyMessage:
+    """Minimal Telegram message capturing replies."""
+
+    def __init__(self, text: str = "", user_id: int = 1) -> None:
+        self.text = text
+        self.from_user = SimpleNamespace(id=user_id)
+        self.sent: list[str] = []
+
+    async def reply_text(self, text: str, **_kwargs: Any) -> None:
+        self.sent.append(text)
+
+
+@pytest.fixture()
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    session_local = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(plans_repo, "SessionLocal", session_local, raising=False)
+    monkeypatch.setattr(progress_repo, "SessionLocal", session_local, raising=False)
+    yield session_local
+    db.dispose_engine(engine)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("question", ["T1", "T2"])
+async def test_first_run_restart_and_type_questions(
+    monkeypatch: pytest.MonkeyPatch, setup_db: sessionmaker[Session], question: str
+) -> None:
+    with setup_db() as session:  # type: ignore[misc]
+        session.add(db.User(telegram_id=1, thread_id=""))
+        session.commit()
+
+    profile_store = {"diabetes_type": "T1"}
+
+    async def fake_get_profile(user_id: int, ctx: Any) -> dict[str, Any]:
+        return profile_store
+
+    monkeypatch.setattr(profiles, "get_profile_for_user", fake_get_profile)
+    monkeypatch.setattr(learning_handlers.settings, "learning_mode_enabled", True)
+    monkeypatch.setattr(learning_handlers.settings, "learning_content_mode", "dynamic")
+    monkeypatch.setattr(learning_handlers, "build_main_keyboard", lambda: None)
+    monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
+    monkeypatch.setattr(learning_handlers, "choose_initial_topic", lambda _p: ("intro", "Intro"))
+
+    async def fake_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
+        return SimpleNamespace(lesson_id=1)
+
+    async def fake_generate_step_text(
+        _profile: Any, _topic: str, step_idx: int, _prev: str | None
+    ) -> str:
+        return f"Шаг {step_idx}"
+
+    async def fake_assistant_chat(_profile: Any, _text: str) -> str:
+        return "feedback"
+
+    async def fake_check_user_answer(
+        _profile: Any, _topic: str, _text: str, _prev: str
+    ) -> tuple[bool, str]:
+        return False, "feedback"
+
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(learning_handlers, "assistant_chat", fake_assistant_chat)
+    monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+    monkeypatch.setattr(
+        learning_handlers, "generate_learning_plan", lambda first_step=None: [first_step or "Шаг 1", "Шаг 2"]
+    )
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
+    async def fake_add_log(*_a: object, **_k: object) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+
+    msg = DummyMessage(text="/learn")
+    update = SimpleNamespace(message=msg, effective_user=msg.from_user)
+    context = SimpleNamespace(user_data={}, bot_data={})
+    await learning_handlers.learn_command(update, context)
+    assert msg.sent == [learning_onboarding.AGE_PROMPT]
+
+    msg_age = DummyMessage(text="49")
+    upd_age = SimpleNamespace(message=msg_age, effective_user=msg_age.from_user)
+    await onboarding_handlers.onboarding_reply(upd_age, context)
+    assert msg_age.sent == [learning_onboarding.LEARNING_LEVEL_PROMPT]
+
+    msg_level = DummyMessage(text="0")
+    upd_level = SimpleNamespace(message=msg_level, effective_user=msg_level.from_user)
+    await onboarding_handlers.onboarding_reply(upd_level, context)
+    assert msg_level.sent == ["Шаг 1"]
+
+    msg_q = DummyMessage(text=question)
+    upd_q = SimpleNamespace(message=msg_q, effective_user=msg_q.from_user)
+    await learning_handlers.lesson_answer_handler(upd_q, context)
+    assert msg_q.sent == ["feedback", "Шаг 2"]
+
+    profile_store.update(context.user_data.get("learn_profile_overrides", {}))
+
+    context2 = SimpleNamespace(user_data={}, bot_data={})
+    msg2 = DummyMessage(text="/learn")
+    upd2 = SimpleNamespace(message=msg2, effective_user=msg2.from_user)
+    await learning_handlers.learn_command(upd2, context2)
+    assert msg2.sent == ["Шаг 2"]

--- a/tests/assistant/test_learning_profile_repo.py
+++ b/tests/assistant/test_learning_profile_repo.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from services.api.app.assistant.repositories import learning_profile
+from services.api.app.diabetes.services import db
+
+
+@pytest.fixture()
+def session_local(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_connection, connection_record) -> None:  # pragma: no cover - setup
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    session_local = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+    monkeypatch.setattr(learning_profile, "SessionLocal", session_local)
+    return session_local
+
+
+@pytest.mark.asyncio
+async def test_get_missing(session_local: sessionmaker[Session]) -> None:
+    assert await learning_profile.get_learning_profile(1) is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_update(session_local: sessionmaker[Session]) -> None:
+    with session_local() as session:
+        session.add(db.User(telegram_id=1, thread_id=""))
+        session.commit()
+
+    await learning_profile.upsert_learning_profile(
+        1, age_group="adult", learning_level="novice", diabetes_type="T1"
+    )
+    profile = await learning_profile.get_learning_profile(1)
+    assert profile is not None
+    assert profile.age_group == "adult"
+    assert profile.learning_level == "novice"
+    assert profile.diabetes_type == "T1"
+
+    await learning_profile.upsert_learning_profile(1, learning_level="expert")
+    profile2 = await learning_profile.get_learning_profile(1)
+    assert profile2 is not None
+    assert profile2.learning_level == "expert"
+    assert profile2.age_group == "adult"
+
+
+@pytest.mark.asyncio
+async def test_upsert_without_user(session_local: sessionmaker[Session]) -> None:
+    with pytest.raises(RuntimeError, match="register"):
+        await learning_profile.upsert_learning_profile(2, age_group="adult")

--- a/tests/test_learning_prompts.py
+++ b/tests/test_learning_prompts.py
@@ -84,3 +84,11 @@ def test_build_system_prompt_warns_on_unknown_type() -> None:
 
     prompt = build_system_prompt({"diabetes_type": "unknown"})
     assert "Тип диабета не определён — избегай тип-специфичных рекомендаций." in prompt
+
+def test_system_prompt_avoids_type_specific_mentions_when_unknown() -> None:
+    """When diabetes type is unknown no T1/T2 hints appear."""
+
+    prompt = build_system_prompt({})
+    assert "Тип диабета не определён" in prompt
+    assert "T1" not in prompt
+    assert "T2" not in prompt


### PR DESCRIPTION
## Summary
- add tests for learning profile repository upsert and retrieval
- ensure onboarding asks for age and level, handles T1/T2 answers, and resumes without prompts after restart
- verify system prompt omits T1/T2 specifics when diabetes type unknown

## Testing
- `pytest tests/assistant/test_learning_profile_repo.py tests/assistant/test_e2e_learning_onboarding.py tests/test_learning_prompts.py::test_system_prompt_avoids_type_specific_mentions_when_unknown -q`
- `mypy --strict tests/assistant/test_learning_profile_repo.py tests/assistant/test_e2e_learning_onboarding.py tests/test_learning_prompts.py`
- `ruff check tests/assistant/test_learning_profile_repo.py tests/assistant/test_e2e_learning_onboarding.py tests/test_learning_prompts.py`


------
https://chatgpt.com/codex/tasks/task_e_68c020444698832aab9892352c92e8fa