### PR TITLE
[reminders] support family plan reminder limit

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -90,6 +90,7 @@ class DbActionResult:
 PLAN_LIMITS = {
     SubscriptionPlan.FREE: 5,
     SubscriptionPlan.PRO: 10,
+    SubscriptionPlan.FAMILY: 20,
 }
 
 

--- a/tests/test_reminder_limit_by_plan.py
+++ b/tests/test_reminder_limit_by_plan.py
@@ -30,9 +30,15 @@ class DummyMessage:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "plan, limit",
-    [(SubscriptionPlan.FREE, 5), (SubscriptionPlan.PRO, 10)],
+    [
+        (SubscriptionPlan.FREE, 5),
+        (SubscriptionPlan.PRO, 10),
+        (SubscriptionPlan.FAMILY, 20),
+    ],
 )
-async def test_reminder_limit_free_vs_pro(plan: SubscriptionPlan, limit: int, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_reminder_limit_by_plan(
+    plan: SubscriptionPlan, limit: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)


### PR DESCRIPTION
## Summary
- add reminder limit for FAMILY subscription plan
- test reminder limits across subscription plans

## Testing
- `pytest -q --cov` *(fails: async def functions are not natively supported)*
- `pytest tests/test_reminder_limit_by_plan.py -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c0f784a3a8832abc2c8e010fb18b75