### PR TITLE
[api] persist tg init data via auth headers

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -362,6 +362,10 @@ async def timezone_webapp(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         raw = str(payload).strip() or "Europe/Moscow"
     if init_data is not None:
         user_data["tg_init_data"] = init_data
+        app = getattr(context, "application", None)
+        user = update.effective_user
+        if app and getattr(app, "persistence", None) and user is not None:
+            await app.persistence.update_user_data(user.id, context.user_data)
     try:
         ZoneInfo(raw)
     except ZoneInfoNotFoundError:

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -333,6 +333,10 @@ async def profile_webapp_save(
     init_data = data.get("init_data")
     if isinstance(init_data, str):
         cast(dict[str, Any], context.user_data)["tg_init_data"] = init_data
+        app = getattr(context, "application", None)
+        user = update.effective_user
+        if app and getattr(app, "persistence", None) and user is not None:
+            await app.persistence.update_user_data(user.id, context.user_data)
     if {
         "icr",
         "cf",
@@ -514,6 +518,10 @@ async def profile_timezone_save(
             init_data = payload.get("init_data")
             if isinstance(init_data, str):
                 cast(dict[str, Any], context.user_data)["tg_init_data"] = init_data
+                app = getattr(context, "application", None)
+                user = update.effective_user
+                if app and getattr(app, "persistence", None) and user is not None:
+                    await app.persistence.update_user_data(user.id, context.user_data)
             raw = str(payload.get("timezone", "")).strip()
         else:
             raw = str(payload).strip()

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -627,6 +627,10 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
     init_data = data.get("init_data")
     if isinstance(init_data, str):
         cast(dict[str, Any], context.user_data)["tg_init_data"] = init_data
+        app = getattr(context, "application", None)
+        user = update.effective_user
+        if app and getattr(app, "persistence", None) and user is not None:
+            await app.persistence.update_user_data(user.id, context.user_data)
 
     sugar_raw = data.get("sugar")
     if sugar_raw is not None:

--- a/services/api/app/profiles.py
+++ b/services/api/app/profiles.py
@@ -4,13 +4,16 @@ from typing import cast
 
 from telegram.ext import ContextTypes
 
-from ..rest_client import get_json
+from ..rest_client import _auth_headers, get_json
 
 
 async def get_profile_for_user(
     _: int, ctx: ContextTypes.DEFAULT_TYPE
 ) -> dict[str, object]:
-    base = await get_json("/profile/self", ctx)
+    base_headers = _auth_headers(ctx)
+    base = {}
+    if base_headers:
+        base = await get_json("/profile/self", ctx)
     db_profile = await get_json("/learning-profile", ctx)
 
     user_data = ctx.user_data or {}

--- a/services/api/rest_client.py
+++ b/services/api/rest_client.py
@@ -19,6 +19,53 @@ class AuthRequiredError(RuntimeError):
         super().__init__(self.MESSAGE)
 
 
+def _auth_headers(ctx: ContextTypes.DEFAULT_TYPE | None) -> dict[str, str]:
+    """Build Authorization headers for API requests.
+
+    Prefers the internal API key if present. Otherwise tries to extract
+    ``tg_init_data`` from the provided ``ctx``.  The token may reside either in
+    ``ctx.user_data`` or in the application's persistence storage.
+    """
+
+    settings = get_settings()
+    if settings.internal_api_key:
+        return {"Authorization": f"Bearer {settings.internal_api_key}"}
+
+    init_data: str | None = None
+    if ctx is not None:
+        user_data = getattr(ctx, "user_data", None)
+        if isinstance(user_data, dict):
+            raw = user_data.get("tg_init_data")
+            if isinstance(raw, str):
+                init_data = raw
+
+        if init_data is None:
+            app = getattr(ctx, "application", None)
+            user_id = getattr(ctx, "user_id", None)
+            if user_id is None:
+                user_id = getattr(ctx, "_user_id", None)
+            if app is not None and user_id is not None:
+                app_ud = getattr(app, "user_data", None)
+                if isinstance(app_ud, dict):
+                    stored = app_ud.get(user_id)
+                    if isinstance(stored, dict):
+                        raw = stored.get("tg_init_data")
+                        if isinstance(raw, str):
+                            init_data = raw
+                if init_data is None:
+                    persistence = getattr(app, "persistence", None)
+                    if persistence is not None and hasattr(persistence, "get_user_data"):
+                        stored = persistence.get_user_data(user_id)
+                        if isinstance(stored, dict):
+                            raw = stored.get("tg_init_data")
+                            if isinstance(raw, str):
+                                init_data = raw
+
+    if init_data is not None:
+        return {"Authorization": f"tg {init_data}"}
+    return {}
+
+
 async def get_json(
     path: str, ctx: ContextTypes.DEFAULT_TYPE | None = None
 ) -> dict[str, object]:
@@ -27,18 +74,9 @@ async def get_json(
     if not base:
         raise RuntimeError("API_URL not configured")
     url = f"{base.rstrip('/')}{path}"
-
-    headers: dict[str, str] = {}
-    if base_settings.internal_api_key:
-        headers["Authorization"] = f"Bearer {base_settings.internal_api_key}"
-    else:
-        user_data = getattr(ctx, "user_data", None) if ctx is not None else None
-        init_data = None
-        if isinstance(user_data, dict):
-            init_data = user_data.get("tg_init_data")
-        if not isinstance(init_data, str):
-            raise AuthRequiredError()
-        headers["Authorization"] = f"tg {init_data}"
+    headers = _auth_headers(ctx)
+    if not headers:
+        raise AuthRequiredError()
 
     async with httpx.AsyncClient() as client:
         resp = await client.get(url, headers=headers)


### PR DESCRIPTION
## Summary
- centralize auth header logic with `_auth_headers`
- only call `/profile/self` when auth token present
- persist tg_init_data from WebApp handlers to bot persistence

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2f61f94d0832a883f1fb7f97c042d