### PR TITLE
[handlers] Handle billing status validation errors

### DIFF
--- a/services/api/app/diabetes/handlers/billing_handlers.py
+++ b/services/api/app/diabetes/handlers/billing_handlers.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime
 
 import httpx
+from pydantic import ValidationError
 from telegram import Message, Update
 from telegram.ext import ContextTypes
 
@@ -192,8 +193,8 @@ async def subscription_button(
         return
     try:
         status = BillingStatusResponse.model_validate(data)
-    except Exception:
-        logger.exception("invalid billing status payload")
+    except ValidationError as exc:
+        logger.exception("invalid billing status payload: %s", exc.errors())
         logger.info(
             "billing_action=user_id:%s action=status result=bad_payload", user.id
         )


### PR DESCRIPTION
## Summary
- handle pydantic `ValidationError` in billing status handler and log details
- test subscription button with invalid billing status payload

## Testing
- `ruff check tests/test_billing_commands.py services/api/app/diabetes/handlers/billing_handlers.py`
- `mypy --strict tests/test_billing_commands.py services/api/app/diabetes/handlers/billing_handlers.py`
- `pytest -q --cov` *(fails: sqlite3.OperationalError: no such table: lessons)*

------
https://chatgpt.com/codex/tasks/task_e_68c03ccb3ad4832ab518279ba44d464a