### PR TITLE
[rest_client] require Telegram auth for API calls

### DIFF
--- a/services/api/app/diabetes/learning_onboarding.py
+++ b/services/api/app/diabetes/learning_onboarding.py
@@ -11,6 +11,8 @@ from telegram.ext import ContextTypes
 
 from services.api.app import profiles
 from services.api.app.assistant.repositories import plans
+from services.api.app.ui.keyboard import build_main_keyboard
+from services.api.rest_client import AuthRequiredError
 
 logger = logging.getLogger(__name__)
 
@@ -143,6 +145,10 @@ async def ensure_overrides(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     if user is not None:
         try:
             profile = await profiles.get_profile_for_user(user.id, context)
+        except AuthRequiredError as exc:
+            if message is not None:
+                await message.reply_text(str(exc), reply_markup=build_main_keyboard())
+            return False
         except (httpx.HTTPError, RuntimeError):
             logger.exception("Failed to get profile for user %s", user.id)
             profile = {}

--- a/tests/diabetes/test_learning_auth.py
+++ b/tests/diabetes/test_learning_auth.py
@@ -9,6 +9,8 @@ from telegram.ext import CallbackContext
 import services.api.app.diabetes.learning_handlers as learning_handlers
 from services.api.app.assistant.repositories.logs import pending_logs
 from services.api.app.config import Settings
+from services.api.app.diabetes import learning_onboarding as onboarding_utils
+from services.api.rest_client import AuthRequiredError
 
 
 class DummyMessage:
@@ -56,3 +58,55 @@ async def test_learn_command_auth_failure(monkeypatch: pytest.MonkeyPatch) -> No
     await learning_handlers.learn_command(update, context)
     assert message.replies == [learning_handlers.AUTH_REQUIRED_MESSAGE]
     pending_logs.clear()
+
+
+@pytest.mark.asyncio
+async def test_learn_command_missing_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        learning_handlers,
+        "settings",
+        Settings(LEARNING_MODE_ENABLED="1", LEARNING_CONTENT_MODE="dynamic", _env_file=None),
+    )
+    monkeypatch.setattr(learning_handlers, "_hydrate", _fake_hydrate)
+
+    async def _fail(_user_id: int, _ctx: object) -> dict[str, object]:
+        raise AuthRequiredError()
+
+    monkeypatch.setattr(learning_handlers.profiles, "get_profile_for_user", _fail)
+
+    message = DummyMessage()
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}, bot_data={}),
+    )
+
+    await learning_handlers.learn_command(update, context)
+    assert message.replies == [learning_handlers.AUTH_REQUIRED_MESSAGE]
+    pending_logs.clear()
+
+
+@pytest.mark.asyncio
+async def test_ensure_overrides_missing_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fail(_user_id: int, _ctx: object) -> dict[str, object]:
+        raise AuthRequiredError()
+
+    monkeypatch.setattr(onboarding_utils.profiles, "get_profile_for_user", _fail)
+
+    message = DummyMessage()
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1), callback_query=None),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}, bot_data={}),
+    )
+
+    result = await onboarding_utils.ensure_overrides(update, context)
+    assert result is False
+    assert message.replies == [learning_handlers.AUTH_REQUIRED_MESSAGE]

--- a/tests/test_bot_persistence.py
+++ b/tests/test_bot_persistence.py
@@ -107,7 +107,7 @@ async def test_tg_init_data_persisted_and_used_by_rest_client(
     monkeypatch.setattr(rest_client, "get_settings", lambda: Settings())
     captured: dict[str, object] = {}
     monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(captured))
-    await rest_client.get_json("/foo", ctx=ctx2)
+    await rest_client.get_json("/api/foo", ctx=ctx2)
     assert captured["headers"]["Authorization"] == "tg secret"
 
 

--- a/tests/test_webapp_init_data_auth.py
+++ b/tests/test_webapp_init_data_auth.py
@@ -65,7 +65,7 @@ async def _assert_header(
     monkeypatch.setattr(rest_client, "get_settings", lambda: Settings())
     captured: dict[str, object] = {}
     monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(captured))
-    await rest_client.get_json("/foo", ctx=ctx)
+    await rest_client.get_json("/api/foo", ctx=ctx)
     assert captured["headers"]["Authorization"] == "tg secret"
 
 


### PR DESCRIPTION
## Summary
- add `AuthRequiredError` and require `tg_init_data` for API requests
- handle missing authorization in learning handlers and onboarding
- adjust tests for new auth behavior

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2e23e39e0832ab797799b68008576