### PR TITLE
[rest_client] add request timeout

### DIFF
--- a/tests/test_bot_persistence.py
+++ b/tests/test_bot_persistence.py
@@ -106,7 +106,7 @@ async def test_tg_init_data_persisted_and_used_by_rest_client(
 
     monkeypatch.setattr(rest_client, "get_settings", lambda: Settings())
     captured: dict[str, object] = {}
-    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(captured))
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_: DummyClient(captured))
     await rest_client.get_json("/api/foo", ctx=ctx2)
     assert captured["headers"]["Authorization"] == "tg secret"
 

--- a/tests/test_webapp_init_data_auth.py
+++ b/tests/test_webapp_init_data_auth.py
@@ -97,7 +97,7 @@ async def _assert_header(
 ) -> None:
     monkeypatch.setattr(rest_client, "get_settings", lambda: Settings())
     captured: dict[str, object] = {}
-    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(captured))
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_: DummyClient(captured))
     await rest_client.get_json("/api/foo", ctx=ctx)
     assert captured["headers"]["Authorization"] == "tg secret"
 
@@ -187,7 +187,7 @@ async def test_existing_init_data_authorizes_request(
 
     monkeypatch.setattr(rest_client, "get_settings", lambda: Settings())
     captured: dict[str, object] = {}
-    monkeypatch.setattr(httpx, "AsyncClient", lambda: DummyClient(captured))
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_: DummyClient(captured))
     await rest_client.get_json("/api/foo", ctx=ctx)
     assert captured["headers"]["Authorization"] == f"tg {init_data}"
 


### PR DESCRIPTION
## Summary
- add logging and timeout to HTTP requests
- log and propagate HTTP timeout errors
- add tests for timeout logging and update existing stubs

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3d4353a4c832aa7adaf87603dc24e