### PR TITLE
[handlers] use async profile fetch in dose_sugar

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import logging
 from enum import IntEnum
@@ -243,8 +244,11 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
 
     user_id = user.id
     if run_db is None:
-        with SessionLocal() as session:
-            profile = session.get(Profile, user_id)
+        def _get_profile() -> Profile | None:
+            with SessionLocal() as session:
+                return session.get(Profile, user_id)
+
+        profile = await asyncio.to_thread(_get_profile)
     else:
         profile = await run_db(
             lambda s: s.get(Profile, user_id),

--- a/tests/test_dose_sugar_missing.py
+++ b/tests/test_dose_sugar_missing.py
@@ -1,7 +1,8 @@
+import asyncio
 import datetime
 import os
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 import pytest
 from telegram import Update
@@ -22,6 +23,20 @@ class DummyMessage:
     async def reply_text(self, text: str, **kwargs: Any) -> None:
         self.replies.append(text)
         self.kwargs.append(kwargs)
+
+
+class DummySession:
+    def __init__(self, profile: Any) -> None:
+        self.profile = profile
+
+    def __enter__(self) -> "DummySession":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def get(self, model: object, user_id: int) -> Any:
+        return self.profile
 
 
 @pytest.mark.asyncio
@@ -63,3 +78,40 @@ async def test_dose_sugar_requires_pending_entry() -> None:
     assert result == dose_calc.DoseState.METHOD
     assert message.replies and "углев" in message.replies[0].lower()
     assert context.user_data == {}
+
+
+@pytest.mark.asyncio
+async def test_dose_sugar_uses_async_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    entry = {
+        "telegram_id": 1,
+        "event_time": datetime.datetime.now(datetime.timezone.utc),
+        "carbs_g": 10,
+    }
+    message = DummyMessage("5.5")
+    update = cast(
+        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
+    )
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(user_data={"pending_entry": entry}),
+    )
+
+    profile = SimpleNamespace(icr=10.0, cf=2.0, target_bg=5.5)
+    monkeypatch.setattr(dose_calc, "SessionLocal", lambda: DummySession(profile))
+    monkeypatch.setattr(dose_calc, "run_db", None)
+
+    called = False
+
+    async def fake_to_thread(func: Callable[[], Any], /) -> Any:
+        nonlocal called
+        called = True
+        return func()
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(dose_calc, "calc_bolus", lambda carbs, sugar, patient: 1.0)
+    monkeypatch.setattr(dose_calc, "confirm_keyboard", lambda: "confirm")
+
+    result = await dose_calc.dose_sugar(update, context)
+
+    assert result == dose_calc.END
+    assert called


### PR DESCRIPTION
## Summary
- use `asyncio.to_thread` to fetch profile when async DB runner isn't available
- cover async DB fallback branch in `dose_sugar`

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c30b57d3e4832a92ae4282d89bf71d