### PR TITLE
[assistant] Restore last mode on startup

### DIFF
--- a/services/api/app/assistant/models.py
+++ b/services/api/app/assistant/models.py
@@ -23,6 +23,9 @@ class AssistantMemory(Base):
     turn_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     last_turn_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
     summary_text: Mapped[str] = mapped_column(String(1024), nullable=False, default="")
+    last_mode: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="", server_default=""
+    )
 
 
 class LessonLog(Base):

--- a/services/api/app/assistant/repositories/memory.py
+++ b/services/api/app/assistant/repositories/memory.py
@@ -22,6 +22,7 @@ def upsert_memory(
     turn_count: int,
     last_turn_at: datetime,
     summary_text: str | None = None,
+    last_mode: str | None = None,
 ) -> AssistantMemory:
     """Insert or update conversation memory for a user."""
     memory = session.get(AssistantMemory, user_id)
@@ -31,6 +32,7 @@ def upsert_memory(
             turn_count=turn_count,
             last_turn_at=last_turn_at,
             summary_text=summary_text or "",
+            last_mode=last_mode or "",
         )
         session.add(memory)
     else:
@@ -38,5 +40,7 @@ def upsert_memory(
         memory.last_turn_at = last_turn_at
         if summary_text is not None:
             memory.summary_text = summary_text
+        if last_mode is not None:
+            memory.last_mode = last_mode
     commit(session)
     return memory

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -30,6 +30,9 @@ from services.api.app.config import settings
 from services.api.app.diabetes.handlers.registration import register_handlers
 from services.api.app.diabetes.services.db import init_db
 from services.api.app.menu_button import post_init as menu_button_post_init
+from services.api.app.diabetes.handlers.assistant_menu import (
+    post_init as assistant_menu_post_init,
+)
 from services.bot.handlers.start_webapp import build_start_handler
 from services.bot.ptb_patches import apply_jobqueue_stop_workaround  # 👈 добавили
 from services.bot.telegram_payments import register_billing_handlers
@@ -69,6 +72,7 @@ async def post_init(
 ) -> None:
     await app.bot.set_my_commands(commands)
     await menu_button_post_init(app)
+    await assistant_menu_post_init(app)
     if app.job_queue:
         logger.info("✅ JobQueue initialized and ready")
     else:

--- a/tests/assistant/test_e2e_assistant_menu.py
+++ b/tests/assistant/test_e2e_assistant_menu.py
@@ -137,6 +137,7 @@ async def test_menu_visit_save_note(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(profile_service, "get_profile", fake_profile)
     monkeypatch.setattr(memory_service, "get_memory", fake_memory)
+    monkeypatch.setattr(memory_service, "set_last_mode", AsyncMock())
 
     message = MagicMock()
     message.edit_text = AsyncMock()

--- a/tests/assistant/test_memory_service.py
+++ b/tests/assistant/test_memory_service.py
@@ -116,3 +116,15 @@ async def test_save_note(setup_db: sessionmaker[Session]) -> None:
         stored = session.get(memory_service.AssistantNote, note.id)
         assert stored is not None
         assert stored.text == "hello"
+
+
+@pytest.mark.asyncio
+async def test_set_last_mode_and_get_all(
+    setup_db: sessionmaker[Session],
+) -> None:
+    await memory_service.set_last_mode(1, "chat")
+    modes = await memory_service.get_all_last_modes()
+    assert modes == [(1, "chat")]
+    await memory_service.set_last_mode(1, None)
+    modes = await memory_service.get_all_last_modes()
+    assert modes == []

--- a/tests/test_assistant_router.py
+++ b/tests/test_assistant_router.py
@@ -10,6 +10,7 @@ from services.api.app.diabetes import assistant_state, learning_handlers
 from services.api.app.diabetes.handlers import gpt_handlers
 from services.api.app.diabetes.utils.ui import SUGAR_BUTTON_TEXT
 from services.api.app.diabetes.metrics import assistant_mode_total
+from services.api.app.assistant.services import memory_service
 
 
 @pytest.mark.asyncio
@@ -67,6 +68,7 @@ async def test_router_chat_routes(
 
 @pytest.mark.asyncio
 async def test_router_labs_waiting(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(memory_service, "set_last_mode", AsyncMock())
     update = MagicMock()
     message = MagicMock()
     message.text = "result"
@@ -85,7 +87,8 @@ async def test_router_labs_waiting(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_router_visit_checklist() -> None:
+async def test_router_visit_checklist(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(memory_service, "set_last_mode", AsyncMock())
     update = MagicMock()
     message = MagicMock()
     message.text = "visit"

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -31,6 +31,7 @@ async def test_post_init_sets_chat_menu_button(
     monkeypatch.setenv("PUBLIC_ORIGIN", "https://app.example")
     monkeypatch.setenv("UI_BASE_URL", "/ui")
     main = _reload_main()
+    monkeypatch.setattr(main, "assistant_menu_post_init", AsyncMock())
     bot = SimpleNamespace(
         set_my_commands=AsyncMock(),
         set_chat_menu_button=AsyncMock(),
@@ -53,6 +54,7 @@ async def test_post_init_skips_chat_menu_button_without_url(
     monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
     monkeypatch.delenv("UI_BASE_URL", raising=False)
     main = _reload_main()
+    monkeypatch.setattr(main, "assistant_menu_post_init", AsyncMock())
     bot = SimpleNamespace(
         set_my_commands=AsyncMock(),
         set_chat_menu_button=AsyncMock(),


### PR DESCRIPTION
## Summary
- Persist assistant mode changes and reload them on startup
- Restore assistant state on boot with new post-init hook
- Add database support for remembering last assistant mode

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68c404b9de18832a9a7929ae44e4fa63