### PR TITLE
[tests] Ensure DummyMessage handles video replies

### DIFF
--- a/tests/assistant/test_e2e_learning_onboarding.py
+++ b/tests/assistant/test_e2e_learning_onboarding.py
@@ -29,6 +29,9 @@ class DummyMessage:
     async def reply_text(self, text: str, **_kwargs: Any) -> None:
         self.sent.append(text)
 
+    async def reply_video(self, video: Any, **_kwargs: Any) -> None:
+        self.sent.append(video)
+
 
 @pytest.fixture()
 def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:

--- a/tests/diabetes/test_learning_onboarding.py
+++ b/tests/diabetes/test_learning_onboarding.py
@@ -38,6 +38,9 @@ class DummyMessage:
         self.replies.append(text)
         self.markups.append(kwargs.get("reply_markup"))
 
+    async def reply_video(self, video: Any, **kwargs: Any) -> None:
+        self.replies.append(video)
+
 
 class DummyCallbackQuery:
     def __init__(self, data: str, message: DummyMessage) -> None:

--- a/tests/diabetes/test_onboarding_flow.py
+++ b/tests/diabetes/test_onboarding_flow.py
@@ -107,6 +107,9 @@ class DummyMessage:
     async def reply_text(self, text: str, **_: Any) -> None:  # noqa: ANN401
         self.replies.append(text)
 
+    async def reply_video(self, video: Any, **_: Any) -> None:  # noqa: ANN401
+        self.replies.append(video)
+
     def get_bot(self) -> Any:
         return SimpleNamespace(set_my_commands=AsyncMock())
 

--- a/tests/diabetes/test_onboarding_reminders.py
+++ b/tests/diabetes/test_onboarding_reminders.py
@@ -27,6 +27,10 @@ class DummyMessage:
         self.replies.append(text)
         self.kwargs.append(kwargs)
 
+    async def reply_video(self, video: Any, **kwargs: Any) -> None:
+        self.replies.append(video)
+        self.kwargs.append(kwargs)
+
     def get_bot(self) -> Any:
         return SimpleNamespace(set_my_commands=AsyncMock())
 

--- a/tests/handlers/test_wizard_navigation.py
+++ b/tests/handlers/test_wizard_navigation.py
@@ -20,6 +20,7 @@ class DummyMessage:
     def __init__(self, text: str | None = None) -> None:
         self.text = text
         self.texts: list[str] = []
+        self.videos: list[Any] = []
         self.polls: list[tuple[str, list[str]]] = []
         self.reply_markups: list[Any] = []
         self.deleted = False
@@ -28,6 +29,9 @@ class DummyMessage:
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.texts.append(text)
         self.reply_markups.append(kwargs.get("reply_markup"))
+
+    async def reply_video(self, video: Any, **kwargs: Any) -> None:
+        self.videos.append(video)
 
     async def reply_poll(self, question: str, options: list[str], **kwargs: Any) -> Any:
         self.polls.append((question, options))

--- a/tests/test_onboarding_conversation.py
+++ b/tests/test_onboarding_conversation.py
@@ -111,6 +111,10 @@ class DummyMessage:
         self.replies.append(text)
         self.kwargs.append(kwargs)
 
+    async def reply_video(self, video: Any, **kwargs: Any) -> None:
+        self.replies.append(video)
+        self.kwargs.append(kwargs)
+
     def get_bot(self) -> Any:
         return SimpleNamespace(set_my_commands=AsyncMock())
 

--- a/tests/test_onboarding_event_logging.py
+++ b/tests/test_onboarding_event_logging.py
@@ -21,6 +21,9 @@ class DummyMessage:
     async def reply_text(self, text: str, **_: Any) -> None:
         self.replies.append(text)
 
+    async def reply_video(self, video: Any, **_: Any) -> None:  # noqa: ANN401
+        self.replies.append(video)
+
 
 class DummyQuery:
     def __init__(self, message: DummyMessage, data: str) -> None:

--- a/tests/test_onboarding_timezone_webapp.py
+++ b/tests/test_onboarding_timezone_webapp.py
@@ -23,6 +23,9 @@ class DummyMessage:
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
 
+    async def reply_video(self, video: Any, **kwargs: Any) -> None:
+        self.replies.append(video)
+
 
 @pytest.fixture()
 def session_local(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[SASession]:

--- a/tests/test_reset_onboarding.py
+++ b/tests/test_reset_onboarding.py
@@ -23,6 +23,9 @@ class DummyMessage:
     async def reply_text(self, text: str) -> None:
         self.replies.append(text)
 
+    async def reply_video(self, video: Any, **_: Any) -> None:  # noqa: ANN401
+        self.replies.append(video)
+
 
 @pytest.fixture()
 def session_local(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[SASession]:

--- a/tests/test_reset_onboarding_command_error.py
+++ b/tests/test_reset_onboarding_command_error.py
@@ -23,6 +23,9 @@ class DummyMessage:
     ) -> None:  # pragma: no cover - fails intentionally
         raise telegram.error.TelegramError("fail")
 
+    async def reply_video(self, video: Any, **_: Any) -> None:  # noqa: ANN401
+        raise telegram.error.TelegramError("fail")
+
 
 class DummyBot:
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- handle video replies in onboarding DummyMessage test helpers
- extend wizard navigation test helpers with video support

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .` *(fails: Job[Any] | None has no attribute data)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c0fb41fa80832aaa5751efb9e1cad0