### PR TITLE
[assistant] Add default mode and emoji settings

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -12,7 +12,9 @@ from pydantic import AliasChoices, Field, field_validator
 try:  # pragma: no cover - import guard
     from pydantic_settings import BaseSettings, SettingsConfigDict
 except ModuleNotFoundError as exc:  # pragma: no cover - executed at import time
-    raise ImportError("`pydantic-settings` is required. Install it with `pip install pydantic-settings`.") from exc
+    raise ImportError(
+        "`pydantic-settings` is required. Install it with `pip install pydantic-settings`."
+    ) from exc
 
 
 logger = logging.getLogger(__name__)
@@ -67,8 +69,12 @@ class Settings(BaseSettings):
     api_url: Optional[str] = Field(default=None, alias="API_URL")
     subscription_url: Optional[str] = Field(default=None, alias="SUBSCRIPTION_URL")
     openai_api_key: Optional[str] = Field(default=None, alias="OPENAI_API_KEY")
-    openai_assistant_id: Optional[str] = Field(default=None, alias="OPENAI_ASSISTANT_ID")
-    openai_command_model: str = Field(default="gpt-4o-mini", alias="OPENAI_COMMAND_MODEL")
+    openai_assistant_id: Optional[str] = Field(
+        default=None, alias="OPENAI_ASSISTANT_ID"
+    )
+    openai_command_model: str = Field(
+        default="gpt-4o-mini", alias="OPENAI_COMMAND_MODEL"
+    )
     api_key_min_length: int = Field(default=32, alias="API_KEY_MIN_LENGTH")
     assistant_mode_enabled: bool = Field(
         default=True,
@@ -90,17 +96,37 @@ class Settings(BaseSettings):
         alias="ASSISTANT_SUMMARY_TRIGGER",
         description="Turns before conversation is summarized",
     )
-    learning_model_default: str = Field(default="gpt-4o-mini", alias="LEARNING_MODEL_DEFAULT")
+    assistant_default_mode: Literal["menu", "chat", "learn", "labs", "visit"] = Field(
+        default="menu",
+        alias="ASSISTANT_DEFAULT_MODE",
+        description="Initial assistant mode",
+    )
+    assistant_menu_emoji: bool = Field(
+        default=True,
+        alias="ASSISTANT_MENU_EMOJI",
+        description="Show emoji in assistant menu button",
+    )
+    learning_model_default: str = Field(
+        default="gpt-4o-mini", alias="LEARNING_MODEL_DEFAULT"
+    )
     learning_prompt_cache: bool = Field(default=True, alias="LEARNING_PROMPT_CACHE")
-    learning_prompt_cache_size: int = Field(default=128, alias="LEARNING_PROMPT_CACHE_SIZE")
+    learning_prompt_cache_size: int = Field(
+        default=128, alias="LEARNING_PROMPT_CACHE_SIZE"
+    )
     learning_prompt_cache_ttl_sec: int = Field(
         default=28800,
         alias="LEARNING_PROMPT_CACHE_TTL_SEC",
         description="TTL of prompt cache in seconds",
     )
-    learning_content_mode: Literal["dynamic", "static"] = Field(default="dynamic", alias="LEARNING_CONTENT_MODE")
-    learning_ui_show_topics: bool = Field(default=False, alias="LEARNING_UI_SHOW_TOPICS")
-    learning_logging_required: bool = Field(default=False, alias="LEARNING_LOGGING_REQUIRED")
+    learning_content_mode: Literal["dynamic", "static"] = Field(
+        default="dynamic", alias="LEARNING_CONTENT_MODE"
+    )
+    learning_ui_show_topics: bool = Field(
+        default=False, alias="LEARNING_UI_SHOW_TOPICS"
+    )
+    learning_logging_required: bool = Field(
+        default=False, alias="LEARNING_LOGGING_REQUIRED"
+    )
     learning_reply_mode: Literal["two_messages", "one_message"] = Field(
         default="two_messages", alias="LEARNING_REPLY_MODE"
     )
@@ -110,25 +136,37 @@ class Settings(BaseSettings):
         description="Max pending lesson logs kept in memory",
     )
     lesson_logs_ttl_days: int = Field(default=14, alias="LESSON_LOGS_TTL_DAYS")
-    assistant_memory_ttl_days: int = Field(default=60, alias="ASSISTANT_MEMORY_TTL_DAYS")
+    assistant_memory_ttl_days: int = Field(
+        default=60, alias="ASSISTANT_MEMORY_TTL_DAYS"
+    )
     openai_proxy: Optional[str] = Field(default=None, alias="OPENAI_PROXY")
-    learning_assistant_id: Optional[str] = Field(default=None, alias="LEARNING_ASSISTANT_ID")
-    learning_command_model: str = Field(default="gpt-4o-mini", alias="LEARNING_COMMAND_MODEL")
+    learning_assistant_id: Optional[str] = Field(
+        default=None, alias="LEARNING_ASSISTANT_ID"
+    )
+    learning_command_model: str = Field(
+        default="gpt-4o-mini", alias="LEARNING_COMMAND_MODEL"
+    )
     learning_planner_model: str = Field(
         default="gpt-4o-mini",
         alias="LEARNING_PLANNER_MODEL",
         description="Model used for lesson planning",
     )
     font_dir: Optional[str] = Field(default=None, alias="FONT_DIR")
-    onboarding_video_url: Optional[str] = Field(default=None, alias="ONBOARDING_VIDEO_URL")
+    onboarding_video_url: Optional[str] = Field(
+        default=None, alias="ONBOARDING_VIDEO_URL"
+    )
     telegram_token: Optional[str] = Field(default=None, alias="TELEGRAM_TOKEN")
-    telegram_payments_provider_token: Optional[str] = Field(default=None, alias="TELEGRAM_PAYMENTS_PROVIDER_TOKEN")
+    telegram_payments_provider_token: Optional[str] = Field(
+        default=None, alias="TELEGRAM_PAYMENTS_PROVIDER_TOKEN"
+    )
     internal_api_key: Optional[str] = Field(default=None, alias="INTERNAL_API_KEY")
     admin_id: Optional[int] = Field(default=None, alias="ADMIN_ID")
 
     @field_validator("log_level", mode="before")
     @classmethod
-    def parse_log_level(cls, v: int | str | None) -> int:  # pragma: no cover - simple parsing
+    def parse_log_level(
+        cls, v: int | str | None
+    ) -> int:  # pragma: no cover - simple parsing
         if isinstance(v, str):
             v_lower = v.lower()
             level_map: dict[str, int] = {

--- a/services/api/app/diabetes/assistant_state.py
+++ b/services/api/app/diabetes/assistant_state.py
@@ -9,6 +9,7 @@ from services.api.app.config import get_settings
 _settings = get_settings()
 ASSISTANT_MAX_TURNS: int = _settings.assistant_max_turns
 ASSISTANT_SUMMARY_TRIGGER: int = _settings.assistant_summary_trigger
+ASSISTANT_DEFAULT_MODE: str = _settings.assistant_default_mode
 
 HISTORY_KEY = "assistant_history"
 SUMMARY_KEY = "assistant_summary"
@@ -66,11 +67,14 @@ def reset_mode_state(user_data: MutableMapping[str, object]) -> None:
     user_data.pop(AWAITING_KIND, None)
 
 
-def get_last_mode(user_data: MutableMapping[str, object]) -> str | None:
-    """Return previously selected assistant mode from ``user_data``."""
+def get_last_mode(user_data: MutableMapping[str, object]) -> str:
+    """Return assistant mode from ``user_data`` initializing with default."""
 
     value = user_data.get(LAST_MODE_KEY)
-    return cast(str | None, value) if isinstance(value, str) else None
+    if isinstance(value, str):
+        return value
+    user_data[LAST_MODE_KEY] = ASSISTANT_DEFAULT_MODE
+    return ASSISTANT_DEFAULT_MODE
 
 
 def set_last_mode(user_data: MutableMapping[str, object], mode: str | None) -> None:
@@ -85,6 +89,7 @@ def set_last_mode(user_data: MutableMapping[str, object], mode: str | None) -> N
 __all__ = [
     "ASSISTANT_MAX_TURNS",
     "ASSISTANT_SUMMARY_TRIGGER",
+    "ASSISTANT_DEFAULT_MODE",
     "HISTORY_KEY",
     "SUMMARY_KEY",
     "LAST_MODE_KEY",

--- a/services/api/app/ui/keyboard.py
+++ b/services/api/app/ui/keyboard.py
@@ -1,8 +1,12 @@
 from telegram import ReplyKeyboardMarkup, KeyboardButton
 
 from services.api.app.diabetes.utils.ui import menu_keyboard
+from services.api.app.config import get_settings
 
-LEARN_BUTTON_TEXT = "🤖 Ассистент_AI"
+_settings = get_settings()
+LEARN_BUTTON_TEXT = (
+    "🤖 Ассистент_AI" if _settings.assistant_menu_emoji else "Ассистент_AI"
+)
 
 
 def build_main_keyboard() -> ReplyKeyboardMarkup:

--- a/tests/test_assistant_state.py
+++ b/tests/test_assistant_state.py
@@ -53,3 +53,10 @@ def test_reset_mode_state() -> None:
     }
     assistant_state.reset_mode_state(data)
     assert data == {}
+
+
+def test_get_last_mode_initializes_with_default() -> None:
+    data: dict[str, Any] = {}
+    mode = assistant_state.get_last_mode(data)
+    assert mode == assistant_state.ASSISTANT_DEFAULT_MODE
+    assert data[assistant_state.LAST_MODE_KEY] == assistant_state.ASSISTANT_DEFAULT_MODE


### PR DESCRIPTION
## Summary
- allow configuring default assistant mode and emoji usage
- initialize assistant state with default mode
- generate assistant button text with optional emoji

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68c4002b35ac832a8a8ff95721d57296