### PR TITLE
[calc_bolus] handle negative max_bolus

### DIFF
--- a/services/api/app/diabetes/utils/calc_bolus.py
+++ b/services/api/app/diabetes/utils/calc_bolus.py
@@ -117,6 +117,8 @@ def calc_bolus(
 
     total_f = float(total)
     if max_bolus is not None:
+        if max_bolus < 0:
+            raise ValueError("max_bolus must be non-negative")
         total_f = min(total_f, max_bolus)
 
     return _round_bolus(total_f, bolus_round_step)

--- a/tests/test_calc_bolus.py
+++ b/tests/test_calc_bolus.py
@@ -82,3 +82,14 @@ def test_calc_bolus_iob_and_dia() -> None:
         dia=8.0,
     )
     assert dose_with_dia == pytest.approx(dose_no_iob - 0.5)
+
+
+def test_calc_bolus_negative_max_bolus() -> None:
+    profile = PatientProfile(icr=10, cf=2, target_bg=6)
+    with pytest.raises(ValueError, match="max_bolus must be non-negative"):
+        calc_bolus(
+            carbs=10,
+            current_bg=7,
+            profile=profile,
+            max_bolus=-1.0,
+        )


### PR DESCRIPTION
## Summary
- raise `ValueError` when `max_bolus` is negative
- add regression test for negative `max_bolus`

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c06f3ad974832aa2b7c2292b51c34f