### PR TITLE
[api] Persist tg init data and use auth helper

### DIFF
--- a/services/api/app/diabetes/handlers/onboarding_handlers.py
+++ b/services/api/app/diabetes/handlers/onboarding_handlers.py
@@ -362,6 +362,14 @@ async def timezone_webapp(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         raw = str(payload).strip() or "Europe/Moscow"
     if init_data is not None:
         user_data["tg_init_data"] = init_data
+        app = getattr(context, "application", None)
+        persistence = getattr(app, "persistence", None) if app else None
+        if persistence is not None:
+            try:
+                await persistence.update_user_data(user_id, user_data)
+                await persistence.flush()
+            except Exception as exc:  # pragma: no cover - log only
+                logger.warning("Failed to persist tg_init_data: %s", exc)
     try:
         ZoneInfo(raw)
     except ZoneInfoNotFoundError:

--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -333,6 +333,15 @@ async def profile_webapp_save(
     init_data = data.get("init_data")
     if isinstance(init_data, str):
         cast(dict[str, Any], context.user_data)["tg_init_data"] = init_data
+        user = update.effective_user
+        app = getattr(context, "application", None)
+        persistence = getattr(app, "persistence", None) if app else None
+        if persistence is not None and user is not None:
+            try:
+                await persistence.update_user_data(user.id, context.user_data)
+                await persistence.flush()
+            except Exception as exc:  # pragma: no cover - log only
+                logger.warning("Failed to persist tg_init_data: %s", exc)
     if {
         "icr",
         "cf",
@@ -514,6 +523,15 @@ async def profile_timezone_save(
             init_data = payload.get("init_data")
             if isinstance(init_data, str):
                 cast(dict[str, Any], context.user_data)["tg_init_data"] = init_data
+                user = update.effective_user
+                app = getattr(context, "application", None)
+                persistence = getattr(app, "persistence", None) if app else None
+                if persistence is not None and user is not None:
+                    try:
+                        await persistence.update_user_data(user.id, context.user_data)
+                        await persistence.flush()
+                    except Exception as exc:  # pragma: no cover - log only
+                        logger.warning("Failed to persist tg_init_data: %s", exc)
             raw = str(payload.get("timezone", "")).strip()
         else:
             raw = str(payload).strip()

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -627,6 +627,14 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
     init_data = data.get("init_data")
     if isinstance(init_data, str):
         cast(dict[str, Any], context.user_data)["tg_init_data"] = init_data
+        app = getattr(context, "application", None)
+        persistence = getattr(app, "persistence", None) if app else None
+        if persistence is not None:
+            try:
+                await persistence.update_user_data(user.id, context.user_data)
+                await persistence.flush()
+            except Exception as exc:  # pragma: no cover - log only
+                logger.warning("Failed to persist tg_init_data: %s", exc)
 
     sugar_raw = data.get("sugar")
     if sugar_raw is not None:

--- a/services/api/app/profiles.py
+++ b/services/api/app/profiles.py
@@ -4,13 +4,16 @@ from typing import cast
 
 from telegram.ext import ContextTypes
 
-from ..rest_client import get_json
+from ..rest_client import _auth_headers, get_json
 
 
 async def get_profile_for_user(
     _: int, ctx: ContextTypes.DEFAULT_TYPE
 ) -> dict[str, object]:
-    db_profile = await get_json("/learning-profile", ctx)
+    if await _auth_headers(ctx):
+        db_profile = await get_json("/profile/self", ctx)
+    else:
+        db_profile = {}
 
     user_data = ctx.user_data or {}
     overrides = cast(dict[str, object], user_data.get("learn_profile_overrides", {}))

--- a/services/api/rest_client.py
+++ b/services/api/rest_client.py
@@ -19,6 +19,40 @@ class AuthRequiredError(RuntimeError):
         super().__init__(self.MESSAGE)
 
 
+async def _auth_headers(ctx: ContextTypes.DEFAULT_TYPE | None) -> dict[str, str]:
+    """Return authorization headers based on context or persistence."""
+
+    settings = get_settings()
+    if settings.internal_api_key:
+        return {"Authorization": f"Bearer {settings.internal_api_key}"}
+
+    init_data: str | None = None
+    user_data = getattr(ctx, "user_data", None) if ctx is not None else None
+    if isinstance(user_data, dict):
+        init_data = cast(str | None, user_data.get("tg_init_data"))
+    if not isinstance(init_data, str) and ctx is not None:
+        application = getattr(ctx, "application", None)
+        persistence = getattr(application, "persistence", None) if application else None
+        user_id = getattr(ctx, "user_id", None) or getattr(ctx, "_user_id", None)
+        if user_id is None:
+            pair = getattr(ctx, "_user_id_and_chat_id", None)
+            if pair is not None:
+                user_id = pair[0]
+        if persistence is not None and user_id is not None:
+            try:
+                persisted = await persistence.get_user_data(user_id)
+            except TypeError:  # pragma: no cover - sync persistence
+                persisted = persistence.get_user_data(user_id)
+            if isinstance(persisted, dict):
+                init_data = cast(str | None, persisted.get("tg_init_data"))
+                if isinstance(init_data, str) and isinstance(user_data, dict):
+                    user_data["tg_init_data"] = init_data
+
+    if isinstance(init_data, str):
+        return {"Authorization": f"tg {init_data}"}
+    return {}
+
+
 async def get_json(
     path: str, ctx: ContextTypes.DEFAULT_TYPE | None = None
 ) -> dict[str, object]:
@@ -28,17 +62,9 @@ async def get_json(
         raise RuntimeError("API_URL not configured")
     url = f"{base.rstrip('/')}{path}"
 
-    headers: dict[str, str] = {}
-    if base_settings.internal_api_key:
-        headers["Authorization"] = f"Bearer {base_settings.internal_api_key}"
-    else:
-        user_data = getattr(ctx, "user_data", None) if ctx is not None else None
-        init_data = None
-        if isinstance(user_data, dict):
-            init_data = user_data.get("tg_init_data")
-        if not isinstance(init_data, str):
-            raise AuthRequiredError()
-        headers["Authorization"] = f"tg {init_data}"
+    headers = await _auth_headers(ctx)
+    if not headers:
+        raise AuthRequiredError()
 
     async with httpx.AsyncClient() as client:
         resp = await client.get(url, headers=headers)


### PR DESCRIPTION
## Summary
- centralize auth header building with `_auth_headers`
- load `/profile/self` only when a tg init data token is present
- persist WebApp-provided init data for onboarding, profile and reminder handlers

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2faa92384832aaa7c2d3d5121d9aa