### PR TITLE
[profile] Complete onboarding after profile save

### DIFF
--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -60,9 +60,7 @@ async def patch_user_settings(
         try:
             ZoneInfo(device_tz)
         except ZoneInfoNotFoundError as exc:  # pragma: no cover - validation
-            raise HTTPException(
-                status_code=400, detail="invalid device timezone"
-            ) from exc
+            raise HTTPException(status_code=400, detail="invalid device timezone") from exc
 
     def _patch(session: SessionProtocol) -> ProfileSchema:
         user = cast(User | None, session.get(User, telegram_id))
@@ -117,12 +115,7 @@ async def patch_user_settings(
         if data.afterMealMinutes is not None:
             profile.postmeal_check_min = data.afterMealMinutes
 
-        if (
-            profile.timezone_auto
-            and device_tz
-            and data.timezone is None
-            and profile.timezone != device_tz
-        ):
+        if profile.timezone_auto and device_tz and data.timezone is None and profile.timezone != device_tz:
             profile.timezone = device_tz
 
         try:
@@ -144,17 +137,13 @@ async def patch_user_settings(
             sosAlertsEnabled=profile.sos_alerts_enabled,
             timezone=profile.timezone,
             timezoneAuto=profile.timezone_auto,
-            therapyType=(
-                TherapyType(profile.therapy_type) if profile.therapy_type else None
-            ),
+            therapyType=(TherapyType(profile.therapy_type) if profile.therapy_type else None),
             dia=profile.dia,
             roundStep=profile.round_step,
             carbUnits=CarbUnits(profile.carb_units),
             gramsPerXe=profile.grams_per_xe,
             glucoseUnits=GlucoseUnits(profile.glucose_units),
-            rapidInsulinType=(
-                RapidInsulinType(profile.insulin_type) if profile.insulin_type else None
-            ),
+            rapidInsulinType=(RapidInsulinType(profile.insulin_type) if profile.insulin_type else None),
             maxBolus=profile.max_bolus,
             preBolus=profile.prebolus_min,
             afterMealMinutes=profile.postmeal_check_min,
@@ -180,17 +169,13 @@ async def get_profile_settings(telegram_id: int) -> ProfileSchema:
         sosAlertsEnabled=profile.sos_alerts_enabled,
         timezone=profile.timezone,
         timezoneAuto=profile.timezone_auto,
-        therapyType=(
-            TherapyType(profile.therapy_type) if profile.therapy_type else None
-        ),
+        therapyType=(TherapyType(profile.therapy_type) if profile.therapy_type else None),
         dia=profile.dia,
         roundStep=profile.round_step,
         carbUnits=CarbUnits(profile.carb_units),
         gramsPerXe=profile.grams_per_xe,
         glucoseUnits=GlucoseUnits(profile.glucose_units),
-        rapidInsulinType=(
-            RapidInsulinType(profile.insulin_type) if profile.insulin_type else None
-        ),
+        rapidInsulinType=(RapidInsulinType(profile.insulin_type) if profile.insulin_type else None),
         maxBolus=profile.max_bolus,
         preBolus=profile.prebolus_min,
         afterMealMinutes=profile.postmeal_check_min,
@@ -283,11 +268,7 @@ async def save_profile(data: ProfileUpdateSchema | ProfileSchema) -> None:
                     profile_data[column] = value
 
         stmt = insert(Profile).values(**profile_data)
-        update_values = {
-            key: getattr(stmt.excluded, key)
-            for key in profile_data.keys()
-            if key != "telegram_id"
-        }
+        update_values = {key: getattr(stmt.excluded, key) for key in profile_data.keys() if key != "telegram_id"}
         session.execute(
             stmt.on_conflict_do_update(
                 index_elements=[Profile.telegram_id],
@@ -296,6 +277,7 @@ async def save_profile(data: ProfileUpdateSchema | ProfileSchema) -> None:
         )
 
         user.onboarding_complete = True
+        cast(Session, session).add(user)
 
         try:
             commit(cast(Session, session))
@@ -314,9 +296,7 @@ async def save_profile(data: ProfileUpdateSchema | ProfileSchema) -> None:
     except HTTPException as exc:
         if exc.status_code == 500:
             logger.exception("save_profile failed for %s", data.telegramId)
-            raise HTTPException(
-                status_code=503, detail="временные проблемы с БД"
-            ) from exc
+            raise HTTPException(status_code=503, detail="временные проблемы с БД") from exc
         raise
 
 
@@ -331,9 +311,7 @@ async def get_profile(telegram_id: int) -> Profile:
         profile = await db.run_db(_get, sessionmaker=db.SessionLocal)
     except (OperationalError, ConnectionError) as exc:
         logger.exception("failed to fetch profile %s", telegram_id)
-        raise HTTPException(
-            status_code=503, detail="database temporarily unavailable"
-        ) from exc
+        raise HTTPException(status_code=503, detail="database temporarily unavailable") from exc
     except SQLAlchemyError as exc:
         logger.exception("sqlalchemy error while fetching profile %s", telegram_id)
         raise HTTPException(status_code=500, detail="database error") from exc

--- a/tests/test_profile_requires_onboarding.py
+++ b/tests/test_profile_requires_onboarding.py
@@ -56,9 +56,7 @@ def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
     return SessionLocal
 
 
-def test_profile_get_requires_onboarding(
-    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
-) -> None:
+def test_profile_get_requires_onboarding(monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]) -> None:
     SessionLocal = setup_db(monkeypatch)
     with SessionLocal() as session:
         session.add(db.User(telegram_id=1, thread_id="t", onboarding_complete=False))
@@ -69,9 +67,7 @@ def test_profile_get_requires_onboarding(
     assert resp.status_code == 422
 
 
-def test_profile_post_enables_get(
-    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
-) -> None:
+def test_profile_post_enables_get(monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]) -> None:
     SessionLocal = setup_db(monkeypatch)
     with SessionLocal() as session:
         session.add(db.User(telegram_id=1, thread_id="t", onboarding_complete=False))
@@ -93,7 +89,10 @@ def test_profile_post_enables_get(
         resp_get = client.get("/api/profile", headers=auth_headers)
 
     assert resp_get.status_code == 200
-    assert resp_get.json()["icr"] == 1.0
+    data = resp_get.json()
+    assert data["icr"] == 1.0
+    assert data["cf"] == 1.0
+    assert data["target"] == 5.0
 
     with SessionLocal() as session:
         user = session.get(db.User, 1)


### PR DESCRIPTION
## Summary
- mark user onboarding complete when saving profile and commit alongside profile data
- expand profile tests to ensure POST then GET returns saved data and flags user as onboarded

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c199ab08c0832a954de1e3c9fcaf91