### PR TITLE
[handlers] refine onboarding error handling

### DIFF
--- a/tests/test_onboarding_log_event_failure.py
+++ b/tests/test_onboarding_log_event_failure.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+import services.api.app.diabetes.handlers.onboarding_handlers as onboarding
+
+
+@pytest.mark.asyncio
+async def test_log_event_handles_db_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    async def fail_run_db(*args: object, **kwargs: object) -> None:
+        raise SQLAlchemyError("db down")
+
+    monkeypatch.setattr(onboarding, "run_db", fail_run_db)
+
+    with caplog.at_level(logging.ERROR):
+        await onboarding._log_event(1, "evt", 1, None)
+    assert "Failed to log onboarding event" in caplog.text

--- a/tests/test_timezone_button_webapp.py
+++ b/tests/test_timezone_button_webapp.py
@@ -59,7 +59,7 @@ async def test_timezone_webapp_saves_tz_and_moves_to_reminders(
     monkeypatch.setattr(handlers, "SessionLocal", TestSession, raising=False)
 
     async def run_db(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-        sessionmaker = kwargs.get("sessionmaker", TestSession)
+        sessionmaker = kwargs.pop("sessionmaker", TestSession)
         with sessionmaker() as session:
             return fn(session, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
- log onboarding events with specific DB error handling
- warn and fall back to text when onboarding video fails
- add tests for database and Telegram failures

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68c067a4c0b4832aae1a0ec6b74dc6e2