### PR TITLE
[tests] add default profile return test

### DIFF
--- a/tests/test_profile_default_return.py
+++ b/tests/test_profile_default_return.py
@@ -1,0 +1,97 @@
+import hashlib
+import hmac
+import json
+import time
+import urllib.parse
+from typing import Any, Callable
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import services.api.app.main as server
+from services.api.app.config import settings
+from services.api.app.diabetes.services import db
+
+TOKEN = "test-token"
+
+
+def build_init_data(user_id: int = 1) -> str:
+    user = json.dumps({"id": user_id, "first_name": "A"}, separators=(",", ":"))
+    params = {"auth_date": str(int(time.time())), "query_id": "abc", "user": user}
+    data_check = "\n".join(f"{k}={v}" for k, v in sorted(params.items()))
+    secret = hmac.new(b"WebAppData", TOKEN.encode(), hashlib.sha256).digest()
+    params["hash"] = hmac.new(secret, data_check.encode(), hashlib.sha256).hexdigest()
+    return urllib.parse.urlencode(params)
+
+
+@pytest.fixture
+def auth_headers(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    return {"Authorization": f"tg {build_init_data()}"}
+
+
+def setup_db(monkeypatch: pytest.MonkeyPatch) -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = sessionmaker(bind=engine, class_=Session)
+    db.Base.metadata.create_all(bind=engine)
+
+    original_run_db = db.run_db
+
+    async def run_db_wrapper(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        kwargs["sessionmaker"] = SessionLocal
+        return await original_run_db(fn, *args, **kwargs)
+
+    monkeypatch.setattr(server, "run_db", run_db_wrapper)
+    import services.api.app.routers.profile as profile_router
+
+    monkeypatch.setattr(profile_router.db_module, "run_db", run_db_wrapper)
+    monkeypatch.setattr(db, "SessionLocal", SessionLocal, raising=False)
+    return SessionLocal
+
+
+def test_profile_get_returns_default_values(
+    monkeypatch: pytest.MonkeyPatch, auth_headers: dict[str, str]
+) -> None:
+    SessionLocal = setup_db(monkeypatch)
+    with SessionLocal() as session:
+        session.add(db.User(telegram_id=1, thread_id="t", onboarding_complete=False))
+        session.commit()
+
+    expected = {
+        "telegramId": 1,
+        "icr": None,
+        "cf": None,
+        "target": None,
+        "low": None,
+        "high": None,
+        "orgId": None,
+        "sosContact": None,
+        "therapyType": "insulin",
+        "quietStart": "23:00:00",
+        "quietEnd": "07:00:00",
+        "sosAlertsEnabled": True,
+        "timezone": "UTC",
+        "timezoneAuto": True,
+        "dia": 4.0,
+        "roundStep": 0.5,
+        "carbUnits": "g",
+        "gramsPerXe": 12.0,
+        "glucoseUnits": "mmol/L",
+        "rapidInsulinType": None,
+        "maxBolus": 10.0,
+        "preBolus": 0,
+        "afterMealMinutes": 0,
+    }
+
+    with TestClient(server.app) as client:
+        resp = client.get("/api/profile", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json() == expected


### PR DESCRIPTION
## Summary
- test default profile return for users without profile

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2d653a150832aa4055659e4297905