### PR TITLE
[handlers] Reject negative dose inputs

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -351,12 +351,12 @@ dose_conv = ConversationHandler(
     ],
     states={
         DoseState.METHOD: [MessageHandler(filters.TEXT & ~filters.COMMAND, dose_method_choice)],
-        DoseState.XE: [MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), dose_xe)],
-        DoseState.CARBS: [MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), dose_carbs)],
-        DoseState.SUGAR: [MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), dose_sugar)],
+        DoseState.XE: [MessageHandler(filters.Regex(r"^\d+(?:[.,]\d+)?$"), dose_xe)],
+        DoseState.CARBS: [MessageHandler(filters.Regex(r"^\d+(?:[.,]\d+)?$"), dose_carbs)],
+        DoseState.SUGAR: [MessageHandler(filters.Regex(r"^\d+(?:[.,]\d+)?$"), dose_sugar)],
         PHOTO_SUGAR: [
             MessageHandler(
-                filters.Regex(r"^-?\d+(?:[.,]\d+)?$"),
+                filters.Regex(r"^\d+(?:[.,]\d+)?$"),
                 dose_sugar,
             )
         ],


### PR DESCRIPTION
## Summary
- disallow negative values in dose calculation conversation filters
- add tests ensuring negative inputs fail regex checks

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2f36b1318832ab9d39ffc56bdd626