### PR TITLE
[tests] Fix unawaited coroutine warning in OpenAI utils test

### DIFF
--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -216,7 +216,7 @@ async def test_openai_client_ctx_disposes(monkeypatch: pytest.MonkeyPatch) -> No
 async def test_openai_client_ctx_disposes_with_running_loop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    dispose_mock = AsyncMock()
+    dispose_mock = Mock()
     monkeypatch.setattr(openai_utils, "dispose_http_client", dispose_mock)
     monkeypatch.setattr(openai_utils, "get_openai_client", Mock())
 
@@ -300,7 +300,7 @@ def test_dispose_http_client_sync_creates_event_loop(
     set_loop = Mock()
     monkeypatch.setattr(asyncio, "set_event_loop", set_loop)
 
-    dispose_mock = AsyncMock()
+    dispose_mock = Mock()
     monkeypatch.setattr(openai_utils, "dispose_http_client", dispose_mock)
     monkeypatch.setattr(openai_utils, "_http_client", {})
     monkeypatch.setattr(openai_utils, "_async_http_client", {})


### PR DESCRIPTION
## Summary
- fix unawaited coroutine warning in synchronous disposal test by using a plain Mock

## Testing
- `pytest tests/test_openai_utils.py::test_dispose_http_client_sync_creates_event_loop -q`
- `mypy --strict tests/test_openai_utils.py`
- `ruff check tests/test_openai_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c17b396d4c832aa31aec9d5ad7e9ed