### PR TITLE
bot: validate update message in payments

### DIFF
--- a/services/bot/telegram_payments.py
+++ b/services/bot/telegram_payments.py
@@ -78,7 +78,8 @@ class TelegramPaymentsAdapter:
         """Notify backend about successful payment."""
 
         msg = update.message
-        assert msg is not None
+        if msg is None:
+            raise ValueError("update.message is required")
         payment = msg.successful_payment
         if payment is None:
             await msg.reply_text("⚠️ Платёж не найден")

--- a/tests/test_telegram_payments.py
+++ b/tests/test_telegram_payments.py
@@ -199,6 +199,15 @@ async def test_handle_successful_payment_http_error(
 
 
 @pytest.mark.asyncio
+async def test_handle_successful_payment_no_message() -> None:
+    adapter = TelegramPaymentsAdapter()
+    update = SimpleNamespace(message=None)
+
+    with pytest.raises(ValueError):
+        await adapter.handle_successful_payment(update, SimpleNamespace())
+
+
+@pytest.mark.asyncio
 async def test_handle_successful_payment_no_payment() -> None:
     adapter = TelegramPaymentsAdapter()
     message = SimpleNamespace(successful_payment=None, reply_text=AsyncMock())


### PR DESCRIPTION
## Summary
- guard Telegram payment handler against missing messages
- cover missing message branch in tests

## Testing
- `ruff check services/bot/telegram_payments.py tests/test_telegram_payments.py`
- `mypy --strict services/bot/telegram_payments.py tests/test_telegram_payments.py`
- `pytest -q tests/test_telegram_payments.py --cov=services.bot.telegram_payments --cov-report=term --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68c41cf6ef94832abd531609bfc4d5af