### PR TITLE
tests: add typing to run_db helpers

### DIFF
--- a/tests/test_profile_timezone_save.py
+++ b/tests/test_profile_timezone_save.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 import pytest
 from telegram import Update
@@ -26,7 +26,7 @@ class DummyMessage:
 async def test_timezone_save_creates_profile(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def run_db(func, sessionmaker):
+    async def run_db(func: Callable[..., Any], sessionmaker: Any) -> Any:
         if func.__name__ == "db_set_timezone":
             return False, True
         if func.__name__ == "db_get_reminders":

--- a/tests/test_profile_webapp_save_flow.py
+++ b/tests/test_profile_webapp_save_flow.py
@@ -128,7 +128,7 @@ async def test_webapp_save_comma_decimal(monkeypatch: pytest.MonkeyPatch) -> Non
     post_mock = MagicMock(return_value=(True, None))
     save_mock = MagicMock(return_value=True)
 
-    async def run_db(func, sessionmaker):
+    async def run_db(func: Callable[..., Any], sessionmaker: Any) -> Any:
         session = MagicMock()
         return func(session)
 
@@ -230,7 +230,9 @@ async def test_profile_view_uses_local_profile_on_stale_api(
     monkeypatch.setattr(handlers, "SessionLocal", TestSession)
     monkeypatch.setattr(profile_service.db, "SessionLocal", TestSession)
 
-    async def run_db(func, sessionmaker):
+    async def run_db(
+        func: Callable[..., Any], sessionmaker: sessionmaker[Session]
+    ) -> Any:
         with sessionmaker() as session:
             return func(session)
 
@@ -275,7 +277,9 @@ async def test_webapp_save_persists_settings(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(handlers, "SessionLocal", TestSession)
     monkeypatch.setattr(profile_service.db, "SessionLocal", TestSession)
 
-    async def run_db(func, *args, sessionmaker, **kwargs):
+    async def run_db(
+        func: Callable[..., Any], *args: Any, sessionmaker: sessionmaker[Session], **kwargs: Any
+    ) -> Any:
         with sessionmaker() as session:
             return func(session, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
- annotate run_db helper in timezone save test
- annotate run_db helpers in profile webapp save flow tests

## Testing
- `ruff check tests/test_profile_timezone_save.py tests/test_profile_webapp_save_flow.py`
- `mypy --strict .`
- `pytest tests/test_profile_timezone_save.py tests/test_profile_webapp_save_flow.py -q` *(fails: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_68c2bb8b4b10832ab5ad04645c699b0a