### PR TITLE
[learning] use curriculum engine for steps

### DIFF
--- a/tests/assistant/test_e2e_learning_onboarding.py
+++ b/tests/assistant/test_e2e_learning_onboarding.py
@@ -69,10 +69,15 @@ async def test_first_run_restart_and_type_questions(
     async def fake_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
         return SimpleNamespace(lesson_id=1)
 
-    async def fake_generate_step_text(
-        _profile: Any, _topic: str, step_idx: int, _prev: str | None
-    ) -> str:
-        return f"Шаг {step_idx}"
+    steps = iter(["Шаг 1", "Шаг 2"])
+
+    async def fake_next_step(
+        user_id: int,
+        lesson_id: int,
+        profile: Any,
+        prev_summary: str | None = None,
+    ) -> tuple[str, bool]:
+        return next(steps), False
 
     async def fake_assistant_chat(_profile: Any, _text: str) -> str:
         return "feedback"
@@ -83,7 +88,7 @@ async def test_first_run_restart_and_type_questions(
         return False, "feedback"
 
     monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
     monkeypatch.setattr(learning_handlers, "assistant_chat", fake_assistant_chat)
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
     monkeypatch.setattr(

--- a/tests/assistant/test_e2e_plan_button.py
+++ b/tests/assistant/test_e2e_plan_button.py
@@ -67,10 +67,15 @@ async def test_plan_button_flow(
     async def fake_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
         return SimpleNamespace(lesson_id=1)
 
+    steps = iter(["Шаг 1", "Шаг 2"])
+
     async def fake_next_step(
-        user_id: int, lesson_id: int, profile: Any
+        user_id: int,
+        lesson_id: int,
+        profile: Any,
+        prev_summary: str | None = None,
     ) -> tuple[str, bool]:
-        return "Шаг 1", False
+        return next(steps), False
 
     monkeypatch.setattr(
         learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
@@ -79,17 +84,9 @@ async def test_plan_button_flow(
         learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
 
-    async def fake_generate_step_text(
-        _profile: Any, _topic: str, step_idx: int, _prev: str | None
-    ) -> str:
-        return f"Шаг {step_idx}"
-
     async def fake_assistant_chat(_profile: Any, _text: str) -> str:
         return "feedback"
 
-    monkeypatch.setattr(
-        learning_handlers, "generate_step_text", fake_generate_step_text
-    )
     monkeypatch.setattr(learning_handlers, "assistant_chat", fake_assistant_chat)
 
     async def fake_add_log(*_a: object, **_k: object) -> None:

--- a/tests/assistant/test_integration.py
+++ b/tests/assistant/test_integration.py
@@ -46,26 +46,18 @@ async def test_flow_idk_with_log_error(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
         return SimpleNamespace(lesson_id=1)
 
+    steps_iter = iter(["step1?", "step2?", "step3?", "step4?"])
+
     async def fake_next_step(
         user_id: int,
         lesson_id: int,
         profile: Mapping[str, str | None],
         prev_summary: str | None = None,
     ) -> tuple[str, bool]:
-        return "step1?", False
+        return next(steps_iter), False
 
     monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
     monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
-
-    async def fake_generate_step_text(
-        profile: Mapping[str, str | None],
-        topic: str,
-        step_idx: int,
-        prev: Any,
-    ) -> str:
-        return f"step{step_idx}?"
-
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
 
     async def fake_check_user_answer(
         profile: Mapping[str, str | None],

--- a/tests/diabetes/test_curriculum_busy.py
+++ b/tests/diabetes/test_curriculum_busy.py
@@ -73,6 +73,7 @@ async def test_dynamic_learn_command_busy(monkeypatch: pytest.MonkeyPatch) -> No
 
     assert msg.replies == [BUSY_MESSAGE]
     assert get_state(context.user_data) is None
+    assert context.user_data.get("lesson_id") is None
 
 
 @pytest.mark.asyncio

--- a/tests/diabetes/test_curriculum_exceptions.py
+++ b/tests/diabetes/test_curriculum_exceptions.py
@@ -94,6 +94,7 @@ async def test_learn_command_start_lesson_exception(
     assert msg.replies == [BUSY_MESSAGE]
     assert get_state(context.user_data) is None
     assert any("lesson start failed" in r.message for r in caplog.records)
+    assert context.user_data.get("lesson_id") is None
 
 
 @pytest.mark.asyncio
@@ -152,6 +153,7 @@ async def test_learn_command_next_step_exception(
     assert msg.replies == [BUSY_MESSAGE]
     assert get_state(context.user_data) is None
     assert any("lesson start failed" in r.message for r in caplog.records)
+    assert context.user_data.get("lesson_id") is None
 
 
 @pytest.mark.asyncio
@@ -190,6 +192,7 @@ async def test_lesson_command_start_lesson_exception(
     assert msg.replies == [BUSY_MESSAGE]
     assert get_state(context.user_data) is None
     assert any("lesson start failed" in r.message for r in caplog.records)
+    assert context.user_data.get("lesson_id") is None
 
 
 @pytest.mark.asyncio
@@ -244,3 +247,4 @@ async def test_lesson_command_next_step_exception(
     assert msg.replies == [BUSY_MESSAGE]
     assert get_state(context.user_data) is None
     assert any("lesson start failed" in r.message for r in caplog.records)
+    assert context.user_data.get("lesson_id") is None

--- a/tests/diabetes/test_curriculum_not_found.py
+++ b/tests/diabetes/test_curriculum_not_found.py
@@ -127,11 +127,9 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
 
     await dynamic_handlers.learn_command(update, context)
 
-    assert msg.replies == [
-        "Не нашёл учебные записи, пробую динамический режим…",
-        "step1",
-    ]
+    assert msg.replies == ["step1"]
     assert get_state(context.user_data) is not None
+    assert context.user_data.get("lesson_id") is None
 
 
 @pytest.mark.asyncio
@@ -206,11 +204,9 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
 
     await dynamic_handlers.lesson_command(update, context)
 
-    assert msg.replies == [
-        "Не нашёл учебные записи, пробую динамический режим…",
-        "step1",
-    ]
+    assert msg.replies == ["step1"]
     assert get_state(context.user_data) is not None
+    assert context.user_data.get("lesson_id") is None
 
 
 @pytest.mark.asyncio

--- a/tests/learning/test_flow_autostart.py
+++ b/tests/learning/test_flow_autostart.py
@@ -59,15 +59,15 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
 
     captured_profile: Mapping[str, str | None] = {}
 
-    async def fake_generate_step_text(
+    async def fake_next_step(
+        user_id: int,
+        lesson_id: int,
         profile: Mapping[str, str | None],
-        slug: str,
-        step_idx: int,
-        prev_summary: str | None,
-    ) -> str:
+        prev_summary: str | None = None,
+    ) -> tuple[str, bool]:
         nonlocal captured_profile
         captured_profile = profile
-        return "шаг1"
+        return "шаг1", False
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -76,7 +76,7 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
         learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
     )
     monkeypatch.setattr(
-        learning_handlers, "generate_step_text", fake_generate_step_text
+        learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
     monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
 

--- a/tests/learning/test_handlers.py
+++ b/tests/learning/test_handlers.py
@@ -67,13 +67,9 @@ async def test_learning_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_ui_show_topics", True)
     steps = iter(["step1", "step2"])
 
-    async def fake_generate_step_text(*args: object, **kwargs: object) -> str:
-        return next(steps)
-
     async def fake_check_user_answer(*args: object, **kwargs: object) -> tuple[bool, str]:
         return True, "feedback"
 
-    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -83,8 +79,10 @@ async def test_learning_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_start_lesson(user_id: int, topic_slug: str) -> object:
         return SimpleNamespace(lesson_id=1)
 
-    async def fake_next_step(user_id: int, lesson_id: int, profile: object) -> tuple[str, object | None]:
-        return next(steps), None
+    async def fake_next_step(
+        user_id: int, lesson_id: int, profile: object, prev_summary: str | None = None
+    ) -> tuple[str, bool]:
+        return next(steps), False
 
     monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
     monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)


### PR DESCRIPTION
## Summary
- integrate curriculum engine next_step across learning flow
- store lesson_id in user state and refine error handling
- expand tests for curriculum busy and onboarding flows

## Testing
- `pytest tests/assistant/test_e2e_restart.py tests/diabetes/test_curriculum_busy.py tests/diabetes/test_curriculum_exceptions.py tests/diabetes/test_learning_chat_handlers.py tests/learning/test_flow_autostart.py tests/learning/test_handlers_rate_limit.py tests/learning/test_onboarding_autostart.py -q`
- `ruff check services/api/app/diabetes/learning_handlers.py tests/assistant/test_e2e_restart.py tests/diabetes/test_curriculum_busy.py tests/diabetes/test_curriculum_exceptions.py tests/diabetes/test_learning_chat_handlers.py tests/learning/test_flow_autostart.py tests/learning/test_handlers_rate_limit.py tests/learning/test_onboarding_autostart.py`
- `mypy --strict services/api/app/diabetes/learning_handlers.py tests/assistant/test_e2e_restart.py tests/diabetes/test_curriculum_busy.py tests/diabetes/test_curriculum_exceptions.py tests/diabetes/test_learning_chat_handlers.py tests/learning/test_flow_autostart.py tests/learning/test_handlers_rate_limit.py tests/learning/test_onboarding_autostart.py` *(failed: process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68c0272d36ac832aabf39fb18a8346f8