### PR TITLE
[tests] add missing type hints

### DIFF
--- a/tests/test_config_thread_safe.py
+++ b/tests/test_config_thread_safe.py
@@ -3,6 +3,8 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
+from typing import Any
+
 import services.api.app.config as config
 
 
@@ -10,7 +12,7 @@ def test_reload_settings_thread_safe(monkeypatch: pytest.MonkeyPatch) -> None:
     spans: list[tuple[float, float]] = []
 
     class SlowSettings(config.Settings):
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
             start = time.perf_counter()
             time.sleep(0.05)
             super().__init__(*args, **kwargs)

--- a/tests/test_reminder_collector.py
+++ b/tests/test_reminder_collector.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from datetime import time as dt_time
-from typing import Callable
+from typing import Any, Callable, Sequence
 from types import SimpleNamespace
 from zoneinfo import ZoneInfo
 import logging
+from sqlite3 import Connection, Cursor
 
 import pytest
 from sqlalchemy import create_engine, event
@@ -206,7 +207,12 @@ async def test_gc_preloads_users(
     statements: list[str] = []
 
     def before_cursor_execute(
-        conn, cursor, statement, parameters, context, executemany
+        conn: Connection,
+        cursor: Cursor,
+        statement: str,
+        parameters: Sequence[Any],
+        context: Any,
+        executemany: bool,
     ) -> None:
         if statement.startswith("SELECT"):
             statements.append(statement)


### PR DESCRIPTION
## Summary
- type annotate reminder collector's `before_cursor_execute` callback
- add annotations to `SlowSettings.__init__` in thread-safe config test

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3b7610aa4832aa78e1a80575befca