### PR TITLE
[services] Mark onboarding complete on profile save

### DIFF
--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -243,7 +243,8 @@ async def save_profile(data: ProfileUpdateSchema | ProfileSchema) -> None:
     _validate_profile(data)
 
     def _save(session: SessionProtocol) -> None:
-        if session.get(User, data.telegramId) is None:
+        user = cast(User | None, session.get(User, data.telegramId))
+        if user is None:
             raise HTTPException(status_code=404, detail="user not found")
 
         profile = cast(Profile | None, session.get(Profile, data.telegramId))
@@ -293,6 +294,8 @@ async def save_profile(data: ProfileUpdateSchema | ProfileSchema) -> None:
                 set_=update_values,
             )
         )
+
+        user.onboarding_complete = True
 
         try:
             commit(cast(Session, session))

--- a/tests/test_profile_requires_onboarding.py
+++ b/tests/test_profile_requires_onboarding.py
@@ -66,4 +66,23 @@ def test_profile_get_requires_onboarding(
         session.commit()
     with TestClient(server.app) as client:
         resp = client.get("/api/profile", headers=auth_headers)
-    assert resp.status_code == 422
+        assert resp.status_code == 422
+
+        payload = {
+            "telegramId": 1,
+            "icr": 1.0,
+            "cf": 1.0,
+            "target": 5.0,
+            "low": 4.0,
+            "high": 6.0,
+        }
+        post_resp = client.post("/api/profile", json=payload, headers=auth_headers)
+        assert post_resp.status_code == 200
+
+        resp_ok = client.get("/api/profile", headers=auth_headers)
+        assert resp_ok.status_code == 200
+        assert resp_ok.json()["icr"] == 1.0
+
+    with SessionLocal() as session:
+        user = session.get(db.User, 1)
+        assert user is not None and user.onboarding_complete is True


### PR DESCRIPTION
## Summary
- mark onboarding complete when profile is saved
- test profile save flow updates onboarding flag
- ensure profile GET works after POST

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c1958d0718832a8ae3cdd510a071b5