### PR TITLE
[ui] add return type for formatNextAt

### DIFF
--- a/services/webapp/ui/src/shared/datetime.ts
+++ b/services/webapp/ui/src/shared/datetime.ts
@@ -1,4 +1,4 @@
-export function formatNextAt(nextAt?: string | null) {
+export function formatNextAt(nextAt?: string | null): string {
   if (!nextAt) return "—";
   const d = new Date(nextAt);
   const dd = d.toLocaleDateString(undefined, { day: "2-digit", month: "2-digit" });


### PR DESCRIPTION
## Summary
- specify string return type for formatNextAt

## Testing
- `pnpm --filter ./services/webapp/ui typecheck`
- `pytest -q --cov` (fails: TypeError: build_system_prompt got an unexpected keyword argument 'task')
- `mypy --strict .` (fails: Unexpected keyword argument "task" for "build_system_prompt")
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3eb00a704832a8f484ddd732de7ab