### PR TITLE
[bot] persist Telegram context across restarts

### DIFF
--- a/services/api/app/bot.py
+++ b/services/api/app/bot.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 
-from telegram.ext import Application
+from telegram.ext import Application, PicklePersistence
 
 from .diabetes.bot_start_handlers import build_start_handler
 from .diabetes.bot_status_handlers import build_status_handler
@@ -20,7 +21,14 @@ def main() -> None:
         raise RuntimeError("TELEGRAM_TOKEN is not configured")
     ui_base_url = os.environ.get("UI_BASE_URL", "/ui")
     api_base_url = os.environ.get("API_BASE_URL", "/api")
-    application = Application.builder().token(token).build()
+
+    state_dir = os.environ.get("STATE_DIRECTORY", "/var/lib/diabetes-bot")
+    default_path = os.path.join(state_dir, "bot_persistence.pkl")
+    persistence_file = Path(os.environ.get("BOT_PERSISTENCE_PATH", default_path))
+    persistence_file.parent.mkdir(parents=True, exist_ok=True)
+    persistence = PicklePersistence(str(persistence_file), single_file=True)
+
+    application = Application.builder().token(token).persistence(persistence).build()
     application.add_handler(build_start_handler(ui_base_url))
     application.add_handler(build_status_handler(ui_base_url, api_base_url))
     application.run_polling()

--- a/tests/test_bot_persistence.py
+++ b/tests/test_bot_persistence.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from telegram.ext import Application, CallbackContext, ExtBot, PicklePersistence
+
+
+@pytest.mark.asyncio
+async def test_tg_init_data_persisted_after_restart(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    persistence_path = tmp_path / "data.pkl"
+
+    async def dummy_initialize(self: ExtBot) -> None:
+        return None
+
+    async def dummy_shutdown(self: ExtBot) -> None:
+        return None
+
+    monkeypatch.setattr(ExtBot, "initialize", dummy_initialize)
+    monkeypatch.setattr(ExtBot, "shutdown", dummy_shutdown)
+
+    persistence1 = PicklePersistence(str(persistence_path), single_file=True)
+    app1 = Application.builder().token("TOKEN").persistence(persistence1).build()
+    await app1.initialize()
+
+    app1.user_data[1]["tg_init_data"] = "abc"
+    await app1.persistence.update_user_data(1, app1.user_data[1])
+    await app1.persistence.flush()
+
+    persistence2 = PicklePersistence(str(persistence_path), single_file=True)
+    app2 = Application.builder().token("TOKEN").persistence(persistence2).build()
+    await app2.initialize()
+
+    ctx2: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]] = CallbackContext(app2, user_id=1)
+    assert ctx2.user_data["tg_init_data"] == "abc"

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -16,16 +16,12 @@ _original_get_async_openai_client = openai_utils.get_async_openai_client
 @pytest.fixture(autouse=True)
 def _restore_openai_utils(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(openai_utils, "get_openai_client", _original_get_openai_client)
-    monkeypatch.setattr(
-        openai_utils, "get_async_openai_client", _original_get_async_openai_client
-    )
+    monkeypatch.setattr(openai_utils, "get_async_openai_client", _original_get_async_openai_client)
 
 
 def test_get_openai_client_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(openai_utils, "_http_client", {})
-    fake_settings = SimpleNamespace(
-        openai_api_key="", openai_proxy=None, openai_assistant_id=None
-    )
+    fake_settings = SimpleNamespace(openai_api_key="", openai_proxy=None, openai_assistant_id=None)
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     with pytest.raises(RuntimeError):
         openai_utils.get_openai_client()
@@ -39,9 +35,7 @@ async def test_get_openai_client_uses_proxy(
     http_client_mock = Mock(return_value=fake_http_client)
     openai_mock = Mock()
 
-    fake_settings = SimpleNamespace(
-        openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None
-    )
+    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None)
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_http_client", {})
     monkeypatch.setattr(httpx, "Client", http_client_mock)
@@ -58,13 +52,9 @@ async def test_get_openai_client_uses_proxy(
     fake_http_client.close.assert_called_once()
 
 
-def test_get_openai_client_logs_assistant(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_get_openai_client_logs_assistant(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     openai_mock = Mock()
-    fake_settings = SimpleNamespace(
-        openai_api_key="key", openai_proxy=None, openai_assistant_id="assistant"
-    )
+    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy=None, openai_assistant_id="assistant")
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_http_client", {})
     monkeypatch.setattr(openai_utils, "OpenAI", openai_mock)
@@ -79,9 +69,7 @@ def test_get_openai_client_without_proxy(monkeypatch: pytest.MonkeyPatch) -> Non
     openai_mock = Mock()
     http_client_mock = Mock()
 
-    fake_settings = SimpleNamespace(
-        openai_api_key="key", openai_proxy=None, openai_assistant_id=None
-    )
+    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy=None, openai_assistant_id=None)
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_http_client", {})
     monkeypatch.setattr(openai_utils, "OpenAI", openai_mock)
@@ -109,9 +97,7 @@ async def test_http_client_lock_used(monkeypatch: pytest.MonkeyPatch) -> None:
 
     dummy_lock = DummyLock()
     fake_http_client = Mock()
-    fake_settings = SimpleNamespace(
-        openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None
-    )
+    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None)
 
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_http_client_lock", dummy_lock)
@@ -133,9 +119,7 @@ def test_get_async_openai_client_requires_api_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(openai_utils, "_async_http_client", {})
-    fake_settings = SimpleNamespace(
-        openai_api_key="", openai_proxy=None, openai_assistant_id=None
-    )
+    fake_settings = SimpleNamespace(openai_api_key="", openai_proxy=None, openai_assistant_id=None)
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     with pytest.raises(RuntimeError):
         openai_utils.get_async_openai_client()
@@ -151,9 +135,7 @@ async def test_get_async_openai_client_uses_proxy(
 
     openai_mock = Mock()
 
-    fake_settings = SimpleNamespace(
-        openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None
-    )
+    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None)
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_async_http_client", {})
 
@@ -197,9 +179,7 @@ async def test_openai_client_ctx_disposes(monkeypatch: pytest.MonkeyPatch) -> No
     http_client_mock = Mock(return_value=fake_http_client)
     openai_mock = Mock()
 
-    fake_settings = SimpleNamespace(
-        openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None
-    )
+    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None)
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_http_client", {})
     monkeypatch.setattr(httpx, "Client", http_client_mock)
@@ -216,7 +196,7 @@ async def test_openai_client_ctx_disposes(monkeypatch: pytest.MonkeyPatch) -> No
 async def test_openai_client_ctx_disposes_with_running_loop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    dispose_mock = Mock()
+    dispose_mock = AsyncMock()
     monkeypatch.setattr(openai_utils, "dispose_http_client", dispose_mock)
     monkeypatch.setattr(openai_utils, "get_openai_client", Mock())
 
@@ -239,9 +219,7 @@ async def test_async_openai_client_ctx_disposes(
     async_client_mock = Mock(return_value=fake_async_client)
     openai_mock = Mock()
 
-    fake_settings = SimpleNamespace(
-        openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None
-    )
+    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None)
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_async_http_client", {})
     monkeypatch.setattr(openai_utils, "_http_client", {})
@@ -260,9 +238,7 @@ async def test_async_openai_client_ctx_logs_dispose_error(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     fake_client = object()
-    monkeypatch.setattr(
-        openai_utils, "get_async_openai_client", Mock(return_value=fake_client)
-    )
+    monkeypatch.setattr(openai_utils, "get_async_openai_client", Mock(return_value=fake_client))
     dispose_mock = AsyncMock(side_effect=RuntimeError("boom"))
     monkeypatch.setattr(openai_utils, "dispose_http_client", dispose_mock)
 
@@ -271,9 +247,7 @@ async def test_async_openai_client_ctx_logs_dispose_error(
             assert client is fake_client
 
     dispose_mock.assert_awaited_once()
-    assert any(
-        "Failed to dispose HTTP client" in record.message for record in caplog.records
-    )
+    assert any("Failed to dispose HTTP client" in record.message for record in caplog.records)
 
 
 def test_dispose_http_client_sync(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Persist Telegram application data with configurable PicklePersistence path
- Support persistence path for systemd deployments via `BOT_PERSISTENCE_PATH`
- Test that `tg_init_data` survives bot restarts

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68c1815fc660832a89647eec0a4ae3a1