### PR TITLE
[reporting] Make history entry datetimes timezone-aware

### DIFF
--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -69,7 +69,9 @@ class EntryLike(Protocol):
 def render_entry(entry: EntryLike) -> str:
     """Render a single diary entry as HTML-formatted text."""
     day_str = html.escape(entry.event_time.strftime("%d.%m %H:%M"))
-    sugar = html.escape(str(entry.sugar_before)) if entry.sugar_before is not None else "—"
+    sugar = (
+        html.escape(str(entry.sugar_before)) if entry.sugar_before is not None else "—"
+    )
     dose = html.escape(str(entry.dose)) if entry.dose is not None else "—"
 
     if entry.carbs_g is not None:
@@ -116,8 +118,9 @@ class HistoryEntry(EntryLike):
 
 def _history_record_to_entry(record: HistoryRecord) -> HistoryEntry:
     """Convert ``HistoryRecord`` to ``HistoryEntry`` for rendering."""
-
-    event_dt = datetime.datetime.combine(record.date, record.time)
+    event_dt = datetime.datetime.combine(
+        record.date, record.time, tzinfo=datetime.timezone.utc
+    )
     return HistoryEntry(
         id=record.id,
         event_time=event_dt,
@@ -192,12 +195,16 @@ async def history_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 [
                     InlineKeyboardButton(
                         "🌐 Открыть историю в WebApp",
-                        web_app=WebAppInfo(config.build_ui_url(f"/history?limit={limit}")),
+                        web_app=WebAppInfo(
+                            config.build_ui_url(f"/history?limit={limit}")
+                        ),
                     )
                 ]
             ]
         )
-        await message.reply_text("История также доступна в WebApp:", reply_markup=open_markup)
+        await message.reply_text(
+            "История также доступна в WebApp:", reply_markup=open_markup
+        )
 
     entries = [_history_record_to_entry(r) for r in records]
     for entry in entries:
@@ -205,18 +212,24 @@ async def history_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         markup = InlineKeyboardMarkup(
             [
                 [
-                    InlineKeyboardButton("✏️ Изменить", callback_data=f"edit:{entry.id}"),
+                    InlineKeyboardButton(
+                        "✏️ Изменить", callback_data=f"edit:{entry.id}"
+                    ),
                     InlineKeyboardButton("🗑 Удалить", callback_data=f"del:{entry.id}"),
                 ]
             ]
         )
         await message.reply_text(text, parse_mode="HTML", reply_markup=markup)
 
-    back_markup = InlineKeyboardMarkup([[InlineKeyboardButton("🔙 Назад", callback_data="report_back")]])
+    back_markup = InlineKeyboardMarkup(
+        [[InlineKeyboardButton("🔙 Назад", callback_data="report_back")]]
+    )
     await message.reply_text("Готово.", reply_markup=back_markup)
 
 
-async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+async def report_period_callback(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
     """Handle report period selection via inline buttons."""
     query = update.callback_query
     if query is None or query.data is None or query.message is None:
@@ -239,10 +252,14 @@ async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_T
         date_from = now.replace(hour=0, minute=0, second=0, microsecond=0)
         await send_report(update, context, date_from, "сегодня", query=query)
     elif period == "week":
-        date_from = (now - datetime.timedelta(days=7)).replace(hour=0, minute=0, second=0, microsecond=0)
+        date_from = (now - datetime.timedelta(days=7)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
         await send_report(update, context, date_from, "последнюю неделю", query=query)
     elif period == "month":
-        date_from = (now - datetime.timedelta(days=30)).replace(hour=0, minute=0, second=0, microsecond=0)
+        date_from = (now - datetime.timedelta(days=30)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
         await send_report(update, context, date_from, "последний месяц", query=query)
     elif period == "custom":
         user_data_raw = context.user_data
@@ -253,7 +270,9 @@ async def report_period_callback(update: Update, context: ContextTypes.DEFAULT_T
             raise RuntimeError("context.user_data could not be initialized")
         user_data = cast(UserData, user_data_raw)
         user_data["awaiting_report_date"] = True
-        await query.edit_message_text("Введите дату начала отчёта в формате YYYY-MM-DD\nОтправьте «назад» для отмены.")
+        await query.edit_message_text(
+            "Введите дату начала отчёта в формате YYYY-MM-DD\nОтправьте «назад» для отмены."
+        )
         await message.reply_text(
             "Ожидаю дату…",
             reply_markup=ReplyKeyboardMarkup(
@@ -402,7 +421,9 @@ async def send_report(
     report_msg = "<b>Отчёт сформирован</b>\n\n" + "\n".join(summary_lines + day_lines)
 
     plot_buf = make_sugar_plot(entries, period_label)
-    pdf_buf = generate_pdf_report(summary_lines, errors, day_lines, gpt_text or default_gpt_text, plot_buf)
+    pdf_buf = generate_pdf_report(
+        summary_lines, errors, day_lines, gpt_text or default_gpt_text, plot_buf
+    )
     plot_buf.seek(0)
     pdf_buf.seek(0)
     if query is not None:

--- a/tests/test_history_record_to_entry_timezone.py
+++ b/tests/test_history_record_to_entry_timezone.py
@@ -1,0 +1,22 @@
+import datetime
+
+from services.api.app.diabetes.handlers.reporting_handlers import (
+    _history_record_to_entry,
+)
+from services.api.app.diabetes.services.db import HistoryRecord
+
+
+def test_history_record_to_entry_sets_utc_timezone() -> None:
+    record = HistoryRecord(
+        id="1",
+        telegram_id=1,
+        date=datetime.date(2024, 1, 1),
+        time=datetime.time(12, 30),
+        type="meal",
+    )
+
+    entry = _history_record_to_entry(record)
+
+    assert entry.event_time == datetime.datetime(
+        2024, 1, 1, 12, 30, tzinfo=datetime.timezone.utc
+    )


### PR DESCRIPTION
## Summary
- ensure HistoryRecord conversions use timezone-aware datetimes
- add regression test for `_history_record_to_entry` timezone handling

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68c0f79ea0a8832aa711d2ba81b9ce21