### PR TITLE
[profile] Allow profile access before onboarding completion

### DIFF
--- a/services/api/app/routers/profile.py
+++ b/services/api/app/routers/profile.py
@@ -29,9 +29,7 @@ router = APIRouter()
 
 def _check_token_with_log(authorization: str | None = Header(None)) -> UserContext:
     if not authorization or not authorization.startswith("tg "):
-        logger.warning(
-            "/profile/self called without tg_init_data; ask user to reopen the WebApp"
-        )
+        logger.warning("/profile/self called without tg_init_data; ask user to reopen the WebApp")
     return check_token(authorization)
 
 
@@ -60,11 +58,6 @@ async def profile(user: UserContext = Depends(check_token)) -> ProfileSchema:
     db_user = await db_module.run_db(_get, sessionmaker=db_module.SessionLocal)
     if db_user is None:
         raise HTTPException(status_code=404, detail="user not found")
-    if not db_user.onboarding_complete:
-        raise HTTPException(
-            status_code=422,
-            detail="Завершите онбординг, чтобы просматривать и сохранять профиль",
-        )
 
     return await get_profile_settings(user["id"])
 


### PR DESCRIPTION
## Summary
- Drop onboarding completion requirement from `/profile` GET endpoint
- Adjust test to ensure profile retrieval succeeds even if onboarding incomplete

## Testing
- `pytest -q --cov`
- `mypy --strict services/api/app/routers/profile.py tests/test_profile_requires_onboarding.py` *(interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2cfb3539c832aa4b4e79a7ce2977e