### PR TITLE
[utils] Validate geo coordinates

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -83,6 +83,12 @@ async def get_coords_and_link(
         if not lat or not lon:
             logger.warning("Invalid location format: %s", loc)
             return None, None
+        try:
+            float(lat)
+            float(lon)
+        except ValueError:
+            logger.warning("Invalid location format: %s", loc)
+            return None, None
         coords = f"{lat},{lon}"
         link = f"https://maps.google.com/?q={lat},{lon}"
         return coords, link

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,6 +86,32 @@ async def test_get_coords_and_link_invalid_loc(
 
 
 @pytest.mark.asyncio
+async def test_get_coords_and_link_non_numeric_coords(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    async def fake_get(self: httpx.AsyncClient, url: str, **kwargs: Any) -> Any:
+        class Resp:
+            status_code = 200
+            headers = {"Content-Type": "application/json"}
+
+            def raise_for_status(self) -> None:  # pragma: no cover - dummy
+                pass
+
+            def json(self) -> dict[str, str]:
+                return {"loc": "abc,2"}
+
+        return Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    with caplog.at_level(logging.WARNING):
+        coords, link = await utils.get_coords_and_link()
+
+    assert coords is None and link is None
+    assert any("Invalid location format" in msg for msg in caplog.messages)
+
+
+@pytest.mark.asyncio
 async def test_get_coords_and_link_custom_source(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- validate IP location coordinates by ensuring latitude and longitude parse as floats, logging a warning and returning `(None, None)` when parsing fails
- add regression test for non-numeric coordinates

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3d42cfa30832a8f5c50571b76cb65