### PR TITLE
[handlers] Prioritize dynamic learning mode

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -83,9 +83,7 @@ async def start_gpt_dialog(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             name=job_name,
             data=user.id,
         )
-    await message.reply_text(
-        "💬 GPT режим активирован. Напишите сообщение или /cancel для выхода."
-    )
+    await message.reply_text("💬 GPT режим активирован. Напишите сообщение или /cancel для выхода.")
 
 
 async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -106,9 +104,7 @@ async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 if TYPE_CHECKING:
     CommandHandlerT: TypeAlias = CommandHandler[ContextTypes.DEFAULT_TYPE, object]
     MessageHandlerT: TypeAlias = MessageHandler[ContextTypes.DEFAULT_TYPE, object]
-    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[
-        ContextTypes.DEFAULT_TYPE, object
-    ]
+    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, object]
 else:
     CommandHandlerT = CommandHandler
     MessageHandlerT = MessageHandler
@@ -131,17 +127,9 @@ def register_profile_handlers(
 
     app.add_handler(profile.profile_conv)
     app.add_handler(profile.profile_webapp_handler)
-    app.add_handler(
-        MessageHandlerT(
-            filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandlerT(profile.profile_security, pattern="^profile_security")
-    )
-    app.add_handler(
-        CallbackQueryHandlerT(profile.profile_back, pattern="^profile_back$")
-    )
+    app.add_handler(MessageHandlerT(filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view))
+    app.add_handler(CallbackQueryHandlerT(profile.profile_security, pattern="^profile_security"))
+    app.add_handler(CallbackQueryHandlerT(profile.profile_back, pattern="^profile_back$"))
 
 
 def register_reminder_handlers(
@@ -169,9 +157,7 @@ def register_reminder_handlers(
             reminder_handlers.reminders_list,
         )
     )
-    app.add_handler(
-        CallbackQueryHandlerT(reminder_handlers.reminder_callback, pattern="^remind_")
-    )
+    app.add_handler(CallbackQueryHandlerT(reminder_handlers.reminder_callback, pattern="^remind_"))
 
     # --- DEBUG HANDLERS ---
     try:
@@ -249,15 +235,11 @@ def register_handlers(
     app.add_handler(CommandHandlerT("cancel", cancel))
     app.add_handler(CommandHandlerT("help", help_command))
     app.add_handler(CommandHandlerT("reset_onboarding", bot_commands.reset_onboarding))
-    if learning_enabled:
-        learning_handlers.register_handlers(app)
     app.add_handler(CommandHandlerT("gpt", start_gpt_dialog))
     app.add_handler(CommandHandlerT("reset", bot_commands.reset_command))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))
-    app.add_handler(
-        CallbackQueryHandlerT(billing_handlers.trial_command, pattern="^trial$")
-    )
+    app.add_handler(CallbackQueryHandlerT(billing_handlers.trial_command, pattern="^trial$"))
     register_reminder_handlers(app)
     app.add_handler(CommandHandlerT("alertstats", alert_handlers.alert_stats))
     app.add_handler(CommandHandlerT("hypoalert", security_handlers.hypo_alert_faq))
@@ -273,19 +255,9 @@ def register_handlers(
             reporting_handlers.history_view,
         )
     )
-    app.add_handler(
-        MessageHandlerT(
-            filters.Regex(PHOTO_BUTTON_PATTERN), photo_handlers.photo_prompt
-        )
-    )
-    app.add_handler(
-        MessageHandlerT(
-            filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help
-        )
-    )
-    app.add_handler(
-        MessageHandlerT(filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command)
-    )
+    app.add_handler(MessageHandlerT(filters.Regex(PHOTO_BUTTON_PATTERN), photo_handlers.photo_prompt))
+    app.add_handler(MessageHandlerT(filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help))
+    app.add_handler(MessageHandlerT(filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command))
     app.add_handler(
         MessageHandlerT(
             filters.Regex(re.escape(SUBSCRIPTION_BUTTON_TEXT)),
@@ -306,21 +278,13 @@ def register_handlers(
         ),
         group=0,
     )
-    app.add_handler(
-        MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler)
-    )
+    if learning_enabled:
+        learning_handlers.register_handlers(app)
+    app.add_handler(MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler))
     app.add_handler(MessageHandlerT(filters.PHOTO, photo_handlers.photo_handler))
     app.add_handler(MessageHandlerT(filters.Document.IMAGE, photo_handlers.doc_handler))
-    app.add_handler(
-        CallbackQueryHandlerT(
-            reporting_handlers.report_period_callback, pattern="^report_back$"
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandlerT(
-            reporting_handlers.report_period_callback, pattern="^report_period:"
-        )
-    )
+    app.add_handler(CallbackQueryHandlerT(reporting_handlers.report_period_callback, pattern="^report_back$"))
+    app.add_handler(CallbackQueryHandlerT(reporting_handlers.report_period_callback, pattern="^report_period:"))
     app.add_handler(CallbackQueryHandlerT(callback_router))
 
     async def _clear_waiting_flags(context: ContextTypes.DEFAULT_TYPE) -> None:


### PR DESCRIPTION
## Summary
- register dynamic learning fallback before static handlers
- guard static quiz handler when content mode is dynamic
- cover dynamic learning quiz handler behavior in tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c308baa848832a89671594c5278c2d