### PR TITLE
[bot] Require auth config and log missing headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ curl http://localhost:8000/api/profile?telegramId=777
 - `PUBLIC_ORIGIN` — публичный URL API;
 - `WEBAPP_URL` — адрес WebApp для онбординга;
 - `API_URL` — базовый URL внешнего API; требует установленный пакет `diabetes_sdk`;
+- `INTERNAL_API_KEY` — ключ для внутренней аутентификации; при отсутствии нужно передавать `tg_init_data`;
 - `OPENAI_API_KEY` — ключ OpenAI для распознавания фото;
 - `OPENAI_ASSISTANT_ID` — идентификатор ассистента для GPT;
 - `SUBSCRIPTION_URL` — страница оформления подписки в WebApp;

--- a/docs/ops-guide.md
+++ b/docs/ops-guide.md
@@ -2,6 +2,8 @@
 
 ## Environment flags
 
+- `API_URL` — базовый URL внешнего API;
+- `INTERNAL_API_KEY` — ключ для внутренней аутентификации бота;
 - `SUBSCRIPTION_URL` — страница подписки в WebApp;
 - `UI_BASE_URL`/`VITE_API_BASE` — базовые пути фронтенда и API;
 - `BILLING_ENABLED`, `BILLING_TEST_MODE`, `BILLING_PROVIDER` — настройки биллинга;

--- a/infra/env/.env.example
+++ b/infra/env/.env.example
@@ -24,6 +24,7 @@ JWT_EXPIRE_DAYS=7
 # Optional service URLs
 WEBAPP_URL=http://localhost:3000
 API_URL=http://localhost:8000
+INTERNAL_API_KEY=
 # URL WebApp-страницы подписки
 SUBSCRIPTION_URL=https://bot.offonika.ru/subscription
 # Base path for the web app; used by both frontend and backend. Defaults to /ui/

--- a/scripts/run_bot.sh
+++ b/scripts/run_bot.sh
@@ -23,6 +23,10 @@ export PYTHONPATH="${REPO_ROOT}:${PYTHONPATH:-}"
 # basic sanity checks for required configuration
 : "${TELEGRAM_TOKEN:?TELEGRAM_TOKEN is not set}"
 : "${PUBLIC_ORIGIN:?PUBLIC_ORIGIN is not set}"
+: "${API_URL:?API_URL is not set}"
+if [[ -z "${INTERNAL_API_KEY:-}" ]]; then
+  echo "Warning: INTERNAL_API_KEY is not set; tg_init_data must be provided" >&2
+fi
 
 # UI_BASE_URL defaults to /ui but can be overridden in the environment
 export UI_BASE_URL="${UI_BASE_URL:-/ui}"

--- a/services/api/rest_client.py
+++ b/services/api/rest_client.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 from typing import cast
 
 import httpx
+import logging
 from telegram.ext import ContextTypes
 
 from .app.config import get_settings
+
+
+logger = logging.getLogger(__name__)
 
 
 async def get_json(
@@ -26,6 +30,9 @@ async def get_json(
             init_data = user_data.get("tg_init_data")
             if isinstance(init_data, str):
                 headers["Authorization"] = f"tg {init_data}"
+
+    if "Authorization" not in headers:
+        logger.warning("No Authorization header for %s", path)
 
     async with httpx.AsyncClient() as client:
         resp = await client.get(url, headers=headers or None)

--- a/tests/test_profiles_overrides.py
+++ b/tests/test_profiles_overrides.py
@@ -53,3 +53,17 @@ async def test_get_profile_for_user_unauthorized(
     ctx = DummyCtx({"learn_profile_overrides": {"learning_level": "expert"}})
     with pytest.raises(httpx.HTTPStatusError):
         await profiles.get_profile_for_user(123, ctx)
+
+
+@pytest.mark.asyncio
+async def test_get_profile_for_user_passes_tg_init_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_get_json(path: str, ctx: object | None = None) -> dict[str, object]:
+        assert isinstance(ctx, DummyCtx)
+        assert ctx.user_data["tg_init_data"] == "abc"
+        return {}
+
+    monkeypatch.setattr(profiles, "get_json", fake_get_json)
+    ctx = DummyCtx({"tg_init_data": "abc"})
+    await profiles.get_profile_for_user(1, ctx)


### PR DESCRIPTION
## Summary
- warn when REST requests lack Authorization headers
- check `API_URL` and `INTERNAL_API_KEY` in bot runner and docs
- cover auth header fallbacks with targeted tests

## Testing
- `pytest tests/test_rest_client_auth.py tests/test_profiles_overrides.py -q`
- `mypy --strict services/api/rest_client.py tests/test_rest_client_auth.py tests/test_profiles_overrides.py --follow-imports=skip`
- `ruff check services/api/rest_client.py tests/test_rest_client_auth.py tests/test_profiles_overrides.py`


------
https://chatgpt.com/codex/tasks/task_e_68c16d87834c832a8cd0edb70c3dc279