### PR TITLE
[diabetes] centralize GPT prompts

### DIFF
--- a/services/api/app/diabetes/curriculum_engine.py
+++ b/services/api/app/diabetes/curriculum_engine.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 
 from ..config import settings
 from .dynamic_tutor import BUSY_MESSAGE, check_user_answer, generate_step_text
-from .learning_prompts import (
+from .prompts import (
     SYSTEM_TUTOR_RU,
     build_explain_step,
     build_feedback,

--- a/services/api/app/diabetes/dynamic_tutor.py
+++ b/services/api/app/diabetes/dynamic_tutor.py
@@ -7,7 +7,7 @@ import httpx
 from openai import OpenAIError
 from openai.types.chat import ChatCompletionMessageParam
 
-from .learning_prompts import build_system_prompt, build_user_prompt_step
+from .prompts import build_system_prompt, build_user_prompt_step
 from .llm_router import LLMTask
 from .services.gpt_client import create_learning_chat_completion
 

--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -23,6 +23,7 @@ from services.api.app.diabetes.services.gpt_client import (
 from services.api.app.diabetes.services.repository import CommitError, commit
 from services.api.app.diabetes.utils.functions import extract_nutrition_info
 from services.api.app.ui.keyboard import build_main_keyboard
+from ..prompts import PHOTO_ANALYSIS_PROMPT
 
 from . import EntryData, UserData
 
@@ -134,19 +135,7 @@ async def photo_handler(
         try:
             run = await send_message(
                 thread_id=thread_id,
-                content=(
-                    "Определи название блюда, вес порции и его пищевую "
-                    "ценность (белки, жиры, углеводы, калории, хлебные "
-                    "единицы). Учитывай изображение и текстовое описание, "
-                    "если они есть. Ответ на русском языке в формате:\n"
-                    "<название блюда>\n"
-                    "Вес: <...> г\n"
-                    "Белки: <...> г\n"
-                    "Жиры: <...> г\n"
-                    "Углеводы: <...> г\n"
-                    "Калории: <...> ккал\n"
-                    "ХЕ: <...>"
-                ),
+                content=PHOTO_ANALYSIS_PROMPT,
                 image_bytes=file_bytes,
             )
         except asyncio.TimeoutError:

--- a/services/api/app/diabetes/handlers/reporting_handlers.py
+++ b/services/api/app/diabetes/handlers/reporting_handlers.py
@@ -38,6 +38,7 @@ from services.api.app.diabetes.services.gpt_client import (
     create_thread,
 )
 from services.api.app.diabetes.services.repository import CommitError, commit
+from ..prompts import REPORT_ANALYSIS_PROMPT_TEMPLATE
 from services.api.app.diabetes.services.reporting import (
     make_sugar_plot,
     generate_pdf_report,
@@ -334,11 +335,11 @@ async def send_report(
     errors_text = "\n".join(errors) if errors else "нет"
     days_text = "\n".join(day_lines)
 
-    prompt = (
-        "Проанализируй дневник диабета пользователя и предложи краткие рекомендации."
-        "\n\nСводка:\n{summary}\n\nОшибки и критические значения:\n{errors}"
-        "\n\nДанные по дням:\n{days}\n"
-    ).format(summary=summary_text, errors=errors_text, days=days_text)
+    prompt = REPORT_ANALYSIS_PROMPT_TEMPLATE.format(
+        summary=summary_text,
+        errors=errors_text,
+        days=days_text,
+    )
 
     default_gpt_text = "Не удалось получить рекомендации."
     gpt_text: str | None = default_gpt_text

--- a/services/api/app/diabetes/learning_fixtures.py
+++ b/services/api/app/diabetes/learning_fixtures.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, TypeAdapter
 from sqlalchemy.orm import Session
 
 from .models_learning import Lesson, LessonProgress, LessonStep, QuizQuestion
+from .prompts import LESSONS_V0_PATH
 from .services.db import SessionLocal, SessionMaker, init_db, run_db
 from .services.repository import CommitError, commit
 
@@ -49,9 +50,7 @@ class LessonModel(BaseModel):
 LESSON_LIST = TypeAdapter(list[LessonModel])
 
 
-DEFAULT_CONTENT_FILE = (
-    Path(__file__).resolve().parents[4] / "content" / "lessons_v0.json"
-)
+DEFAULT_CONTENT_FILE = LESSONS_V0_PATH
 
 
 async def load_lessons(

--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -24,7 +24,7 @@ from .learning_utils import choose_initial_topic
 # Including it in ``__all__`` below marks the import as used for the linter.
 from . import curriculum_engine as curriculum_engine
 from .curriculum_engine import LessonNotFoundError, ProgressNotFoundError
-from .learning_prompts import build_system_prompt, disclaimer
+from .prompts import build_system_prompt, disclaimer
 from .llm_router import LLMTask
 from .services.gpt_client import (
     create_learning_chat_completion,

--- a/services/api/app/diabetes/prompts/__init__.py
+++ b/services/api/app/diabetes/prompts/__init__.py
@@ -1,10 +1,11 @@
-"""Prompt templates for diabetes learning module."""
+"""Central storage for GPT prompt templates and instructions."""
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
+from pathlib import Path
 from textwrap import dedent
-
 
 MAX_PROMPT_LEN = 1_500
 
@@ -17,6 +18,7 @@ def _trim(text: str, limit: int = MAX_PROMPT_LEN) -> str:
 
 def disclaimer() -> str:
     """Return the standard medical warning."""
+
     return "Проконсультируйтесь с врачом."
 
 
@@ -31,12 +33,14 @@ SYSTEM_TUTOR_RU = (
 
 def build_explain_step(step: str) -> str:
     """Build a prompt asking and explaining a learning step."""
+
     prompt = f"Что ты знаешь о {step}? Объясни.".strip()
     return prompt
 
 
 def build_quiz_check(question: str, options: list[str]) -> str:
     """Build a prompt that checks knowledge with multiple options."""
+
     opts = "; ".join(options)
     prompt = f"{question}? Варианты: {opts}. Выбери один.".strip()
     return prompt
@@ -44,6 +48,7 @@ def build_quiz_check(question: str, options: list[str]) -> str:
 
 def build_feedback(correct: bool, explanation: str) -> str:
     """Build feedback for quiz answers."""
+
     prefix = "Верно." if correct else "Неверно."
     prompt = f"{prefix} {explanation}".strip()
     return prompt
@@ -93,3 +98,45 @@ def build_user_prompt_step(topic_slug: str, step_idx: int, prev_summary: str | N
         "Сначала объясни, затем задай один вопрос. Ответ не показывай."
     )
     return _trim(prompt)
+
+
+PHOTO_ANALYSIS_PROMPT = (
+    "Определи название блюда, вес порции и его пищевую "
+    "ценность (белки, жиры, углеводы, калории, хлебные "
+    "единицы). Учитывай изображение и текстовое описание, "
+    "если они есть. Ответ на русском языке в формате:\n"
+    "<название блюда>\n"
+    "Вес: <...> г\n"
+    "Белки: <...> г\n"
+    "Жиры: <...> г\n"
+    "Углеводы: <...> г\n"
+    "Калории: <...> ккал\n"
+    "ХЕ: <...>"
+)
+
+REPORT_ANALYSIS_PROMPT_TEMPLATE = (
+    "Проанализируй дневник диабета пользователя и предложи краткие рекомендации."
+    "\n\nСводка:\n{summary}\n\nОшибки и критические значения:\n{errors}"
+    "\n\nДанные по дням:\n{days}\n"
+)
+
+LESSONS_V0_PATH = Path(__file__).resolve().parents[5] / "content" / "lessons_v0.json"
+
+with LESSONS_V0_PATH.open(encoding="utf-8") as fp:
+    LESSONS_V0_DATA = json.load(fp)
+
+__all__ = [
+    "MAX_PROMPT_LEN",
+    "disclaimer",
+    "SYSTEM_TUTOR_RU",
+    "build_explain_step",
+    "build_quiz_check",
+    "build_feedback",
+    "build_system_prompt",
+    "build_user_prompt_step",
+    "PHOTO_ANALYSIS_PROMPT",
+    "REPORT_ANALYSIS_PROMPT_TEMPLATE",
+    "LESSONS_V0_PATH",
+    "LESSONS_V0_DATA",
+]
+

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -9,7 +9,7 @@ from telegram.ext import CallbackContext
 
 from services.api.app.config import settings
 from services.api.app.diabetes import dynamic_tutor, learning_handlers
-from services.api.app.diabetes.learning_prompts import disclaimer
+from services.api.app.diabetes.prompts import disclaimer
 from services.api.app.diabetes.learning_state import LearnState, get_state, set_state
 from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
 from services.api.app.diabetes.planner import generate_learning_plan, pretty_plan

--- a/tests/learning/test_curriculum.py
+++ b/tests/learning/test_curriculum.py
@@ -10,7 +10,7 @@ from services.api.app.diabetes.curriculum_engine import (
     start_lesson,
 )
 from services.api.app.diabetes.learning_fixtures import load_lessons
-from services.api.app.diabetes.learning_prompts import disclaimer
+from services.api.app.diabetes.prompts import LESSONS_V0_PATH, disclaimer
 from services.api.app.diabetes.models_learning import Lesson, LessonProgress, QuizQuestion
 from services.api.app.diabetes.services import db, gpt_client
 from services.api.app.config import settings
@@ -29,7 +29,7 @@ async def test_happy_path_one_lesson(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "static")
 
     await load_lessons(
-        "content/lessons_v0.json",
+        LESSONS_V0_PATH,
         sessionmaker=db.SessionLocal,
     )
 

--- a/tests/learning/test_curriculum_engine.py
+++ b/tests/learning/test_curriculum_engine.py
@@ -18,7 +18,7 @@ from services.api.app.diabetes.curriculum_engine import (
 )
 from services.api.app.diabetes.dynamic_tutor import BUSY_MESSAGE
 from services.api.app.diabetes.learning_fixtures import load_lessons
-from services.api.app.diabetes.learning_prompts import disclaimer
+from services.api.app.diabetes.prompts import LESSONS_V0_PATH, disclaimer
 from services.api.app.diabetes.models_learning import (
     Lesson,
     LessonProgress,
@@ -47,7 +47,7 @@ async def test_curriculum_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "static")
 
     await load_lessons(
-        "content/lessons_v0.json",
+        LESSONS_V0_PATH,
         sessionmaker=db.SessionLocal,
     )
 

--- a/tests/learning/test_lesson_metrics.py
+++ b/tests/learning/test_lesson_metrics.py
@@ -12,6 +12,7 @@ from services.api.app.diabetes.curriculum_engine import (
 )
 from services.api.app.config import settings
 from services.api.app.diabetes.learning_fixtures import load_lessons
+from services.api.app.diabetes.prompts import LESSONS_V0_PATH
 from services.api.app.diabetes.models_learning import (
     Lesson,
     LessonProgress,
@@ -33,7 +34,7 @@ async def test_lesson_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "static")
 
     await load_lessons(
-        "content/lessons_v0.json",
+        LESSONS_V0_PATH,
         sessionmaker=db.SessionLocal,
     )
 

--- a/tests/learning/test_load_lessons.py
+++ b/tests/learning/test_load_lessons.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import patch
 
 import logging
@@ -10,6 +9,7 @@ from sqlalchemy.pool import StaticPool
 
 from services.api.app.diabetes import learning_fixtures
 from services.api.app.diabetes.models_learning import Lesson, QuizQuestion
+from services.api.app.diabetes.prompts import LESSONS_V0_PATH
 from services.api.app.diabetes.services import db
 
 
@@ -23,7 +23,7 @@ async def test_load_lessons_v0() -> None:
     db.SessionLocal.configure(bind=engine)
     db.Base.metadata.create_all(bind=engine)
     try:
-        path = Path(__file__).resolve().parents[2] / "content/lessons_v0.json"
+        path = LESSONS_V0_PATH
         await learning_fixtures.load_lessons(path, sessionmaker=db.SessionLocal)
         with db.SessionLocal() as session:
             lessons = session.query(Lesson).all()
@@ -56,7 +56,7 @@ async def test_main_loads_lessons(
         db.SessionLocal.configure(bind=engine)
         db.Base.metadata.create_all(bind=engine)
 
-    path = Path(__file__).resolve().parents[2] / "content/lessons_v0.json"
+    path = LESSONS_V0_PATH
     with patch(
         "services.api.app.diabetes.learning_fixtures.init_db", side_effect=fake_init_db
     ) as init_db_mock, caplog.at_level(logging.INFO):

--- a/tests/learning/test_prompts.py
+++ b/tests/learning/test_prompts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from services.api.app.diabetes.learning_prompts import (
+from services.api.app.diabetes.prompts import (
     build_system_prompt,
     build_user_prompt_step,
 )

--- a/tests/test_learning_prompts.py
+++ b/tests/test_learning_prompts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from services.api.app.diabetes.learning_prompts import (
+from services.api.app.diabetes.prompts import (
     SYSTEM_TUTOR_RU,
     build_explain_step,
     build_feedback,


### PR DESCRIPTION
## Summary
- centralize GPT templates and system instructions in `prompts` module
- reuse new prompt constants in photo and reporting handlers
- expose lessons fixture path through prompts and update tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c10ad21c78832a8c6840164d02a228