### PR TITLE
assistant: deduplicate lesson logs

### DIFF
--- a/services/api/alembic/versions/20251016_lesson_logs_unique_constraint.py
+++ b/services/api/alembic/versions/20251016_lesson_logs_unique_constraint.py
@@ -1,0 +1,27 @@
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20251016_lesson_logs_unique_constraint"
+down_revision: Union[str, Sequence[str], None] = "5fbcb2a13695"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.create_unique_constraint(
+            "uq_lesson_logs_user_plan_module_step_role",
+            "lesson_logs",
+            ["user_id", "plan_id", "module_idx", "step_idx", "role"],
+        )
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.drop_constraint(
+            "uq_lesson_logs_user_plan_module_step_role",
+            "lesson_logs",
+            type_="unique",
+        )

--- a/services/api/app/assistant/models.py
+++ b/services/api/app/assistant/models.py
@@ -33,7 +33,17 @@ class LessonLog(Base):
     """Stores conversation steps within a learning plan."""
 
     __tablename__ = "lesson_logs"
-    __table_args__ = (sa.Index("ix_lesson_logs_user_plan", "user_id", "plan_id"),)
+    __table_args__ = (
+        sa.Index("ix_lesson_logs_user_plan", "user_id", "plan_id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "plan_id",
+            "module_idx",
+            "step_idx",
+            "role",
+            name="uq_lesson_logs_user_plan_module_step_role",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(

--- a/tests/assistant/test_logs.py
+++ b/tests/assistant/test_logs.py
@@ -69,8 +69,8 @@ async def test_logs_queue_and_flush(monkeypatch: pytest.MonkeyPatch) -> None:
     inserted: list[LessonLog] = []
 
     class DummySession:
-        def add_all(self, objs: list[LessonLog]) -> None:
-            inserted.extend(objs)
+        def add(self, obj: LessonLog) -> None:  # pragma: no cover - test helper
+            inserted.append(obj)
 
         def get(self, *args: object, **kwargs: object) -> object | None:
             return object()
@@ -100,8 +100,8 @@ async def test_flush_does_not_block_new_logs(
     inserted: list[LessonLog] = []
 
     class DummySession:
-        def add_all(self, objs: list[LessonLog]) -> None:
-            inserted.extend(objs)
+        def add(self, obj: LessonLog) -> None:  # pragma: no cover - test helper
+            inserted.append(obj)
 
         def get(self, *args: object, **kwargs: object) -> object | None:
             return object()


### PR DESCRIPTION
## Summary
- add unique constraint on lesson log tuple to prevent duplicate rows
- skip duplicate entries when flushing pending logs
- cover duplicate flush behaviour with tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `make migrate` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_68c14d7cbb78832a81787fb928ae18eb