### PR TITLE
[handlers] Keep pending entry on commit failure

### DIFF
--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -48,6 +48,7 @@ async def handle_confirm_entry(
         try:
             commit(session)
         except CommitError:
+            user_data["pending_entry"] = entry_data
             await query.edit_message_text("⚠️ Не удалось сохранить запись.")
             return
     sugar = entry_data.get("sugar_before")

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -186,6 +186,7 @@ async def test_callback_router_commit_failure(
     assert session.rollback.called
     assert "DB commit failed" in caplog.text
     assert query.edited == ["⚠️ Не удалось сохранить запись."]
+    assert context.user_data["pending_entry"] == pending_entry
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep pending entry in user data when DB commit fails so user can retry saving
- test that confirm_entry restores pending entry after CommitError

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c1c3418634832a92865dedfa370421