### PR TITLE
[assistant] Add visit checklist and note saving

### DIFF
--- a/services/api/app/assistant/models.py
+++ b/services/api/app/assistant/models.py
@@ -55,4 +55,22 @@ class LessonLog(Base):
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False)
 
 
-__all__ = ["AssistantMemory", "LessonLog"]
+class AssistantNote(Base):
+    """Free-form notes saved by the assistant for a user."""
+
+    __tablename__ = "assistant_notes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.telegram_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False
+    )
+
+
+__all__ = ["AssistantMemory", "LessonLog", "AssistantNote"]

--- a/services/api/app/assistant/repositories/notes.py
+++ b/services/api/app/assistant/repositories/notes.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from services.api.app.assistant.models import AssistantNote
+from services.api.app.diabetes.services.repository import commit
+
+__all__ = ["create_note"]
+
+
+def create_note(session: Session, *, user_id: int, text: str) -> AssistantNote:
+    """Persist a new assistant note."""
+    note = AssistantNote(user_id=user_id, text=text)
+    session.add(note)
+    commit(session)
+    session.refresh(note)
+    return note

--- a/services/api/app/assistant/services/memory_service.py
+++ b/services/api/app/assistant/services/memory_service.py
@@ -7,19 +7,22 @@ from sqlalchemy.orm import Session
 
 from ...diabetes.services.db import SessionLocal, run_db
 from ...diabetes.services.repository import commit
-from ..models import AssistantMemory
+from ..models import AssistantMemory, AssistantNote
 from ..repositories.memory import (
     get_memory as repo_get_memory,
     upsert_memory as repo_upsert_memory,
 )
+from ..repositories.notes import create_note
 
 __all__ = [
     "AssistantMemory",
+    "AssistantNote",
     "get_memory",
     "save_memory",
     "clear_memory",
     "record_turn",
     "cleanup_old_memory",
+    "save_note",
 ]
 
 
@@ -51,6 +54,17 @@ async def save_memory(
             last_turn_at=last_turn_at,
             summary_text=summary_text,
         )
+
+    return await run_db(_save, sessionmaker=SessionLocal)
+
+
+async def save_note(user_id: int, text: str) -> AssistantNote:
+    """Store a free-form note for ``user_id``."""
+
+    text = text[:4096]
+
+    def _save(session: Session) -> AssistantNote:
+        return create_note(session, user_id=user_id, text=text)
 
     return await run_db(_save, sessionmaker=SessionLocal)
 

--- a/services/api/app/diabetes/handlers/assistant_menu.py
+++ b/services/api/app/diabetes/handlers/assistant_menu.py
@@ -10,6 +10,7 @@ from telegram.ext import CallbackQueryHandler, ContextTypes
 from services.api.app.diabetes.utils.ui import BACK_BUTTON_TEXT
 from services.api.app.diabetes.assistant_state import set_last_mode
 from services.api.app.diabetes.labs_handlers import AWAITING_KIND
+from services.api.app.diabetes import visit_handlers
 
 __all__ = [
     "assistant_keyboard",
@@ -64,6 +65,9 @@ async def assistant_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> 
     data = query.data
     message = query.message
     await query.answer()
+    if data == "asst:save_note":
+        await visit_handlers.save_note_callback(update, ctx)
+        return
     if data in {"asst:back", "asst:menu"}:
         if message and hasattr(message, "edit_text"):
             await cast(Message, message).edit_text(
@@ -81,6 +85,9 @@ async def assistant_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> 
         set_last_mode(user_data, None)
     else:
         set_last_mode(user_data, mode)
+        if mode == "visit":
+            await visit_handlers.send_checklist(update, ctx)
+            return
 
 
 if TYPE_CHECKING:

--- a/services/api/app/diabetes/visit_handlers.py
+++ b/services/api/app/diabetes/visit_handlers.py
@@ -1,0 +1,57 @@
+"""Handlers for preparing doctor visit checklists and notes."""
+
+from __future__ import annotations
+
+import logging
+from typing import cast
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes
+
+from services.api.app.assistant.services import memory_service
+from services.api.app.services import profile as profile_service
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["send_checklist", "save_note_callback"]
+
+
+async def send_checklist(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    """Collect user profile and send visit checklist."""
+
+    user = update.effective_user
+    message = update.effective_message
+    if user is None or message is None:
+        return
+    profile = await profile_service.get_profile(user.id)
+    await memory_service.get_memory(user.id)  # placeholder usage
+    questions = [
+        "Как вы себя чувствуете?",
+        "Какой у вас был последний сахар?",
+        f"Целевая гликемия: {profile.target_bg if profile.target_bg is not None else 'не задана'}",
+    ]
+    text = "Чек-лист визита:\n" + "\n".join(f"- {q}" for q in questions)
+    user_data = cast(dict[str, object], ctx.user_data)
+    user_data["visit_note"] = text
+    keyboard = InlineKeyboardMarkup(
+        [[InlineKeyboardButton("Сохранить заметку", callback_data="asst:save_note")]]
+    )
+    await message.reply_text(text, reply_markup=keyboard)
+
+
+async def save_note_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    """Persist generated note via memory service."""
+
+    query = update.callback_query
+    user = update.effective_user
+    if query is None or user is None:
+        return
+    await query.answer()
+    user_data = cast(dict[str, object], ctx.user_data)
+    note = cast(str | None, user_data.get("visit_note"))
+    if not note:
+        await query.edit_message_text("❗ Нет заметки для сохранения.")
+        return
+    await memory_service.save_note(user.id, note)
+    user_data.pop("visit_note", None)
+    await query.edit_message_text("✅ Заметка сохранена.")

--- a/tests/assistant/test_memory_service.py
+++ b/tests/assistant/test_memory_service.py
@@ -106,3 +106,13 @@ async def test_cleanup_old_memory(setup_db: sessionmaker[Session]) -> None:
 
     assert await memory_service.get_memory(1) is None
     assert await memory_service.get_memory(2) is not None
+
+
+@pytest.mark.asyncio
+async def test_save_note(setup_db: sessionmaker[Session]) -> None:
+    note = await memory_service.save_note(1, "hello")
+    assert note.text == "hello"
+    with setup_db() as session:
+        stored = session.get(memory_service.AssistantNote, note.id)
+        assert stored is not None
+        assert stored.text == "hello"

--- a/tests/test_visit_handlers.py
+++ b/tests/test_visit_handlers.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.api.app.diabetes import visit_handlers
+
+
+@pytest.mark.asyncio
+async def test_send_checklist(monkeypatch: pytest.MonkeyPatch) -> None:
+    profile = MagicMock()
+    profile.target_bg = 5.5
+    monkeypatch.setattr(
+        visit_handlers.profile_service, "get_profile", AsyncMock(return_value=profile)
+    )
+    monkeypatch.setattr(
+        visit_handlers.memory_service, "get_memory", AsyncMock(return_value=None)
+    )
+    message = MagicMock()
+    message.reply_text = AsyncMock()
+    update = MagicMock()
+    update.effective_user.id = 1
+    update.effective_message = message
+    ctx = MagicMock()
+    ctx.user_data = {}
+
+    await visit_handlers.send_checklist(update, ctx)
+
+    message.reply_text.assert_awaited_once()
+    markup = message.reply_text.call_args.kwargs["reply_markup"]
+    data = [btn.callback_data for row in markup.inline_keyboard for btn in row]
+    assert "asst:save_note" in data
+    assert "visit_note" in ctx.user_data
+
+
+@pytest.mark.asyncio
+async def test_save_note_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(visit_handlers.memory_service, "save_note", AsyncMock())
+    query = MagicMock()
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    update = MagicMock()
+    update.callback_query = query
+    update.effective_user.id = 2
+    ctx = MagicMock()
+    ctx.user_data = {"visit_note": "note"}
+
+    await visit_handlers.save_note_callback(update, ctx)
+
+    visit_handlers.memory_service.save_note.assert_awaited_once_with(2, "note")
+    query.edit_message_text.assert_awaited_once()
+    assert ctx.user_data == {}


### PR DESCRIPTION
## Summary
- gather profile data to build visit checklist and inline save button
- persist assistant notes via new repository and memory service method
- handle `asst:save_note` callback and confirm note storage

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c3fb6935e0832aa77c36de60fb57da