### PR TITLE
[handlers] Cap parse_qsl parameters in reminder handler

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -622,7 +622,11 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
-        data = dict(parse_qsl(raw))
+        try:
+            data = dict(parse_qsl(raw, max_num_fields=1000))
+        except ValueError:
+            await msg.reply_text("Слишком много параметров")
+            return
 
     init_data = data.get("init_data")
     if isinstance(init_data, str):

--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -572,6 +572,18 @@ async def test_reminder_webapp_save_unknown_type(reminder_handlers: Any) -> None
 
 
 @pytest.mark.asyncio
+async def test_reminder_webapp_save_too_many_params(reminder_handlers: Any) -> None:
+    raw = "&".join(f"a{i}=1" for i in range(1001))
+    message = DummyWebAppMessage(raw)
+    update = make_update(effective_message=message, effective_user=make_user(1))
+    context = make_context()
+
+    await reminder_handlers.reminder_webapp_save(update, context)
+
+    assert message.texts == ["Слишком много параметров"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "payload",
     [json.dumps({"id": 1, "snooze": 7}), "snooze=7&id=1"],


### PR DESCRIPTION
## Summary
- prevent excessive form fields in `reminder_webapp_save` by limiting `parse_qsl`
- reply with error when query contains too many parameters
- cover new limit handling with tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3bf680f80832a947481c1a734094c