### PR TITLE
[handlers] Validate reminder value explicitly

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -501,7 +501,8 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             "Использование: /addreminder <type> <value>"  # noqa: RUF001
         )
         return
-    assert value is not None
+    if value is None:
+        raise ValueError("value must be provided")
     if rtype not in REMINDER_NAMES:
         await message.reply_text("Неизвестный тип напоминания.")
         return


### PR DESCRIPTION
## Summary
- prevent silent failures when adding reminders by replacing assert with explicit ValueError

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68c41cfc5f64832ab4aa40a7558e9475