### PR TITLE
[webapp] secure subscription window

### DIFF
--- a/services/webapp/ui/src/pages/Subscription.tsx
+++ b/services/webapp/ui/src/pages/Subscription.tsx
@@ -138,7 +138,7 @@ const Subscription = () => {
     if (typeof telegramId !== 'number') return;
     try {
       const { url } = await subscribePlan(String(telegramId), planId);
-      window.open(url, '_blank');
+      window.open(url, '_blank', 'noopener,noreferrer');
     } catch (e) {
       toast({ title: 'Ошибка', description: String(e), variant: 'destructive' });
     }


### PR DESCRIPTION
## Summary
- prevent subscription links from accessing `window.opener`
- test subscription link opens with `noopener,noreferrer`

## Testing
- `pnpm --filter ./services/webapp/ui test src/pages/Subscription.test.tsx`
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c0704b1754832a99fef35f77d75147