### PR TITLE
[bot] add persistence

### DIFF
--- a/tests/test_bot_debug_logging.py
+++ b/tests/test_bot_debug_logging.py
@@ -28,6 +28,7 @@ def test_log_level_debug(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # Stub external interactions
     monkeypatch.setattr(bot, "init_db", lambda: None)
+    monkeypatch.setattr(bot, "build_persistence", lambda: object())
 
     class DummyJobQueue:
         class _Scheduler:
@@ -76,6 +77,9 @@ def test_log_level_debug(monkeypatch: pytest.MonkeyPatch) -> None:
 
     class DummyBuilder:
         def token(self, _: str) -> "DummyBuilder":
+            return self
+
+        def persistence(self, _: object) -> "DummyBuilder":
             return self
 
         def post_init(self, _: object) -> "DummyBuilder":

--- a/tests/test_bot_persistence.py
+++ b/tests/test_bot_persistence.py
@@ -5,9 +5,10 @@ from typing import Any
 
 import httpx
 import pytest
-from telegram.ext import Application, CallbackContext, ExtBot, PicklePersistence
+from telegram.ext import Application, CallbackContext, ExtBot
 
 from services.api import rest_client
+from services.bot.main import build_persistence
 
 
 @pytest.mark.asyncio
@@ -23,7 +24,8 @@ async def test_tg_init_data_persisted_after_restart(tmp_path: Path, monkeypatch:
     monkeypatch.setattr(ExtBot, "initialize", dummy_initialize)
     monkeypatch.setattr(ExtBot, "shutdown", dummy_shutdown)
 
-    persistence1 = PicklePersistence(str(persistence_path), single_file=True)
+    monkeypatch.setenv("BOT_PERSISTENCE_PATH", str(persistence_path))
+    persistence1 = build_persistence()
     app1 = Application.builder().token("TOKEN").persistence(persistence1).build()
     await app1.initialize()
 
@@ -31,7 +33,7 @@ async def test_tg_init_data_persisted_after_restart(tmp_path: Path, monkeypatch:
     await app1.persistence.update_user_data(1, app1.user_data[1])
     await app1.persistence.flush()
 
-    persistence2 = PicklePersistence(str(persistence_path), single_file=True)
+    persistence2 = build_persistence()
     app2 = Application.builder().token("TOKEN").persistence(persistence2).build()
     await app2.initialize()
 
@@ -54,14 +56,15 @@ async def test_tg_init_data_persisted_and_used_by_rest_client(
     monkeypatch.setattr(ExtBot, "initialize", dummy_initialize)
     monkeypatch.setattr(ExtBot, "shutdown", dummy_shutdown)
 
-    persistence1 = PicklePersistence(str(persistence_path), single_file=True)
+    monkeypatch.setenv("BOT_PERSISTENCE_PATH", str(persistence_path))
+    persistence1 = build_persistence()
     app1 = Application.builder().token("TOKEN").persistence(persistence1).build()
     await app1.initialize()
     app1.user_data[1]["tg_init_data"] = "secret"
     await app1.persistence.update_user_data(1, app1.user_data[1])
     await app1.persistence.flush()
 
-    persistence2 = PicklePersistence(str(persistence_path), single_file=True)
+    persistence2 = build_persistence()
     app2 = Application.builder().token("TOKEN").persistence(persistence2).build()
     await app2.initialize()
 

--- a/tests/test_bot_single_test_reminder.py
+++ b/tests/test_bot_single_test_reminder.py
@@ -21,6 +21,7 @@ def test_single_test_reminder(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(bot.settings, "admin_id", 1, raising=False)
     monkeypatch.setattr(bot, "TELEGRAM_TOKEN", "token")
     monkeypatch.setattr(bot, "init_db", lambda: None)
+    monkeypatch.setattr(bot, "build_persistence", lambda: object())
 
     class DummyJobQueue:
         class _Scheduler:
@@ -79,6 +80,9 @@ def test_single_test_reminder(monkeypatch: pytest.MonkeyPatch) -> None:
 
     class DummyBuilder:
         def token(self, _: str) -> "DummyBuilder":
+            return self
+
+        def persistence(self, _: object) -> "DummyBuilder":
             return self
 
         def post_init(self, _: object) -> "DummyBuilder":


### PR DESCRIPTION
## Summary
- add PicklePersistence setup with configurable path and directory validation
- persist user data across restarts and assert rest_client uses stored token
- adjust bot tests to accommodate persistence builder

## Testing
- `python -m pytest -q --cov --cov-fail-under=85`
- `mypy --strict services/bot/main.py tests/test_bot_persistence.py tests/test_bot_debug_logging.py tests/test_bot_single_test_reminder.py`
- `ruff check services/bot/main.py tests/test_bot_persistence.py tests/test_bot_debug_logging.py tests/test_bot_single_test_reminder.py`


------
https://chatgpt.com/codex/tasks/task_e_68c19b5d9da4832aa7cd5703cbb4fb6b