### PR TITLE
[gpt] Add disclaimer flag for GPT mode

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -12,6 +12,7 @@ from .learning_handlers import learn_command, topics_command
 from .handlers.onboarding_handlers import reset_onboarding as _reset_onboarding
 from ..ui.keyboard import LEARN_BUTTON_TEXT
 from .assistant_state import reset as _reset_assistant
+from .handlers.registration import MODE_DISCLAIMED_KEY
 from ..assistant.services.memory_service import clear_memory as _clear_memory
 from services.api.app.config import settings
 
@@ -111,9 +112,7 @@ async def reset_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         try:
             await context.bot.send_message(
                 chat_id=message.chat_id,
-                text=(
-                    "Не удалось отправить предупреждение о сбросе. Попробуйте снова."
-                ),
+                text=("Не удалось отправить предупреждение о сбросе. Попробуйте снова."),
             )
         except telegram.error.TelegramError as exc2:
             logger.exception(
@@ -131,6 +130,7 @@ async def reset_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         return
     user_data = cast(dict[str, object], context.user_data)
     _reset_assistant(user_data)
+    user_data.pop(MODE_DISCLAIMED_KEY, None)
     if user is not None:
         await _clear_memory(user.id)
     await message.reply_text("История очищена.")

--- a/tests/test_gpt_mode.py
+++ b/tests/test_gpt_mode.py
@@ -20,9 +20,7 @@ class DummyMessage:
 
 
 def make_update(message: DummyMessage) -> Update:
-    return cast(
-        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    )
+    return cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
 
 
 def make_context(
@@ -30,9 +28,7 @@ def make_context(
 ) -> CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]:
     return cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
-        SimpleNamespace(
-            user_data=user_data if user_data is not None else {}, job_queue=None
-        ),
+        SimpleNamespace(user_data=user_data if user_data is not None else {}, job_queue=None),
     )
 
 
@@ -43,20 +39,20 @@ async def test_start_gpt_sets_flag() -> None:
     context = make_context({})
     await registration.start_gpt_dialog(update, context)
     assert context.user_data.get(registration.GPT_MODE_KEY) is True
+    assert registration.MODE_DISCLAIMED_KEY not in context.user_data
 
 
 @pytest.mark.asyncio
 async def test_cancel_clears_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     message = DummyMessage("/cancel")
     update = make_update(message)
-    user_data = {registration.GPT_MODE_KEY: True}
+    user_data = {registration.GPT_MODE_KEY: True, registration.MODE_DISCLAIMED_KEY: True}
     fake_cancel = AsyncMock()
-    monkeypatch.setattr(
-        "services.api.app.diabetes.handlers.dose_calc.dose_cancel", fake_cancel
-    )
+    monkeypatch.setattr("services.api.app.diabetes.handlers.dose_calc.dose_cancel", fake_cancel)
     context = make_context(user_data)
     await registration.cancel(update, context)
     assert registration.GPT_MODE_KEY not in user_data
+    assert registration.MODE_DISCLAIMED_KEY not in user_data
     fake_cancel.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
- Track whether GPT mode has shown its medical disclaimer
- Record conversation turns via assistant_state and memory_service
- Reset disclaimer flag on mode exit and reset command

## Testing
- `pytest tests/test_gpt_handlers.py::test_chat_with_gpt_replies_and_history tests/test_gpt_handlers.py::test_chat_with_gpt_passes_context tests/test_gpt_handlers.py::test_chat_with_gpt_handles_openai_error tests/test_gpt_handlers.py::test_chat_with_gpt_handles_http_error tests/test_gpt_handlers.py::test_chat_with_gpt_handles_timeout_error tests/test_gpt_handlers.py::test_reset_command_clears_history tests/test_gpt_mode.py::test_start_gpt_sets_flag tests/test_gpt_mode.py::test_cancel_clears_flag tests/test_assistant_memory_integration.py::test_memory_reset -q`
- `mypy --strict .` *(fails: Unexpected keyword argument "task" for build_system_prompt)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3f3032ae0832a8c246023901dd76c