### PR TITLE
[api] mark onboarding complete on profile save

### DIFF
--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -243,7 +243,8 @@ async def save_profile(data: ProfileUpdateSchema | ProfileSchema) -> None:
     _validate_profile(data)
 
     def _save(session: SessionProtocol) -> None:
-        if session.get(User, data.telegramId) is None:
+        user = cast(User | None, session.get(User, data.telegramId))
+        if user is None:
             raise HTTPException(status_code=404, detail="user not found")
 
         profile = cast(Profile | None, session.get(Profile, data.telegramId))
@@ -293,6 +294,8 @@ async def save_profile(data: ProfileUpdateSchema | ProfileSchema) -> None:
                 set_=update_values,
             )
         )
+
+        user.onboarding_complete = True
 
         try:
             commit(cast(Session, session))


### PR DESCRIPTION
## Summary
- mark onboarding complete when a profile is saved
- ensure profile GET succeeds after profile POST

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68c193ca1e04832a900d14d1ed359966