### PR TITLE
[diabetes] Handle first dict in array for GPT parser

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -117,10 +117,9 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
             i += 1
             continue
         if isinstance(obj, list):
-            dict_count = sum(1 for item in obj if isinstance(item, dict))
-            if dict_count > 1:
-                i = end
-                continue
+            for item in obj:
+                if isinstance(item, dict):
+                    return item
 
         i = end
         queue: deque[object] = deque([obj])

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -188,8 +188,10 @@ async def test_parse_command_with_array_multiple_objects(
     monkeypatch.setattr(gpt_command_parser, "create_chat_completion", create)
 
     result = await gpt_command_parser.parse_command("test")
-
-    assert result is None
+    assert result == {
+        "action": "add_entry",
+        "fields": {},
+    }
 
 
 @pytest.mark.asyncio
@@ -537,7 +539,10 @@ def test_extract_first_json_multi_object_array() -> None:
     text = (
         '[{"action":"add_entry","fields":{}},' '{"action":"delete_entry","fields":{}}]'
     )
-    assert gpt_command_parser._extract_first_json(text) is None
+    assert gpt_command_parser._extract_first_json(text) == {
+        "action": "add_entry",
+        "fields": {},
+    }
 
 
 def test_extract_first_json_nested_object_wrapper() -> None:
@@ -628,7 +633,10 @@ def test_extract_first_json_array_with_many_objects() -> None:
     text = (
         '[{"action":"add_entry","fields":{}},' ' {"action":"delete_entry","fields":{}}]'
     )
-    assert gpt_command_parser._extract_first_json(text) is None
+    assert gpt_command_parser._extract_first_json(text) == {
+        "action": "add_entry",
+        "fields": {},
+    }
 
 
 def test_extract_first_json_malformed_then_valid() -> None:


### PR DESCRIPTION
## Summary
- fix `_extract_first_json` to return first dict from arrays instead of skipping
- test parsing of multiple-object arrays for JSON extraction and command parsing

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68c1c343d144832a9906010d529f6d25