### PR TITLE
[openai_utils] Suppress disposal errors in async context

### DIFF
--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -146,7 +146,10 @@ async def async_openai_client_ctx() -> AsyncIterator[AsyncOpenAI]:
     try:
         yield client
     finally:
-        await dispose_http_client()
+        try:
+            await dispose_http_client()
+        except Exception:  # pragma: no cover - best effort on shutdown
+            logger.exception("[OpenAI] Failed to dispose HTTP client")
 
 
 def _dispose_http_client_sync() -> None:


### PR DESCRIPTION
## Summary
- handle disposal failures in `async_openai_client_ctx`
- add regression test for disposal error logging

## Testing
- `pytest tests/test_openai_utils.py -q --cov=services.api.app.diabetes.utils.openai_utils --cov-fail-under=85`
- `mypy --strict services/api/app/diabetes/utils/openai_utils.py tests/test_openai_utils.py`
- `ruff check services/api/app/diabetes/utils/openai_utils.py tests/test_openai_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c057cf3a9c832abf2970c736996be7