### PR TITLE
[deploy] ensure Matplotlib cache dir exists

### DIFF
--- a/docs/deploy/diabetes-assistant.service
+++ b/docs/deploy/diabetes-assistant.service
@@ -9,8 +9,7 @@ PermissionsStartOnly=true
 WorkingDirectory=/opt/saharlight-ux
 EnvironmentFile=/opt/saharlight-ux/.env
 Environment=MPLCONFIGDIR=/var/cache/diabetes-bot/mpl
-ExecStartPre=/usr/bin/mkdir -p /var/cache/diabetes-bot/mpl
-ExecStartPre=/usr/bin/chown www-data:www-data /var/cache/diabetes-bot/mpl
+ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /var/cache/diabetes-bot/mpl
 ExecStart=/usr/bin/env uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000 --workers 4
 Restart=on-failure
 RestartSec=5

--- a/docs/deploy/diabetes-bot.service
+++ b/docs/deploy/diabetes-bot.service
@@ -9,8 +9,7 @@ PermissionsStartOnly=true
 WorkingDirectory=/opt/saharlight-ux
 EnvironmentFile=/opt/saharlight-ux/.env
 Environment=MPLCONFIGDIR=/var/cache/diabetes-bot/mpl
-ExecStartPre=/usr/bin/mkdir -p /var/cache/diabetes-bot/mpl
-ExecStartPre=/usr/bin/chown www-data:www-data /var/cache/diabetes-bot/mpl
+ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /var/cache/diabetes-bot/mpl
 ExecStart=/opt/saharlight-ux/scripts/run_bot.sh
 Restart=on-failure
 RestartSec=5

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -12,6 +12,20 @@ export MPLCONFIGDIR="${MPLCONFIGDIR:-/opt/saharlight-ux/data/mpl-cache}"
 mkdir -p "$MPLCONFIGDIR"
 chmod 700 "$MPLCONFIGDIR"
 
+# Validate Matplotlib config directory
+python - <<'PY'
+import os
+import sys
+import matplotlib
+
+cfg = matplotlib.get_configdir()
+expected = os.environ["MPLCONFIGDIR"]
+if os.path.realpath(cfg) != os.path.realpath(expected):
+    raise SystemExit(f"matplotlib config dir {cfg!r} doesn't match {expected!r}")
+if not os.access(cfg, os.W_OK):
+    raise SystemExit(f"matplotlib config dir {cfg!r} is not writable")
+PY
+
 # Запускаем API с авто-reload (1 процесс)
 uvicorn services.api.app.main:app \
         --reload --host 0.0.0.0 --port 8000 &

--- a/scripts/run_bot.sh
+++ b/scripts/run_bot.sh
@@ -18,6 +18,20 @@ export MPLCONFIGDIR="${MPLCONFIGDIR:-/opt/saharlight-ux/data/mpl-cache}"
 mkdir -p "$MPLCONFIGDIR"
 chmod 700 "$MPLCONFIGDIR"
 
+# Validate that Matplotlib uses the configured directory and it's writable
+python - <<'PY'
+import os
+import sys
+import matplotlib
+
+cfg = matplotlib.get_configdir()
+expected = os.environ["MPLCONFIGDIR"]
+if os.path.realpath(cfg) != os.path.realpath(expected):
+    raise SystemExit(f"matplotlib config dir {cfg!r} doesn't match {expected!r}")
+if not os.access(cfg, os.W_OK):
+    raise SystemExit(f"matplotlib config dir {cfg!r} is not writable")
+PY
+
 export PYTHONPATH="${REPO_ROOT}:${PYTHONPATH:-}"
 
 # basic sanity checks for required configuration

--- a/services/deploy/systemd/diabetes-bot.service.example
+++ b/services/deploy/systemd/diabetes-bot.service.example
@@ -5,12 +5,15 @@
 Description=Diabetes Telegram bot
 After=network.target
 
+# Service configuration
 [Service]
 Type=simple
+User=www-data
+PermissionsStartOnly=true
 WorkingDirectory=/srv/diabetes-bot
 EnvironmentFile=/srv/diabetes-bot/.env
-Environment=MPLCONFIGDIR=/opt/saharlight-ux/data/mpl-cache
-ExecStartPre=/usr/bin/install -d -m 700 /opt/saharlight-ux/data/mpl-cache
+Environment=MPLCONFIGDIR=/var/cache/diabetes-bot/mpl
+ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /var/cache/diabetes-bot/mpl
 ExecStartPre=/usr/bin/curl -fsS "$PUBLIC_ORIGIN/health"
 ExecStart=/srv/diabetes-bot/scripts/run_bot.sh
 Restart=on-failure


### PR DESCRIPTION
## Summary
- verify Matplotlib uses MPLCONFIGDIR and cache dir is writable at startup
- provision MPLCONFIGDIR in systemd units with correct ownership

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c16d8ed6e8832abc10104fc04ec511