### PR TITLE
[bot] set MPLCONFIGDIR for matplotlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ curl http://localhost:8000/api/profile?telegramId=777
 
 ## Переменные окружения
 Основные параметры указываются в `.env`:
+- `MPLCONFIGDIR` — каталог конфигурации Matplotlib. По умолчанию `<repo_root>/data/mpl-cache`, должен существовать и быть доступен на запись (скрипты запуска и unit-файлы systemd создают его автоматически);
 - `TELEGRAM_TOKEN` — токен бота (обязательно; при отсутствии бот завершится с ошибкой);
 - `PUBLIC_ORIGIN` — публичный URL API;
 - `WEBAPP_URL` — адрес WebApp для онбординга;

--- a/docs/deploy/diabetes-assistant.service
+++ b/docs/deploy/diabetes-assistant.service
@@ -8,8 +8,8 @@ User=www-data
 PermissionsStartOnly=true
 WorkingDirectory=/opt/saharlight-ux
 EnvironmentFile=/opt/saharlight-ux/.env
-Environment=MPLCONFIGDIR=/var/cache/diabetes-bot/mpl
-ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /var/cache/diabetes-bot/mpl
+Environment=MPLCONFIGDIR=/opt/saharlight-ux/data/mpl-cache
+ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /opt/saharlight-ux/data/mpl-cache
 ExecStart=/usr/bin/env uvicorn services.api.app.main:app --host 0.0.0.0 --port 8000 --workers 4
 Restart=on-failure
 RestartSec=5

--- a/docs/deploy/diabetes-bot.service
+++ b/docs/deploy/diabetes-bot.service
@@ -5,13 +5,11 @@ After=network.target
 [Service]
 Type=simple
 User=www-data
-# systemd will create /var/lib/diabetes-bot and expose it via STATE_DIRECTORY
 StateDirectory=diabetes-bot
-# use systemd-managed cache directory for matplotlib config
-CacheDirectory=diabetes-bot
 WorkingDirectory=/opt/saharlight-ux
 EnvironmentFile=/opt/saharlight-ux/.env
-Environment=MPLCONFIGDIR=%C/mpl
+Environment=MPLCONFIGDIR=/opt/saharlight-ux/data/mpl-cache
+ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /opt/saharlight-ux/data/mpl-cache
 ExecStart=/opt/saharlight-ux/scripts/run_bot.sh
 Restart=on-failure
 RestartSec=5

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -11,7 +11,7 @@ source ./.env
 set +a
 
 # Конфигурация для Matplotlib
-export MPLCONFIGDIR="${MPLCONFIGDIR:-/opt/saharlight-ux/data/mpl-cache}"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-${REPO_ROOT}/data/mpl-cache}"
 mkdir -p "$MPLCONFIGDIR"
 chmod 700 "$MPLCONFIGDIR"
 

--- a/scripts/run_bot.sh
+++ b/scripts/run_bot.sh
@@ -14,7 +14,7 @@ if [[ -f .env ]]; then
   set +a
 fi
 
-export MPLCONFIGDIR="${MPLCONFIGDIR:-/opt/saharlight-ux/data/mpl-cache}"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-${REPO_ROOT}/data/mpl-cache}"
 mkdir -p "$MPLCONFIGDIR"
 chmod 700 "$MPLCONFIGDIR"
 

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -1,11 +1,17 @@
 # file: services/bot/main.py
 """Bot entry point and configuration."""
 
-import logging
 import os
+from pathlib import Path
+
+os.environ.setdefault(
+    "MPLCONFIGDIR",
+    str(Path(__file__).resolve().parents[2] / "data/mpl-cache"),
+)
+
+import logging
 import sys
 from datetime import timedelta
-from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias
 from zoneinfo import ZoneInfo
 

--- a/services/deploy/systemd/diabetes-bot.service.example
+++ b/services/deploy/systemd/diabetes-bot.service.example
@@ -12,8 +12,8 @@ User=www-data
 PermissionsStartOnly=true
 WorkingDirectory=/srv/diabetes-bot
 EnvironmentFile=/srv/diabetes-bot/.env
-Environment=MPLCONFIGDIR=/var/cache/diabetes-bot/mpl
-ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /var/cache/diabetes-bot/mpl
+Environment=MPLCONFIGDIR=/srv/diabetes-bot/data/mpl-cache
+ExecStartPre=/usr/bin/install -d -o www-data -g www-data -m 700 /srv/diabetes-bot/data/mpl-cache
 ExecStartPre=/usr/bin/curl -fsS "$PUBLIC_ORIGIN/health"
 ExecStart=/srv/diabetes-bot/scripts/run_bot.sh
 Restart=on-failure


### PR DESCRIPTION
## Summary
- Ensure the bot uses a repo-local Matplotlib config directory via `MPLCONFIGDIR`
- Document `MPLCONFIGDIR` requirement and update systemd units and scripts

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2877e5b44832a997b822a9b016942