### PR TITLE
tests: remove blocking sleeps in progress service

### DIFF
--- a/tests/assistant/test_progress_service.py
+++ b/tests/assistant/test_progress_service.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-import contextvars
-import time
+from datetime import datetime
 
 import pytest
 from sqlalchemy import create_engine, event
@@ -59,20 +58,23 @@ async def test_upsert_updates_timestamp(session_local: sessionmaker[Session]) ->
     await progress_service.upsert_progress(1, plan_id, {"step": 1})
     progress = await progress_service.get_progress(1, plan_id)
     assert progress is not None
-    first_ts = progress.updated_at
 
-    time.sleep(1)
+    old_ts = datetime(2000, 1, 1)
+    with session_local() as session:
+        stored = session.get(progress_service.LearningProgress, progress.id)
+        assert stored is not None
+        stored.updated_at = old_ts
+        session.commit()
+
     await progress_service.upsert_progress(1, plan_id, {"step": 2})
     progress2 = await progress_service.get_progress(1, plan_id)
     assert progress2 is not None
     assert progress2.progress_json == {"step": 2}
-    assert progress2.updated_at > first_ts
+    assert progress2.updated_at > old_ts
 
 
 @pytest.mark.asyncio()
-async def test_upsert_progress_concurrent(
-    session_local: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_upsert_progress_concurrent(session_local: sessionmaker[Session]) -> None:
     with session_local() as session:
         session.add(db.User(telegram_id=1, thread_id=""))
         plan = LearningPlan(user_id=1, version=1, plan_json=[])
@@ -80,24 +82,10 @@ async def test_upsert_progress_concurrent(
         session.commit()
         plan_id = plan.id
 
-    step_ctx: contextvars.ContextVar[int] = contextvars.ContextVar("step")
-
-    original_commit = progress_service.commit
-
-    def delayed_commit(session: Session) -> None:
-        step = step_ctx.get()
-        if step == 1:
-            time.sleep(0.1)
-        original_commit(session)
-
-    monkeypatch.setattr(progress_service, "commit", delayed_commit)
-
     async def upsert(step: int) -> None:
-        token = step_ctx.set(step)
-        try:
-            await progress_service.upsert_progress(1, plan_id, {"step": step})
-        finally:
-            step_ctx.reset(token)
+        if step == 2:
+            await asyncio.sleep(0)
+        await progress_service.upsert_progress(1, plan_id, {"step": step})
 
     await asyncio.gather(upsert(1), upsert(2))
     progress = await progress_service.get_progress(1, plan_id)


### PR DESCRIPTION
## Summary
- avoid blocking sleep by manually resetting `updated_at` in progress service tests
- simulate concurrent updates without blocking the event loop

## Testing
- `pytest -q tests/assistant/test_progress_service.py`
- `pytest -q --cov=services.api.app.assistant.services.progress_service --cov-fail-under=85 tests/assistant/test_progress_service.py`
- `mypy --strict .` *(fails: Unexpected keyword argument "task" for build_system_prompt; TypedDict ambiguous)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3eaffbe5c832a8e6bef50d0a6e40c