### PR TITLE
[learning] Use curriculum engine for lesson flow

### DIFF
--- a/tests/assistant/test_e2e_plan_button.py
+++ b/tests/assistant/test_e2e_plan_button.py
@@ -67,10 +67,17 @@ async def test_plan_button_flow(
     async def fake_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
         return SimpleNamespace(lesson_id=1)
 
+    step = 0
+
     async def fake_next_step(
-        user_id: int, lesson_id: int, profile: Any
+        user_id: int,
+        lesson_id: int,
+        profile: Any,
+        prev_summary: str | None = None,
     ) -> tuple[str, bool]:
-        return "Шаг 1", False
+        nonlocal step
+        step += 1
+        return f"Шаг {step}", False
 
     monkeypatch.setattr(
         learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
@@ -79,17 +86,9 @@ async def test_plan_button_flow(
         learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
 
-    async def fake_generate_step_text(
-        _profile: Any, _topic: str, step_idx: int, _prev: str | None
-    ) -> str:
-        return f"Шаг {step_idx}"
-
     async def fake_assistant_chat(_profile: Any, _text: str) -> str:
         return "feedback"
 
-    monkeypatch.setattr(
-        learning_handlers, "generate_step_text", fake_generate_step_text
-    )
     monkeypatch.setattr(learning_handlers, "assistant_chat", fake_assistant_chat)
 
     async def fake_add_log(*_a: object, **_k: object) -> None:

--- a/tests/assistant/test_integration.py
+++ b/tests/assistant/test_integration.py
@@ -46,26 +46,20 @@ async def test_flow_idk_with_log_error(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
         return SimpleNamespace(lesson_id=1)
 
+    calls = 0
+
     async def fake_next_step(
         user_id: int,
         lesson_id: int,
         profile: Mapping[str, str | None],
         prev_summary: str | None = None,
     ) -> tuple[str, bool]:
-        return "step1?", False
+        nonlocal calls
+        calls += 1
+        return f"step{calls}?", False
 
     monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
     monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
-
-    async def fake_generate_step_text(
-        profile: Mapping[str, str | None],
-        topic: str,
-        step_idx: int,
-        prev: Any,
-    ) -> str:
-        return f"step{step_idx}?"
-
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
 
     async def fake_check_user_answer(
         profile: Mapping[str, str | None],

--- a/tests/diabetes/test_curriculum_busy.py
+++ b/tests/diabetes/test_curriculum_busy.py
@@ -73,6 +73,7 @@ async def test_dynamic_learn_command_busy(monkeypatch: pytest.MonkeyPatch) -> No
 
     assert msg.replies == [BUSY_MESSAGE]
     assert get_state(context.user_data) is None
+    assert context.user_data.get("lesson_id") is None
 
 
 @pytest.mark.asyncio

--- a/tests/diabetes/test_curriculum_exceptions.py
+++ b/tests/diabetes/test_curriculum_exceptions.py
@@ -94,6 +94,7 @@ async def test_learn_command_start_lesson_exception(
     assert msg.replies == [BUSY_MESSAGE]
     assert get_state(context.user_data) is None
     assert any("lesson start failed" in r.message for r in caplog.records)
+    assert context.user_data.get("lesson_id") is None
 
 
 @pytest.mark.asyncio
@@ -152,6 +153,7 @@ async def test_learn_command_next_step_exception(
     assert msg.replies == [BUSY_MESSAGE]
     assert get_state(context.user_data) is None
     assert any("lesson start failed" in r.message for r in caplog.records)
+    assert context.user_data.get("lesson_id") is None
 
 
 @pytest.mark.asyncio
@@ -190,6 +192,7 @@ async def test_lesson_command_start_lesson_exception(
     assert msg.replies == [BUSY_MESSAGE]
     assert get_state(context.user_data) is None
     assert any("lesson start failed" in r.message for r in caplog.records)
+    assert context.user_data.get("lesson_id") is None
 
 
 @pytest.mark.asyncio
@@ -244,3 +247,4 @@ async def test_lesson_command_next_step_exception(
     assert msg.replies == [BUSY_MESSAGE]
     assert get_state(context.user_data) is None
     assert any("lesson start failed" in r.message for r in caplog.records)
+    assert context.user_data.get("lesson_id") is None

--- a/tests/diabetes/test_curriculum_not_found.py
+++ b/tests/diabetes/test_curriculum_not_found.py
@@ -127,10 +127,7 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
 
     await dynamic_handlers.learn_command(update, context)
 
-    assert msg.replies == [
-        "Не нашёл учебные записи, пробую динамический режим…",
-        "step1",
-    ]
+    assert msg.replies == ["step1"]
     assert get_state(context.user_data) is not None
 
 
@@ -206,10 +203,7 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
 
     await dynamic_handlers.lesson_command(update, context)
 
-    assert msg.replies == [
-        "Не нашёл учебные записи, пробую динамический режим…",
-        "step1",
-    ]
+    assert msg.replies == ["step1"]
     assert get_state(context.user_data) is not None
 
 

--- a/tests/learning/test_empty_lessons.py
+++ b/tests/learning/test_empty_lessons.py
@@ -10,6 +10,7 @@ from telegram.ext import Application, CommandHandler
 from services.api.app.config import settings
 from services.api.app.diabetes import learning_handlers as dynamic_handlers
 from services.api.app.diabetes.handlers import learning_handlers
+from services.api.app.diabetes.curriculum_engine import LessonNotFoundError
 
 
 class DummyBot(Bot):
@@ -60,6 +61,18 @@ async def test_dynamic_mode_empty_lessons(monkeypatch: pytest.MonkeyPatch) -> No
         return "step1"
 
     monkeypatch.setattr(dynamic_handlers, "generate_step_text", fake_generate_step_text)
+
+    async def raise_start_lesson(user_id: int, slug: str) -> object:
+        raise LessonNotFoundError(slug)
+
+    monkeypatch.setattr(
+        dynamic_handlers.curriculum_engine, "start_lesson", raise_start_lesson
+    )
+
+    async def fail_next_step(*args: object, **kwargs: object) -> tuple[str, bool]:
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(dynamic_handlers.curriculum_engine, "next_step", fail_next_step)
     monkeypatch.setattr(
         dynamic_handlers,
         "generate_learning_plan",

--- a/tests/learning/test_flow_autostart.py
+++ b/tests/learning/test_flow_autostart.py
@@ -59,15 +59,15 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
 
     captured_profile: Mapping[str, str | None] = {}
 
-    async def fake_generate_step_text(
+    async def fake_next_step(
+        user_id: int,
+        lesson_id: int,
         profile: Mapping[str, str | None],
-        slug: str,
-        step_idx: int,
-        prev_summary: str | None,
-    ) -> str:
+        prev_summary: str | None = None,
+    ) -> tuple[str, bool]:
         nonlocal captured_profile
         captured_profile = profile
-        return "шаг1"
+        return "шаг1", False
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -76,7 +76,7 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
         learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
     )
     monkeypatch.setattr(
-        learning_handlers, "generate_step_text", fake_generate_step_text
+        learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
 

--- a/tests/learning/test_handlers.py
+++ b/tests/learning/test_handlers.py
@@ -67,13 +67,9 @@ async def test_learning_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_ui_show_topics", True)
     steps = iter(["step1", "step2"])
 
-    async def fake_generate_step_text(*args: object, **kwargs: object) -> str:
-        return next(steps)
-
     async def fake_check_user_answer(*args: object, **kwargs: object) -> tuple[bool, str]:
         return True, "feedback"
 
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -83,8 +79,13 @@ async def test_learning_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_start_lesson(user_id: int, topic_slug: str) -> object:
         return SimpleNamespace(lesson_id=1)
 
-    async def fake_next_step(user_id: int, lesson_id: int, profile: object) -> tuple[str, object | None]:
-        return next(steps), None
+    async def fake_next_step(
+        user_id: int,
+        lesson_id: int,
+        profile: object,
+        prev_summary: str | None = None,
+    ) -> tuple[str, bool]:
+        return next(steps), False
 
     monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
     monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)

--- a/tests/learning/test_onboarding_autostart.py
+++ b/tests/learning/test_onboarding_autostart.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any, Mapping
+from types import SimpleNamespace
 
 import pytest
 from telegram import Bot, Chat, Message, MessageEntity, Update, User
@@ -61,10 +62,17 @@ async def test_onboarding_completion_triggers_plan(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(onboarding_utils.profiles, "get_profile_for_user", fake_get_profile_for_user)
 
-    async def fake_generate_step_text(*_a: object, **_k: object) -> str:
-        return "first"
+    async def fake_next_step(
+        user_id: int,
+        lesson_id: int,
+        profile: Mapping[str, str | None],
+        prev_summary: str | None = None,
+    ) -> tuple[str, bool]:
+        return "first", False
 
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "next_step", fake_next_step
+    )
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
     monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
 
@@ -78,8 +86,8 @@ async def test_onboarding_completion_triggers_plan(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(learning_handlers.plans_repo, "create_plan", _noop)
     monkeypatch.setattr(learning_handlers.plans_repo, "update_plan", _noop)
     monkeypatch.setattr(learning_handlers.progress_service, "upsert_progress", _noop)
-    async def _start(*args: object, **kwargs: object) -> None:
-        return None
+    async def _start(*args: object, **kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(lesson_id=1)
 
     monkeypatch.setattr(
         learning_handlers.curriculum_engine, "start_lesson", _start

--- a/tests/test_profile_self.py
+++ b/tests/test_profile_self.py
@@ -24,6 +24,17 @@ def build_init_data(user_id: int = 1) -> str:
 
 def test_profile_self_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    async def fake_get_learning_profile(_id: int) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "services.api.app.routers.profile.get_learning_profile", fake_get_learning_profile
+    )
+
+    async def fake_run_db(*args: object, **kwargs: object) -> int:
+        return 0
+
+    monkeypatch.setattr("services.api.app.main.run_db", fake_run_db)
     init_data = build_init_data(42)
     with TestClient(app) as client:
 


### PR DESCRIPTION
## Summary
- Drive learning commands through the curriculum engine, storing lesson IDs and fetching steps with `next_step`
- Refactor lesson flow to reuse `next_step` on answers and persist lesson context
- Extend tests for busy states, exception handling, and autostart scenarios

## Testing
- `pytest -q`
- `mypy --strict services/api/app/diabetes/learning_handlers.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c0205a9b6c832a80f0f2468beea200