### PR TITLE
[handlers] Treat empty LEARNING_MODE_ENABLED as disabled

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -211,8 +211,10 @@ def register_handlers(
 
     reload_settings()
     learning_env = os.getenv("LEARNING_MODE_ENABLED")
-    if learning_env is not None:
-        learning_enabled = learning_env.lower() not in {"0", "false"}
+    if learning_env not in (None, "", "0", "false"):
+        learning_enabled = True
+    elif learning_env in {"0", "false", ""}:
+        learning_enabled = False
     else:
         learning_enabled = settings.learning_mode_enabled
 

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -358,6 +358,25 @@ def test_register_handlers_skips_learning_handlers_when_disabled(
     reload_settings()
 
 
+def test_register_handlers_skips_learning_handlers_when_env_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from services.api.app import config
+
+    monkeypatch.setenv("LEARNING_MODE_ENABLED", "")
+    monkeypatch.setattr(config, "reload_settings", lambda: config.settings)
+
+    app = ApplicationBuilder().token("TESTTOKEN").build()
+    register_handlers(app)
+
+    handlers = app.handlers[0]
+    commands = [
+        cmd for h in handlers if isinstance(h, CommandHandler) for cmd in h.commands
+    ]
+    for name in ["learn", "lesson", "quiz", "progress", "exit", "learn_reset"]:
+        assert name not in commands
+
+
 def test_register_learning_onboarding_handlers() -> None:
     app = ApplicationBuilder().token("TESTTOKEN").build()
     learning_onboarding.register_handlers(app)


### PR DESCRIPTION
## Summary
- handle empty LEARNING_MODE_ENABLED env var as disabled
- add regression test ensuring empty LEARNING_MODE_ENABLED skips learning handlers

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3c6a0fdb0832ab7e5b298ea625352