### PR TITLE
[models] Alias date type for onboarding metrics

### DIFF
--- a/services/api/app/models/onboarding_metrics.py
+++ b/services/api/app/models/onboarding_metrics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date as DateType, datetime
 
 from sqlalchemy import Date, Integer, String, TIMESTAMP, func, Index
 from sqlalchemy.orm import Mapped, mapped_column
@@ -35,7 +35,7 @@ class OnboardingMetricDaily(Base):
 
     __tablename__ = "onboarding_metrics_daily"
 
-    date: Mapped[date] = mapped_column(Date, primary_key=True)
+    date: Mapped[DateType] = mapped_column(Date, primary_key=True)
     variant: Mapped[str] = mapped_column(String, primary_key=True)
     step: Mapped[str] = mapped_column(String, primary_key=True)
     count: Mapped[int] = mapped_column(Integer, nullable=False)


### PR DESCRIPTION
## Summary
- alias `date` import as `DateType`
- use `DateType` in `OnboardingMetricDaily.date`

## Testing
- `pyflakes services/api/app/models/onboarding_metrics.py`
- `pytest -q --cov --cov-report=term --cov-fail-under=85` *(fails: build_system_prompt() unexpected keyword argument)*
- `mypy --strict .` *(fails: Unexpected keyword argument "task" for build_system_prompt, TypedDict ambiguous)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3eafdf200832ab8fed652662e81b9