### PR TITLE
[bot] Add logging to PTB patches

### DIFF
--- a/services/bot/ptb_patches.py
+++ b/services/bot/ptb_patches.py
@@ -7,13 +7,18 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+
+logger = logging.getLogger(__name__)
 
 def apply_jobqueue_stop_workaround() -> None:
     try:
         # Импортируем внутренности PTB — да, это «приватный» модуль.
         import telegram.ext._jobqueue as jq_mod  # type: ignore[attr-defined]
-    except Exception:
+    except ImportError as exc:
+        logger.exception("Failed to import telegram.ext._jobqueue", exc_info=exc)
         return
 
     if getattr(jq_mod.JobQueue.stop, "_patched_asyncio_executor_fix", False):  # уже пропатчено
@@ -32,8 +37,10 @@ def apply_jobqueue_stop_workaround() -> None:
                     # мягко гасим планировщик; wait=False, чтобы не ловить "Event loop is closed"
                     if hasattr(self, "scheduler") and self.scheduler:
                         self.scheduler.shutdown(wait=False)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.exception(
+                        "Failed to shutdown JobQueue scheduler", exc_info=exc
+                    )
                 return
             raise
 


### PR DESCRIPTION
## Summary
- log ImportError when JobQueue internals are missing
- report scheduler shutdown failures instead of silently ignoring them

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3015fa054832a871f1015dbf34ff8