### PR TITLE
[profiles] remove base profile fetch

### DIFF
--- a/services/api/app/profiles.py
+++ b/services/api/app/profiles.py
@@ -10,12 +10,11 @@ from ..rest_client import get_json
 async def get_profile_for_user(
     _: int, ctx: ContextTypes.DEFAULT_TYPE
 ) -> dict[str, object]:
-    base = await get_json("/profile/self", ctx)
     db_profile = await get_json("/learning-profile", ctx)
 
     user_data = ctx.user_data or {}
     overrides = cast(dict[str, object], user_data.get("learn_profile_overrides", {}))
-    profile = {**base, **db_profile, **overrides}
+    profile = {**db_profile, **overrides}
     profile.setdefault("age_group", "adult")
     profile.setdefault("diabetes_type", "unknown")
     profile.setdefault("learning_level", "novice")

--- a/tests/test_profiles_overrides.py
+++ b/tests/test_profiles_overrides.py
@@ -12,12 +12,6 @@ class DummyCtx:
 @pytest.mark.asyncio
 async def test_get_profile_for_user_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_get_json(path: str, _ctx: object | None = None) -> dict[str, object]:
-        if path == "/profile/self":
-            return {
-                "therapyType": "bolus",
-                "rapidInsulinType": "aspart",
-                "carbUnits": "grams",
-            }
         assert path == "/learning-profile"
         return {
             "age_group": "child",
@@ -31,8 +25,6 @@ async def test_get_profile_for_user_overrides(monkeypatch: pytest.MonkeyPatch) -
     )
     result = await profiles.get_profile_for_user(123, ctx)
     assert result == {
-        "therapyType": "bolus",
-        "rapidInsulinType": "aspart",
         "carbUnits": "units",
         "age_group": "child",
         "diabetes_type": "T1",
@@ -60,6 +52,7 @@ async def test_get_profile_for_user_passes_tg_init_data(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def fake_get_json(path: str, ctx: object | None = None) -> dict[str, object]:
+        assert path == "/learning-profile"
         assert isinstance(ctx, DummyCtx)
         assert ctx.user_data["tg_init_data"] == "abc"
         return {}


### PR DESCRIPTION
## Summary
- remove expensive `/profile/self` fetch when getting learning profile
- update tests for profile overrides

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2f6219208832a937caeaef956d955