### PR TITLE
deploy: precreate state dir for diabetes bot

### DIFF
--- a/docs/deploy/diabetes-bot.service
+++ b/docs/deploy/diabetes-bot.service
@@ -9,6 +9,7 @@ PermissionsStartOnly=true
 WorkingDirectory=/opt/saharlight-ux
 EnvironmentFile=/opt/saharlight-ux/.env
 Environment=MPLCONFIGDIR=/var/cache/diabetes-bot/mpl
+ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /var/lib/diabetes-bot
 ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /var/cache/diabetes-bot/mpl
 ExecStart=/opt/saharlight-ux/scripts/run_bot.sh
 Restart=on-failure

--- a/tests/test_profile_user_missing.py
+++ b/tests/test_profile_user_missing.py
@@ -1,5 +1,4 @@
 import pytest
-from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 


### PR DESCRIPTION
## Summary
- ensure diabetes-bot service creates /var/lib/diabetes-bot before start
- clean up unused import in test_profile_user_missing

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c1ae062140832a81efb091259bf081