### PR TITLE
[handlers] Add timeout for Vision run retrieval

### DIFF
--- a/tests/test_photo_handlers_additional.py
+++ b/tests/test_photo_handlers_additional.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from pathlib import Path
@@ -90,11 +91,15 @@ async def test_photo_handler_commit_failure(
     assert user_data is not None
     assert photo_handlers.WAITING_GPT_FLAG not in user_data
     assert not send_message_mock.called
-    assert any("[PHOTO] Failed to commit user 1" in r.getMessage() for r in caplog.records)
+    assert any(
+        "[PHOTO] Failed to commit user 1" in r.getMessage() for r in caplog.records
+    )
 
 
 @pytest.mark.asyncio
-async def test_photo_handler_run_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+async def test_photo_handler_run_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     class StatusMessage:
         def __init__(self) -> None:
             self.edits: list[str] = []
@@ -139,7 +144,9 @@ async def test_photo_handler_run_failure(monkeypatch: pytest.MonkeyPatch, tmp_pa
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(bot=SimpleNamespace(get_file=fake_get_file), user_data={"thread_id": "tid"}),
+        SimpleNamespace(
+            bot=SimpleNamespace(get_file=fake_get_file), user_data={"thread_id": "tid"}
+        ),
     )
 
     monkeypatch.chdir(tmp_path)
@@ -147,14 +154,89 @@ async def test_photo_handler_run_failure(monkeypatch: pytest.MonkeyPatch, tmp_pa
 
     assert result == photo_handlers.END
     assert message.status is not None
-    assert message.status.edits == ["⚠️ Vision не смог обработать фото. Попробуйте ещё раз."]
+    assert message.status.edits == [
+        "⚠️ Vision не смог обработать фото. Попробуйте ещё раз."
+    ]
     user_data = context.user_data
     assert user_data is not None
     assert photo_handlers.WAITING_GPT_FLAG not in user_data
 
 
 @pytest.mark.asyncio
-async def test_photo_handler_unparsed_response(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+async def test_photo_handler_run_retrieve_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class StatusMessage:
+        def __init__(self) -> None:
+            self.delete = AsyncMock()
+
+    class DummyMessage:
+        def __init__(self) -> None:
+            self.photo = (DummyPhoto(),)
+            self.texts: list[str] = []
+            self.status = StatusMessage()
+
+        async def reply_text(self, text: str, **kwargs: Any) -> StatusMessage | None:
+            self.texts.append(text)
+            if text.startswith("🔍"):
+                return self.status
+            return None
+
+    async def fake_get_file(file_id: str) -> Any:
+        class File:
+            async def download_as_bytearray(self) -> bytearray:
+                return bytearray(b"img")
+
+        return File()
+
+    class Run:
+        status = "in_progress"
+        thread_id = "tid"
+        id = "rid"
+
+    async def fake_send_message(**kwargs: Any) -> Run:
+        return Run()
+
+    def timeout_retrieve(*args: Any, **kwargs: Any) -> None:
+        raise asyncio.TimeoutError
+
+    dummy_client = SimpleNamespace(
+        beta=SimpleNamespace(
+            threads=SimpleNamespace(runs=SimpleNamespace(retrieve=timeout_retrieve))
+        )
+    )
+
+    monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
+    monkeypatch.setattr(photo_handlers, "_get_client", lambda: dummy_client)
+    monkeypatch.setattr(photo_handlers.asyncio, "sleep", AsyncMock())
+
+    message = DummyMessage()
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(
+            bot=SimpleNamespace(get_file=fake_get_file), user_data={"thread_id": "tid"}
+        ),
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = await photo_handlers.photo_handler(update, context)
+
+    assert result == photo_handlers.END
+    assert message.texts[-1] == "⚠️ Превышено время ожидания Vision. Попробуйте ещё раз."
+    assert message.status.delete.called
+    user_data = context.user_data
+    assert user_data is not None
+    assert photo_handlers.WAITING_GPT_FLAG not in user_data
+    assert photo_handlers.WAITING_GPT_TIMESTAMP not in user_data
+
+
+@pytest.mark.asyncio
+async def test_photo_handler_unparsed_response(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     class DummyMessage:
         def __init__(self) -> None:
             self.photo = (DummyPhoto(),)
@@ -190,7 +272,11 @@ async def test_photo_handler_unparsed_response(monkeypatch: pytest.MonkeyPatch, 
         ]
 
     class DummyClient:
-        beta = SimpleNamespace(threads=SimpleNamespace(messages=SimpleNamespace(list=lambda thread_id: Messages())))
+        beta = SimpleNamespace(
+            threads=SimpleNamespace(
+                messages=SimpleNamespace(list=lambda thread_id: Messages())
+            )
+        )
 
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
@@ -207,7 +293,9 @@ async def test_photo_handler_unparsed_response(monkeypatch: pytest.MonkeyPatch, 
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(bot=SimpleNamespace(get_file=fake_get_file), user_data={"thread_id": "tid"}),
+        SimpleNamespace(
+            bot=SimpleNamespace(get_file=fake_get_file), user_data={"thread_id": "tid"}
+        ),
     )
 
     monkeypatch.chdir(tmp_path)
@@ -260,7 +348,11 @@ async def test_photo_handler_unparsed_response_clears_pending_entry(
         ]
 
     class DummyClient:
-        beta = SimpleNamespace(threads=SimpleNamespace(messages=SimpleNamespace(list=lambda thread_id: Messages())))
+        beta = SimpleNamespace(
+            threads=SimpleNamespace(
+                messages=SimpleNamespace(list=lambda thread_id: Messages())
+            )
+        )
 
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
@@ -296,7 +388,9 @@ async def test_photo_handler_unparsed_response_clears_pending_entry(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("mime", [None, "text/plain"])
-async def test_doc_handler_rejects_non_image(monkeypatch: pytest.MonkeyPatch, mime: str | None) -> None:
+async def test_doc_handler_rejects_non_image(
+    monkeypatch: pytest.MonkeyPatch, mime: str | None
+) -> None:
     document = SimpleNamespace(
         mime_type=mime,
         file_name="f.txt",
@@ -324,7 +418,9 @@ async def test_doc_handler_rejects_non_image(monkeypatch: pytest.MonkeyPatch, mi
 
 
 @pytest.mark.asyncio
-async def test_photo_handler_long_vision_text(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+async def test_photo_handler_long_vision_text(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     long_text = "x" * (photo_handlers.MessageLimit.MAX_TEXT_LENGTH + 100)
 
     class DummyMessage:
@@ -385,7 +481,11 @@ async def test_photo_handler_long_vision_text(monkeypatch: pytest.MonkeyPatch, t
         ]
 
     class DummyClient:
-        beta = SimpleNamespace(threads=SimpleNamespace(messages=SimpleNamespace(list=lambda thread_id: Messages())))
+        beta = SimpleNamespace(
+            threads=SimpleNamespace(
+                messages=SimpleNamespace(list=lambda thread_id: Messages())
+            )
+        )
 
     monkeypatch.setattr(photo_handlers, "SessionLocal", lambda: DummySession())
     monkeypatch.setattr(photo_handlers, "create_thread", fake_create_thread)
@@ -400,7 +500,9 @@ async def test_photo_handler_long_vision_text(monkeypatch: pytest.MonkeyPatch, t
     monkeypatch.setattr(photo_handlers, "build_main_keyboard", lambda: None)
 
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=bot, user_data={}),
@@ -416,7 +518,9 @@ async def test_photo_handler_long_vision_text(monkeypatch: pytest.MonkeyPatch, t
 
 
 @pytest.mark.asyncio
-async def test_photo_handler_long_vision_text_parse_fail(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+async def test_photo_handler_long_vision_text_parse_fail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     long_text = "y" * (photo_handlers.MessageLimit.MAX_TEXT_LENGTH + 100)
 
     class DummyMessage:
@@ -479,7 +583,11 @@ async def test_photo_handler_long_vision_text_parse_fail(monkeypatch: pytest.Mon
         ]
 
     class DummyClient:
-        beta = SimpleNamespace(threads=SimpleNamespace(messages=SimpleNamespace(list=lambda thread_id: Messages())))
+        beta = SimpleNamespace(
+            threads=SimpleNamespace(
+                messages=SimpleNamespace(list=lambda thread_id: Messages())
+            )
+        )
 
     monkeypatch.setattr(photo_handlers, "SessionLocal", lambda: DummySession())
     monkeypatch.setattr(photo_handlers, "create_thread", fake_create_thread)
@@ -494,7 +602,9 @@ async def test_photo_handler_long_vision_text_parse_fail(monkeypatch: pytest.Mon
     monkeypatch.setattr(photo_handlers, "build_main_keyboard", lambda: None)
 
     message = DummyMessage()
-    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=bot, user_data={}),


### PR DESCRIPTION
## Summary
- add `RUN_RETRIEVE_TIMEOUT` to avoid hanging run retrieval
- notify user and clear waiting flag on Vision retrieval timeout
- test Vision run retrieval timeout cleanup

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68c067ad362c832aa038cca16326b28b