### PR TITLE
[learning] Refactor lesson answer logging flow

### DIFF
--- a/tests/assistant/test_e2e_learning_onboarding.py
+++ b/tests/assistant/test_e2e_learning_onboarding.py
@@ -67,7 +67,9 @@ async def test_first_run_restart_and_type_questions(
     monkeypatch.setattr(learning_handlers.settings, "learning_content_mode", "dynamic")
     monkeypatch.setattr(learning_handlers, "build_main_keyboard", lambda: None)
     monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
-    monkeypatch.setattr(learning_handlers, "choose_initial_topic", lambda _p: ("intro", "Intro"))
+    monkeypatch.setattr(
+        learning_handlers, "choose_initial_topic", lambda _p: ("intro", "Intro")
+    )
 
     async def fake_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
         return SimpleNamespace(lesson_id=1)
@@ -90,18 +92,25 @@ async def test_first_run_restart_and_type_questions(
     ) -> tuple[bool, str]:
         return False, "feedback"
 
-    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
-    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
+    )
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "next_step", fake_next_step
+    )
     monkeypatch.setattr(learning_handlers, "assistant_chat", fake_assistant_chat)
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
     monkeypatch.setattr(
-        learning_handlers, "generate_learning_plan", lambda first_step=None: [first_step or "Шаг 1", "Шаг 2"]
+        learning_handlers,
+        "generate_learning_plan",
+        lambda first_step=None: [first_step or "Шаг 1", "Шаг 2"],
     )
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
+
     async def fake_add_log(*_a: object, **_k: object) -> None:
         return None
 
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
 
     msg = DummyMessage(text="/learn")
     update = SimpleNamespace(message=msg, effective_user=msg.from_user)
@@ -120,7 +129,7 @@ async def test_first_run_restart_and_type_questions(
     from services.api.app.diabetes.planner import pretty_plan
 
     plan = ["Шаг 1", "Шаг 2"]
-    assert msg_level.sent == [f"\U0001F5FA План обучения\n{pretty_plan(plan)}", "Шаг 1"]
+    assert msg_level.sent == [f"\U0001f5fa План обучения\n{pretty_plan(plan)}", "Шаг 1"]
 
     msg_q = DummyMessage(text=question)
     upd_q = SimpleNamespace(message=msg_q, effective_user=msg_q.from_user)

--- a/tests/assistant/test_e2e_plan_button.py
+++ b/tests/assistant/test_e2e_plan_button.py
@@ -93,7 +93,7 @@ async def test_plan_button_flow(
     async def fake_add_log(*_a: object, **_k: object) -> None:
         return None
 
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
 
     msg_learn = DummyMessage(text="/learn")
     update_learn = SimpleNamespace(
@@ -102,19 +102,15 @@ async def test_plan_button_flow(
     context = SimpleNamespace(user_data={}, bot_data={})
     await learning_handlers.learn_command(update_learn, context)
     plan = generate_learning_plan("Шаг 1")
-    assert msg_learn.sent == [f"\U0001F5FA План обучения\n{pretty_plan(plan)}", "Шаг 1"]
+    assert msg_learn.sent == [f"\U0001f5fa План обучения\n{pretty_plan(plan)}", "Шаг 1"]
 
     msg_ans = DummyMessage(text="Не знаю")
-    update_ans = SimpleNamespace(
-        message=msg_ans, effective_user=msg_ans.from_user
-    )
+    update_ans = SimpleNamespace(message=msg_ans, effective_user=msg_ans.from_user)
     await learning_handlers.lesson_answer_handler(update_ans, context)
     assert msg_ans.sent == ["feedback", "Шаг 2"]
 
     plan_msg = DummyMessage()
-    plan_update = SimpleNamespace(
-        message=plan_msg, effective_user=plan_msg.from_user
-    )
+    plan_update = SimpleNamespace(message=plan_msg, effective_user=plan_msg.from_user)
     await learning_handlers.plan_command(plan_update, context)
     assert plan_msg.sent
     assert "Шаг 2" in plan_msg.sent[0]

--- a/tests/diabetes/test_curriculum_not_found.py
+++ b/tests/diabetes/test_curriculum_not_found.py
@@ -66,6 +66,7 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
         dynamic_handlers, "choose_initial_topic", lambda _p: ("slug", "t")
     )
     monkeypatch.setattr(dynamic_handlers, "build_main_keyboard", lambda: None)
+
     async def fake_step_text(
         profile: Mapping[str, str | None], slug: str, step: int, prev: str | None
     ) -> str:
@@ -91,7 +92,9 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
         dynamic_handlers.curriculum_engine, "start_lesson", raise_start_lesson
     )
 
-    monkeypatch.setattr(dynamic_handlers, "generate_learning_plan", lambda _t: ["step1"])
+    monkeypatch.setattr(
+        dynamic_handlers, "generate_learning_plan", lambda _t: ["step1"]
+    )
 
     async def ok_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -101,9 +104,7 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
     async def fake_get_active_plan(user_id: int) -> None:
         return None
 
-    async def fake_create_plan(
-        user_id: int, version: int, plan: list[str]
-    ) -> int:
+    async def fake_create_plan(user_id: int, version: int, plan: list[str]) -> int:
         return 1
 
     async def fake_update_plan(plan_id: int, plan_json: list[str]) -> None:
@@ -114,11 +115,13 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
     ) -> None:
         return None
 
-    monkeypatch.setattr(dynamic_handlers.plans_repo, "get_active_plan", fake_get_active_plan)
+    monkeypatch.setattr(
+        dynamic_handlers.plans_repo, "get_active_plan", fake_get_active_plan
+    )
     monkeypatch.setattr(dynamic_handlers.plans_repo, "create_plan", fake_create_plan)
     monkeypatch.setattr(dynamic_handlers.plans_repo, "update_plan", fake_update_plan)
     monkeypatch.setattr(
-        dynamic_handlers.progress_service, "upsert_progress", fake_upsert_progress
+        dynamic_handlers.progress_repo, "upsert_progress", fake_upsert_progress
     )
 
     msg = DummyMessage()
@@ -127,7 +130,7 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
 
     await dynamic_handlers.learn_command(update, context)
     assert msg.replies == [
-        "\U0001F5FA План обучения\n1. step1",
+        "\U0001f5fa План обучения\n1. step1",
         "step1",
     ]
     assert get_state(context.user_data) is not None
@@ -145,6 +148,7 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(dynamic_handlers, "TOPICS_RU", {"slug": "Topic"})
     monkeypatch.setattr(dynamic_handlers, "build_main_keyboard", lambda: None)
     monkeypatch.setattr(dynamic_handlers, "disclaimer", lambda: "")
+
     async def fake_step_text(
         profile: Mapping[str, str | None], slug: str, step: int, prev: str | None
     ) -> str:
@@ -170,7 +174,9 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
 
     monkeypatch.setattr(dynamic_handlers.curriculum_engine, "next_step", fail_next_step)
 
-    monkeypatch.setattr(dynamic_handlers, "generate_learning_plan", lambda _t: ["step1"])
+    monkeypatch.setattr(
+        dynamic_handlers, "generate_learning_plan", lambda _t: ["step1"]
+    )
 
     async def ok_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -180,9 +186,7 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
     async def fake_get_active_plan(user_id: int) -> None:
         return None
 
-    async def fake_create_plan(
-        user_id: int, version: int, plan: list[str]
-    ) -> int:
+    async def fake_create_plan(user_id: int, version: int, plan: list[str]) -> int:
         return 1
 
     async def fake_update_plan(plan_id: int, plan_json: list[str]) -> None:
@@ -193,11 +197,13 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
     ) -> None:
         return None
 
-    monkeypatch.setattr(dynamic_handlers.plans_repo, "get_active_plan", fake_get_active_plan)
+    monkeypatch.setattr(
+        dynamic_handlers.plans_repo, "get_active_plan", fake_get_active_plan
+    )
     monkeypatch.setattr(dynamic_handlers.plans_repo, "create_plan", fake_create_plan)
     monkeypatch.setattr(dynamic_handlers.plans_repo, "update_plan", fake_update_plan)
     monkeypatch.setattr(
-        dynamic_handlers.progress_service, "upsert_progress", fake_upsert_progress
+        dynamic_handlers.progress_repo, "upsert_progress", fake_upsert_progress
     )
 
     msg = DummyMessage()
@@ -206,7 +212,7 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
 
     await dynamic_handlers.lesson_command(update, context)
     assert msg.replies == [
-        "\U0001F5FA План обучения\n1. step1",
+        "\U0001f5fa План обучения\n1. step1",
         "step1",
     ]
     assert get_state(context.user_data) is not None

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -106,7 +106,7 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(
         learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
 
     msg = DummyMessage()
     update = make_update(message=msg)
@@ -126,7 +126,7 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
     await learning_handlers.lesson_callback(update_cb, context_cb)
     plan = learning_handlers.generate_learning_plan(f"{disclaimer()}\n\nstep1?")
     assert msg2.replies == [
-        f"\U0001F5FA План обучения\n{learning_handlers.pretty_plan(plan)}",
+        f"\U0001f5fa План обучения\n{learning_handlers.pretty_plan(plan)}",
         f"{disclaimer()}\n\nstep1?",
     ]
     assert isinstance(msg2.markups[0], ReplyKeyboardMarkup)
@@ -148,7 +148,7 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
 
     async def fake_ensure_overrides(update: object, context: object) -> bool:
         return True
@@ -185,7 +185,7 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await learning_handlers.lesson_command(update, context)
     expected_plan = generate_learning_plan(f"{disclaimer()}\n\nstep1?")
-    plan_text = f"\U0001F5FA План обучения\n{pretty_plan(expected_plan)}"
+    plan_text = f"\U0001f5fa План обучения\n{pretty_plan(expected_plan)}"
     assert msg.replies == [plan_text, f"{disclaimer()}\n\nstep1?"]
     assert isinstance(msg.markups[0], ReplyKeyboardMarkup)
 
@@ -313,7 +313,7 @@ async def test_learn_command_autostarts_when_topics_hidden(
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
 
     msg = DummyMessage()
     update = make_update(message=msg, user_id=7)
@@ -322,7 +322,7 @@ async def test_learn_command_autostarts_when_topics_hidden(
     await learning_handlers.learn_command(update, context)
     plan = learning_handlers.generate_learning_plan("first")
     assert msg.replies == [
-        f"\U0001F5FA План обучения\n{learning_handlers.pretty_plan(plan)}",
+        f"\U0001f5fa План обучения\n{learning_handlers.pretty_plan(plan)}",
         "first",
     ]
     assert isinstance(msg.markups[0], ReplyKeyboardMarkup)
@@ -366,10 +366,11 @@ async def test_lesson_answer_double_click(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(
         learning_handlers, "generate_step_text", fake_generate_step_text
     )
+
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     user_data: dict[str, Any] = {}
@@ -419,7 +420,7 @@ async def test_lesson_answer_handler_error_keeps_state(
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
 
     msg = DummyMessage(text="ans")
     user_data: dict[str, Any] = {}
@@ -449,13 +450,37 @@ async def test_lesson_answer_handler_add_log_failure(
     async def fail_add_log(*args: object, **kwargs: object) -> None:
         raise SQLAlchemyError("db error")
 
-    async def fail_check_user_answer(
+    calls: list[tuple[object, ...]] = []
+
+    async def fake_check_user_answer(
         *args: object, **kwargs: object
     ) -> tuple[bool, str]:
-        raise AssertionError("should not be called")
+        calls.append(args)
+        return True, "feedback"
 
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fail_add_log)
-    monkeypatch.setattr(learning_handlers, "check_user_answer", fail_check_user_answer)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fail_add_log)
+    monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+
+    async def fake_generate_step_text(*_a: object, **_k: object) -> str:
+        return "step2"
+
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fake_generate_step_text
+    )
+
+    async def fake_next_step(
+        user_id: int,
+        lesson_id: int,
+        profile: Mapping[str, str | None],
+        prev_summary: str | None = None,
+    ) -> tuple[str, bool]:
+        return "step2", False
+
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "next_step", fake_next_step
+    )
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
+    monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
 
     msg = DummyMessage(text="ans")
     user_data: dict[str, Any] = {}
@@ -467,10 +492,10 @@ async def test_lesson_answer_handler_add_log_failure(
     context = make_context(user_data=user_data)
 
     await learning_handlers.lesson_answer_handler(update, context)
-
-    assert msg.replies == [dynamic_tutor.BUSY_MESSAGE]
+    assert calls, "check_user_answer should be called"
+    assert msg.replies == ["feedback", "step2"]
     state = get_state(user_data)
     assert state is not None
-    assert state.step == 1
+    assert state.step == 2
     assert state.awaiting
     assert not context.user_data.get("learn_busy", False)

--- a/tests/learning/test_empty_lessons.py
+++ b/tests/learning/test_empty_lessons.py
@@ -71,9 +71,7 @@ async def test_dynamic_mode_empty_lessons(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(
         dynamic_handlers.curriculum_engine, "start_lesson", raise_start_lesson
     )
-    monkeypatch.setattr(
-        dynamic_handlers.curriculum_engine, "next_step", fail_next_step
-    )
+    monkeypatch.setattr(dynamic_handlers.curriculum_engine, "next_step", fail_next_step)
     monkeypatch.setattr(
         dynamic_handlers,
         "generate_learning_plan",
@@ -85,13 +83,17 @@ async def test_dynamic_mode_empty_lessons(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(dynamic_handlers.plans_repo, "get_active_plan", _fake_persist)
     monkeypatch.setattr(dynamic_handlers.plans_repo, "create_plan", _fake_persist)
     monkeypatch.setattr(dynamic_handlers.plans_repo, "update_plan", _fake_persist)
-    monkeypatch.setattr(dynamic_handlers.progress_service, "upsert_progress", _fake_persist)
+    monkeypatch.setattr(
+        dynamic_handlers.progress_repo, "upsert_progress", _fake_persist
+    )
 
     async def fake_ensure_overrides(*_a: object, **_k: object) -> bool:
         return True
 
     monkeypatch.setattr(dynamic_handlers, "ensure_overrides", fake_ensure_overrides)
-    monkeypatch.setattr(dynamic_handlers, "choose_initial_topic", lambda _p: ("slug", "t"))
+    monkeypatch.setattr(
+        dynamic_handlers, "choose_initial_topic", lambda _p: ("slug", "t")
+    )
 
     bot = DummyBot()
     app = Application.builder().bot(bot).build()
@@ -112,7 +114,7 @@ async def test_dynamic_mode_empty_lessons(monkeypatch: pytest.MonkeyPatch) -> No
     await app.process_update(Update(update_id=1, message=msg))
 
     assert bot.sent == [
-        "\U0001F5FA План обучения\n1. step1\n2. step2",
+        "\U0001f5fa План обучения\n1. step1\n2. step2",
         "step1",
     ]
 
@@ -120,7 +122,9 @@ async def test_dynamic_mode_empty_lessons(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 @pytest.mark.asyncio
-async def test_static_mode_empty_lessons_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_static_mode_empty_lessons_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Static /learn should fall back to dynamic when no lessons."""
 
     monkeypatch.setattr(settings, "learning_content_mode", "static")

--- a/tests/learning/test_flow_autostart.py
+++ b/tests/learning/test_flow_autostart.py
@@ -79,7 +79,7 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
 
     bot = DummyBot()
     app = Application.builder().bot(bot).build()
@@ -118,7 +118,7 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
     await app.process_update(Update(update_id=2, message=_msg(2, "49")))
     await app.process_update(Update(update_id=3, message=_msg(3, "0")))
     expected_plan = generate_learning_plan("шаг1")
-    assert bot.sent[-2] == f"\U0001F5FA План обучения\n{pretty_plan(expected_plan)}"
+    assert bot.sent[-2] == f"\U0001f5fa План обучения\n{pretty_plan(expected_plan)}"
     assert bot.sent[-1] == "шаг1"
     assert all(
         title not in s and "Выберите тему" not in s and "Доступные темы" not in s
@@ -130,5 +130,3 @@ async def test_flow_autostart(monkeypatch: pytest.MonkeyPatch) -> None:
     }
 
     await app.shutdown()
-
-

--- a/tests/learning/test_handlers_rate_limit.py
+++ b/tests/learning/test_handlers_rate_limit.py
@@ -85,7 +85,7 @@ async def test_lesson_callback_rate_limit(monkeypatch: pytest.MonkeyPatch) -> No
     await learning_handlers.lesson_callback(update1, context1)
     plan = learning_handlers.generate_learning_plan("step1")
     assert msg1.replies == [
-        f"\U0001F5FA План обучения\n{learning_handlers.pretty_plan(plan)}",
+        f"\U0001f5fa План обучения\n{learning_handlers.pretty_plan(plan)}",
         "step1",
     ]
 
@@ -104,10 +104,8 @@ async def test_lesson_answer_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None
     async def _noop(*_a: object, **_k: object) -> None:
         return None
 
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", _noop)
-    monkeypatch.setattr(
-        learning_handlers, "_rate_limited", lambda *_args, **_kw: True
-    )
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", _noop)
+    monkeypatch.setattr(learning_handlers, "_rate_limited", lambda *_args, **_kw: True)
 
     user_data: dict[str, object] = {}
     learning_handlers.set_state(

--- a/tests/learning/test_on_any_text.py
+++ b/tests/learning/test_on_any_text.py
@@ -51,7 +51,7 @@ async def test_on_any_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     msg = DummyMessage("ans")
@@ -99,7 +99,7 @@ async def test_on_any_text_idontknow(monkeypatch: pytest.MonkeyPatch) -> None:
         learning_handlers, "generate_step_text", fake_generate_step_text
     )
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     msg = DummyMessage("Не знаю")
@@ -180,7 +180,7 @@ async def test_on_any_text_within_grace(monkeypatch: pytest.MonkeyPatch) -> None
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
 
     msg = DummyMessage("ans")

--- a/tests/learning/test_plan_handlers.py
+++ b/tests/learning/test_plan_handlers.py
@@ -76,7 +76,7 @@ async def test_learn_command_stores_plan(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(
         learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
-    monkeypatch.setattr(learning_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
 
     message = DummyMessage()
     update = make_update(message=message)
@@ -86,7 +86,9 @@ async def test_learn_command_stores_plan(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert context.user_data["learning_plan_index"] == 0
     assert context.user_data["learning_plan"][0] == "step1"
-    plan_text = f"\U0001F5FA План обучения\n{pretty_plan(context.user_data['learning_plan'])}"
+    plan_text = (
+        f"\U0001f5fa План обучения\n{pretty_plan(context.user_data['learning_plan'])}"
+    )
     assert message.replies == [plan_text, "step1"]
 
 
@@ -154,7 +156,7 @@ async def test_plan_command_respects_existing_plan(
         learning_handlers.plans_repo, "get_active_plan", fail_get_active_plan
     )
     monkeypatch.setattr(
-        learning_handlers.progress_service, "get_progress", fail_get_progress
+        learning_handlers.progress_repo, "get_progress", fail_get_progress
     )
 
     await learning_handlers.plan_command(update, context)


### PR DESCRIPTION
## Summary
- persist lesson progress before logging and capture logging failures
- wrap lesson log writes with `safe_add_lesson_log` and track pending entries
- adjust tests for new progress and logging behavior

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c157bf8f0c832ab42c14e48f1387ad