### PR TITLE
[handlers] Add blood sugar upper limit check

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -19,7 +19,7 @@ from services.api.app.diabetes.services.db import (
     SessionLocal,
 )
 from services.api.app.diabetes.services.repository import commit
-from services.api.app.diabetes.utils.constants import XE_GRAMS
+from services.api.app.diabetes.utils.constants import MAX_SUGAR_MMOL_L, XE_GRAMS
 from services.api.app.diabetes.utils.calc_bolus import (
     PatientProfile,
     calc_bolus,
@@ -211,6 +211,11 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         return DoseState.SUGAR
     if sugar < 0:
         await message.reply_text("Сахар не может быть отрицательным.")
+        return DoseState.SUGAR
+    if sugar > MAX_SUGAR_MMOL_L:
+        await message.reply_text(
+            f"Сахар не должен превышать {MAX_SUGAR_MMOL_L} ммоль/л."
+        )
         return DoseState.SUGAR
 
     entry = cast("EntryData | None", user_data.get("pending_entry"))

--- a/services/api/app/diabetes/utils/constants.py
+++ b/services/api/app/diabetes/utils/constants.py
@@ -1,5 +1,6 @@
 """Shared constants for the diabetes module."""
 
 XE_GRAMS: int = 12
+MAX_SUGAR_MMOL_L: float = 33.3
 
-__all__ = ["XE_GRAMS"]
+__all__ = ["XE_GRAMS", "MAX_SUGAR_MMOL_L"]

--- a/tests/handlers/test_dose_calc.py
+++ b/tests/handlers/test_dose_calc.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from services.api.app.diabetes.handlers import dose_calc
+from services.api.app.diabetes.utils.constants import MAX_SUGAR_MMOL_L
+
+
+class DummyMessage:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.replies.append(text)
+
+
+@pytest.mark.asyncio
+async def test_dose_sugar_rejects_high_value() -> None:
+    message = DummyMessage(str(MAX_SUGAR_MMOL_L + 1))
+    update = cast(
+        Update,
+        SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)),
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={"pending_entry": {"carbs_g": 10}}, chat_data={}),
+    )
+
+    result = await dose_calc.dose_sugar(update, context)
+
+    assert result == dose_calc.DoseState.SUGAR
+    assert any(
+        "не должен превышать" in text and str(MAX_SUGAR_MMOL_L) in text
+        for text in message.replies
+    )
+


### PR DESCRIPTION
## Summary
- limit dose calculator sugar input using `MAX_SUGAR_MMOL_L`
- test high sugar branch for dose calculation handler

## Testing
- `pytest -q --cov`
- `pytest tests/handlers/test_dose_calc.py -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c2fd396b74832aa99d63588bcd8577