### PR TITLE
[assistant] Restore last assistant mode on startup

### DIFF
--- a/services/api/app/assistant/models.py
+++ b/services/api/app/assistant/models.py
@@ -23,6 +23,7 @@ class AssistantMemory(Base):
     turn_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     last_turn_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
     summary_text: Mapped[str] = mapped_column(String(1024), nullable=False, default="")
+    last_mode: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
 
 class LessonLog(Base):

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -69,6 +69,9 @@ async def post_init(
 ) -> None:
     await app.bot.set_my_commands(commands)
     await menu_button_post_init(app)
+    from services.api.app.diabetes.handlers import assistant_menu
+
+    await assistant_menu.post_init(app)
     if app.job_queue:
         logger.info("✅ JobQueue initialized and ready")
     else:

--- a/tests/assistant/test_e2e_assistant_menu.py
+++ b/tests/assistant/test_e2e_assistant_menu.py
@@ -15,6 +15,11 @@ from services.api.app.assistant.services import memory_service
 from services.api.app.services import profile as profile_service
 
 
+@pytest.fixture(autouse=True)
+def _patch_set_last_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(memory_service, "set_last_mode", AsyncMock())
+
+
 @pytest.mark.asyncio
 async def test_menu_chat_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     user_data: dict[str, object] = {}

--- a/tests/assistant/test_memory_service.py
+++ b/tests/assistant/test_memory_service.py
@@ -116,3 +116,17 @@ async def test_save_note(setup_db: sessionmaker[Session]) -> None:
         stored = session.get(memory_service.AssistantNote, note.id)
         assert stored is not None
         assert stored.text == "hello"
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_last_modes(
+    setup_db: sessionmaker[Session],
+) -> None:
+    await memory_service.set_last_mode(1, "chat")
+    await memory_service.set_last_mode(2, "learn")
+    modes = await memory_service.get_last_modes()
+    assert (1, "chat") in modes
+    assert (2, "learn") in modes
+    await memory_service.set_last_mode(1, None)
+    modes = await memory_service.get_last_modes()
+    assert (1, "chat") not in modes

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from telegram import MenuButtonDefault
+from services.api.app.assistant.services import memory_service
 
 
 
@@ -35,7 +36,8 @@ async def test_post_init_sets_chat_menu_button(
         set_my_commands=AsyncMock(),
         set_chat_menu_button=AsyncMock(),
     )
-    app = SimpleNamespace(bot=bot, job_queue=None)
+    monkeypatch.setattr(memory_service, "get_last_modes", AsyncMock(return_value=[]))
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
     await main.post_init(app)
     bot.set_my_commands.assert_awaited_once_with(main.commands)
     bot.set_chat_menu_button.assert_awaited_once()
@@ -57,7 +59,8 @@ async def test_post_init_skips_chat_menu_button_without_url(
         set_my_commands=AsyncMock(),
         set_chat_menu_button=AsyncMock(),
     )
-    app = SimpleNamespace(bot=bot, job_queue=None)
+    monkeypatch.setattr(memory_service, "get_last_modes", AsyncMock(return_value=[]))
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
     await main.post_init(app)
     bot.set_my_commands.assert_awaited_once_with(main.commands)
     bot.set_chat_menu_button.assert_awaited_once()


### PR DESCRIPTION
## Summary
- persist assistant last mode in database and expose helpers to fetch it
- restore saved mode on bot startup and send the appropriate menu
- save mode changes to memory when users interact with the assistant

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict services/api/app/diabetes/handlers/assistant_menu.py services/api/app/assistant/services/memory_service.py services/api/app/assistant/repositories/memory.py tests/test_assistant_menu.py tests/assistant/test_memory_service.py tests/test_chat_menu_button.py`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68c40b88ab70832a956161f9c1e93071