### PR TITLE
[utils] remove unused markdown helpers

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -7,36 +7,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from reportlab.pdfbase.pdfmetrics import stringWidth
-from reportlab.lib.units import mm
-
 logger = logging.getLogger(__name__)
-
-# utils.py
-
-
-def clean_markdown(text: str) -> str:
-    """
-    Удаляет простую Markdown-разметку: **жирный**, _курсив_, # заголовки,
-    списки (*, -, +, 1. и т.д.).
-    """
-    replacements = [
-        (r"\*\*([^*]+)\*\*", r"\1"),  # **жирный**
-        (r"__([^_]+)__", r"\1"),  # __жирный__
-        (r"_([^_]+)_", r"\1"),  # _курсив_
-        (r"\*([^*]+)\*", r"\1"),  # *курсив*
-        (r"~~([^~]+)~~", r"\1"),  # ~~зачеркнуто~~
-        (r"\[([^\]]+)\]\([^\)]+\)", r"\1"),  # [текст](ссылка)
-        (r"!\[([^\]]*)\]\([^\)]+\)", r"\1"),  # ![alt](ссылка)
-        (r"`([^`]+)`", r"\1"),  # `код`
-    ]
-    for pattern, repl in replacements:
-        text = re.sub(pattern, repl, text)
-    text = re.sub(r"^#+\s*", "", text, flags=re.MULTILINE)  # ### Заголовки
-    text = re.sub(r"^\s*\d+\.\s*", "", text, flags=re.MULTILINE)  # 1. списки
-    text = re.sub(r"^\s*[*+-]\s*", "", text, flags=re.MULTILINE)  # bullet lists
-    return text
-
 
 INVALID_TIME_MSG = "❌ Неверный формат. Примеры: 22:30 | 6:00 | 5h | 3d"
 
@@ -116,74 +87,3 @@ async def get_coords_and_link(
     if loc is not None:
         logger.warning("Invalid location format: %s", loc)
     return None, None
-
-
-def split_text_by_width(
-    text: str,
-    font_name: str,
-    font_size: float,
-    max_width_mm: float,
-) -> list[str]:
-    """
-    Разбивает строку так, чтобы она не выходила за max_width_mm по ширине в PDF (мм).
-
-    Raises:
-        ValueError: если ``font_name`` не зарегистрирован в ReportLab или
-            ``font_size``/``max_width_mm`` неположительны.
-    """
-    if font_size <= 0 or max_width_mm <= 0:
-        raise ValueError("font_size and max_width_mm must be positive")
-
-    words = text.split()
-    lines: list[str] = []
-    current_line = ""
-
-    def _width(chunk: str) -> float:
-        try:
-
-            raw: float = float(stringWidth(chunk, font_name, font_size))
-            mm_value: float = mm
-            return raw / mm_value
-
-        except KeyError as exc:
-            raise ValueError(f"Unknown font '{font_name}'") from exc
-
-    def _split_word(word: str) -> list[str]:
-        """Split a single word into chunks that fit within ``max_width_mm``."""
-
-        parts: list[str] = []
-        part = ""
-        for ch in word:
-            test_part = part + ch
-
-            if _width(test_part) > max_width_mm and part:
-
-                parts.append(part)
-                part = ch
-            else:
-                part = test_part
-        if part:
-            parts.append(part)
-        return parts
-
-    for word in words:
-        test_line = (current_line + " " + word).strip()
-        width = _width(test_line)
-        if width <= max_width_mm:
-            current_line = test_line
-            continue
-
-        if current_line:
-            lines.append(current_line)
-            current_line = ""
-
-        if _width(word) <= max_width_mm:
-            current_line = word
-        else:
-            parts = _split_word(word)
-            lines.extend(parts[:-1])
-            current_line = parts[-1] if parts else ""
-
-    if current_line:
-        lines.append(current_line)
-    return lines

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,94 +6,12 @@ import asyncio
 import time
 import logging
 from datetime import timedelta
-from reportlab.pdfbase import pdfmetrics
-from reportlab.pdfbase.ttfonts import TTFont
-from reportlab.pdfbase.pdfmetrics import stringWidth
-from reportlab.lib.units import mm
-
 import pytest
 
 import httpx
 
 import services.api.app.diabetes.utils.helpers as utils
-from services.api.app.diabetes.utils.helpers import (
-    clean_markdown,
-    parse_time_interval,
-    split_text_by_width,
-)
-
-
-def test_clean_markdown() -> None:
-    text = (
-        "**Жирный** __подчёркнутый__ _курсив_ *italic* "
-        "[ссылка](http://example.com) ![alt](img.png) `код` ~~зачёркнуто~~\n"
-        "# Заголовок\n* элемент\n- минус\n+ плюс\n1. Первый"
-    )
-    cleaned = clean_markdown(text)
-    assert "Жирный" in cleaned
-    assert "подчёркнутый" in cleaned
-    assert "курсив" in cleaned
-    assert "italic" in cleaned
-    assert "ссылка" in cleaned
-    assert "alt" in cleaned
-    assert "код" in cleaned
-    assert "зачёркнуто" in cleaned
-    assert "минус" in cleaned
-    assert "плюс" in cleaned
-    assert "#" not in cleaned
-    assert "*" not in cleaned
-    assert "-" not in cleaned
-    assert "+" not in cleaned
-    assert "1." not in cleaned
-    assert "__" not in cleaned
-    assert "_" not in cleaned
-    assert "~~" not in cleaned
-
-
-def test_split_text_by_width_simple() -> None:
-    text = "Это короткая строка"
-    pdfmetrics.registerFont(TTFont("DejaVuSans", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"))
-    lines = split_text_by_width(text, "DejaVuSans", 12, 50)
-    assert isinstance(lines, list)
-    assert all(isinstance(line, str) for line in lines)
-
-
-def test_split_text_by_width_unknown_font() -> None:
-    with pytest.raises(ValueError, match="Unknown font"):
-        split_text_by_width("text", "NoSuchFont", 12, 50)
-
-
-@pytest.mark.parametrize(
-    ("font_size", "max_width"),
-    [
-        (0, 50),
-        (12, 0),
-        (-1, 50),
-        (12, -5),
-    ],
-)
-def test_split_text_by_width_invalid_params(font_size: float, max_width: float) -> None:
-    pdfmetrics.registerFont(
-        TTFont("DejaVuSans", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
-    )
-    with pytest.raises(ValueError, match="must be positive"):
-        split_text_by_width("text", "DejaVuSans", font_size, max_width)
-
-
-@pytest.mark.parametrize(
-    "text",
-    [
-        "Supercalifragilisticexpialidocious",
-        "Hello Supercalifragilisticexpialidocious world",
-    ],
-)
-def test_split_text_by_width_respects_limit(text: Any) -> None:
-    pdfmetrics.registerFont(TTFont("DejaVuSans", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"))
-    max_width = 20
-    lines = split_text_by_width(text, "DejaVuSans", 12, max_width)
-    for line in lines:
-        assert stringWidth(line, "DejaVuSans", 12) / mm <= max_width
-
+from services.api.app.diabetes.utils.helpers import parse_time_interval
 
 @pytest.mark.asyncio
 async def test_get_coords_and_link_non_blocking(


### PR DESCRIPTION
## Summary
- remove clean_markdown and split_text_by_width from helpers
- drop related tests and reportlab imports

## Testing
- `pytest -q --cov` *(fails: test_dispose_http_client_sync_creates_event_loop)*
- `pytest tests/test_utils.py -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3aab82710832ab0000ea24b3f75ea