### PR TITLE
[utils] Normalize geolocation host handling

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -43,7 +43,7 @@ async def get_coords_and_link(
     url = source_url or GEO_DATA_URL
 
     parsed = urlparse(url)
-    host = parsed.hostname
+    host = parsed.hostname.lower() if parsed.hostname else None
     if (
         parsed.scheme not in {"http", "https"}
         or host is None


### PR DESCRIPTION
## Summary
- normalize hostname before allowed-host check in IP lookup helper
- test that mixed-case geolocation hostnames are accepted

## Testing
- `ruff check services/api/app/diabetes/utils/helpers.py tests/test_utils.py`
- `mypy --strict --config-file=/tmp/mypy.ini --follow-imports=skip --disable-error-code=misc services/api/app/diabetes/utils/helpers.py tests/test_utils.py`
- `pytest tests/test_utils.py -q --cov=services.api.app.diabetes.utils.helpers`


------
https://chatgpt.com/codex/tasks/task_e_68c3c6b693a8832aa683406222ceb402