### PR TITLE
[learning] Prevent skip past plan end

### DIFF
--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -133,9 +133,8 @@ async def _hydrate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
         overrides = cast(
             Mapping[str, str | None], user_data.get("learn_profile_overrides", {})
         )
-        if (
-            not user_data.get("learning_profile_backfilled")
-            and (overrides.get("age_group") or overrides.get("learning_level"))
+        if not user_data.get("learning_profile_backfilled") and (
+            overrides.get("age_group") or overrides.get("learning_level")
         ):
             try:
                 await upsert_learning_profile(
@@ -318,9 +317,7 @@ async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         progress = await curriculum_engine.start_lesson(user.id, slug)
         lesson_id = progress.lesson_id
         user_data["lesson_id"] = lesson_id
-        text, _ = await curriculum_engine.next_step(
-            user.id, lesson_id, profile, None
-        )
+        text, _ = await curriculum_engine.next_step(user.id, lesson_id, profile, None)
     except LessonNotFoundError:
         logger.warning(
             "no_static_lessons; run dynamic",
@@ -345,7 +342,7 @@ async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     user_data["learning_plan"] = plan
     user_data["learning_plan_index"] = 0
     await message.reply_text(
-        f"\U0001F5FA План обучения\n{pretty_plan(plan)}",
+        f"\U0001f5fa План обучения\n{pretty_plan(plan)}",
         reply_markup=build_main_keyboard(),
     )
     text = format_reply(plan[0])
@@ -417,7 +414,7 @@ async def _start_lesson(
     user_data["learning_plan"] = plan
     user_data["learning_plan_index"] = 0
     await message.reply_text(
-        f"\U0001F5FA План обучения\n{pretty_plan(plan)}",
+        f"\U0001f5fa План обучения\n{pretty_plan(plan)}",
         reply_markup=build_main_keyboard(),
     )
     text = format_reply(plan[0])
@@ -754,9 +751,10 @@ async def skip_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return
     idx = cast(int, user_data.get("learning_plan_index", 0)) + 1
     if idx >= len(plan):
+        user_data["learning_plan_index"] = len(plan) - 1
         await message.reply_text("План завершён.", reply_markup=build_main_keyboard())
-    else:
-        await message.reply_text(plan[idx], reply_markup=build_main_keyboard())
+        return
+    await message.reply_text(plan[idx], reply_markup=build_main_keyboard())
     user_data["learning_plan_index"] = idx
     user = update.effective_user
     if user is not None:

--- a/tests/learning/test_plan_handlers.py
+++ b/tests/learning/test_plan_handlers.py
@@ -86,7 +86,9 @@ async def test_learn_command_stores_plan(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert context.user_data["learning_plan_index"] == 0
     assert context.user_data["learning_plan"][0] == "step1"
-    plan_text = f"\U0001F5FA План обучения\n{pretty_plan(context.user_data['learning_plan'])}"
+    plan_text = (
+        f"\U0001f5fa План обучения\n{pretty_plan(context.user_data['learning_plan'])}"
+    )
     assert message.replies == [plan_text, "step1"]
 
 
@@ -107,7 +109,7 @@ async def test_plan_and_skip_commands() -> None:
 
     await learning_handlers.skip_command(update, context)
     assert message.replies[-1] == "План завершён."
-    assert user_data["learning_plan_index"] == 2
+    assert user_data["learning_plan_index"] == 1
 
 
 @pytest.mark.asyncio
@@ -137,4 +139,21 @@ async def test_plan_command_respects_existing_plan(
 
     assert message.replies == [pretty_plan(plan)]
     assert user_data["learning_plan"] == plan
+    assert user_data["learning_plan_index"] == 0
+
+
+@pytest.mark.asyncio
+async def test_skip_after_completion_does_not_grow_index() -> None:
+    plan = ["step1"]
+    user_data = {"learning_plan": plan, "learning_plan_index": 0}
+    message = DummyMessage()
+    update = make_update(message=message)
+    context = make_context(user_data=user_data)
+
+    await learning_handlers.skip_command(update, context)
+    assert message.replies[-1] == "План завершён."
+    assert user_data["learning_plan_index"] == 0
+
+    await learning_handlers.skip_command(update, context)
+    assert message.replies[-1] == "План завершён."
     assert user_data["learning_plan_index"] == 0


### PR DESCRIPTION
## Summary
- cap learning plan skip index at last step and avoid persisting when plan finished
- add regression test ensuring repeated /skip doesn't advance plan

## Testing
- `python -m black services/api/app/diabetes/learning_handlers.py tests/learning/test_plan_handlers.py`
- `ruff check services/api/app/diabetes/learning_handlers.py tests/learning/test_plan_handlers.py`
- `mypy --strict services/api/app/diabetes/learning_handlers.py tests/learning/test_plan_handlers.py`
- `pytest tests/learning/test_plan_handlers.py::test_skip_after_completion_does_not_grow_index -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68c05f36f644832aadd5f712a0471daf