### PR TITLE
[stats] Authorize via tg token

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ curl -X POST http://localhost:8000/api/profile \
 curl http://localhost:8000/api/profile?telegramId=777
 ```
 
+### Пример `/stats`
+```bash
+curl -H 'Authorization: tg <init-data>' \
+  http://localhost:8000/api/stats?telegramId=777
+```
+
 ## Переменные окружения
 Основные параметры указываются в `.env`:
 - `MPLCONFIGDIR` — каталог конфигурации Matplotlib. По умолчанию `<repo_root>/data/mpl-cache`, должен существовать и быть доступен на запись (скрипты запуска и unit-файлы systemd создают его автоматически);

--- a/services/api/app/routers/stats.py
+++ b/services/api/app/routers/stats.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from ..schemas.stats import AnalyticsPoint, DayStats
 from ..schemas.user import UserContext
 from ..services.stats import get_day_stats
-from ..telegram_auth import require_tg_user
+from ..telegram_auth import check_token
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ router = APIRouter()
 )
 async def get_stats(
     telegram_id: int = Query(alias="telegramId"),
-    user: UserContext = Depends(require_tg_user),
+    user: UserContext = Depends(check_token),
 ) -> DayStats | Response:
     if telegram_id != user["id"]:
         raise HTTPException(status_code=403, detail="telegram id mismatch")
@@ -32,7 +32,7 @@ async def get_stats(
 @router.get("/analytics")
 async def get_analytics(
     telegram_id: int = Query(alias="telegramId"),
-    user: UserContext = Depends(require_tg_user),
+    user: UserContext = Depends(check_token),
 ) -> list[AnalyticsPoint]:
     if telegram_id != user["id"]:
         raise HTTPException(status_code=403, detail="telegram id mismatch")

--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -94,11 +94,19 @@ def get_tg_user(init_data: str) -> UserContext:
 
 def require_tg_user(
     init_data: str | None = Header(None, alias=TG_INIT_DATA_HEADER),
+    authorization: str | None = Header(None),
 ) -> UserContext:
-    """Dependency ensuring request contains valid Telegram user info."""
-    if not init_data:
-        raise HTTPException(status_code=401, detail="missing init data")
+    """Dependency ensuring request contains valid Telegram user info.
 
+    Accepts Telegram init data from ``X-Telegram-Init-Data`` or
+    ``Authorization: tg <init_data>`` header.
+    """
+    if not init_data:
+        if isinstance(authorization, str) and authorization.startswith("tg "):
+            init_data = authorization[3:]
+        else:
+            raise HTTPException(status_code=401, detail="missing init data")
+    assert init_data is not None
     return get_tg_user(init_data)
 
 

--- a/tests/test_stats_api.py
+++ b/tests/test_stats_api.py
@@ -11,7 +11,6 @@ from services.api.app.config import settings
 from services.api.app.main import app
 from services.api.app.schemas.stats import DayStats
 from services.api.app.routers import stats as stats_router
-from services.api.app.telegram_auth import TG_INIT_DATA_HEADER
 
 TOKEN = "test-token"
 
@@ -37,7 +36,7 @@ def test_stats_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
         resp = client.get(
             "/api/stats",
             params={"telegramId": 42},
-            headers={TG_INIT_DATA_HEADER: init_data},
+            headers={"Authorization": f"tg {init_data}"},
         )
     assert resp.status_code == 200
     body = resp.json()
@@ -57,7 +56,7 @@ def test_stats_mismatched_id(monkeypatch: pytest.MonkeyPatch) -> None:
         resp = client.get(
             "/api/stats",
             params={"telegramId": 2},
-            headers={TG_INIT_DATA_HEADER: init_data},
+            headers={"Authorization": f"tg {init_data}"},
         )
     assert resp.status_code == 403
 
@@ -74,7 +73,7 @@ def test_empty_stats_returns_default(monkeypatch: pytest.MonkeyPatch) -> None:
         resp = client.get(
             "/api/stats",
             params={"telegramId": 11},
-            headers={TG_INIT_DATA_HEADER: init_data},
+            headers={"Authorization": f"tg {init_data}"},
         )
     assert resp.status_code == 200
     assert resp.json() == {"sugar": 5.7, "breadUnits": 3, "insulin": 10}
@@ -87,7 +86,7 @@ def test_analytics_valid_header(monkeypatch: pytest.MonkeyPatch) -> None:
         resp = client.get(
             "/api/analytics",
             params={"telegramId": 7},
-            headers={TG_INIT_DATA_HEADER: init_data},
+            headers={"Authorization": f"tg {init_data}"},
         )
     assert resp.status_code == 200
     body = resp.json()
@@ -102,7 +101,7 @@ def test_analytics_mismatched_id(monkeypatch: pytest.MonkeyPatch) -> None:
         resp = client.get(
             "/api/analytics",
             params={"telegramId": 2},
-            headers={TG_INIT_DATA_HEADER: init_data},
+            headers={"Authorization": f"tg {init_data}"},
         )
     assert resp.status_code == 403
 
@@ -120,7 +119,7 @@ def test_stats_no_data(monkeypatch: pytest.MonkeyPatch) -> None:
         resp = client.get(
             "/api/stats",
             params={"telegramId": 5},
-            headers={TG_INIT_DATA_HEADER: init_data},
+            headers={"Authorization": f"tg {init_data}"},
         )
     assert resp.status_code == 204
     assert resp.content == b""

--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -117,6 +117,16 @@ def test_require_tg_user_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
         require_tg_user("bad")
 
 
+def test_require_tg_user_authorization_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "telegram_token", TOKEN)
+    init_data: str = build_init_data()
+    header = f"tg {init_data}"
+    user: UserContext = require_tg_user(None, header)
+    assert user["id"] == 1
+
+
 def test_require_tg_user_missing_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """Requests fail with a clear error if the bot token is not configured."""
     monkeypatch.setattr(settings, "telegram_token", "")


### PR DESCRIPTION
## Summary
- use `check_token` for stats and analytics routers so endpoints accept `Authorization: tg <init-data>`
- allow `require_tg_user` to fall back to the same Authorization header
- document and test the new header format

## Testing
- `pytest --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2dab48d14832aa4e674f7681396d6