### PR TITLE
[api] Add Authorization header to rest client

### DIFF
--- a/services/api/app/profiles.py
+++ b/services/api/app/profiles.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import cast
 
+import httpx
 from telegram.ext import ContextTypes
 
 from ..rest_client import get_json
@@ -10,8 +11,22 @@ from ..rest_client import get_json
 async def get_profile_for_user(
     _: int, ctx: ContextTypes.DEFAULT_TYPE
 ) -> dict[str, object]:
-    base = await get_json("/profile/self")
-    db_profile = await get_json("/learning-profile")
+    try:
+        base = await get_json("/profile/self", ctx)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            base = {}
+        else:  # pragma: no cover - re-raise unexpected errors
+            raise
+
+    try:
+        db_profile = await get_json("/learning-profile", ctx)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            db_profile = {}
+        else:  # pragma: no cover - re-raise unexpected errors
+            raise
+
     user_data = ctx.user_data or {}
     overrides = cast(
         dict[str, object], user_data.get("learn_profile_overrides", {})

--- a/services/api/rest_client.py
+++ b/services/api/rest_client.py
@@ -3,16 +3,31 @@ from __future__ import annotations
 from typing import cast
 
 import httpx
+from telegram.ext import ContextTypes
 
 from .app.config import get_settings
 
 
-async def get_json(path: str) -> dict[str, object]:
-    base = get_settings().api_url
+async def get_json(
+    path: str, ctx: ContextTypes.DEFAULT_TYPE | None = None
+) -> dict[str, object]:
+    base_settings = get_settings()
+    base = base_settings.api_url
     if not base:
         raise RuntimeError("API_URL not configured")
     url = f"{base.rstrip('/')}{path}"
+
+    headers: dict[str, str] = {}
+    if base_settings.internal_api_key:
+        headers["Authorization"] = f"Bearer {base_settings.internal_api_key}"
+    elif ctx is not None:
+        user_data = getattr(ctx, "user_data", None)
+        if isinstance(user_data, dict):
+            init_data = user_data.get("tg_init_data")
+            if isinstance(init_data, str):
+                headers["Authorization"] = f"tg {init_data}"
+
     async with httpx.AsyncClient() as client:
-        resp = await client.get(url)
+        resp = await client.get(url, headers=headers or None)
         resp.raise_for_status()
         return cast(dict[str, object], resp.json())

--- a/tests/test_profiles_overrides.py
+++ b/tests/test_profiles_overrides.py
@@ -1,4 +1,6 @@
+import httpx
 import pytest
+
 import services.api.app.profiles as profiles
 
 
@@ -9,7 +11,7 @@ class DummyCtx:
 
 @pytest.mark.asyncio
 async def test_get_profile_for_user_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake_get_json(path: str) -> dict[str, object]:
+    async def fake_get_json(path: str, _ctx: object | None = None) -> dict[str, object]:
         if path == "/profile/self":
             return {
                 "therapyType": "bolus",
@@ -35,4 +37,21 @@ async def test_get_profile_for_user_overrides(monkeypatch: pytest.MonkeyPatch) -
         "age_group": "child",
         "diabetes_type": "T1",
         "learning_level": "expert",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_profile_for_user_unauthorized(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_json(path: str, _ctx: object | None = None) -> dict[str, object]:
+        request = httpx.Request("GET", f"http://example{path}")
+        response = httpx.Response(401, request=request)
+        raise httpx.HTTPStatusError("unauthorized", request=request, response=response)
+
+    monkeypatch.setattr(profiles, "get_json", fake_get_json)
+    ctx = DummyCtx({"learn_profile_overrides": {"learning_level": "expert"}})
+    result = await profiles.get_profile_for_user(123, ctx)
+    assert result == {
+        "learning_level": "expert",
+        "age_group": "adult",
+        "diabetes_type": "unknown",
     }

--- a/tests/test_rest_client_auth.py
+++ b/tests/test_rest_client_auth.py
@@ -1,0 +1,61 @@
+import httpx
+import pytest
+
+from services.api import rest_client
+
+
+class DummyCtx:
+    def __init__(self, init_data: str | None = None) -> None:
+        self.user_data = {"tg_init_data": init_data} if init_data is not None else {}
+
+
+class DummyResponse:
+    def __init__(self) -> None:
+        self._json: dict[str, object] = {}
+
+    def raise_for_status(self) -> None:
+        return
+
+    def json(self) -> dict[str, object]:
+        return self._json
+
+
+class DummyClient:
+    def __init__(self, capture: dict[str, object]) -> None:
+        self.capture = capture
+
+    async def __aenter__(self) -> "DummyClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def get(self, url: str, headers: dict[str, str] | None = None) -> DummyResponse:
+        self.capture["headers"] = headers
+        return DummyResponse()
+
+
+@pytest.mark.asyncio
+async def test_get_json_uses_tg_init_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Settings:
+        api_url = "http://example"
+        internal_api_key: str | None = None
+
+    monkeypatch.setattr(rest_client, "get_settings", lambda: Settings())
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(captured))
+    await rest_client.get_json("/foo", ctx=DummyCtx("abc"))
+    assert captured["headers"]["Authorization"] == "tg abc"
+
+
+@pytest.mark.asyncio
+async def test_get_json_prefers_internal_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Settings:
+        api_url = "http://example"
+        internal_api_key = "secret"
+
+    monkeypatch.setattr(rest_client, "get_settings", lambda: Settings())
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(captured))
+    await rest_client.get_json("/foo", ctx=DummyCtx("abc"))
+    assert captured["headers"]["Authorization"] == "Bearer secret"


### PR DESCRIPTION
## Summary
- send `Authorization` header using internal key or Telegram init data in `get_json`
- handle 401 in profile loading and keep local defaults
- cover auth header selection and 401 fallback with tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c1493a2c84832ab937f0e73fc81ea8