### PR TITLE
[onboarding] Guard step order lookup

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -87,17 +87,26 @@ VARIANT_ORDER: dict[str | None, list[int]] = {
 
 def _step_num(step: int, variant: str | None) -> int:
     order = VARIANT_ORDER.get(variant, VARIANT_ORDER[None])
+    if step not in order:
+        logger.warning("Step %s not in variant order %s", step, variant)
+        return 1
     return order.index(step) + 1
 
 
 def _next_step(step: int, variant: str | None) -> int | None:
     order = VARIANT_ORDER.get(variant, VARIANT_ORDER[None])
+    if step not in order:
+        logger.warning("Step %s not in variant order %s", step, variant)
+        return None
     idx = order.index(step)
     return order[idx + 1] if idx + 1 < len(order) else None
 
 
 def _prev_step(step: int, variant: str | None) -> int | None:
     order = VARIANT_ORDER.get(variant, VARIANT_ORDER[None])
+    if step not in order:
+        logger.warning("Step %s not in variant order %s", step, variant)
+        return None
     idx = order.index(step)
     return order[idx - 1] if idx > 0 else None
 

--- a/tests/test_onboarding_step_helpers.py
+++ b/tests/test_onboarding_step_helpers.py
@@ -1,0 +1,22 @@
+import logging
+
+from services.api.app.diabetes.handlers.onboarding_handlers import (
+    _next_step,
+    _prev_step,
+    _step_num,
+)
+
+
+def test_step_helpers_invalid_step_logs_warning(caplog) -> None:
+    variant = "A"
+    with caplog.at_level(logging.WARNING):
+        assert _step_num(99, variant) == 1
+    assert "variant order" in caplog.text
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        assert _next_step(99, variant) is None
+    assert "variant order" in caplog.text
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        assert _prev_step(99, variant) is None
+    assert "variant order" in caplog.text


### PR DESCRIPTION
## Summary
- guard against missing step in onboarding step helpers and log warnings
- add tests for safe defaults when step is absent

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: Interrupted)*
- `pytest -q tests/test_onboarding_conversation.py tests/test_onboarding_event_logging.py tests/test_onboarding_log_event_failure.py tests/test_onboarding_metrics_indexes.py tests/test_onboarding_router.py tests/test_onboarding_state.py tests/test_onboarding_timezone_webapp.py tests/test_onboarding_video.py tests/test_reset_onboarding.py tests/test_reset_onboarding_command_error.py tests/test_onboarding_step_helpers.py --cov --cov-fail-under=85` *(fails: Required test coverage of 85% not reached. Total coverage: 43.93%)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ce7f5ca8832a83c2bfe14b3a8534