### PR TITLE
[handlers] Add GPT dialog state

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -37,6 +37,7 @@ from services.api.app.ui.keyboard import build_main_keyboard
 from services.api.app.diabetes.services import gpt_client
 from services.api.app.config import settings
 from services.api.app.assistant.services import memory_service
+from .registration import GPT_MODE_KEY
 
 from .alert_handlers import check_alert as _check_alert
 from .dose_validation import _sanitize
@@ -629,6 +630,10 @@ async def freeform_handler(
     raw_text = text.strip()
     user_id = user.id
     logger.info("FREEFORM raw='%s'  user=%s", _sanitize(raw_text), user_id)
+
+    if user_data.get(GPT_MODE_KEY):
+        await chat_with_gpt(update, context)
+        return
 
     if await _handle_report_request(
         raw_text,

--- a/tests/test_gpt_mode.py
+++ b/tests/test_gpt_mode.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.diabetes.handlers import gpt_handlers
+from services.api.app.diabetes.handlers import registration
+
+
+class DummyMessage:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **_: Any) -> None:
+        self.replies.append(text)
+
+
+def make_update(message: DummyMessage) -> Update:
+    return cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+
+
+def make_context(
+    user_data: dict[str, Any] | None = None,
+) -> CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]:
+    return cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(
+            user_data=user_data if user_data is not None else {}, job_queue=None
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_gpt_sets_flag() -> None:
+    message = DummyMessage("/gpt")
+    update = make_update(message)
+    context = make_context({})
+    await registration.start_gpt_dialog(update, context)
+    assert context.user_data.get(registration.GPT_MODE_KEY) is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_clears_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    message = DummyMessage("/cancel")
+    update = make_update(message)
+    user_data = {registration.GPT_MODE_KEY: True}
+    fake_cancel = AsyncMock()
+    monkeypatch.setattr(
+        "services.api.app.diabetes.handlers.dose_calc.dose_cancel", fake_cancel
+    )
+    context = make_context(user_data)
+    await registration.cancel(update, context)
+    assert registration.GPT_MODE_KEY not in user_data
+    fake_cancel.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_freeform_routes_to_gpt(monkeypatch: pytest.MonkeyPatch) -> None:
+    message = DummyMessage("hello")
+    update = make_update(message)
+    context = make_context({registration.GPT_MODE_KEY: True})
+    chat_called = AsyncMock()
+    monkeypatch.setattr(gpt_handlers, "chat_with_gpt", chat_called)
+
+    def fail_parse(*args: object, **kwargs: object) -> None:
+        raise AssertionError("parse_quick_values should not be called")
+
+    monkeypatch.setattr(gpt_handlers, "parse_quick_values", fail_parse)
+    await gpt_handlers.freeform_handler(update, context)
+    chat_called.assert_awaited_once()

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -24,6 +24,8 @@ from services.api.app.diabetes.handlers.registration import (
     register_handlers,
     register_profile_handlers,
     register_reminder_handlers,
+    start_gpt_dialog,
+    cancel,
 )
 from services.api.app.diabetes.handlers.router import callback_router
 from services.api.app.diabetes.handlers import (
@@ -63,7 +65,7 @@ def test_register_handlers_attaches_expected_handlers(
     assert photo_handlers.photo_handler in callbacks
     assert photo_handlers.doc_handler in callbacks
     assert photo_handlers.prompt_photo in callbacks
-    assert dose_calc.dose_cancel in callbacks
+    assert cancel in callbacks
     assert sugar_handlers.prompt_sugar not in callbacks
     assert callback_router in callbacks
     assert reporting_handlers.report_period_callback in callbacks
@@ -77,7 +79,7 @@ def test_register_handlers_attaches_expected_handlers(
         and "history" in h.commands
         for h in handlers
     )
-    assert gpt_handlers.chat_with_gpt in callbacks
+    assert start_gpt_dialog in callbacks
     assert security_handlers.hypo_alert_faq in callbacks
     assert billing_handlers.trial_command in callbacks
     assert billing_handlers.upgrade_command in callbacks
@@ -252,9 +254,7 @@ def test_register_handlers_attaches_expected_handlers(
     assert not sugar_cmd
 
     cancel_cmd = [
-        h
-        for h in handlers
-        if isinstance(h, CommandHandler) and h.callback is dose_calc.dose_cancel
+        h for h in handlers if isinstance(h, CommandHandler) and h.callback is cancel
     ]
     assert cancel_cmd and "cancel" in cancel_cmd[0].commands
 
@@ -284,7 +284,7 @@ def test_register_handlers_attaches_expected_handlers(
     gpt_cmd = [
         h
         for h in handlers
-        if isinstance(h, CommandHandler) and h.callback is gpt_handlers.chat_with_gpt
+        if isinstance(h, CommandHandler) and h.callback is start_gpt_dialog
     ]
     assert gpt_cmd and "gpt" in gpt_cmd[0].commands
 


### PR DESCRIPTION
## Summary
- add GPT dialog mode flag stored in user data
- reroute free-form text to GPT when dialog is active
- cover GPT dialog flow with tests

## Testing
- `pytest tests/test_gpt_mode.py -q`
- `ruff check .`
- `mypy --strict .` *(fails: interrupted)*
- `pytest -q --cov` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f604ba08832aa2e0a52de31557a5