### PR TITLE
[ui] always patch profile and notify when no changes

### DIFF
--- a/services/webapp/ui/src/locales/ru/profile.ts
+++ b/services/webapp/ui/src/locales/ru/profile.ts
@@ -2,6 +2,7 @@ const profile = {
   title: 'Мой профиль',
   save: 'Сохранить настройки',
   saved: 'Профиль сохранен',
+  noChanges: 'Изменений не было',
   settingsUpdated: 'Ваши настройки успешно обновлены',
   updated: 'Профиль обновлен',
   timezoneUpdated: 'Часовой пояс обновлен',

--- a/services/webapp/ui/src/pages/Profile.tsx
+++ b/services/webapp/ui/src/pages/Profile.tsx
@@ -480,18 +480,18 @@ const Profile = ({ therapyType: therapyTypeProp }: ProfileProps) => {
       }
 
       await saveProfile(payload);
-      if (Object.keys(data.patch).length > 0) {
-        await patchProfileMutation.mutateAsync(data.patch);
-      }
+      await patchProfileMutation.mutateAsync(data.patch);
       queryClient.invalidateQueries({ queryKey: ["profile"] });
       setOriginal(profile);
       if (data.therapyType) {
         setOriginalTherapyType(therapyTypeValue);
       }
-      toast({
-        title: t('profile.saved'),
-        description: t('profile.settingsUpdated'),
-      });
+      const noChanges = Object.keys(data.patch).length === 0;
+      toast(
+        noChanges
+          ? { title: t('profile.noChanges') }
+          : { title: t('profile.saved'), description: t('profile.settingsUpdated') },
+      );
       postOnboardingEvent('profile_saved', onboardingStep, {
         timezone_set: Boolean(profile.timezone),
       }).catch(() => undefined);


### PR DESCRIPTION
## Summary
- always call profile patch mutation
- inform the user when profile data has no changes

## Testing
- `pnpm --filter ./services/webapp/ui lint`
- `pnpm --filter ./services/webapp/ui test`
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c0f94f3be0832aba225d8c9ba67c6b