### PR TITLE
[assistant] Add mode routing and state

### DIFF
--- a/services/api/app/diabetes/assistant_state.py
+++ b/services/api/app/diabetes/assistant_state.py
@@ -12,6 +12,7 @@ ASSISTANT_SUMMARY_TRIGGER: int = _settings.assistant_summary_trigger
 
 HISTORY_KEY = "assistant_history"
 SUMMARY_KEY = "assistant_summary"
+LAST_MODE_KEY = "assistant_last_mode"
 
 
 def summarize(parts: list[str]) -> str:
@@ -54,6 +55,23 @@ def reset(user_data: MutableMapping[str, object]) -> None:
     """Remove assistant history and summary from ``user_data``."""
     user_data.pop(HISTORY_KEY, None)
     user_data.pop(SUMMARY_KEY, None)
+    user_data.pop(LAST_MODE_KEY, None)
+
+
+def get_last_mode(user_data: MutableMapping[str, object]) -> str | None:
+    """Return previously selected assistant mode from ``user_data``."""
+
+    value = user_data.get(LAST_MODE_KEY)
+    return cast(str | None, value) if isinstance(value, str) else None
+
+
+def set_last_mode(user_data: MutableMapping[str, object], mode: str | None) -> None:
+    """Persist ``mode`` in ``user_data`` or clear it when ``None``."""
+
+    if mode is None:
+        user_data.pop(LAST_MODE_KEY, None)
+    else:
+        user_data[LAST_MODE_KEY] = mode
 
 
 __all__ = [
@@ -61,7 +79,10 @@ __all__ = [
     "ASSISTANT_SUMMARY_TRIGGER",
     "HISTORY_KEY",
     "SUMMARY_KEY",
+    "LAST_MODE_KEY",
     "summarize",
     "add_turn",
     "reset",
+    "get_last_mode",
+    "set_last_mode",
 ]

--- a/services/api/app/diabetes/handlers/assistant_menu.py
+++ b/services/api/app/diabetes/handlers/assistant_menu.py
@@ -7,12 +7,8 @@ from typing import TYPE_CHECKING, TypeAlias, cast
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
 from telegram.ext import CallbackQueryHandler, ContextTypes
 
-from services.api.app.diabetes.utils.ui import (
-    BACK_BUTTON_TEXT,
-    PROFILE_BUTTON_TEXT,
-    REMINDERS_BUTTON_TEXT,
-    REPORT_BUTTON_TEXT,
-)
+from services.api.app.diabetes.utils.ui import BACK_BUTTON_TEXT
+from services.api.app.diabetes.assistant_state import set_last_mode
 
 __all__ = [
     "assistant_keyboard",
@@ -22,15 +18,17 @@ __all__ = [
 ]
 
 MENU_LAYOUT: tuple[tuple[InlineKeyboardButton, ...], ...] = (
-    (InlineKeyboardButton(PROFILE_BUTTON_TEXT, callback_data="asst:profile"),),
-    (InlineKeyboardButton(REMINDERS_BUTTON_TEXT, callback_data="asst:reminders"),),
-    (InlineKeyboardButton(REPORT_BUTTON_TEXT, callback_data="asst:report"),),
+    (InlineKeyboardButton("🎓 Обучение", callback_data="asst:learn"),),
+    (InlineKeyboardButton("💬 Чат", callback_data="asst:chat"),),
+    (InlineKeyboardButton("🧪 Анализы", callback_data="asst:labs"),),
+    (InlineKeyboardButton("🩺 Визит", callback_data="asst:visit"),),
 )
 
 MODE_TEXTS: dict[str, str] = {
-    "profile": "Раздел профиля недоступен.",
-    "reminders": "Раздел напоминаний недоступен.",
-    "report": "Раздел отчётов недоступен.",
+    "learn": "Режим обучения активирован.",
+    "chat": "Свободный диалог активирован.",
+    "labs": "Пришлите файл или текст анализов.",
+    "visit": "Подготовка чек-листа визита.",
 }
 
 
@@ -74,13 +72,15 @@ async def assistant_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> 
     mode = data.split(":", 1)[1]
     text = MODE_TEXTS.get(mode, "Неизвестная команда.")
     if message and hasattr(message, "edit_text"):
-        await cast(Message, message).edit_text(
-            text, reply_markup=_back_keyboard()
-        )
+        await cast(Message, message).edit_text(text, reply_markup=_back_keyboard())
+    user_data = cast(dict[str, object], ctx.user_data)
+    set_last_mode(user_data, mode)
 
 
 if TYPE_CHECKING:
-    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, object]
+    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[
+        ContextTypes.DEFAULT_TYPE, object
+    ]
 else:
     CallbackQueryHandlerT = CallbackQueryHandler
 

--- a/services/api/app/diabetes/handlers/assistant_router.py
+++ b/services/api/app/diabetes/handlers/assistant_router.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import MutableMapping, Sequence, cast
+
+from telegram import Update
+from telegram.ext import ApplicationHandlerStop, ContextTypes
+
+from services.api.app.diabetes.assistant_state import get_last_mode, set_last_mode
+from services.api.app.diabetes import learning_handlers
+from services.api.app.diabetes.handlers import gpt_handlers
+from services.api.app.diabetes.utils.ui import (
+    HELP_BUTTON_TEXT,
+    PHOTO_BUTTON_PATTERN,
+    QUICK_INPUT_BUTTON_TEXT,
+    REPORT_BUTTON_TEXT,
+    SUGAR_BUTTON_TEXT,
+    DOSE_BUTTON_TEXT,
+    HISTORY_BUTTON_TEXT,
+    SOS_BUTTON_TEXT,
+    SUBSCRIPTION_BUTTON_TEXT,
+)
+from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+
+logger = logging.getLogger(__name__)
+
+BOTTOM_BUTTON_PATTERNS: Sequence[re.Pattern[str]] = (
+    PHOTO_BUTTON_PATTERN,
+    re.compile(re.escape(SUGAR_BUTTON_TEXT)),
+    re.compile(re.escape(DOSE_BUTTON_TEXT)),
+    re.compile(re.escape(HISTORY_BUTTON_TEXT)),
+    re.compile(re.escape(REPORT_BUTTON_TEXT)),
+    re.compile(re.escape(QUICK_INPUT_BUTTON_TEXT)),
+    re.compile(re.escape(HELP_BUTTON_TEXT)),
+    re.compile(re.escape(SOS_BUTTON_TEXT)),
+    re.compile(re.escape(SUBSCRIPTION_BUTTON_TEXT)),
+    re.compile(re.escape(LEARN_BUTTON_TEXT)),
+)
+
+
+async def on_any_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Route arbitrary text based on the assistant's ``last_mode``."""
+
+    message = update.message
+    if message is None or message.text is None:
+        return
+    text = message.text
+    for pattern in BOTTOM_BUTTON_PATTERNS:
+        if pattern.match(text):
+            return
+    user_data = cast(MutableMapping[str, object], context.user_data or {})
+    mode = get_last_mode(user_data)
+    logger.debug("assistant_router mode=%s text=%s", mode, text)
+    if mode == "learn":
+        await learning_handlers.on_any_text(update, context)
+        raise ApplicationHandlerStop
+    if mode == "chat":
+        await gpt_handlers.freeform_handler(update, context)
+        raise ApplicationHandlerStop
+    if mode == "labs":
+        user_data["waiting_labs"] = True
+        await message.reply_text("Отправьте анализы в виде файла или текста.")
+        set_last_mode(user_data, None)
+        raise ApplicationHandlerStop
+    if mode == "visit":
+        await message.reply_text(
+            "Чек-лист визита: измерения, вопросы врачу, назначения."
+        )
+        set_last_mode(user_data, None)
+        raise ApplicationHandlerStop
+
+
+__all__ = ["on_any_text"]

--- a/tests/test_assistant_menu.py
+++ b/tests/test_assistant_menu.py
@@ -7,7 +7,7 @@ from services.api.app.diabetes.handlers import assistant_menu
 def test_assistant_keyboard_layout() -> None:
     keyboard = assistant_menu.assistant_keyboard()
     data = [btn.callback_data for row in keyboard.inline_keyboard for btn in row]
-    assert data == ["asst:profile", "asst:reminders", "asst:report"]
+    assert data == ["asst:learn", "asst:chat", "asst:labs", "asst:visit"]
 
 
 @pytest.mark.asyncio
@@ -27,7 +27,7 @@ async def test_assistant_callback_back_to_menu() -> None:
     message.edit_text.assert_awaited_once()
     markup = message.edit_text.call_args.kwargs["reply_markup"]
     back = [btn.callback_data for row in markup.inline_keyboard for btn in row]
-    assert "asst:profile" in back
+    assert "asst:learn" in back
 
 
 @pytest.mark.asyncio
@@ -35,7 +35,7 @@ async def test_assistant_callback_mode_has_back_button() -> None:
     message = MagicMock()
     message.edit_text = AsyncMock()
     query = MagicMock()
-    query.data = "asst:profile"
+    query.data = "asst:chat"
     query.message = message
     query.answer = AsyncMock()
     update = MagicMock()
@@ -48,3 +48,22 @@ async def test_assistant_callback_mode_has_back_button() -> None:
     markup = message.edit_text.call_args.kwargs["reply_markup"]
     callbacks = [btn.callback_data for row in markup.inline_keyboard for btn in row]
     assert "asst:back" in callbacks
+
+
+@pytest.mark.asyncio
+async def test_assistant_callback_saves_mode() -> None:
+    user_data: dict[str, object] = {}
+    message = MagicMock()
+    message.edit_text = AsyncMock()
+    query = MagicMock()
+    query.data = "asst:learn"
+    query.message = message
+    query.answer = AsyncMock()
+    update = MagicMock()
+    update.callback_query = query
+    ctx = MagicMock()
+    ctx.user_data = user_data
+
+    await assistant_menu.assistant_callback(update, ctx)
+
+    assert user_data.get("assistant_last_mode") == "learn"


### PR DESCRIPTION
## Summary
- Track assistant last_mode in user_data with helpers
- Allow selecting assistant modes and persist selection
- Route text by last_mode to learning, chat, labs or visit flows

## Testing
- `ruff check .`
- `mypy --strict --follow-imports=skip services/api/app/diabetes/assistant_state.py services/api/app/diabetes/handlers/assistant_menu.py services/api/app/diabetes/handlers/assistant_router.py tests/test_assistant_menu.py tests/test_assistant_router.py`
- `pytest tests/test_assistant_menu.py tests/test_assistant_router.py -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68c3ef5738bc832ab4a871953f449965