### PR TITLE
[tests] Update profile onboarding tests

### DIFF
--- a/tests/test_profile_timezone_save.py
+++ b/tests/test_profile_timezone_save.py
@@ -5,8 +5,14 @@ from types import SimpleNamespace
 from typing import Any, Callable, cast
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
 from telegram import Update
 from telegram.ext import CallbackContext
+
+import services.api.app.diabetes.services.db as db
+import services.api.app.services.profile as profile_service
 
 handlers = importlib.import_module(
     "services.api.app.diabetes.handlers.profile.conversation"
@@ -26,14 +32,27 @@ class DummyMessage:
 async def test_timezone_save_creates_profile(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def run_db(func: Callable[..., Any], sessionmaker: Any) -> Any:
-        if func.__name__ == "db_set_timezone":
-            return False, True
-        if func.__name__ == "db_get_reminders":
-            return []
-        raise AssertionError(func)
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    db.Base.metadata.create_all(
+        engine, tables=[db.User.__table__, db.Profile.__table__, db.Reminder.__table__]
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal, raising=False)
+    monkeypatch.setattr(handlers, "SessionLocal", SessionLocal)
+    monkeypatch.setattr(profile_service.db, "SessionLocal", SessionLocal)
+
+    async def run_db(
+        func: Callable[..., Any], *args: Any, sessionmaker: sessionmaker[Session], **kwargs: Any
+    ) -> Any:
+        with sessionmaker() as session:
+            return func(session, *args, **kwargs)
 
     monkeypatch.setattr(handlers, "run_db", run_db)
+    monkeypatch.setattr(profile_service.db, "run_db", run_db)
 
     msg = DummyMessage("Europe/Moscow")
     update = cast(
@@ -46,3 +65,7 @@ async def test_timezone_save_creates_profile(
 
     await handlers.profile_timezone_save(update, context)
     assert msg.replies == ["✅ Профиль создан. Часовой пояс сохранён."]
+
+    settings = await profile_service.get_profile_settings(1)
+    assert settings.timezone == "Europe/Moscow"
+    engine.dispose()


### PR DESCRIPTION
## Summary
- adjust profile WebApp tests to expect access without onboarding
- ensure timezone save allows subsequent profile retrieval
- verify defaults served for new users without onboarding

## Testing
- `pytest tests/test_profile_webapp_save_flow.py tests/test_profile_timezone_save.py tests/test_profile_requires_onboarding.py -q` *(fails: assert 422 == 200)*
- `mypy --strict tests/test_profile_webapp_save_flow.py tests/test_profile_timezone_save.py tests/test_profile_requires_onboarding.py`
- `ruff check tests/test_profile_webapp_save_flow.py tests/test_profile_timezone_save.py tests/test_profile_requires_onboarding.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2cfb80bd4832aaccae7e3b1169176