### PR TITLE
[bot] Test set_my_commands flood control warnings

### DIFF
--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import importlib
+import logging
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-
 from telegram import MenuButtonDefault
+from telegram.error import NetworkError, RetryAfter
+
 from services.api.app.assistant.services import memory_service
 
 
@@ -66,3 +68,56 @@ async def test_post_init_skips_chat_menu_button_without_url(
     bot.set_chat_menu_button.assert_awaited_once()
     button = bot.set_chat_menu_button.call_args.kwargs["menu_button"]
     assert isinstance(button, MenuButtonDefault)
+
+
+@pytest.mark.asyncio
+async def test_post_init_warns_and_retries_on_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Retry setting bot commands once and log a warning."""
+    main = _reload_main()
+    bot = SimpleNamespace(
+        set_my_commands=AsyncMock(side_effect=[RetryAfter(1), None]),
+    )
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    monkeypatch.setattr(main, "menu_button_post_init", AsyncMock())
+    import services.api.app.diabetes.handlers.assistant_menu as assistant_menu
+
+    monkeypatch.setattr(assistant_menu, "post_init", AsyncMock())
+    monkeypatch.setattr(main.asyncio, "sleep", AsyncMock())
+
+    with caplog.at_level(logging.WARNING):
+        await main.post_init(app)
+
+    assert bot.set_my_commands.await_count == 2
+    main.asyncio.sleep.assert_awaited_once_with(1)
+    warnings = [r for r in caplog.records if "Flood control" in r.message]
+    assert len(warnings) == 1
+
+
+@pytest.mark.asyncio
+async def test_post_init_warns_when_retry_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Log warnings if retrying to set commands fails again."""
+    main = _reload_main()
+    bot = SimpleNamespace(
+        set_my_commands=AsyncMock(
+            side_effect=[RetryAfter(1), NetworkError("boom")]
+        ),
+    )
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    monkeypatch.setattr(main, "menu_button_post_init", AsyncMock())
+    import services.api.app.diabetes.handlers.assistant_menu as assistant_menu
+
+    monkeypatch.setattr(assistant_menu, "post_init", AsyncMock())
+    monkeypatch.setattr(main.asyncio, "sleep", AsyncMock())
+
+    with caplog.at_level(logging.WARNING):
+        await main.post_init(app)
+
+    assert bot.set_my_commands.await_count == 2
+    warnings = [r for r in caplog.records if "Flood control" in r.message]
+    assert len(warnings) == 2


### PR DESCRIPTION
## Summary
- test that `post_init` retries `set_my_commands` once on `RetryAfter` and logs a flood control warning
- test flood control logging when retry fails again

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68c423dbb130832ab4d94f8f90f2450e