### PR TITLE
[learning] test dynamic tutor sanitization

### DIFF
--- a/tests/learning/test_dynamic_tutor.py
+++ b/tests/learning/test_dynamic_tutor.py
@@ -60,3 +60,18 @@ async def test_cancellation_not_suppressed(monkeypatch: pytest.MonkeyPatch) -> N
         await dynamic_tutor.generate_step_text({}, "topic", 1, None)
     with pytest.raises(asyncio.CancelledError):
         await dynamic_tutor.check_user_answer({}, "topic", "42", "step")
+
+
+def test_sanitize_feedback_removes_questions() -> None:
+    feedback = "Верно. Что дальше? Повтори тему."
+    result = dynamic_tutor.sanitize_feedback(feedback)
+    assert "?" not in result
+    assert result == "Верно. Повтори тему."
+
+
+def test_sanitize_feedback_limits_sentences_and_length() -> None:
+    long = "x" * (dynamic_tutor.MAX_FEEDBACK_LEN + 50)
+    text = f"{long}. Вторая. Третья?"
+    result = dynamic_tutor.sanitize_feedback(text)
+    assert len(result) <= dynamic_tutor.MAX_FEEDBACK_LEN
+    assert result.count(".") <= 2

--- a/tests/learning/test_prompts.py
+++ b/tests/learning/test_prompts.py
@@ -4,6 +4,7 @@ from services.api.app.diabetes.prompts import (
     build_system_prompt,
     build_user_prompt_step,
 )
+from services.api.app.diabetes.llm_router import LLMTask
 
 
 def test_build_system_prompt_includes_profile() -> None:
@@ -28,3 +29,9 @@ def test_build_user_prompt_step_contains_goal_and_instruction() -> None:
     assert "Номер шага: 2" in prompt
     assert prompt.endswith("Ответ не показывай.")
     assert len(prompt) <= 1_500
+
+
+def test_system_prompt_quiz_check_instructions() -> None:
+    prompt = build_system_prompt({}, LLMTask.QUIZ_CHECK)
+    assert "вердикта" in prompt.lower()
+    assert "не задавай вопросов" in prompt.lower()

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call
 
 import httpx
 import pytest
@@ -281,7 +281,7 @@ def test_dispose_http_client_sync_creates_event_loop(
 
     openai_utils._dispose_http_client_sync()
 
-    set_loop.assert_called_once_with(fake_loop)
+    set_loop.assert_has_calls([call(fake_loop), call(None)])
     fake_loop.run_until_complete.assert_called_once()
     fake_loop.close.assert_called_once()
 


### PR DESCRIPTION
## Summary
- sanitize dynamic tutor feedback to drop questions and limit length
- allow system prompt builder to inject quiz-check instructions
- test dynamic tutor sanitization and quiz system prompts

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3aa940cac832a83713b584fbcf99b