### PR TITLE
[assistant] Add safe lesson log persistence

### DIFF
--- a/services/api/app/assistant/repositories/logs.py
+++ b/services/api/app/assistant/repositories/logs.py
@@ -112,22 +112,45 @@ async def safe_add_lesson_log(
     role: str,
     content: str,
 ) -> bool:
-    """Safely add a lesson log entry.
+    """Safely queue and flush a lesson log entry.
 
-    Returns ``True`` on success. If an error occurs and
-    ``learning_logging_required`` is ``True``, the error is logged and an
-    alert is sent, but ``False`` is returned so that the caller can
-    continue without interruption.
+    The log is first constructed so it can be re-queued on failure.  The
+    existing :func:`add_lesson_log` is invoked to perform the actual
+    enqueue and flush.  ``True`` is returned if the log was successfully
+    flushed to the database, otherwise ``False``.
+
+    When an exception occurs the log is kept in ``pending_logs`` without
+    duplication, the ``lesson_log_failures`` metric is incremented and a
+    warning is emitted.  If ``learning_logging_required`` is enabled, the
+    error is escalated via an error log and Sentry notification but the
+    function still returns ``False`` so callers can proceed.
     """
+
+    log = _PendingLog(
+        user_id=user_id,
+        plan_id=plan_id,
+        module_idx=module_idx,
+        step_idx=step_idx,
+        role=role,
+        content=content,
+    )
 
     try:
         await add_lesson_log(user_id, plan_id, module_idx, step_idx, role, content)
-    except Exception as exc:  # pragma: no cover - simple pass through
+    except Exception as exc:  # pragma: no cover - defensive
+        async with pending_logs_lock:
+            if log not in pending_logs:
+                pending_logs.append(log)
+        lesson_log_failures.inc()
+        logger.warning("Failed to add lesson log: %s", asdict(log), exc_info=exc)
         if settings.learning_logging_required:
             logger.error("Failed to add lesson log", exc_info=exc)
             notify("lesson_log_failure")
         return False
-    return True
+
+    async with pending_logs_lock:
+        flushed = log not in pending_logs
+    return flushed
 
 
 async def _flush_periodically(interval: float) -> None:

--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -32,7 +32,6 @@ from .services.gpt_client import (
 )
 from services.api.app.assistant.repositories.logs import (
     _PendingLog,
-    add_lesson_log,
     pending_logs,
     safe_add_lesson_log,
 )
@@ -352,7 +351,7 @@ async def learn_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     )
     text = format_reply(plan[0])
     await message.reply_text(text, reply_markup=build_main_keyboard())
-    await add_lesson_log(
+    await safe_add_lesson_log(
         user.id,
         0,
         cast(int, user_data.get("learning_module_idx", 0)),
@@ -428,7 +427,7 @@ async def _start_lesson(
     )
     text = format_reply(plan[0])
     await message.reply_text(text, reply_markup=build_main_keyboard())
-    await add_lesson_log(
+    await safe_add_lesson_log(
         from_user.id,
         0,
         cast(int, user_data.get("learning_module_idx", 0)),

--- a/tests/assistant/test_logs.py
+++ b/tests/assistant/test_logs.py
@@ -56,7 +56,7 @@ async def test_add_lesson_log_raises_when_required(
 async def test_safe_add_lesson_log_handles_failure_not_required(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """safe_add_lesson_log returns True and keeps state when logging optional."""
+    """safe_add_lesson_log returns False and keeps state when logging optional."""
 
     monkeypatch.setattr(settings, "learning_logging_required", False)
 
@@ -69,7 +69,7 @@ async def test_safe_add_lesson_log_handles_failure_not_required(
 
     ok = await safe_add_lesson_log(1, 1, 0, 1, "assistant", "hi")
 
-    assert ok is True
+    assert ok is False
     assert len(logs.pending_logs) == 1
     assert lesson_log_failures._value.get() == 1  # type: ignore[attr-defined]
 

--- a/tests/diabetes/test_curriculum_busy.py
+++ b/tests/diabetes/test_curriculum_busy.py
@@ -63,7 +63,7 @@ async def test_dynamic_learn_command_busy(monkeypatch: pytest.MonkeyPatch) -> No
     async def fail_add_log(*args: object, **kwargs: object) -> None:
         raise AssertionError("should not be called")
 
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fail_add_log)
+    monkeypatch.setattr(dynamic_handlers, "safe_add_lesson_log", fail_add_log)
 
     msg = DummyMessage()
     update = make_update(message=msg)

--- a/tests/diabetes/test_curriculum_exceptions.py
+++ b/tests/diabetes/test_curriculum_exceptions.py
@@ -82,7 +82,7 @@ async def test_learn_command_start_lesson_exception(
     async def fail_add_log(*args: object, **kwargs: object) -> None:
         raise AssertionError("should not be called")
 
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fail_add_log)
+    monkeypatch.setattr(dynamic_handlers, "safe_add_lesson_log", fail_add_log)
 
     msg = DummyMessage()
     update = make_update(message=msg)
@@ -141,7 +141,7 @@ async def test_learn_command_next_step_exception(
     async def fail_add_log(*args: object, **kwargs: object) -> None:
         raise AssertionError("should not be called")
 
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fail_add_log)
+    monkeypatch.setattr(dynamic_handlers, "safe_add_lesson_log", fail_add_log)
 
     msg = DummyMessage()
     update = make_update(message=msg)
@@ -235,7 +235,7 @@ async def test_lesson_command_next_step_exception(
     async def fail_add_log(*args: object, **kwargs: object) -> None:
         raise AssertionError("should not be called")
 
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fail_add_log)
+    monkeypatch.setattr(dynamic_handlers, "safe_add_lesson_log", fail_add_log)
 
     msg = DummyMessage()
     update = make_update(message=msg)

--- a/tests/diabetes/test_curriculum_not_found.py
+++ b/tests/diabetes/test_curriculum_not_found.py
@@ -99,7 +99,7 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
     async def ok_add_log(*args: object, **kwargs: object) -> None:
         return None
 
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", ok_add_log)
+    monkeypatch.setattr(dynamic_handlers, "safe_add_lesson_log", ok_add_log)
 
     async def fake_get_active_plan(user_id: int) -> None:
         return None
@@ -181,7 +181,7 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
     async def ok_add_log(*args: object, **kwargs: object) -> None:
         return None
 
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", ok_add_log)
+    monkeypatch.setattr(dynamic_handlers, "safe_add_lesson_log", ok_add_log)
 
     async def fake_get_active_plan(user_id: int) -> None:
         return None

--- a/tests/diabetes/test_learning_handlers.py
+++ b/tests/diabetes/test_learning_handlers.py
@@ -215,7 +215,7 @@ async def test_plan_precedes_step(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(dynamic_handlers, "pretty_plan", lambda p: "|".join(p))
     monkeypatch.setattr(dynamic_handlers, "format_reply", lambda t: t)
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(dynamic_handlers, "safe_add_lesson_log", fake_add_log)
     monkeypatch.setattr(dynamic_handlers, "_persist", fake_persist)
 
     message = DummyMessage()
@@ -304,7 +304,7 @@ async def test_reenter_after_onboarding(monkeypatch: pytest.MonkeyPatch) -> None
     )
     monkeypatch.setattr(dynamic_handlers, "pretty_plan", lambda p: "|".join(p))
     monkeypatch.setattr(dynamic_handlers, "format_reply", lambda t: t)
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", fake_add_log)
+    monkeypatch.setattr(dynamic_handlers, "safe_add_lesson_log", fake_add_log)
     monkeypatch.setattr(dynamic_handlers, "_persist", fake_persist)
 
     user_data: dict[str, Any] = {

--- a/tests/learning/test_empty_lessons.py
+++ b/tests/learning/test_empty_lessons.py
@@ -79,7 +79,7 @@ async def test_dynamic_mode_empty_lessons(monkeypatch: pytest.MonkeyPatch) -> No
     )
     monkeypatch.setattr(dynamic_handlers, "format_reply", lambda t: t)
     monkeypatch.setattr(dynamic_handlers, "disclaimer", lambda: "")
-    monkeypatch.setattr(dynamic_handlers, "add_lesson_log", _fake_persist)
+    monkeypatch.setattr(dynamic_handlers, "safe_add_lesson_log", _fake_persist)
     monkeypatch.setattr(dynamic_handlers.plans_repo, "get_active_plan", _fake_persist)
     monkeypatch.setattr(dynamic_handlers.plans_repo, "create_plan", _fake_persist)
     monkeypatch.setattr(dynamic_handlers.plans_repo, "update_plan", _fake_persist)


### PR DESCRIPTION
## Summary
- add `safe_add_lesson_log` to keep pending logs and log/alert on failure
- call `safe_add_lesson_log` from dynamic learning handlers
- adjust tests for new safe logging behavior

## Testing
- `pytest -q --cov`
- `mypy --strict .` *(fails: Interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c15e67f6d8832a9b2bf3521e017558