### PR TITLE
[commands] log reset timeout exceptions

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -77,9 +77,10 @@ async def reset_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 )
         except asyncio.CancelledError:
             raise
-        except Exception:
+        except Exception as exc:
             logger.exception(
                 "Reset onboarding timeout task failed",
+                exc_info=exc,
             )
 
     user_data["_onb_reset_confirm"] = True


### PR DESCRIPTION
## Summary
- capture reset timeout errors and log with exc_info

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68c30b511134832a98a65531cf895a08