### PR TITLE
[handlers] Refine GPT error handling

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -731,9 +731,6 @@ async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     except asyncio.TimeoutError as exc:
         logger.exception("GPT request timed out: %s", exc)
         reply = "⚠️ Не удалось получить ответ. Попробуйте позже."
-    except Exception:
-        logger.exception("Unexpected GPT error")
-        raise
 
     await message.reply_text(reply)
     summarized = assistant_state.add_turn(


### PR DESCRIPTION
## Summary
- remove broad fallback catch in GPT chat handler
- handle HTTP errors in GPT chat tests

## Testing
- `pytest -q --cov` *(fails: RuntimeError, CommitError, TypeError in unrelated tests)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c067b25fa0832a8565cb46684fa214