### PR TITLE
[profile] create missing user on profile save

### DIFF
--- a/services/api/app/services/profile.py
+++ b/services/api/app/services/profile.py
@@ -230,7 +230,10 @@ async def save_profile(data: ProfileUpdateSchema | ProfileSchema) -> None:
     def _save(session: SessionProtocol) -> None:
         user = cast(User | None, session.get(User, data.telegramId))
         if user is None:
-            raise HTTPException(status_code=404, detail="user not found")
+            user = User(telegram_id=data.telegramId, thread_id="api")
+            cast(Session, session).add(user)
+        if not user.onboarding_complete:
+            user.onboarding_complete = True
 
         profile = cast(Profile | None, session.get(Profile, data.telegramId))
 
@@ -275,9 +278,6 @@ async def save_profile(data: ProfileUpdateSchema | ProfileSchema) -> None:
                 set_=update_values,
             )
         )
-
-        user.onboarding_complete = True
-        cast(Session, session).add(user)
 
         try:
             commit(cast(Session, session))

--- a/tests/test_profile_post_endpoint.py
+++ b/tests/test_profile_post_endpoint.py
@@ -102,10 +102,10 @@ def test_profile_post_invalid_icr_returns_422(
     assert resp.json() == {"detail": "icr must be greater than 0"}
 
 
-def test_profile_post_user_missing_returns_404(
+def test_profile_post_creates_user(
     monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
 ) -> None:
-    setup_db(monkeypatch)
+    SessionLocal = setup_db(monkeypatch)
     payload = {
         "telegramId": 1,
         "icr": 1.0,
@@ -117,5 +117,10 @@ def test_profile_post_user_missing_returns_404(
     }
     with TestClient(server.app) as client:
         resp = client.post("/api/profile", json=payload, headers=auth_headers)
-    assert resp.status_code == 404
-    assert resp.json() == {"detail": "user not found"}
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    with SessionLocal() as session:
+        user = session.get(db.User, 1)
+        assert user is not None
+        assert user.thread_id == "api"
+        assert user.onboarding_complete is True

--- a/tests/test_profiles_api.py
+++ b/tests/test_profiles_api.py
@@ -94,9 +94,7 @@ def test_profiles_get_db_connection_error_returns_503(
     assert resp.json() == {"detail": "database temporarily unavailable"}
 
 
-def test_profiles_post_user_missing_returns_404(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_profiles_post_creates_user(monkeypatch: pytest.MonkeyPatch) -> None:
     app = FastAPI()
     app.include_router(router, prefix="/api")
     engine = create_engine(
@@ -119,7 +117,12 @@ def test_profiles_post_user_missing_returns_404(
     }
     with TestClient(app) as client:
         resp = client.post("/api/profiles", json=payload)
-    assert resp.status_code == 404
+    assert resp.status_code == 200
+    with TestSession() as session:
+        user = session.get(db.User, 777)
+        assert user is not None
+        assert user.thread_id == "api"
+        assert user.onboarding_complete is True
     engine.dispose()
 
 


### PR DESCRIPTION
## Summary
- create `User(thread_id="api")` when saving profile for a new telegram id
- mark onboarding as complete after save_profile or POST /profile
- adjust tests for new behaviour

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c1a80ad608832a88aa2c225451f659