### PR TITLE
[bot] Support configurable state directory

### DIFF
--- a/services/api/app/bot.py
+++ b/services/api/app/bot.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import logging
 import os
-from pathlib import Path
 
-from telegram.ext import Application, PicklePersistence
+from telegram.ext import Application
+
+from services.bot.main import build_persistence
 
 from .diabetes.bot_start_handlers import build_start_handler
 from .diabetes.bot_status_handlers import build_status_handler
@@ -22,11 +23,7 @@ def main() -> None:
     ui_base_url = os.environ.get("UI_BASE_URL", "/ui")
     api_base_url = os.environ.get("API_BASE_URL", "/api")
 
-    state_dir = os.environ.get("STATE_DIRECTORY", "/var/lib/diabetes-bot")
-    default_path = os.path.join(state_dir, "bot_persistence.pkl")
-    persistence_file = Path(os.environ.get("BOT_PERSISTENCE_PATH", default_path))
-    persistence_file.parent.mkdir(parents=True, exist_ok=True)
-    persistence = PicklePersistence(str(persistence_file), single_file=True)
+    persistence = build_persistence()
 
     application = Application.builder().token(token).persistence(persistence).build()
     application.add_handler(build_start_handler(ui_base_url))


### PR DESCRIPTION
## Summary
- store bot state under repository `data/state` by default
- allow overriding state directory via `STATE_DIRECTORY`
- reuse persistence builder in API bot
- test persistence directory override

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c270088238832aa9f31c044884f559