### PR TITLE
[migrations] add assistant_memory last_mode column

### DIFF
--- a/services/api/alembic/versions/20251017_add_assistant_memory_last_mode.py
+++ b/services/api/alembic/versions/20251017_add_assistant_memory_last_mode.py
@@ -1,0 +1,36 @@
+"""add assistant_memory last_mode"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20251017_add_assistant_memory_last_mode"
+down_revision: Union[str, None] = "20251016_lesson_logs_unique_step_role"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        with op.batch_alter_table("assistant_memory") as batch_op:
+            batch_op.add_column(
+                sa.Column("last_mode", sa.String(length=16), nullable=True)
+            )
+    else:
+        op.add_column(
+            "assistant_memory",
+            sa.Column("last_mode", sa.String(length=16), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        with op.batch_alter_table("assistant_memory") as batch_op:
+            batch_op.drop_column("last_mode")
+    else:
+        op.drop_column("assistant_memory", "last_mode")

--- a/tests/migrations/test_upgrade.py
+++ b/tests/migrations/test_upgrade.py
@@ -35,6 +35,7 @@ def test_upgrade(monkeypatch: pytest.MonkeyPatch) -> None:
         inspector = sa.inspect(engine)
         cols = [col["name"] for col in inspector.get_columns("assistant_memory")]
         assert "summary_text" in cols
+        assert "last_mode" in cols
 
         logging.config.dictConfig({"version": 1, "disable_existing_loggers": False})
         assert logging.getLogger(__name__).disabled is False


### PR DESCRIPTION
## Summary
- add migration for assistant_memory.last_mode
- cover migration with test

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`
- `alembic -c services/api/alembic.ini upgrade heads` *(fails: NotImplementedError: No support for ALTER of constraints in SQLite dialect)*

------
https://chatgpt.com/codex/tasks/task_e_68c41370fefc832a86ff64f87476d8d5