### PR TITLE
[utils] Restore previous event loop after disposing HTTP client

### DIFF
--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -157,12 +157,17 @@ def _dispose_http_client_sync() -> None:
 
     loop: asyncio.AbstractEventLoop
     created_loop = False
+    previous_loop: asyncio.AbstractEventLoop | None = None
     try:
         try:
             loop = asyncio.get_event_loop()
             if not loop.is_running():
                 raise RuntimeError
         except RuntimeError:
+            try:
+                previous_loop = asyncio.get_event_loop()
+            except RuntimeError:
+                previous_loop = None
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             created_loop = True
@@ -173,6 +178,7 @@ def _dispose_http_client_sync() -> None:
     finally:
         if created_loop:
             loop.close()
+            asyncio.set_event_loop(previous_loop)
 
 
 atexit.register(_dispose_http_client_sync)


### PR DESCRIPTION
## Summary
- Preserve and restore the previous asyncio event loop when disposing of OpenAI HTTP clients synchronously

## Testing
- `pytest -q --cov` *(fails: IndentationError in services/api/app/assistant/repositories/logs.py)*
- `mypy --strict .` *(fails: Unexpected indent in services/api/app/assistant/repositories/logs.py:219)*
- `ruff check .` *(fails: invalid-syntax in services/api/app/assistant/repositories/logs.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c39813d934832a890c1bd5fcb69710