### PR TITLE
[rest_client] support persistence map for auth

### DIFF
--- a/services/api/rest_client.py
+++ b/services/api/rest_client.py
@@ -40,13 +40,15 @@ async def _auth_headers(ctx: ContextTypes.DEFAULT_TYPE | None) -> dict[str, str]
                 user_id = pair[0]
         if persistence is not None and user_id is not None:
             try:
-                persisted = await persistence.get_user_data(user_id)
+                persisted_all = await persistence.get_user_data()
             except TypeError:  # pragma: no cover - sync persistence
-                persisted = persistence.get_user_data(user_id)
-            if isinstance(persisted, dict):
-                init_data = cast(str | None, persisted.get("tg_init_data"))
-                if isinstance(init_data, str) and isinstance(user_data, dict):
-                    user_data["tg_init_data"] = init_data
+                persisted_all = persistence.get_user_data()
+            if isinstance(persisted_all, dict):
+                user_dict = persisted_all.get(user_id)
+                if isinstance(user_dict, dict):
+                    init_data = cast(str | None, user_dict.get("tg_init_data"))
+                    if isinstance(init_data, str) and isinstance(user_data, dict):
+                        user_data["tg_init_data"] = init_data
 
     if isinstance(init_data, str):
         return {"Authorization": f"tg {init_data}"}


### PR DESCRIPTION
## Summary
- fetch full persistence data before reading per-user tg_init_data
- test auth header retrieval with async and sync persistence

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68c302dfb428832a94ceb3a00434c7f0