### PR TITLE
[handlers] Narrow tg_init_data persistence error handling

### DIFF
--- a/services/api/app/diabetes/handlers/profile/conversation.py
+++ b/services/api/app/diabetes/handlers/profile/conversation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from pickle import PickleError
 from datetime import time as dt_time
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
@@ -340,8 +341,11 @@ async def profile_webapp_save(
             try:
                 await persistence.update_user_data(user.id, context.user_data)
                 await persistence.flush()
-            except Exception as exc:  # pragma: no cover - log only
+            except (OSError, PickleError) as exc:  # pragma: no cover - log only
                 logger.warning("Failed to persist tg_init_data: %s", exc)
+            except Exception:  # pragma: no cover - log & propagate
+                logger.exception("Unexpected error persisting tg_init_data")
+                raise
     if {
         "icr",
         "cf",
@@ -530,8 +534,11 @@ async def profile_timezone_save(
                     try:
                         await persistence.update_user_data(user.id, context.user_data)
                         await persistence.flush()
-                    except Exception as exc:  # pragma: no cover - log only
+                    except (OSError, PickleError) as exc:  # pragma: no cover - log only
                         logger.warning("Failed to persist tg_init_data: %s", exc)
+                    except Exception:  # pragma: no cover - log & propagate
+                        logger.exception("Unexpected error persisting tg_init_data")
+                        raise
             raw = str(payload.get("timezone", "")).strip()
         else:
             raw = str(payload).strip()


### PR DESCRIPTION
## Summary
- handle persistence failures for `tg_init_data` narrowly, catching only I/O or pickle errors
- log and re-raise unexpected errors during `tg_init_data` persistence

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c30763fce0832a91e4fe32f9eb98bd