### PR TITLE
[diabetes] Support integer SOS contact

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -129,7 +129,9 @@ async def _send_alert_message(
     if profile_info.get("sos_contact") and profile_info.get("sos_alerts_enabled"):
         contact_raw = profile_info["sos_contact"]
         chat_id: int | str | None
-        if isinstance(contact_raw, str):
+        if isinstance(contact_raw, int):
+            chat_id = contact_raw
+        elif isinstance(contact_raw, str):
             contact = contact_raw
             if contact.startswith("@"):
                 chat_id = contact

--- a/tests/diabetes/test_alert_int_contact.py
+++ b/tests/diabetes/test_alert_int_contact.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.ext import ContextTypes
+
+from tests.context_stub import AlertContext, ContextStub
+import services.api.app.diabetes.handlers.alert_handlers as handlers
+
+
+async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
+    """Return empty coordinates for tests."""
+    return None, None
+
+
+@pytest.mark.asyncio
+async def test_send_alert_message_int_contact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Numeric SOS contact triggers message sending."""
+
+    bot = SimpleNamespace(send_message=AsyncMock())
+    context = cast(AlertContext, ContextStub(bot=bot))
+    monkeypatch.setattr(handlers, "get_coords_and_link", fake_get_coords_and_link)
+
+    profile: dict[str, Any] = {
+        "sos_contact": 12345,
+        "sos_alerts_enabled": True,
+    }
+
+    await handlers._send_alert_message(
+        1,
+        10.0,
+        profile,
+        cast(ContextTypes.DEFAULT_TYPE, context),
+        "Ivan",
+    )
+
+    assert bot.send_message.await_count == 2
+    assert bot.send_message.await_args_list[1].kwargs["chat_id"] == 12345
+
+
+__all__ = ["test_send_alert_message_int_contact"]
+


### PR DESCRIPTION
## Summary
- handle integer sos_contact when sending alerts
- test numeric sos_contact

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68c2a649e7a4832ab6826bc0c77bfe7c