### PR TITLE
[learning] Add quiz check system prompt

### DIFF
--- a/services/api/app/diabetes/curriculum_engine.py
+++ b/services/api/app/diabetes/curriculum_engine.py
@@ -15,6 +15,7 @@ from .prompts import (
     SYSTEM_TUTOR_RU,
     build_explain_step,
     build_feedback,
+    build_system_prompt,
     disclaimer,
 )
 from .llm_router import LLMTask
@@ -289,7 +290,10 @@ async def check_answer(
     message = await gpt_client.create_learning_chat_completion(
         task=LLMTask.QUIZ_CHECK,
         messages=[
-            {"role": "system", "content": SYSTEM_TUTOR_RU},
+            {
+                "role": "system",
+                "content": build_system_prompt(profile, task=LLMTask.QUIZ_CHECK),
+            },
             {"role": "user", "content": build_feedback(correct, explanation)},
         ],
     )

--- a/services/api/app/diabetes/dynamic_tutor.py
+++ b/services/api/app/diabetes/dynamic_tutor.py
@@ -38,7 +38,7 @@ async def generate_step_text(
 ) -> str:
     """Generate explanation text for a learning step."""
     try:
-        system = build_system_prompt(profile)
+        system = build_system_prompt(profile, task=LLMTask.EXPLAIN_STEP)
         user = build_user_prompt_step(topic_slug, step_idx, prev_summary)
         return await _chat(LLMTask.EXPLAIN_STEP, system, user)
     except (OpenAIError, httpx.HTTPError, RuntimeError):
@@ -60,7 +60,7 @@ async def check_user_answer(
     LLM judged the answer as correct. The feedback message is returned as-is
     from the model.
     """
-    system = build_system_prompt(profile)
+    system = build_system_prompt(profile, task=LLMTask.QUIZ_CHECK)
     user = (
         f"Тема: {topic_slug}. Текст предыдущего шага:\n{last_step_text}\n\n"
         f"Ответ пользователя: «{user_answer}». Оцени кратко (верно/почти/неверно), "

--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -178,7 +178,8 @@ def _dispose_http_client_sync() -> None:
     finally:
         if created_loop:
             loop.close()
-            asyncio.set_event_loop(previous_loop)
+            if previous_loop is not None:
+                asyncio.set_event_loop(previous_loop)
 
 
 atexit.register(_dispose_http_client_sync)

--- a/tests/learning/test_prompts.py
+++ b/tests/learning/test_prompts.py
@@ -4,6 +4,7 @@ from services.api.app.diabetes.prompts import (
     build_system_prompt,
     build_user_prompt_step,
 )
+from services.api.app.diabetes.llm_router import LLMTask
 
 
 def test_build_system_prompt_includes_profile() -> None:
@@ -28,3 +29,9 @@ def test_build_user_prompt_step_contains_goal_and_instruction() -> None:
     assert "Номер шага: 2" in prompt
     assert prompt.endswith("Ответ не показывай.")
     assert len(prompt) <= 1_500
+
+
+def test_build_system_prompt_quiz_check_format() -> None:
+    prompt = build_system_prompt({}, task=LLMTask.QUIZ_CHECK)
+    assert "✅" in prompt and "⚠️" in prompt and "❌" in prompt
+    assert "Не задавай вопросов" in prompt


### PR DESCRIPTION
## Summary
- extend prompts with QUIZ_CHECK-specific format instructions and task-aware `build_system_prompt`
- route quiz checking through task-aware system prompts in tutor and curriculum engine
- cover new prompt branch with unit test and fix HTTP client disposal when no loop exists

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3aa8e7a78832ab911646ba1a567e8