### PR TITLE
[bot] handle RetryAfter for set_my_commands

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -9,6 +9,7 @@ os.environ.setdefault(
     str(Path(__file__).resolve().parents[2] / "data/mpl-cache"),
 )
 
+import asyncio
 import logging
 import sys
 from datetime import timedelta
@@ -17,6 +18,7 @@ from zoneinfo import ZoneInfo
 
 from sqlalchemy.exc import SQLAlchemyError
 from telegram import BotCommand
+from telegram.error import NetworkError, RetryAfter
 from telegram.ext import (
     Application,
     ContextTypes,
@@ -67,7 +69,15 @@ async def post_init(
         DefaultJobQueue,
     ],
 ) -> None:
-    await app.bot.set_my_commands(commands)
+    try:
+        await app.bot.set_my_commands(commands)
+    except RetryAfter as exc:
+        logger.warning("Flood control: retrying in %ss", exc.retry_after)
+        await asyncio.sleep(exc.retry_after)
+        try:
+            await app.bot.set_my_commands(commands)
+        except (RetryAfter, NetworkError):
+            logger.warning("Flood control: unable to set commands")
     await menu_button_post_init(app)
     from services.api.app.diabetes.handlers import assistant_menu
 

--- a/tests/test_set_my_commands_retry.py
+++ b/tests/test_set_my_commands_retry.py
@@ -1,0 +1,61 @@
+"""Tests for retrying setting bot commands in main.post_init."""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.error import NetworkError, RetryAfter
+
+
+def _reload_main() -> ModuleType:
+    import services.bot.main as main
+
+    importlib.reload(main)
+    return main
+
+
+@pytest.mark.asyncio
+async def test_post_init_retries_on_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    main = _reload_main()
+    bot = SimpleNamespace(
+        set_my_commands=AsyncMock(side_effect=[RetryAfter(1), None]),
+    )
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    monkeypatch.setattr(main, "menu_button_post_init", AsyncMock())
+    import services.api.app.diabetes.handlers.assistant_menu as assistant_menu
+
+    monkeypatch.setattr(assistant_menu, "post_init", AsyncMock())
+    monkeypatch.setattr(main.asyncio, "sleep", AsyncMock())
+
+    await main.post_init(app)
+
+    assert bot.set_my_commands.await_count == 2
+    main.asyncio.sleep.assert_awaited_once_with(1)
+    main.menu_button_post_init.assert_awaited_once()
+    assistant_menu.post_init.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_init_handles_retry_after_and_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    main = _reload_main()
+    bot = SimpleNamespace(
+        set_my_commands=AsyncMock(side_effect=[RetryAfter(1), NetworkError("boom")]),
+    )
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    monkeypatch.setattr(main, "menu_button_post_init", AsyncMock())
+    import services.api.app.diabetes.handlers.assistant_menu as assistant_menu
+
+    monkeypatch.setattr(assistant_menu, "post_init", AsyncMock())
+    monkeypatch.setattr(main.asyncio, "sleep", AsyncMock())
+
+    await main.post_init(app)
+
+    assert bot.set_my_commands.await_count == 2
+    main.menu_button_post_init.assert_awaited_once()
+    assistant_menu.post_init.assert_awaited_once()
+


### PR DESCRIPTION
## Summary
- retry setting bot commands if Telegram rate limits, then swallow second RetryAfter/NetworkError
- add tests for command setup flood control

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c41fc6f018832aa49aac04ab2b9d4b