### PR TITLE
[learning_onboarding] drop diabetes type onboarding

### DIFF
--- a/services/api/app/diabetes/handlers/learning_onboarding.py
+++ b/services/api/app/diabetes/handlers/learning_onboarding.py
@@ -87,7 +87,12 @@ async def onboarding_callback(update: Update, context: ContextTypes.DEFAULT_TYPE
 
 
 def register_handlers(app: App) -> None:
-    """Register learning onboarding handlers on the application."""
+    """Register learning onboarding handlers on the application.
+
+    The reply handler is added without extra patterns so free-form messages
+    like "T1" or "T2" are ignored unless onboarding is active and are
+    processed by regular assistant handlers instead.
+    """
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, onboarding_reply))
     app.add_handler(CallbackQueryHandler(onboarding_callback, pattern=f"^{CB_PREFIX}"))
     app.add_handler(CommandHandler("learn_reset", learn_reset))

--- a/services/api/app/diabetes/learning_onboarding.py
+++ b/services/api/app/diabetes/learning_onboarding.py
@@ -36,17 +36,6 @@ def _norm_age_group(text: str) -> str | None:
     return mapping.get(t)
 
 
-def _norm_diabetes_type(text: str) -> str | None:
-    """Normalize *text* to a diabetes type code."""
-
-    t = text.strip().lower().replace(" ", "")
-    if t in {"1", "t1", "type1", "i"}:
-        return "T1"
-    if t in {"2", "t2", "type2", "ii"}:
-        return "T2"
-    return None
-
-
 def _norm_level(text: str) -> str | None:
     """Normalize *text* to a learning level."""
 
@@ -84,7 +73,6 @@ def needs_level(profile_db: Mapping[str, object]) -> bool:
 
 # Questions asked during the onboarding flow.
 AGE_PROMPT = "Укажите вашу возрастную группу."
-DIABETES_TYPE_PROMPT = "Укажите тип диабета."
 LEARNING_LEVEL_PROMPT = "Укажите ваш уровень знаний."
 
 
@@ -113,19 +101,6 @@ _ORDER: list[
         ),
     ),
     (
-        "diabetes_type",
-        DIABETES_TYPE_PROMPT,
-        _norm_diabetes_type,
-        InlineKeyboardMarkup(
-            [
-                [
-                    InlineKeyboardButton("T1", callback_data=f"{CB_PREFIX}T1"),
-                    InlineKeyboardButton("T2", callback_data=f"{CB_PREFIX}T2"),
-                ]
-            ]
-        ),
-    ),
-    (
         "learning_level",
         LEARNING_LEVEL_PROMPT,
         _norm_level,
@@ -149,8 +124,8 @@ _ORDER: list[
 async def ensure_overrides(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
     """Ensure learning mode prerequisites are satisfied.
 
-    Sequentially ask the user for ``age_group``, ``diabetes_type`` and
-    ``learning_level``. Answers are stored in
+    Sequentially ask the user for ``age_group`` and ``learning_level``.
+    Answers are stored in
     ``ctx.user_data['learn_profile_overrides']``. While onboarding is in
     progress the function returns ``False`` so that callers can stop further
     processing. ``True`` is returned once all fields are collected.
@@ -172,13 +147,6 @@ async def ensure_overrides(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         except (httpx.HTTPError, RuntimeError):
             logger.exception("Failed to get profile for user %s", user.id)
             profile = {}
-        diabetes_type = profile.get("diabetes_type")
-        if (
-            isinstance(diabetes_type, str)
-            and diabetes_type != "unknown"
-            and "diabetes_type" not in overrides
-        ):
-            overrides["diabetes_type"] = diabetes_type
     for key, prompt, norm, keyboard in _ORDER:
         if key == "age_group" and not needs_age(profile):
             val = profile.get("age_group")

--- a/services/api/tests/test_learning_mode_toggle.py
+++ b/services/api/tests/test_learning_mode_toggle.py
@@ -89,7 +89,6 @@ async def test_learning_mode_enabled_lists_lessons(
                 "learning_onboarded": True,
                 "learn_profile_overrides": {
                     "age_group": "adult",
-                    "diabetes_type": "T1",
                     "learning_level": "novice",
                 },
             }
@@ -124,7 +123,6 @@ async def test_learning_mode_disabled_denies_access(
                 "learning_onboarded": True,
                 "learn_profile_overrides": {
                     "age_group": "adult",
-                    "diabetes_type": "T1",
                     "learning_level": "novice",
                 },
             }

--- a/tests/diabetes/test_learning_handlers.py
+++ b/tests/diabetes/test_learning_handlers.py
@@ -89,7 +89,6 @@ async def test_learn_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
                 "learning_onboarded": True,
                 "learn_profile_overrides": {
                     "age_group": "adult",
-                    "diabetes_type": "T1",
                     "learning_level": "novice",
                 },
             }

--- a/tests/diabetes/test_learning_onboarding.py
+++ b/tests/diabetes/test_learning_onboarding.py
@@ -106,30 +106,24 @@ async def test_learning_onboarding_flow(
         message2 = DummyMessage("взрослый")
         update2 = cast(Update, SimpleNamespace(message=message2, effective_user=None))
         await learning_onboarding.onboarding_reply(update2, context)
-        assert message2.replies == [onboarding_utils.DIABETES_TYPE_PROMPT]
+        assert message2.replies == [onboarding_utils.LEARNING_LEVEL_PROMPT]
 
-        message3 = DummyMessage("type1")
+        message3 = DummyMessage("новичок")
         update3 = cast(Update, SimpleNamespace(message=message3, effective_user=None))
         await learning_onboarding.onboarding_reply(update3, context)
-        assert message3.replies == [onboarding_utils.LEARNING_LEVEL_PROMPT]
-
-        message4 = DummyMessage("новичок")
-        update4 = cast(Update, SimpleNamespace(message=message4, effective_user=None))
-        await learning_onboarding.onboarding_reply(update4, context)
         assert any(
-            LEARN_BUTTON_TEXT in text or "Урок" in text for text in message4.replies
+            LEARN_BUTTON_TEXT in text or "Урок" in text for text in message3.replies
         )
         assert context.user_data["learn_profile_overrides"] == {
             "age_group": "adult",
-            "diabetes_type": "T1",
             "learning_level": "novice",
         }
 
-        message5 = DummyMessage()
-        update5 = cast(Update, SimpleNamespace(message=message5, effective_user=None))
-        await learning_handlers.learn_command(update5, context)
+        message4 = DummyMessage()
+        update4 = cast(Update, SimpleNamespace(message=message4, effective_user=None))
+        await learning_handlers.learn_command(update4, context)
         assert any(
-            LEARN_BUTTON_TEXT in text or "Урок" in text for text in message5.replies
+            LEARN_BUTTON_TEXT in text or "Урок" in text for text in message4.replies
         )
 
         message_reset = DummyMessage()
@@ -142,10 +136,10 @@ async def test_learning_onboarding_flow(
         assert "learn_profile_overrides" not in context.user_data
         assert "learn_onboarding_stage" not in context.user_data
 
-        message6 = DummyMessage()
-        update6 = cast(Update, SimpleNamespace(message=message6, effective_user=None))
-        await learning_handlers.learn_command(update6, context)
-        assert message6.replies == [onboarding_utils.AGE_PROMPT]
+        message5 = DummyMessage()
+        update5 = cast(Update, SimpleNamespace(message=message5, effective_user=None))
+        await learning_handlers.learn_command(update5, context)
+        assert message5.replies == [onboarding_utils.AGE_PROMPT]
     finally:
         engine.dispose()
 
@@ -191,17 +185,8 @@ async def test_learning_onboarding_callback_flow(
             SimpleNamespace(callback_query=q1, message=None, effective_user=None),
         )
         await learning_onboarding.onboarding_callback(upd_cb1, ctx)
-        assert q1_msg.replies == [onboarding_utils.DIABETES_TYPE_PROMPT]
-
-        q2_msg = DummyMessage()
-        q2 = DummyCallbackQuery(f"{onboarding_utils.CB_PREFIX}T1", q2_msg)
-        upd_cb2 = cast(
-            Update,
-            SimpleNamespace(callback_query=q2, message=None, effective_user=None),
-        )
-        await learning_onboarding.onboarding_callback(upd_cb2, ctx)
-        assert q2_msg.replies == [onboarding_utils.LEARNING_LEVEL_PROMPT]
-        markup = q2_msg.markups[0]
+        assert q1_msg.replies == [onboarding_utils.LEARNING_LEVEL_PROMPT]
+        markup = q1_msg.markups[0]
         assert isinstance(markup, InlineKeyboardMarkup)
         assert [b.text for b in markup.inline_keyboard[0]] == [
             "Новичок",
@@ -209,19 +194,18 @@ async def test_learning_onboarding_callback_flow(
             "Продвинутый",
         ]
 
-        q3_msg = DummyMessage()
-        q3 = DummyCallbackQuery(f"{onboarding_utils.CB_PREFIX}novice", q3_msg)
-        upd_cb3 = cast(
+        q2_msg = DummyMessage()
+        q2 = DummyCallbackQuery(f"{onboarding_utils.CB_PREFIX}novice", q2_msg)
+        upd_cb2 = cast(
             Update,
-            SimpleNamespace(callback_query=q3, message=None, effective_user=None),
+            SimpleNamespace(callback_query=q2, message=None, effective_user=None),
         )
-        await learning_onboarding.onboarding_callback(upd_cb3, ctx)
+        await learning_onboarding.onboarding_callback(upd_cb2, ctx)
         assert any(
-            LEARN_BUTTON_TEXT in text or "Урок" in text for text in q3_msg.replies
+            LEARN_BUTTON_TEXT in text or "Урок" in text for text in q2_msg.replies
         )
         assert ctx.user_data["learn_profile_overrides"] == {
             "age_group": "adult",
-            "diabetes_type": "T1",
             "learning_level": "novice",
         }
 
@@ -254,7 +238,6 @@ async def test_ensure_overrides_normalizes_level() -> None:
             user_data={
                 "learn_profile_overrides": {
                     "age_group": "adult",
-                    "diabetes_type": "T1",
                     "learning_level": "продвинутый",
                 }
             }
@@ -267,40 +250,6 @@ async def test_ensure_overrides_normalizes_level() -> None:
     assert context.user_data["learn_profile_overrides"]["learning_level"] == "expert"
     assert context.user_data.get("learning_onboarded") is True
 
-
-@pytest.mark.asyncio
-async def test_skip_diabetes_type_if_profile_has_it(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    async def fake_get_profile(_: int, __: object) -> dict[str, object]:
-        return {"diabetes_type": "T1"}
-
-    monkeypatch.setattr(
-        onboarding_utils.profiles,
-        "get_profile_for_user",
-        fake_get_profile,
-    )
-    user = SimpleNamespace(id=1)
-    context = cast(
-        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(user_data={}),
-    )
-    msg1 = DummyMessage()
-    upd1 = cast(
-        Update, SimpleNamespace(message=msg1, callback_query=None, effective_user=user)
-    )
-    assert not await onboarding_utils.ensure_overrides(upd1, context)
-    assert msg1.replies == [onboarding_utils.AGE_PROMPT]
-
-    overrides = cast(dict[str, str], context.user_data["learn_profile_overrides"])
-    overrides["age_group"] = "adult"
-    msg2 = DummyMessage()
-    upd2 = cast(
-        Update, SimpleNamespace(message=msg2, callback_query=None, effective_user=user)
-    )
-    assert not await onboarding_utils.ensure_overrides(upd2, context)
-    assert msg2.replies == [onboarding_utils.LEARNING_LEVEL_PROMPT]
-    assert overrides["diabetes_type"] == "T1"
 
 
 @pytest.mark.asyncio

--- a/tests/learning/test_flow_autostart.py
+++ b/tests/learning/test_flow_autostart.py
@@ -115,8 +115,7 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
         )
     )
     await app.process_update(Update(update_id=2, message=_msg(2, "49")))
-    await app.process_update(Update(update_id=3, message=_msg(3, "2")))
-    await app.process_update(Update(update_id=4, message=_msg(4, "0")))
+    await app.process_update(Update(update_id=3, message=_msg(3, "0")))
     assert bot.sent[-1] == "шаг1"
     assert all(
         title not in s
@@ -126,7 +125,6 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     assert captured_profile == {
         "age_group": "adult",
-        "diabetes_type": "T2",
         "learning_level": "novice",
     }
 

--- a/tests/learning/test_onboarding_normalization.py
+++ b/tests/learning/test_onboarding_normalization.py
@@ -4,7 +4,6 @@ import pytest
 
 from services.api.app.diabetes.learning_onboarding import (
     _norm_age_group,
-    _norm_diabetes_type,
     _norm_level,
 )
 
@@ -19,11 +18,6 @@ def test_norm_age_group_numeric() -> None:
 )
 def test_norm_age_group_russian(text: str, code: str) -> None:
     assert _norm_age_group(text) == code
-
-
-def test_norm_diabetes_type_numeric() -> None:
-    assert _norm_diabetes_type("2") == "T2"
-
 
 def test_norm_level_numeric() -> None:
     assert _norm_level("0") == "novice"

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -97,7 +97,6 @@ async def test_learn_command_no_lessons(monkeypatch: pytest.MonkeyPatch) -> None
                 "learning_onboarded": True,
                 "learn_profile_overrides": {
                     "age_group": "adult",
-                    "diabetes_type": "T1",
                     "learning_level": "novice",
                 },
             }
@@ -165,7 +164,6 @@ async def test_learn_command_lists_lessons(
                 "learning_onboarded": True,
                 "learn_profile_overrides": {
                     "age_group": "adult",
-                    "diabetes_type": "T1",
                     "learning_level": "novice",
                 },
             }


### PR DESCRIPTION
## Summary
- remove diabetes type question from learning onboarding
- clarify handler registration to let free-form `T1`/`T2` messages pass through
- update tests to only ask for age and learning level

## Testing
- `pytest -q --cov` *(fails: OpenAI API key missing, database engine not initialized)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c023e5f8a4832a95df92486b6aca0a