### PR TITLE
[tests] centralize openai_utils import

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,14 @@ pytest_plugins = ("pytest_asyncio",)
 setattr(_dynamic_learning_handlers, "curriculum_engine", curriculum_engine)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _import_openai_utils() -> None:
+    """Import ``openai_utils`` once to register its side effects."""
+    import importlib
+
+    importlib.import_module("services.api.app.diabetes.utils.openai_utils")
+
+
 @pytest.fixture(autouse=True)
 def _fake_learning_profile(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stub profile lookups to avoid external API calls in tests."""

--- a/tests/handlers/test_photo_handler_recognition.py
+++ b/tests/handlers/test_photo_handler_recognition.py
@@ -15,7 +15,6 @@ from telegram.ext import CallbackContext
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
 import services.api.app.diabetes.utils.functions as functions
 

--- a/tests/learning/test_lesson_logs.py
+++ b/tests/learning/test_lesson_logs.py
@@ -13,7 +13,7 @@ from services.api.app.assistant.repositories.logs import (
     cleanup_old_logs,
     get_lesson_logs,
 )
-from services.api.app.assistant.models import LessonLog  # noqa: F401
+from services.api.app.assistant.models import LessonLog
 
 
 @pytest.fixture()

--- a/tests/test_dose_conv_photo_fallback.py
+++ b/tests/test_dose_conv_photo_fallback.py
@@ -11,7 +11,6 @@ from telegram.ext import BaseHandler, CallbackContext, MessageHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import dose_calc
 from services.api.app.diabetes.utils.ui import (
     PHOTO_BUTTON_PATTERN,

--- a/tests/test_dose_info_unit.py
+++ b/tests/test_dose_info_unit.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import Session, sessionmaker
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 import services.api.app.diabetes.handlers.dose_calc as dose_calc
 import services.api.app.diabetes.handlers.gpt_handlers as gpt_handlers
 

--- a/tests/test_dose_sugar_missing.py
+++ b/tests/test_dose_sugar_missing.py
@@ -10,7 +10,6 @@ from telegram.ext import CallbackContext
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import dose_calc
 
 

--- a/tests/test_edit_record.py
+++ b/tests/test_edit_record.py
@@ -64,7 +64,6 @@ class DummyBot:
 async def test_edit_dose(monkeypatch: pytest.MonkeyPatch) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
     import services.api.app.diabetes.handlers.dose_calc as dose_calc
 

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -11,7 +11,6 @@ import pytest
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
 from services.api.app import config  # noqa: E402
-from services.api.app.diabetes.utils import openai_utils  # noqa: F401,E402
 from services.api.app.diabetes import gpt_command_parser  # noqa: E402
 
 

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -47,7 +47,6 @@ async def test_callback_router_cancel_entry_sends_menu(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
 
     query = DummyQuery(DummyMessage(), "cancel_entry")
@@ -80,7 +79,6 @@ async def test_callback_router_invalid_entry_id(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
 
     query = DummyQuery(DummyMessage(), "del:abc")
@@ -104,7 +102,6 @@ async def test_handle_edit_or_delete_missing_colon(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
 
     query = DummyQuery(DummyMessage(), "del")
@@ -128,7 +125,6 @@ async def test_callback_router_unknown_data(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
 
     query = DummyQuery(DummyMessage(), "foo")
@@ -151,7 +147,6 @@ async def test_callback_router_ignores_reminder_action(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
 
     query = DummyQuery(DummyMessage(), "rem_toggle:1")

--- a/tests/test_handlers_commit_failures.py
+++ b/tests/test_handlers_commit_failures.py
@@ -95,7 +95,6 @@ async def test_profile_command_saves_locally(
     """Profile command persists profile to local DB."""
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
 
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
@@ -133,7 +132,6 @@ async def test_profile_command_db_error(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
 
     run_db = AsyncMock(return_value=False)
     monkeypatch.setattr(profile_handlers, "run_db", run_db)
@@ -159,7 +157,6 @@ async def test_callback_router_commit_failure(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
 
     session = MagicMock()
     session.__enter__.return_value = session

--- a/tests/test_handlers_history_edit.py
+++ b/tests/test_handlers_history_edit.py
@@ -70,7 +70,6 @@ class DummyBot:
 async def test_history_view_buttons(monkeypatch: pytest.MonkeyPatch) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.reporting_handlers as reporting_handlers
     import services.api.app.diabetes.handlers.router as router
     import services.api.app.diabetes.handlers.dose_calc as dose_calc
@@ -216,7 +215,6 @@ async def test_history_view_webapp_button(
 async def test_edit_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
     import services.api.app.diabetes.handlers.dose_calc as dose_calc
 
@@ -321,7 +319,6 @@ async def test_handle_edit_entry_missing_metadata(
 ) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
     engine = create_engine(
         "sqlite:///:memory:",

--- a/tests/test_handlers_profile.py
+++ b/tests/test_handlers_profile.py
@@ -74,7 +74,6 @@ async def test_profile_command_and_view(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     from services.api.app.diabetes.handlers import profile as handlers
 
     engine = create_engine("sqlite:///:memory:")
@@ -172,7 +171,6 @@ async def test_profile_command_invalid_values(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     from services.api.app.diabetes.handlers import profile as handlers
 
     commit_mock = MagicMock()
@@ -204,7 +202,6 @@ async def test_profile_command_invalid_values(
 async def test_profile_command_help(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     from services.api.app.diabetes.handlers import profile as handlers
 
     help_msg = DummyMessage()
@@ -226,7 +223,6 @@ async def test_profile_command_view_existing_profile(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     from services.api.app.diabetes.handlers import profile as handlers
 
     engine = create_engine("sqlite:///:memory:")
@@ -269,7 +265,6 @@ async def test_profile_view_preserves_user_data(
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     from services.api.app.diabetes.handlers import profile as handlers
 
     engine = create_engine("sqlite:///:memory:")

--- a/tests/test_handlers_prompts.py
+++ b/tests/test_handlers_prompts.py
@@ -9,7 +9,6 @@ import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
 import services.api.app.diabetes.handlers.sugar_handlers as sugar_handlers
 from services.api.app.diabetes.handlers import dose_calc

--- a/tests/test_handlers_report_request.py
+++ b/tests/test_handlers_report_request.py
@@ -43,7 +43,6 @@ async def test_report_request_and_custom_flow(
 ) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.reporting_handlers as reporting_handlers
     import services.api.app.diabetes.handlers.dose_calc as dose_calc
 
@@ -118,7 +117,6 @@ async def test_report_period_callback_week(
 ) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.reporting_handlers as reporting_handlers
 
     called: dict[str, dt.datetime | str] = {}

--- a/tests/test_menu_fallbacks.py
+++ b/tests/test_menu_fallbacks.py
@@ -8,7 +8,6 @@ from telegram.ext import CallbackContext, CommandHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import dose_calc
 from services.api.app.diabetes.utils.ui import PHOTO_BUTTON_TEXT
 

--- a/tests/test_photo_button_regex.py
+++ b/tests/test_photo_button_regex.py
@@ -26,7 +26,6 @@ class DummyMessage:
 async def test_photo_button_without_emoji_triggers_prompt() -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
     handlers.register_handlers(app)

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -11,7 +11,6 @@ from telegram.ext import BaseHandler, CallbackContext, MessageHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import (
     dose_calc,
     profile as profile_handlers,

--- a/tests/test_photo_handlers_additional.py
+++ b/tests/test_photo_handlers_additional.py
@@ -14,7 +14,6 @@ from telegram.ext import CallbackContext
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
 import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
 import services.api.app.diabetes.utils.functions as functions

--- a/tests/test_profile_ignores_sugar_conv.py
+++ b/tests/test_profile_ignores_sugar_conv.py
@@ -10,7 +10,6 @@ from telegram.ext import CallbackContext
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import profile as profile_handlers
 import services.api.app.diabetes.services.db as db
 from services.api.app.diabetes.services.db import Base, Entry, User

--- a/tests/test_profile_no_sdk.py
+++ b/tests/test_profile_no_sdk.py
@@ -136,7 +136,6 @@ async def test_profile_command_and_view_without_sdk(
     monkeypatch.delenv("API_URL", raising=False)
     import services.api.app.config as config_module
     monkeypatch.setattr(config_module, "settings", Settings(_env_file=None))
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
     import importlib
 

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -46,7 +46,6 @@ def test_register_handlers_attaches_expected_handlers(
 ) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     from services.api.app.diabetes.handlers import (
         dose_calc,
         profile as profile_handlers,
@@ -381,7 +380,6 @@ def test_register_learning_onboarding_handlers() -> None:
 def test_register_profile_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     from services.api.app.diabetes.handlers import profile as profile_handlers
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
@@ -410,7 +408,6 @@ def test_register_profile_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_register_reminder_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
     from services.api.app.diabetes.handlers import reminder_handlers as rh
 
     called = False

--- a/tests/test_reminders_button_regex.py
+++ b/tests/test_reminders_button_regex.py
@@ -11,7 +11,6 @@ import services.api.app.diabetes.handlers.reminder_handlers as reminder_handlers
 def test_reminders_button_regex_matches_text() -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
     app = ApplicationBuilder().token("TESTTOKEN").build()
     handlers.register_handlers(app)

--- a/tests/test_router_mapping.py
+++ b/tests/test_router_mapping.py
@@ -37,7 +37,6 @@ async def test_callback_router_dispatch(
 ) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils  # noqa: F401
     import services.api.app.diabetes.handlers.router as router
 
     called: list[str] = []

--- a/tests/test_sos_contact.py
+++ b/tests/test_sos_contact.py
@@ -193,7 +193,6 @@ async def test_sos_contact_menu_button_starts_conv(
 ) -> None:
     os.environ.setdefault("OPENAI_API_KEY", "test")
     os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-    import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 
     button_texts = [btn.text for row in menu_keyboard().keyboard for btn in row]
     assert SOS_BUTTON_TEXT in button_texts

--- a/tests/test_sugar_exit.py
+++ b/tests/test_sugar_exit.py
@@ -10,7 +10,6 @@ from telegram.ext import CallbackContext, ConversationHandler, MessageHandler
 
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("OPENAI_ASSISTANT_ID", "asst_test")
-import services.api.app.diabetes.utils.openai_utils as openai_utils  # noqa: F401
 from services.api.app.diabetes.handlers import dose_calc
 from services.api.app.diabetes.utils.ui import BACK_BUTTON_TEXT
 

--- a/tests/test_telegram_compat.py
+++ b/tests/test_telegram_compat.py
@@ -1,7 +1,10 @@
-import services.api.app  # noqa: F401  # ensures compatibility patch is applied
 from telegram.ext import ApplicationBuilder
 
 
 def test_application_builder_build() -> None:
+    import importlib
+
+    importlib.import_module("services.api.app")
+
     app = ApplicationBuilder().token("TESTTOKEN").build()
     assert app is not None


### PR DESCRIPTION
## Summary
- load openai_utils once via session fixture
- drop scattered side-effect imports from tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3b4940018832aad71550d907c0cb9