### PR TITLE
[handlers] Handle missing reply_video in onboarding start

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -177,7 +177,11 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     video_url = config.ONBOARDING_VIDEO_URL
     if video_url:
         try:
-            await message.reply_video(video_url)
+            reply_video = getattr(message, "reply_video", None)
+            if callable(reply_video):
+                await reply_video(video_url)
+            else:  # pragma: no cover - simple fallback
+                await message.reply_text(video_url)
         except telegram.error.TelegramError as exc:  # pragma: no cover - fallback
             logger.warning("Failed to send onboarding video: %s", exc)
             await message.reply_text(video_url)


### PR DESCRIPTION
## Summary
- avoid AttributeError if message has no reply_video in onboarding start

## Testing
- `pytest tests/diabetes/test_onboarding_flow.py::test_skip_flow_finishes tests/diabetes/test_onboarding_flow.py::test_back_and_cancel tests/diabetes/test_onboarding_flow.py::test_variant_b_starts_from_timezone tests/handlers/test_wizard_navigation.py::test_start_triggers_onboarding tests/handlers/test_wizard_navigation.py::test_variant_b_starts_with_timezone tests/test_onboarding_conversation.py::test_happy_path tests/test_onboarding_conversation.py::test_navigation_buttons tests/test_onboarding_conversation.py::test_resume_from_saved_step tests/test_onboarding_event_logging.py::test_profile_step_logs_event tests/test_onboarding_event_logging.py::test_cancel_logs_event -q`
- `mypy --strict --follow-imports=skip services/api/app/diabetes/handlers/onboarding_handlers.py` *(fails: Returning Any from function declared to return "int")*
- `ruff check services/api/app/diabetes/handlers/onboarding_handlers.py tests/diabetes/test_onboarding_flow.py tests/handlers/test_wizard_navigation.py tests/test_onboarding_conversation.py tests/test_onboarding_event_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0fde0ba2c832aa52539a4d1fd4fef