### PR TITLE
[utils] Make _round_bolus internal

### DIFF
--- a/services/api/app/diabetes/utils/calc_bolus.py
+++ b/services/api/app/diabetes/utils/calc_bolus.py
@@ -124,4 +124,4 @@ def calc_bolus(
     return _round_bolus(total_f, bolus_round_step)
 
 
-__all__ = ["PatientProfile", "_round_bolus", "calc_bolus"]
+__all__ = ["PatientProfile", "calc_bolus"]

--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -178,7 +178,8 @@ def _dispose_http_client_sync() -> None:
     finally:
         if created_loop:
             loop.close()
-            asyncio.set_event_loop(previous_loop)
+            if previous_loop is not None:
+                asyncio.set_event_loop(previous_loop)
 
 
 atexit.register(_dispose_http_client_sync)


### PR DESCRIPTION
## Summary
- keep bolus rounding helper private by removing `_round_bolus` from exports
- avoid resetting event loop to `None` in OpenAI HTTP client disposal

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3aabee9fc832a87621be08bd3b286