### PR TITLE
[handlers] Reject non-finite numeric entries

### DIFF
--- a/services/api/app/diabetes/handlers/gpt_handlers.py
+++ b/services/api/app/diabetes/handlers/gpt_handlers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
+import math
 import re
 from collections.abc import Awaitable, Callable
 from typing import Protocol, TypeVar, cast
@@ -153,6 +154,14 @@ async def _handle_pending_entry(
         try:
             value = float(text)
         except ValueError:
+            if field == "sugar":
+                await message.reply_text("Введите сахар числом в ммоль/л.")
+            elif field == "xe":
+                await message.reply_text("Введите число ХЕ.")
+            else:
+                await message.reply_text("Введите дозу инсулина числом.")
+            return True
+        if not math.isfinite(value):
             if field == "sugar":
                 await message.reply_text("Введите сахар числом в ммоль/л.")
             elif field == "xe":
@@ -720,9 +729,9 @@ async def chat_with_gpt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     user_data = cast(dict[str, object], context.user_data)
     user_text = message.text
 
-    history = cast(
-        list[str], user_data.get(assistant_state.HISTORY_KEY, [])
-    )[-assistant_state.ASSISTANT_MAX_TURNS :]
+    history = cast(list[str], user_data.get(assistant_state.HISTORY_KEY, []))[
+        -assistant_state.ASSISTANT_MAX_TURNS :
+    ]
     messages: list[dict[str, str]] = []
     summary = cast(str | None, user_data.get(assistant_state.SUMMARY_KEY))
     if summary:

--- a/tests/diabetes/test_gpt_handlers_nan_inf.py
+++ b/tests/diabetes/test_gpt_handlers_nan_inf.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace, TracebackType
+from typing import Any, cast
+
+import pytest
+from telegram import Message, Update
+from telegram.ext import CallbackContext
+from sqlalchemy.orm import Session, sessionmaker
+
+from services.api.app.diabetes.handlers import UserData, gpt_handlers
+
+
+class DummyMessage:
+    def __init__(self, text: str | None = None) -> None:
+        self.text = text
+        self.texts: list[str] = []
+        self.kwargs: list[dict[str, Any]] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.texts.append(text)
+        self.kwargs.append(kwargs)
+
+
+async def _noop_alert(
+    update: Update, context: CallbackContext[Any, Any, Any, Any], sugar: float
+) -> None:
+    return None
+
+
+class DummySession:
+    def __enter__(self) -> "DummySession":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        pass
+
+    def add(self, obj: Any) -> None:
+        pass
+
+
+def session_factory() -> Session:
+    return cast(Session, DummySession())
+
+
+SESSION_FACTORY = cast(sessionmaker[Session], session_factory)
+
+
+@pytest.mark.asyncio
+async def test_handle_pending_entry_nan() -> None:
+    message = DummyMessage("nan")
+    update = cast(Update, SimpleNamespace(message=cast(Message, message)))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    user_data: dict[str, Any] = {"pending_entry": {}, "pending_fields": ["xe"]}
+
+    handled = await gpt_handlers._handle_pending_entry(
+        "nan",
+        cast(UserData, user_data),
+        cast(Message, message),
+        update,
+        context,
+        1,
+        SessionLocal=SESSION_FACTORY,
+        commit=lambda s: None,
+        check_alert=_noop_alert,
+        menu_keyboard=None,
+    )
+    assert handled is True
+    assert user_data["pending_entry"] == {}
+    assert message.texts == ["Введите число ХЕ."]
+
+
+@pytest.mark.asyncio
+async def test_handle_pending_entry_inf() -> None:
+    message = DummyMessage("inf")
+    update = cast(Update, SimpleNamespace(message=cast(Message, message)))
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(),
+    )
+    user_data: dict[str, Any] = {"pending_entry": {}, "pending_fields": ["dose"]}
+
+    handled = await gpt_handlers._handle_pending_entry(
+        "inf",
+        cast(UserData, user_data),
+        cast(Message, message),
+        update,
+        context,
+        1,
+        SessionLocal=SESSION_FACTORY,
+        commit=lambda s: None,
+        check_alert=_noop_alert,
+        menu_keyboard=None,
+    )
+    assert handled is True
+    assert user_data["pending_entry"] == {}
+    assert message.texts == ["Введите дозу инсулина числом."]


### PR DESCRIPTION
## Summary
- ensure pending entry handler rejects NaN and infinite values
- cover non-finite numeric inputs in handler tests

## Testing
- `python -m pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2a6497978832abbc73a90708525d4