### PR TITLE
[helpers] Reject non-positive time intervals

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -27,6 +27,8 @@ def parse_time_interval(value: str) -> time | timedelta:
             num, unit = match.groups()
             unit = unit.lower()
             amount = int(num)
+            if amount <= 0:
+                raise ValueError(INVALID_TIME_MSG)
             return timedelta(hours=amount) if unit == "h" else timedelta(days=amount)
         raise ValueError(INVALID_TIME_MSG)
 

--- a/tests/test_parse_time_interval.py
+++ b/tests/test_parse_time_interval.py
@@ -42,7 +42,7 @@ def test_parse_interval_success(text: Any, expected: Any) -> None:
 
 @pytest.mark.parametrize(
     "value",
-    ["", "25:00", "5x", "1:60", "2h30", "3 d"],
+    ["", "25:00", "5x", "1:60", "2h30", "3 d", "0h", "0d"],
 )
 def test_parse_time_invalid(value: Any) -> None:
     with pytest.raises(ValueError) as exc:

--- a/tests/test_reminder_handlers.py
+++ b/tests/test_reminder_handlers.py
@@ -132,6 +132,18 @@ async def test_add_reminder_sugar_invalid_time(reminder_handlers: Any, monkeypat
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("interval", ["0h", "0d"])
+async def test_add_reminder_meal_zero_interval(reminder_handlers: Any, interval: str) -> None:
+    message = DummyMessage()
+    update = make_update(message=message, effective_user=make_user(1))
+    context = make_context(args=["meal", interval])
+
+    await reminder_handlers.add_reminder(update, context)
+
+    assert message.texts == [INVALID_TIME_MSG]
+
+
+@pytest.mark.asyncio
 async def test_add_reminder_sugar_non_numeric_interval(reminder_handlers: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     message = DummyMessage()
     update = make_update(message=message, effective_user=make_user(1))


### PR DESCRIPTION
## Summary
- Validate parse_time_interval rejects zero or negative durations
- Cover zero-length intervals in helper and reminder tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3c6ae4940832a9098074dbeb30e2a