### PR TITLE
[handlers] remove redundant learn_handlers shim

### DIFF
--- a/services/api/app/diabetes/handlers/learn_handlers.py
+++ b/services/api/app/diabetes/handlers/learn_handlers.py
@@ -1,5 +1,0 @@
-from __future__ import annotations
-
-from ..learning_handlers import learn_command
-
-__all__ = ["learn_command"]


### PR DESCRIPTION
## Summary
- remove outdated learn_handlers shim module that only re-exported learn_command

## Testing
- `pytest -q --cov` *(fails: tests/test_openai_utils.py::test_dispose_http_client_sync_creates_event_loop)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3aaaba778832aa4b7d9fb7818c8f4