### PR TITLE
[handlers] validate carbs before sugar

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -213,7 +213,15 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         await message.reply_text("Сахар не может быть отрицательным.")
         return DoseState.SUGAR
 
-    entry = cast(EntryData, user_data.get("pending_entry", {}))
+    entry = cast("EntryData | None", user_data.get("pending_entry"))
+    if entry is None or ("xe" not in entry and "carbs_g" not in entry):
+        await message.reply_text(
+            "Сначала укажите углеводы или ХЕ.",
+            reply_markup=dose_keyboard,
+        )
+        user_data.pop("pending_entry", None)
+        return DoseState.METHOD
+
     entry["sugar_before"] = sugar
     xe = entry.get("xe")
     carbs_g = entry.get("carbs_g")

--- a/tests/test_dose_sugar_missing.py
+++ b/tests/test_dose_sugar_missing.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext, ConversationHandler
+from telegram.ext import CallbackContext
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
@@ -41,6 +41,25 @@ async def test_dose_sugar_requires_carbs_or_xe() -> None:
 
     result = await dose_calc.dose_sugar(update, context)
 
-    assert result == ConversationHandler.END
+    assert result == dose_calc.DoseState.METHOD
+    assert message.replies and "углев" in message.replies[0].lower()
+    assert context.user_data == {}
+
+
+
+@pytest.mark.asyncio
+async def test_dose_sugar_requires_pending_entry() -> None:
+    message = DummyMessage("5.5")
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={}),
+    )
+
+    result = await dose_calc.dose_sugar(update, context)
+
+    assert result == dose_calc.DoseState.METHOD
     assert message.replies and "углев" in message.replies[0].lower()
     assert context.user_data == {}


### PR DESCRIPTION
## Summary
- ensure sugar entry only after carbs/XE provided
- cover missing carbs/XE cases in tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2f36403a0832a9fcb8252cc24ba7f