### PR TITLE
[handlers] replace asyncio.run with sync thread creation

### DIFF
--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Session
 from services.api.app.diabetes.services.db import SessionLocal, User, run_db
 from services.api.app.diabetes.services.gpt_client import (
     _get_client,
-    create_thread,
+    create_thread_sync,
     send_message,
 )
 from services.api.app.diabetes.services.repository import CommitError, commit
@@ -122,7 +122,7 @@ async def photo_handler(
                 user = session.get(User, user_id)
                 if user:
                     return user.thread_id
-                thread_id_local = asyncio.run(create_thread())
+                thread_id_local = create_thread_sync()
                 session.add(User(telegram_id=user_id, thread_id=thread_id_local))
                 commit(session)
                 return thread_id_local

--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -305,6 +305,22 @@ async def create_thread() -> str:
     return thread.id
 
 
+def create_thread_sync() -> str:
+    """Synchronously create an empty thread.
+
+    This is a convenience wrapper around :func:`create_thread` for code that
+    runs in a synchronous context.  It simply executes the asynchronous helper
+    via :func:`asyncio.run`.
+
+    Returns
+    -------
+    str
+        Identifier of the created thread.
+    """
+
+    return asyncio.run(create_thread())
+
+
 def _validate_image_path(image_path: str) -> str:
     """Return absolute path within ``settings.photos_dir`` if valid.
 

--- a/tests/handlers/test_photo_handler_recognition.py
+++ b/tests/handlers/test_photo_handler_recognition.py
@@ -82,7 +82,7 @@ async def test_photo_handler_recognition_success_db_save(
         nonlocal commit_called
         commit_called = True
 
-    async def fake_create_thread() -> str:
+    def fake_create_thread_sync() -> str:
         return "tid"
 
     class Run:
@@ -109,7 +109,7 @@ async def test_photo_handler_recognition_success_db_save(
         )
 
     monkeypatch.setattr(photo_handlers, "SessionLocal", lambda: session)
-    monkeypatch.setattr(photo_handlers, "create_thread", fake_create_thread)
+    monkeypatch.setattr(photo_handlers, "create_thread_sync", fake_create_thread_sync)
     monkeypatch.setattr(photo_handlers, "commit", fake_commit)
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -185,9 +185,7 @@ def test_dispose_openai_clients_resets_all_sync(
 
     monkeypatch.setattr(gpt_client, "_client", fake_client)
     loop = asyncio.new_event_loop()
-    monkeypatch.setattr(
-        gpt_client, "_async_clients", {loop: fake_async_client}
-    )
+    monkeypatch.setattr(gpt_client, "_async_clients", {loop: fake_async_client})
 
     asyncio.run(gpt_client.dispose_openai_clients())
 
@@ -208,9 +206,7 @@ async def test_dispose_openai_clients_resets_all_async(
 
     monkeypatch.setattr(gpt_client, "_client", fake_client)
     loop = asyncio.get_running_loop()
-    monkeypatch.setattr(
-        gpt_client, "_async_clients", {loop: fake_async_client}
-    )
+    monkeypatch.setattr(gpt_client, "_async_clients", {loop: fake_async_client})
 
     await gpt_client.dispose_openai_clients()
 
@@ -333,6 +329,25 @@ async def test_create_thread_timeout(
             await gpt_client.create_thread()
 
     assert any("Thread creation timed out" in r.message for r in caplog.records)
+
+
+def test_create_thread_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_create_thread() -> str:
+        return "tid"
+
+    monkeypatch.setattr(gpt_client, "create_thread", fake_create_thread)
+
+    assert gpt_client.create_thread_sync() == "tid"
+
+
+def test_create_thread_sync_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_create_thread() -> str:
+        raise OpenAIError("boom")
+
+    monkeypatch.setattr(gpt_client, "create_thread", fake_create_thread)
+
+    with pytest.raises(OpenAIError):
+        gpt_client.create_thread_sync()
 
 
 @pytest.mark.asyncio

--- a/tests/test_photo_handlers_additional.py
+++ b/tests/test_photo_handlers_additional.py
@@ -57,13 +57,13 @@ async def test_photo_handler_commit_failure(
         def add(self, obj: Any) -> None:
             pass
 
-    async def fake_create_thread() -> str:
+    def fake_create_thread_sync() -> str:
         return "tid"
 
     send_message_mock = AsyncMock()
 
     monkeypatch.setattr(photo_handlers, "SessionLocal", lambda: DummySession())
-    monkeypatch.setattr(photo_handlers, "create_thread", fake_create_thread)
+    monkeypatch.setattr(photo_handlers, "create_thread_sync", fake_create_thread_sync)
 
     def fail_commit(session: object) -> None:
         raise photo_handlers.CommitError
@@ -137,7 +137,7 @@ async def test_photo_handler_commit_failure_resets_waiting_flag(
         def add(self, obj: Any) -> None:
             pass
 
-    async def fake_create_thread() -> str:
+    def fake_create_thread_sync() -> str:
         return "tid"
 
     def fail_commit(session: object) -> None:
@@ -146,7 +146,7 @@ async def test_photo_handler_commit_failure_resets_waiting_flag(
     send_message_mock = AsyncMock()
 
     monkeypatch.setattr(photo_handlers, "SessionLocal", lambda: DummySession())
-    monkeypatch.setattr(photo_handlers, "create_thread", fake_create_thread)
+    monkeypatch.setattr(photo_handlers, "create_thread_sync", fake_create_thread_sync)
     monkeypatch.setattr(photo_handlers, "commit", fail_commit)
     monkeypatch.setattr(photo_handlers, "send_message", send_message_mock)
 
@@ -531,7 +531,7 @@ async def test_photo_handler_long_vision_text(
         send_chat_action=AsyncMock(),
     )
 
-    async def fake_create_thread() -> str:
+    def fake_create_thread_sync() -> str:
         return "tid"
 
     class DummySession:
@@ -571,7 +571,7 @@ async def test_photo_handler_long_vision_text(
         )
 
     monkeypatch.setattr(photo_handlers, "SessionLocal", lambda: DummySession())
-    monkeypatch.setattr(photo_handlers, "create_thread", fake_create_thread)
+    monkeypatch.setattr(photo_handlers, "create_thread_sync", fake_create_thread_sync)
     monkeypatch.setattr(photo_handlers, "commit", lambda s: None)
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
@@ -642,7 +642,7 @@ async def test_photo_handler_long_vision_text_parse_fail(
         send_chat_action=AsyncMock(),
     )
 
-    async def fake_create_thread() -> str:
+    def fake_create_thread_sync() -> str:
         return "tid"
 
     class DummySession:
@@ -682,7 +682,7 @@ async def test_photo_handler_long_vision_text_parse_fail(
         )
 
     monkeypatch.setattr(photo_handlers, "SessionLocal", lambda: DummySession())
-    monkeypatch.setattr(photo_handlers, "create_thread", fake_create_thread)
+    monkeypatch.setattr(photo_handlers, "create_thread_sync", fake_create_thread_sync)
     monkeypatch.setattr(photo_handlers, "commit", lambda s: None)
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())


### PR DESCRIPTION
## Summary
- add `create_thread_sync` helper
- use synchronous thread creation in photo handler
- test thread creation through sync API

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check tests/test_gpt_client.py services/api/app/diabetes/services/gpt_client.py services/api/app/diabetes/handlers/photo_handlers.py tests/handlers/test_photo_handler_recognition.py tests/test_photo_handlers_additional.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3b76d51cc832aa61f036d9f14eaeb