### PR TITLE
[bot] handle persistence setup errors

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -132,7 +132,15 @@ def main() -> None:  # pragma: no cover
         sys.exit(1)
 
     # ---- Build application
-    persistence = build_persistence()
+    try:
+        persistence = build_persistence()
+    except Exception as exc:  # pragma: no cover - runtime safety
+        logger.error(
+            "Failed to initialize persistence. "
+            "Ensure STATE_DIRECTORY points to a writable directory.",
+            exc_info=exc,
+        )
+        sys.exit(1)
     application: Application[
         ExtBot[None],
         ContextTypes.DEFAULT_TYPE,

--- a/tests/test_bot_persistence_error.py
+++ b/tests/test_bot_persistence_error.py
@@ -1,0 +1,24 @@
+import logging
+import pytest
+
+import services.bot.main as bot
+
+
+def test_main_logs_persistence_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(bot.settings, "telegram_token", "token")
+    monkeypatch.setattr(bot, "TELEGRAM_TOKEN", "token")
+    monkeypatch.setattr(bot, "init_db", lambda: None)
+
+    def faulty_build_persistence() -> object:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(bot, "build_persistence", faulty_build_persistence)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as exc:
+            bot.main()
+
+    assert exc.value.code == 1
+    assert any("STATE_DIRECTORY" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
## Summary
- guard persistence setup with error logging and a non-zero exit
- cover persistence error path with test

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c287adafec832ab9769f32f95ee0ee