### PR TITLE
[repository] Avoid broad exception catch

### DIFF
--- a/services/api/app/diabetes/services/repository.py
+++ b/services/api/app/diabetes/services/repository.py
@@ -37,15 +37,11 @@ def commit(session: Session) -> None:
 
 @contextmanager
 def transactional(session: Session) -> Iterator[Session]:
-    """Context manager that commits on success and rolls back on failure."""
+    """Context manager that commits on success and rolls back on SQL errors."""
     try:
         yield session
         session.commit()
     except SQLAlchemyError as exc:  # pragma: no cover - logging only
         session.rollback()
         logger.exception("DB transaction failed: %s", exc.__class__.__name__)
-        raise
-    except Exception:  # pragma: no cover - logging only
-        session.rollback()
-        logger.exception("Unexpected DB transaction error")
         raise

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -49,5 +49,5 @@ def test_transactional_value_error() -> None:
     with pytest.raises(ValueError):
         with repository.transactional(session):
             raise ValueError("boom")
-    session.rollback.assert_called_once()
+    session.rollback.assert_not_called()
     session.commit.assert_not_called()


### PR DESCRIPTION
## Summary
- simplify database transactional helper by catching only SQLAlchemy errors
- adjust repository tests for new transactional behavior

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3b767c42c832aa693338a621a31df