### PR TITLE
[deploy] use systemd StateDirectory for bot

### DIFF
--- a/docs/deploy/diabetes-bot.service
+++ b/docs/deploy/diabetes-bot.service
@@ -5,12 +5,13 @@ After=network.target
 [Service]
 Type=simple
 User=www-data
-PermissionsStartOnly=true
+# systemd will create /var/lib/diabetes-bot and expose it via STATE_DIRECTORY
+StateDirectory=diabetes-bot
+# use systemd-managed cache directory for matplotlib config
+CacheDirectory=diabetes-bot
 WorkingDirectory=/opt/saharlight-ux
 EnvironmentFile=/opt/saharlight-ux/.env
-Environment=MPLCONFIGDIR=/var/cache/diabetes-bot/mpl
-ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /var/lib/diabetes-bot
-ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /var/cache/diabetes-bot/mpl
+Environment=MPLCONFIGDIR=%C/mpl
 ExecStart=/opt/saharlight-ux/scripts/run_bot.sh
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
## Summary
- ensure systemd service defines StateDirectory and CacheDirectory so bot persistence path is writable

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c1cef5b120832a81bcff9f7f7d540e