### PR TITLE
[handlers] enforce async db runner

### DIFF
--- a/tests/test_alert_handlers.py
+++ b/tests/test_alert_handlers.py
@@ -88,10 +88,7 @@ async def test_send_alert_message_invalid_contact(
         )
 
     assert expected in caplog.text
-    assert (
-        "SOS contact 'bad_contact' is not a Telegram username, chat id, or phone number; skipping"
-        in caplog.text
-    )
+    assert "SOS contact 'bad_contact' is not a Telegram username, chat id, or phone number; skipping" in caplog.text
     assert bot.send_message.await_count == 1
 
 
@@ -194,3 +191,15 @@ def test_schedule_alert_without_timezone_kwarg() -> None:
         profile=profile,
     )
     assert len(job_queue.jobs) == 1
+
+
+@pytest.mark.asyncio
+async def test_evaluate_sugar_requires_run_db(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """evaluate_sugar raises when run_db is missing."""
+
+    monkeypatch.setattr(handlers, "run_db", None)
+
+    with pytest.raises(RuntimeError, match="run_db"):
+        await handlers.evaluate_sugar(1, 5.5)


### PR DESCRIPTION
## Summary
- require presence of run_db for alert handler operations
- offload alert handler queries via run_db instead of blocking sessions
- test evaluate_sugar fails fast when run_db is missing

## Testing
- `pytest tests/test_alert_handlers.py tests/test_alert_stats.py tests/test_run_db.py -q`
- `mypy --strict services/api/app/diabetes/handlers/alert_handlers.py tests/test_alert_handlers.py`
- `ruff check services/api/app/diabetes/handlers/alert_handlers.py tests/test_alert_handlers.py`
- `pytest tests/test_alert_handlers.py tests/test_run_db.py -q --cov --cov-fail-under=85` *(fails: No data was collected)*


------
https://chatgpt.com/codex/tasks/task_e_68c0348adfe0832ab1050de8f6449207