### PR TITLE
[bot] retry set_my_commands on flood control

### DIFF
--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from telegram import MenuButtonDefault
+from telegram.error import NetworkError, RetryAfter
 from services.api.app.assistant.services import memory_service
 
 
@@ -66,3 +67,50 @@ async def test_post_init_skips_chat_menu_button_without_url(
     bot.set_chat_menu_button.assert_awaited_once()
     button = bot.set_chat_menu_button.call_args.kwargs["menu_button"]
     assert isinstance(button, MenuButtonDefault)
+
+
+@pytest.mark.asyncio
+async def test_post_init_retries_set_my_commands(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Retries once on flood control and logs warning."""
+    monkeypatch.setenv("PUBLIC_ORIGIN", "https://app.example")
+    monkeypatch.setenv("UI_BASE_URL", "/ui")
+    main = _reload_main()
+    bot = SimpleNamespace(
+        set_my_commands=AsyncMock(side_effect=[RetryAfter(0), None]),
+        set_chat_menu_button=AsyncMock(),
+    )
+    monkeypatch.setattr(memory_service, "get_last_modes", AsyncMock(return_value=[]))
+    monkeypatch.setattr(main.asyncio, "sleep", AsyncMock())
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    with caplog.at_level("WARNING"):
+        await main.post_init(app)
+
+    assert bot.set_my_commands.await_count == 2
+    warnings = [r for r in caplog.records if "Flood control" in r.getMessage()]
+    assert len(warnings) == 1
+
+
+@pytest.mark.asyncio
+async def test_post_init_retry_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Stops retrying if flood control persists or network error occurs."""
+    monkeypatch.setenv("PUBLIC_ORIGIN", "https://app.example")
+    monkeypatch.setenv("UI_BASE_URL", "/ui")
+    main = _reload_main()
+    bot = SimpleNamespace(
+        set_my_commands=AsyncMock(
+            side_effect=[RetryAfter(0), NetworkError("boom")]
+        ),
+        set_chat_menu_button=AsyncMock(),
+    )
+    monkeypatch.setattr(memory_service, "get_last_modes", AsyncMock(return_value=[]))
+    monkeypatch.setattr(main.asyncio, "sleep", AsyncMock())
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    with caplog.at_level("WARNING"):
+        await main.post_init(app)
+
+    warnings = [r for r in caplog.records if "Flood control" in r.getMessage()]
+    assert len(warnings) == 1


### PR DESCRIPTION
## Summary
- retry setting bot commands once when Telegram API returns flood control
- cover flood-control retry logic in `post_init`

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c41fcb9d84832aa051e3e3a69b9cec