### PR TITLE
[handlers] Refine trial date parsing errors

### DIFF
--- a/services/api/app/diabetes/handlers/billing_handlers.py
+++ b/services/api/app/diabetes/handlers/billing_handlers.py
@@ -97,12 +97,12 @@ async def trial_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             raise TypeError("endDate must be str")
         end_dt = datetime.fromisoformat(end_raw)
     except (KeyError, TypeError, ValueError):
+        logger.exception("invalid trial end date")
         await message.reply_text("❌ Ошибка сервера: неверный формат даты trial.")
         return
     except Exception:  # pragma: no cover - unexpected
         logger.exception("unexpected error parsing trial end date")
-        await message.reply_text("❌ Ошибка сервера.")
-        return
+        raise
     end_str = end_dt.strftime("%d.%m.%Y")
     await message.reply_text(f"🎉 Активирован trial до {end_str}")
     kb = subscription_keyboard(False)


### PR DESCRIPTION
## Summary
- tighten trial end date parsing: log invalid data and re-raise unexpected errors

## Testing
- `pytest -q --cov tests` *(fails: KeyboardInterrupt)*
- `mypy --strict .` *(fails: interrupted)*
- `ruff check services/api/app tests`


------
https://chatgpt.com/codex/tasks/task_e_68c0f79466c4832abd33c137926f15e9