### PR TITLE
[handlers] Consolidate reset command

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -13,6 +13,7 @@ from .handlers.onboarding_handlers import reset_onboarding as _reset_onboarding
 from ..ui.keyboard import LEARN_BUTTON_TEXT
 from .assistant_state import reset as _reset_assistant
 from ..assistant.services.memory_service import clear_memory as _clear_memory
+from services.api.app.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +88,7 @@ async def reset_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 
     message = update.effective_message
     user = getattr(update, "effective_user", None)
-    if message is None:
+    if message is None or not settings.assistant_mode_enabled:
         return
     user_data = cast(dict[str, object], context.user_data)
     _reset_assistant(user_data)

--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -745,25 +745,10 @@ async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         await memory_service.record_turn(user.id, summary_text=summary)
 
 
-async def reset_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Clear assistant conversation history and summary."""
-
-    message = update.message
-    if message is None:
-        return
-    if not settings.assistant_mode_enabled:
-        return
-
-    user_data = cast(dict[str, object], context.user_data)
-    assistant_state.reset(user_data)
-    await message.reply_text("История диалога очищена.")
-
-
 __all__ = [
     "SessionLocal",
     "freeform_handler",
     "chat_with_gpt",
-    "reset_command",
     "ParserTimeoutError",
     "parse_quick_values",
     "apply_pending_entry",


### PR DESCRIPTION
## Summary
- unify reset command handling in `commands.reset_command`
- drop redundant `gpt_handlers.reset_command`
- test reset command behavior and assistant mode guard

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c04e7065fc832a8a648efd018f48a9