### PR TITLE
handlers: implement assistant menu

### DIFF
--- a/services/api/app/diabetes/handlers/assistant_menu.py
+++ b/services/api/app/diabetes/handlers/assistant_menu.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+"""Inline assistant menu with callback handlers."""
+
+from typing import TYPE_CHECKING, TypeAlias, cast
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
+from telegram.ext import CallbackQueryHandler, ContextTypes
+
+from services.api.app.diabetes.utils.ui import (
+    BACK_BUTTON_TEXT,
+    PROFILE_BUTTON_TEXT,
+    REMINDERS_BUTTON_TEXT,
+    REPORT_BUTTON_TEXT,
+)
+
+__all__ = [
+    "assistant_keyboard",
+    "show_menu",
+    "assistant_callback",
+    "ASSISTANT_HANDLER",
+]
+
+MENU_LAYOUT: tuple[tuple[InlineKeyboardButton, ...], ...] = (
+    (InlineKeyboardButton(PROFILE_BUTTON_TEXT, callback_data="asst:profile"),),
+    (InlineKeyboardButton(REMINDERS_BUTTON_TEXT, callback_data="asst:reminders"),),
+    (InlineKeyboardButton(REPORT_BUTTON_TEXT, callback_data="asst:report"),),
+)
+
+MODE_TEXTS: dict[str, str] = {
+    "profile": "Раздел профиля недоступен.",
+    "reminders": "Раздел напоминаний недоступен.",
+    "report": "Раздел отчётов недоступен.",
+}
+
+
+def assistant_keyboard() -> InlineKeyboardMarkup:
+    """Build assistant menu keyboard."""
+
+    return InlineKeyboardMarkup(MENU_LAYOUT)
+
+
+async def show_menu(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    """Reply with the assistant menu."""
+
+    message = update.effective_message
+    if message:
+        await message.reply_text("Ассистент:", reply_markup=assistant_keyboard())
+
+
+def _back_keyboard() -> InlineKeyboardMarkup:
+    """Create a back button keyboard."""
+
+    return InlineKeyboardMarkup(
+        ((InlineKeyboardButton(BACK_BUTTON_TEXT, callback_data="asst:back"),),)
+    )
+
+
+async def assistant_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle assistant menu callbacks."""
+
+    query = update.callback_query
+    if query is None or query.data is None:
+        return
+    data = query.data
+    message = query.message
+    await query.answer()
+    if data in {"asst:back", "asst:menu"}:
+        if message and hasattr(message, "edit_text"):
+            await cast(Message, message).edit_text(
+                "Ассистент:", reply_markup=assistant_keyboard()
+            )
+        return
+    mode = data.split(":", 1)[1]
+    text = MODE_TEXTS.get(mode, "Неизвестная команда.")
+    if message and hasattr(message, "edit_text"):
+        await cast(Message, message).edit_text(
+            text, reply_markup=_back_keyboard()
+        )
+
+
+if TYPE_CHECKING:
+    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, object]
+else:
+    CallbackQueryHandlerT = CallbackQueryHandler
+
+ASSISTANT_HANDLER = CallbackQueryHandlerT(assistant_callback, pattern="^asst:")

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -203,6 +203,7 @@ def register_handlers(
         sugar_handlers,
         gpt_handlers,
         billing_handlers,
+        assistant_menu,
     )
     from services.api.app.diabetes import commands as bot_commands
     from services.api.app.config import reload_settings, settings
@@ -219,6 +220,7 @@ def register_handlers(
         learning_enabled = settings.learning_mode_enabled
 
     app.add_handler(CommandHandlerT("menu", learning_handlers.cmd_menu))
+    app.add_handler(CommandHandlerT("assistant", assistant_menu.show_menu))
     app.add_handler(
         MessageHandlerT(
             filters.TEXT & filters.Regex(LEARN_BUTTON_PATTERN),
@@ -284,6 +286,7 @@ def register_handlers(
     app.add_handler(MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler))
     app.add_handler(MessageHandlerT(filters.PHOTO, photo_handlers.photo_handler))
     app.add_handler(MessageHandlerT(filters.Document.IMAGE, photo_handlers.doc_handler))
+    app.add_handler(CallbackQueryHandlerT(assistant_menu.assistant_callback, pattern="^asst:"))
     app.add_handler(CallbackQueryHandlerT(reporting_handlers.report_period_callback, pattern="^report_back$"))
     app.add_handler(CallbackQueryHandlerT(reporting_handlers.report_period_callback, pattern="^report_period:"))
     app.add_handler(CallbackQueryHandlerT(callback_router))

--- a/tests/test_assistant_menu.py
+++ b/tests/test_assistant_menu.py
@@ -1,0 +1,50 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from services.api.app.diabetes.handlers import assistant_menu
+
+
+def test_assistant_keyboard_layout() -> None:
+    keyboard = assistant_menu.assistant_keyboard()
+    data = [btn.callback_data for row in keyboard.inline_keyboard for btn in row]
+    assert data == ["asst:profile", "asst:reminders", "asst:report"]
+
+
+@pytest.mark.asyncio
+async def test_assistant_callback_back_to_menu() -> None:
+    message = MagicMock()
+    message.edit_text = AsyncMock()
+    query = MagicMock()
+    query.data = "asst:back"
+    query.message = message
+    query.answer = AsyncMock()
+    update = MagicMock()
+    update.callback_query = query
+
+    await assistant_menu.assistant_callback(update, MagicMock())
+
+    query.answer.assert_awaited_once()
+    message.edit_text.assert_awaited_once()
+    markup = message.edit_text.call_args.kwargs["reply_markup"]
+    back = [btn.callback_data for row in markup.inline_keyboard for btn in row]
+    assert "asst:profile" in back
+
+
+@pytest.mark.asyncio
+async def test_assistant_callback_mode_has_back_button() -> None:
+    message = MagicMock()
+    message.edit_text = AsyncMock()
+    query = MagicMock()
+    query.data = "asst:profile"
+    query.message = message
+    query.answer = AsyncMock()
+    update = MagicMock()
+    update.callback_query = query
+
+    await assistant_menu.assistant_callback(update, MagicMock())
+
+    query.answer.assert_awaited_once()
+    message.edit_text.assert_awaited_once()
+    markup = message.edit_text.call_args.kwargs["reply_markup"]
+    callbacks = [btn.callback_data for row in markup.inline_keyboard for btn in row]
+    assert "asst:back" in callbacks

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -33,6 +33,7 @@ from services.api.app.diabetes.handlers import (
     reminder_handlers as rh,
     billing_handlers,
     learning_onboarding,
+    assistant_menu,
 )
 from services.api.app.diabetes import learning_handlers
 from services.api.app.diabetes import commands
@@ -84,10 +85,17 @@ def test_register_handlers_attaches_expected_handlers(
     assert billing_handlers.trial_command in callbacks
     assert billing_handlers.upgrade_command in callbacks
     assert billing_handlers.subscription_button in callbacks
+    assert assistant_menu.assistant_callback in callbacks
     assert any(
         isinstance(h, CommandHandler)
         and h.callback is learning_handlers.cmd_menu
         and "menu" in h.commands
+        for h in handlers
+    )
+    assert any(
+        isinstance(h, CommandHandler)
+        and h.callback is assistant_menu.show_menu
+        and "assistant" in h.commands
         for h in handlers
     )
     assert any(


### PR DESCRIPTION
## Summary
- add inline assistant menu with callback handling and back navigation
- wire assistant menu into registration with new command and callback handler
- test assistant menu layout and registration integration

## Testing
- `pytest tests/test_assistant_menu.py -q`
- `pytest -q --cov` *(fails: build_system_prompt unexpected keyword argument)*
- `mypy --strict services/api/app/diabetes/handlers/assistant_menu.py` *(fails: unexpected keyword argument task in other modules)*
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68c3ecc35ba4832ab98699f30fa039b9