### PR TITLE
[assistant] ensure lesson logs unique and handle duplicates

### DIFF
--- a/services/api/alembic/versions/20251016_lesson_logs_unique_step_role.py
+++ b/services/api/alembic/versions/20251016_lesson_logs_unique_step_role.py
@@ -1,0 +1,28 @@
+"""lesson_logs unique step role"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20251016_lesson_logs_unique_step_role"
+down_revision: Union[str, None] = "5fbcb2a13695"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        "uq_lesson_logs_user_plan_module_step_role",
+        "lesson_logs",
+        ["user_id", "plan_id", "module_idx", "step_idx", "role"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_lesson_logs_user_plan_module_step_role",
+        "lesson_logs",
+        type_="unique",
+    )

--- a/services/api/app/assistant/models.py
+++ b/services/api/app/assistant/models.py
@@ -21,19 +21,25 @@ class AssistantMemory(Base):
         index=True,
     )
     turn_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    last_turn_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=False
-    )
-    summary_text: Mapped[str] = mapped_column(
-        String(1024), nullable=False, default=""
-    )
+    last_turn_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    summary_text: Mapped[str] = mapped_column(String(1024), nullable=False, default="")
 
 
 class LessonLog(Base):
     """Stores conversation steps within a learning plan."""
 
     __tablename__ = "lesson_logs"
-    __table_args__ = (sa.Index("ix_lesson_logs_user_plan", "user_id", "plan_id"),)
+    __table_args__ = (
+        sa.Index("ix_lesson_logs_user_plan", "user_id", "plan_id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "plan_id",
+            "module_idx",
+            "step_idx",
+            "role",
+            name="uq_lesson_logs_user_plan_module_step_role",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
@@ -41,16 +47,12 @@ class LessonLog(Base):
         ForeignKey("users.telegram_id", ondelete="CASCADE"),
         nullable=False,
     )
-    plan_id: Mapped[int] = mapped_column(
-        ForeignKey("learning_plans.id", ondelete="CASCADE"), nullable=False
-    )
+    plan_id: Mapped[int] = mapped_column(ForeignKey("learning_plans.id", ondelete="CASCADE"), nullable=False)
     module_idx: Mapped[int] = mapped_column(Integer, nullable=False)
     step_idx: Mapped[int] = mapped_column(Integer, nullable=False)
     role: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False
-    )
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False)
 
 
 __all__ = ["AssistantMemory", "LessonLog"]

--- a/services/api/app/assistant/repositories/logs.py
+++ b/services/api/app/assistant/repositories/logs.py
@@ -5,14 +5,15 @@ import logging
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone, timedelta
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from services.api.app.config import settings
 from services.api.app.assistant.models import LessonLog
 from services.api.app.diabetes.metrics import lesson_log_failures
 from services.api.app.diabetes.services.db import SessionLocal, run_db, User
-from services.api.app.diabetes.services.repository import commit
 from services.api.app.diabetes.services.monitoring import notify
+from services.api.app.diabetes.services.repository import commit
 
 logger = logging.getLogger(__name__)
 
@@ -54,15 +55,15 @@ async def flush_pending_logs() -> None:
 
     def _flush(session: Session) -> list[_PendingLog]:
         missing: list[_PendingLog] = []
-        entries: list[LessonLog] = []
         for log in queued:
             if session.get(User, log.user_id) is None:
                 missing.append(log)
                 continue
-            entries.append(LessonLog(**asdict(log)))
-        if entries:
-            session.add_all(entries)
-            commit(session)
+            session.add(LessonLog(**asdict(log)))
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
         return missing
 
     try:


### PR DESCRIPTION
## Summary
- add unique constraint for lesson log steps and roles
- skip duplicate entries when flushing lesson logs
- test that re-flushing logs doesn't duplicate records

## Testing
- `pytest tests/assistant/test_lesson_logs.py -q`
- `mypy --strict .`
- `ruff check services/api/app/assistant/models.py services/api/app/assistant/repositories/logs.py tests/assistant/test_lesson_logs.py services/api/alembic/versions/20251016_lesson_logs_unique_step_role.py`
- `make migrate` *(fails: connection to server at "localhost" (127.0.0.1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1582f1c70832a8052fca63e43139d