### PR TITLE
[openai_utils] handle client closing errors

### DIFF
--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -102,11 +102,17 @@ async def dispose_http_client() -> None:
     global _http_client, _async_http_client
     with _http_client_lock:
         for sync_client in _http_client.values():
-            sync_client.close()
+            try:
+                sync_client.close()
+            except Exception:
+                logger.exception("[OpenAI] Failed to close sync HTTP client")
         _http_client.clear()
     with _async_http_client_lock:
         for async_client in _async_http_client.values():
-            await async_client.aclose()
+            try:
+                await async_client.aclose()
+            except Exception:
+                logger.exception("[OpenAI] Failed to close async HTTP client")
         _async_http_client.clear()
 
 


### PR DESCRIPTION
## Summary
- log failures when closing OpenAI HTTP clients
- ensure other clients are closed even if one fails
- add tests for disposal error handling

## Testing
- `pytest -q --cov` *(fails: Database engine is not initialized; run init_db() before calling run_db())*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c052bdcca4832aaab8504e4732622f