### PR TITLE
[handlers] Remove learn_handlers module

### DIFF
--- a/services/api/app/diabetes/handlers/learn_handlers.py
+++ b/services/api/app/diabetes/handlers/learn_handlers.py
@@ -1,5 +1,0 @@
-from __future__ import annotations
-
-from .learning_handlers import learn_command
-
-__all__ = ["learn_command"]


### PR DESCRIPTION
## Summary
- remove redundant learn_handlers re-export module

## Testing
- `pytest -q --cov` *(fails: unexpected indent in services/api/app/assistant/repositories/logs.py)*
- `mypy --strict .` *(fails: Unexpected indent in services/api/app/assistant/repositories/logs.py:219)*
- `ruff check .` *(fails: invalid syntax at services/api/app/assistant/repositories/logs.py:219)*

------
https://chatgpt.com/codex/tasks/task_e_68c399e992fc832ab7775d622709e10d