### PR TITLE
[handlers] use run_db for confirm entry

### DIFF
--- a/tests/test_handlers_photo_sugar_save.py
+++ b/tests/test_handlers_photo_sugar_save.py
@@ -209,6 +209,12 @@ async def test_photo_flow_saves_entry(
     assert user_data["pending_entry"]["sugar_before"] == 5.5
 
     monkeypatch.setattr(router, "SessionLocal", session_factory)
+
+    async def run_db_stub(fn, *args, sessionmaker, **kwargs):
+        with sessionmaker() as session:
+            return fn(session, *args, **kwargs)
+
+    monkeypatch.setattr(router, "run_db", run_db_stub)
     import services.api.app.diabetes.handlers.alert_handlers as alert_handlers
 
     async def noop(*args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
## Summary
- delegate entry creation to `_save_entry` and run it via `run_db`
- adjust photo sugar save test to provide `run_db` stub

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3d43d0914832a8ea4649a6275ed96