### PR TITLE
[learning] log onboarding and track step timing

### DIFF
--- a/services/api/app/diabetes/learning_state.py
+++ b/services/api/app/diabetes/learning_state.py
@@ -15,6 +15,7 @@ class LearnState:
     last_step_text: str | None = None
     prev_summary: str | None = None
     awaiting: bool = True
+    last_step_at: float = 0.0
 
 
 def get_state(data: MutableMapping[str, object]) -> LearnState | None:

--- a/tests/learning/test_learn_command_logging.py
+++ b/tests/learning/test_learn_command_logging.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+from typing import Mapping, cast
+
+import pytest
+
+from services.api.app.config import settings
+from services.api.app.diabetes import learning_handlers
+from tests.utils.telegram import make_context, make_update
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.replies: list[str] = []
+
+    async def reply_text(
+        self, text: str, **_: object
+    ) -> None:  # pragma: no cover - helper
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_learn_command_logs(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+    monkeypatch.setattr(settings, "learning_ui_show_topics", False)
+
+    async def fake_get_profile(user_id: int, ctx: object) -> Mapping[str, object]:
+        return {}
+
+    monkeypatch.setattr(
+        learning_handlers.profiles, "get_profile_for_user", fake_get_profile
+    )
+
+    async def fake_hydrate(update: object, context: object) -> bool:
+        return True
+
+    monkeypatch.setattr(learning_handlers, "_hydrate", fake_hydrate)
+
+    async def fake_ensure_overrides(update: object, context: object) -> bool:
+        user_data = cast(dict[str, object], context.user_data)
+        user_data["learn_onboarding_stage"] = "age_group"
+        return False
+
+    monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
+
+    msg = DummyMessage()
+    update = make_update(message=msg)
+    context = make_context()
+
+    with caplog.at_level(logging.INFO):
+        await learning_handlers.learn_command(update, context)
+
+    assert any(
+        r.message == "learn_command" and r.asked == "age" for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- log age/level/dtype presence at learn start and during onboarding questions
- track last lesson step time to accept quick follow-up answers
- add tests for onboarding logging and step answer grace period

## Testing
- `pytest tests/diabetes/test_learning_onboarding.py::test_ensure_overrides_logs_age tests/diabetes/test_learning_onboarding.py::test_ensure_overrides_logs_level tests/learning/test_on_any_text.py::test_on_any_text_within_grace tests/learning/test_learn_command_logging.py::test_learn_command_logs -q`
- `mypy --strict services/api/app/diabetes/learning_state.py services/api/app/diabetes/learning_onboarding.py services/api/app/diabetes/learning_handlers.py tests/diabetes/test_learning_onboarding.py tests/learning/test_on_any_text.py tests/learning/test_learn_command_logging.py` *(failed: Interrupted)*
- `ruff check services/api/app/diabetes/learning_state.py services/api/app/diabetes/learning_onboarding.py services/api/app/diabetes/learning_handlers.py tests/diabetes/test_learning_onboarding.py tests/learning/test_on_any_text.py tests/learning/test_learn_command_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68c01fb96248832a8fdd9ade7c5593b3