### PR TITLE
[commands] Re-raise reset timeout errors

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -77,11 +77,9 @@ async def reset_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE) -
                 )
         except asyncio.CancelledError:
             raise
-        except Exception as exc:
-            logger.exception(
-                "Reset onboarding timeout task failed",
-                exc_info=exc,
-            )
+        except Exception:
+            logger.exception("Reset onboarding timeout task failed")
+            raise
 
     user_data["_onb_reset_confirm"] = True
     task = asyncio.create_task(_reset_timeout())


### PR DESCRIPTION
## Summary
- Avoid swallowing exceptions during onboarding reset timeout by logging and re-raising

## Testing
- `pip install pytest-asyncio`
- `pytest tests -q --cov` *(fails: KeyboardInterrupt, no tests ran)*
- `mypy --strict services/api/app/diabetes/commands.py` *(fails: interrupted due to long runtime)*
- `ruff check services/api/app/diabetes/commands.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3bf619b4c832aa350541a786327ae