### PR TITLE
[auth] handle missing telegram init data

### DIFF
--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -106,7 +106,8 @@ def require_tg_user(
             init_data = authorization[3:]
         else:
             raise HTTPException(status_code=401, detail="missing init data")
-    assert init_data is not None
+    if init_data is None:
+        raise HTTPException(status_code=401, detail="missing init data")
     return get_tg_user(init_data)
 
 

--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -107,8 +107,10 @@ def test_require_tg_user_invalid_id_type(
 
 
 def test_require_tg_user_missing() -> None:
-    with pytest.raises(HTTPException):
+    with pytest.raises(HTTPException) as exc:
         require_tg_user(None)
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "missing init data"
 
 
 def test_require_tg_user_invalid(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- raise HTTPException when Telegram init data header is missing instead of relying on assert
- extend tests to verify missing init data results in 401 error

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c41d092120832a9d8d75909aa7775e