### PR TITLE
[db] Handle engine initialization errors

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -27,7 +27,7 @@ from sqlalchemy import (
 )
 import sqlalchemy as sa
 from sqlalchemy.engine import URL, Engine
-from sqlalchemy.exc import UnboundExecutionError
+from sqlalchemy.exc import SQLAlchemyError, UnboundExecutionError
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
@@ -553,7 +553,11 @@ def init_db() -> None:
         if engine is None or engine.url != database_url:
             if engine is not None:
                 engine.dispose()
-            engine = create_engine(database_url)
+            try:
+                engine = create_engine(database_url)
+            except SQLAlchemyError as exc:
+                logger.error("Failed to initialize database engine: %s", exc)
+                raise RuntimeError("Failed to initialize database engine") from exc
             SessionLocal.configure(bind=engine)
 
     if engine is None:

--- a/tests/test_db_init_engine_error.py
+++ b/tests/test_db_init_engine_error.py
@@ -1,0 +1,33 @@
+import importlib
+import logging
+import sys
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+
+def _reload(module: str) -> object:
+    if module in sys.modules:
+        del sys.modules[module]
+    return importlib.import_module(module)
+
+
+def test_init_db_logs_and_raises_on_engine_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "sqlite://")
+    _reload("services.api.app.config")
+    db = _reload("services.api.app.diabetes.services.db")
+
+    def faulty_create_engine(*args: object, **kwargs: object) -> object:
+        raise SQLAlchemyError("boom")
+
+    monkeypatch.setattr(db, "create_engine", faulty_create_engine)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError, match="Failed to initialize database engine"):
+            db.init_db()
+    assert any(
+        "Failed to initialize database engine" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- wrap engine creation with SQLAlchemy error handling
- log failure and surface runtime error to user
- cover engine init failure scenario with tests

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c1ce80a84c832abc8000bb99bc738c