### PR TITLE
chore: configure mpl cache dir

### DIFF
--- a/run_dev.sh
+++ b/run_dev.sh
@@ -8,8 +8,9 @@ source ./.env
 set +a
 
 # Конфигурация для Matplotlib
-export MPLCONFIGDIR="${MPLCONFIGDIR:-/var/cache/diabetes-bot/mpl}"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-/opt/saharlight-ux/data/mpl-cache}"
 mkdir -p "$MPLCONFIGDIR"
+chmod 700 "$MPLCONFIGDIR"
 
 # Запускаем API с авто-reload (1 процесс)
 uvicorn services.api.app.main:app \

--- a/scripts/run_bot.sh
+++ b/scripts/run_bot.sh
@@ -14,6 +14,10 @@ if [[ -f .env ]]; then
   set +a
 fi
 
+export MPLCONFIGDIR="${MPLCONFIGDIR:-/opt/saharlight-ux/data/mpl-cache}"
+mkdir -p "$MPLCONFIGDIR"
+chmod 700 "$MPLCONFIGDIR"
+
 export PYTHONPATH="${REPO_ROOT}:${PYTHONPATH:-}"
 
 # basic sanity checks for required configuration

--- a/services/deploy/systemd/diabetes-bot.service.example
+++ b/services/deploy/systemd/diabetes-bot.service.example
@@ -9,6 +9,8 @@ After=network.target
 Type=simple
 WorkingDirectory=/srv/diabetes-bot
 EnvironmentFile=/srv/diabetes-bot/.env
+Environment=MPLCONFIGDIR=/opt/saharlight-ux/data/mpl-cache
+ExecStartPre=/usr/bin/install -d -m 700 /opt/saharlight-ux/data/mpl-cache
 ExecStartPre=/usr/bin/curl -fsS "$PUBLIC_ORIGIN/health"
 ExecStart=/srv/diabetes-bot/scripts/run_bot.sh
 Restart=on-failure


### PR DESCRIPTION
## Summary
- set MPLCONFIGDIR to /opt/saharlight-ux/data/mpl-cache for bot startup scripts
- ensure cache dir is created with permissions
- persist MPLCONFIGDIR in systemd service example

## Testing
- `pytest -q --cov` (fails: async def functions are not natively supported)
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c165d8d6f8832a8d68e0b3d5794692