### PR TITLE
[diabetes] Handle reply errors for reset onboarding

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -76,10 +76,26 @@ async def reset_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
     user_data["_onb_reset_confirm"] = True
     user_data["_onb_reset_task"] = asyncio.create_task(_reset_timeout())
-    await message.reply_text(
-        "⚠️ Это сбросит прогресс онбординга. Профиль и напоминания не затронутся.\n"
-        "Отправьте /reset_onboarding ещё раз для подтверждения.",
-    )
+    try:
+        await message.reply_text(
+            "⚠️ Это сбросит прогресс онбординга. Профиль и напоминания не"
+            " затронутся.\n"
+            "Отправьте /reset_onboarding ещё раз для подтверждения.",
+        )
+    except telegram.error.TelegramError as exc:
+        logger.exception("Failed to send onboarding reset warning: %s", exc)
+        try:
+            await context.bot.send_message(
+                chat_id=message.chat_id,
+                text=(
+                    "Не удалось отправить предупреждение о сбросе. " "Попробуйте снова."
+                ),
+            )
+        except telegram.error.TelegramError as exc2:
+            logger.exception(
+                "Failed to notify user about onboarding reset warning failure: %s",
+                exc2,
+            )
 
 
 async def reset_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/tests/test_reset_onboarding_command_error.py
+++ b/tests/test_reset_onboarding_command_error.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import asyncio
+import logging
+
+import pytest
+import telegram
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.diabetes import commands
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.chat_id = 1
+
+    async def reply_text(
+        self, text: str
+    ) -> None:  # pragma: no cover - fails intentionally
+        raise telegram.error.TelegramError("fail")
+
+
+class DummyBot:
+    def __init__(self) -> None:
+        self.sent: list[tuple[int, str]] = []
+
+    async def send_message(self, chat_id: int, text: str) -> None:
+        self.sent.append((chat_id, text))
+
+
+class DummyTask:
+    def cancel(self) -> None:  # pragma: no cover - test helper
+        pass
+
+
+def _fake_create_task(coro: Any) -> DummyTask:
+    coro.close()
+    return DummyTask()
+
+
+@pytest.mark.asyncio
+async def test_reset_onboarding_reply_error_fallback(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(asyncio, "create_task", _fake_create_task)
+    message = DummyMessage()
+    update = cast(
+        Update,
+        SimpleNamespace(
+            effective_message=message, effective_user=SimpleNamespace(id=1)
+        ),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(bot=DummyBot(), user_data={}),
+    )
+    with caplog.at_level(logging.ERROR):
+        await commands.reset_onboarding(update, context)
+    assert context.bot.sent
+    assert "Не удалось отправить предупреждение" in context.bot.sent[0][1]
+    assert any(
+        "Failed to send onboarding reset warning" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- handle Telegram API failures when warning about onboarding reset
- test onboarding reset command error handling

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: sqlite3.OperationalError: no such table: lessons)*

------
https://chatgpt.com/codex/tasks/task_e_68c04e72b620832a90ac7b3659cf24ad