### PR TITLE
[learning] Cap skip index and prevent redundant persistence

### DIFF
--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -721,13 +721,15 @@ async def skip_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         )
         return
     idx = cast(int, user_data.get("learning_plan_index", 0)) + 1
-    if idx >= len(plan):
+    completed = idx >= len(plan)
+    if completed:
         await message.reply_text("План завершён.", reply_markup=build_main_keyboard())
     else:
         await message.reply_text(plan[idx], reply_markup=build_main_keyboard())
+    idx = min(idx, len(plan) - 1)
     user_data["learning_plan_index"] = idx
     user = update.effective_user
-    if user is not None:
+    if user is not None and not completed:
         await _persist(user.id, user_data, context.bot_data)
 
 

--- a/tests/learning/test_plan_handlers.py
+++ b/tests/learning/test_plan_handlers.py
@@ -107,7 +107,31 @@ async def test_plan_and_skip_commands() -> None:
 
     await learning_handlers.skip_command(update, context)
     assert message.replies[-1] == "План завершён."
-    assert user_data["learning_plan_index"] == 2
+    assert user_data["learning_plan_index"] == 1
+
+
+@pytest.mark.asyncio
+async def test_skip_command_does_not_grow_after_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = ["step1", "step2"]
+    user_data = {"learning_plan": plan, "learning_plan_index": 1}
+    message = DummyMessage()
+    update = make_update(message=message)
+    context = make_context(user_data=user_data)
+
+    async def fail_persist(*args: object, **kwargs: object) -> None:
+        raise AssertionError("should not persist")
+
+    monkeypatch.setattr(learning_handlers, "_persist", fail_persist)
+
+    await learning_handlers.skip_command(update, context)
+    assert message.replies[-1] == "План завершён."
+    assert user_data["learning_plan_index"] == 1
+
+    await learning_handlers.skip_command(update, context)
+    assert message.replies[-1] == "План завершён."
+    assert user_data["learning_plan_index"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- cap `/skip` index at end of plan and skip persistence once completed
- cover repeated `/skip` after completion in tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c0613fb314832a8e373b86968364e0