### PR TITLE
[scripts] improve database URL handling in check script

### DIFF
--- a/scripts/check_learning_db.py
+++ b/scripts/check_learning_db.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+import logging
 import os
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
 
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
 def main() -> None:
-    url = os.environ["DATABASE_URL"]
+    url = os.environ.get("DATABASE_URL")
+    if url is None:
+        logger.error("DATABASE_URL environment variable is not set")
+        raise SystemExit(1)
+
     engine: Engine = create_engine(url)
     try:
         with engine.connect() as conn:
@@ -16,7 +25,7 @@ def main() -> None:
             quizzes = conn.execute(
                 text("SELECT count(*) FROM quiz_questions")
             ).scalar_one()
-        print(f"lessons={lessons}, steps={steps}, quizzes={quizzes}")
+        logger.info(f"lessons={lessons}, steps={steps}, quizzes={quizzes}")
     finally:
         engine.dispose()
 


### PR DESCRIPTION
## Summary
- handle missing DATABASE_URL in `scripts/check_learning_db.py`
- switch to logging with basic configuration

## Testing
- `make ci` *(fails: No rule to make target 'ci')*
- `pytest -q --cov` *(fails: No module named 'pytest_asyncio')*
- `mypy --strict .` *(interrupted)*
- `ruff check .`
- `python scripts/check_learning_db.py` *(without DATABASE_URL)*
- `DATABASE_URL=sqlite:///temp.db python scripts/check_learning_db.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2bb8f8384832a8d466106f5e54e90