### PR TITLE
[services] handle missing reminder id

### DIFF
--- a/services/api/app/services/reminders.py
+++ b/services/api/app/services/reminders.py
@@ -43,12 +43,22 @@ def _default_title(rem_type: str, rem_time: time_ | None) -> str | None:
 async def list_reminders(telegram_id: int) -> list[Reminder]:
     def _list(session: Session) -> list[Reminder]:
         profile = cast(Profile | None, session.get(Profile, telegram_id))
-        reminders_ = list(session.scalars(sa.select(Reminder).filter_by(telegram_id=telegram_id)).all())
+        reminders_ = list(
+            session.scalars(
+                sa.select(Reminder).filter_by(telegram_id=telegram_id)
+            ).all()
+        )
         if not reminders_:
             return []
-        sql = resources.files("services.api.app.diabetes.sql").joinpath("reminders_stats.sql").read_text()
+        sql = (
+            resources.files("services.api.app.diabetes.sql")
+            .joinpath("reminders_stats.sql")
+            .read_text()
+        )
         since = datetime.now(timezone.utc) - timedelta(days=7)
-        rows = session.execute(text(sql), {"telegram_id": telegram_id, "since": since}).mappings()
+        rows = session.execute(
+            text(sql), {"telegram_id": telegram_id, "since": since}
+        ).mappings()
         stats = {row["reminder_id"]: row for row in rows}
         tz = ZoneInfo(profile.timezone if profile else "UTC")
         for rem in reminders_:
@@ -98,13 +108,18 @@ async def save_reminder(data: ReminderSchema) -> int:
         except CommitError:
             raise HTTPException(status_code=500, detail="db commit failed")
         cast(Session, session).refresh(rem)
-        assert rem.id is not None
+        if rem.id is None:
+            raise HTTPException(
+                status_code=500, detail="reminder id missing after commit"
+            )
         return rem.id
 
     try:
         return cast(
             int,
-            await run_db(cast(Callable[[Session], int], _save), sessionmaker=SessionLocal),
+            await run_db(
+                cast(Callable[[Session], int], _save), sessionmaker=SessionLocal
+            ),
         )
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
@@ -116,7 +131,9 @@ async def delete_reminder(telegram_id: int, reminder_id: int) -> None:
         if rem is None or rem.telegram_id != telegram_id:
             raise HTTPException(status_code=404, detail="reminder not found")
         cast(Session, session).execute(
-            sa.update(ReminderLog).where(ReminderLog.reminder_id == reminder_id).values(reminder_id=None)
+            sa.update(ReminderLog)
+            .where(ReminderLog.reminder_id == reminder_id)
+            .values(reminder_id=None)
         )
         session.delete(rem)
         try:


### PR DESCRIPTION
## Summary
- ensure save_reminder raises HTTP 500 when ID missing after commit
- add regression test for missing reminder ID

## Testing
- `ruff check services/api/app/services/reminders.py tests/test_services_reminders.py`
- `mypy --strict .`
- `pytest -q --cov --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68c41d023aa0832a8454873800543b02