### PR TITLE
[bot] Configure Matplotlib cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ scripts/run_bot.sh
 ```
 Скрипт подгружает `.env` и запускает `services.api.app.bot`.
 
+> Matplotlib требует явного каталога конфигурации. Установите
+> `MPLCONFIGDIR=<repo_root>/data/mpl-cache`. Скрипты `run_dev.sh` и
+> `scripts/run_bot.sh`, а также unit-файлы systemd делают это автоматически.
+
 ### Команды BotFather
 
 Зарегистрируйте дополнительные команды в BotFather:

--- a/docs/deploy/diabetes-assistant.service
+++ b/docs/deploy/diabetes-assistant.service
@@ -8,8 +8,8 @@ User=www-data
 PermissionsStartOnly=true
 WorkingDirectory=/opt/saharlight-ux
 EnvironmentFile=/opt/saharlight-ux/.env
-Environment=MPLCONFIGDIR=/var/cache/diabetes-bot/mpl
-ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /var/cache/diabetes-bot/mpl
+Environment=MPLCONFIGDIR=/opt/saharlight-ux/data/mpl-cache
+ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /opt/saharlight-ux/data/mpl-cache
 ExecStart=/usr/bin/env uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000 --workers 4
 Restart=on-failure
 RestartSec=5

--- a/docs/deploy/diabetes-bot.service
+++ b/docs/deploy/diabetes-bot.service
@@ -7,11 +7,11 @@ Type=simple
 User=www-data
 # systemd will create /var/lib/diabetes-bot and expose it via STATE_DIRECTORY
 StateDirectory=diabetes-bot
-# use systemd-managed cache directory for matplotlib config
-CacheDirectory=diabetes-bot
+# use repo-managed cache directory for matplotlib config
 WorkingDirectory=/opt/saharlight-ux
 EnvironmentFile=/opt/saharlight-ux/.env
-Environment=MPLCONFIGDIR=%C/mpl
+Environment=MPLCONFIGDIR=/opt/saharlight-ux/data/mpl-cache
+ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /opt/saharlight-ux/data/mpl-cache
 ExecStart=/opt/saharlight-ux/scripts/run_bot.sh
 Restart=on-failure
 RestartSec=5

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -2,13 +2,15 @@
 # file: run_dev.sh
 set -e
 
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+
 # Загружаем переменные окружения
 set -a
 source ./.env
 set +a
 
 # Конфигурация для Matplotlib
-export MPLCONFIGDIR="${MPLCONFIGDIR:-/opt/saharlight-ux/data/mpl-cache}"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-$REPO_ROOT/data/mpl-cache}"
 mkdir -p "$MPLCONFIGDIR"
 chmod 700 "$MPLCONFIGDIR"
 

--- a/scripts/run_bot.sh
+++ b/scripts/run_bot.sh
@@ -14,7 +14,7 @@ if [[ -f .env ]]; then
   set +a
 fi
 
-export MPLCONFIGDIR="${MPLCONFIGDIR:-/opt/saharlight-ux/data/mpl-cache}"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-$REPO_ROOT/data/mpl-cache}"
 mkdir -p "$MPLCONFIGDIR"
 chmod 700 "$MPLCONFIGDIR"
 

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -9,6 +9,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias
 from zoneinfo import ZoneInfo
 
+os.environ.setdefault(
+    "MPLCONFIGDIR",
+    str(Path(__file__).resolve().parent.parent / "data" / "mpl-cache"),
+)
+
 from sqlalchemy.exc import SQLAlchemyError
 from telegram import BotCommand
 from telegram.ext import (
@@ -70,12 +75,14 @@ async def post_init(
 
 
 async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
-    logger.exception("Exception while handling update %s", update, exc_info=context.error)
+    logger.exception(
+        "Exception while handling update %s", update, exc_info=context.error
+    )
 
 
-def build_persistence() -> PicklePersistence[
-    dict[str, object], dict[str, object], dict[str, object]
-]:
+def build_persistence() -> (
+    PicklePersistence[dict[str, object], dict[str, object], dict[str, object]]
+):
     """Create PicklePersistence with configurable path.
 
     Path can be overridden via ``BOT_PERSISTENCE_PATH``. By default it is
@@ -98,7 +105,9 @@ def main() -> None:  # pragma: no cover
     level = settings.log_level
     if isinstance(level, str):  # pragma: no cover - runtime config
         level = getattr(logging, level.upper(), logging.INFO)
-    logging.basicConfig(level=level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    logging.basicConfig(
+        level=level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
     logger.info("=== Bot started ===")
 
     # применяем воркараунд к PTB JobQueue.stop
@@ -111,7 +120,9 @@ def main() -> None:  # pragma: no cover
         sys.exit("Invalid configuration. Please check your settings and try again.")
     except SQLAlchemyError as exc:
         logger.error("Failed to initialize the database", exc_info=exc)
-        sys.exit("Database initialization failed. Please check your configuration and try again.")
+        sys.exit(
+            "Database initialization failed. Please check your configuration and try again."
+        )
 
     BOT_TOKEN = TELEGRAM_TOKEN
     if not BOT_TOKEN:
@@ -169,7 +180,9 @@ def main() -> None:  # pragma: no cover
         if admin_id is None:
             logger.warning("Admin ID not configured; skipping test reminder")
             return
-        await context.bot.send_message(chat_id=admin_id, text="🔔 Test reminder fired! JobQueue работает ✅")
+        await context.bot.send_message(
+            chat_id=admin_id, text="🔔 Test reminder fired! JobQueue работает ✅"
+        )
 
     job_queue.run_once(test_job, when=timedelta(seconds=30), name="test_job")
     logger.info("🧪 Scheduled test_job in +30s")

--- a/services/deploy/systemd/diabetes-bot.service.example
+++ b/services/deploy/systemd/diabetes-bot.service.example
@@ -12,8 +12,8 @@ User=www-data
 PermissionsStartOnly=true
 WorkingDirectory=/srv/diabetes-bot
 EnvironmentFile=/srv/diabetes-bot/.env
-Environment=MPLCONFIGDIR=/var/cache/diabetes-bot/mpl
-ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /var/cache/diabetes-bot/mpl
+Environment=MPLCONFIGDIR=/srv/diabetes-bot/data/mpl-cache
+ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /srv/diabetes-bot/data/mpl-cache
 ExecStartPre=/usr/bin/curl -fsS "$PUBLIC_ORIGIN/health"
 ExecStart=/srv/diabetes-bot/scripts/run_bot.sh
 Restart=on-failure


### PR DESCRIPTION
## Summary
- Ensure bot uses repo-local `data/mpl-cache` for Matplotlib by default
- Document MPLCONFIGDIR requirement and update run scripts
- Align systemd service files with the same Matplotlib cache path

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2700f9604832a8032b25bdcb22a23