### PR TITLE
[config] Reload settings when validating any tokens

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,6 +35,9 @@ DB_PASSWORD = os.getenv("DB_PASSWORD")
 def validate_tokens(required: Iterable[str] | None = None) -> None:
     """Validate that the given environment variables are present.
 
+    Providing a non-empty ``required`` list also refreshes the application
+    settings so that subsequent checks see the latest environment values.
+
     Parameters
     ----------
     required:
@@ -51,14 +54,11 @@ def validate_tokens(required: Iterable[str] | None = None) -> None:
     required_vars = list(required or [])
     missing = []
 
-    if "TELEGRAM_TOKEN" in required_vars:
+    if required_vars:
         reload_settings()
 
     for var in required_vars:
-        if var == "TELEGRAM_TOKEN":
-            if not os.getenv("TELEGRAM_TOKEN"):
-                missing.append(var)
-        elif not os.getenv(var):
+        if not os.getenv(var):
             missing.append(var)
     if missing:
         raise RuntimeError(

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -36,6 +36,27 @@ def test_validate_tokens_env_not_declared(monkeypatch: pytest.MonkeyPatch) -> No
     config.validate_tokens(["UNDECLARED_TOKEN"])
 
 
+def test_validate_tokens_reload_settings_on_any_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Any required variable triggers a settings reload."""
+
+    monkeypatch.setenv("UNDECLARED_TOKEN", "secret")
+    config = _reload("config")
+
+    called = False
+
+    def fake_reload_settings() -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(config, "reload_settings", fake_reload_settings)
+
+    config.validate_tokens(["UNDECLARED_TOKEN"])
+
+    assert called
+
+
 def test_validate_tokens_reflects_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """``validate_tokens`` checks the current ``TELEGRAM_TOKEN`` value."""
 


### PR DESCRIPTION
## Summary
- reload settings whenever `validate_tokens` checks any required variables
- document settings refresh in `validate_tokens`
- test `validate_tokens` refresh behavior

## Testing
- `pytest tests/test_root_config.py -q --cov=config`
- `mypy --strict config.py tests/test_root_config.py --follow-imports=skip`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c052b74840832a9bd6caa9c5404bb2