### PR TITLE
[utils] Validate geolocation coordinates

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -46,11 +46,7 @@ async def get_coords_and_link(
 
     parsed = urlparse(url)
     host = parsed.hostname.lower() if parsed.hostname else None
-    if (
-        parsed.scheme not in {"http", "https"}
-        or host is None
-        or host not in ALLOWED_GEO_HOSTS
-    ):
+    if parsed.scheme not in {"http", "https"} or host is None or host not in ALLOWED_GEO_HOSTS:
         logger.warning("Invalid source URL: %s", url)
         return None, None
 
@@ -77,10 +73,9 @@ async def get_coords_and_link(
     if isinstance(loc, str):
         try:
             lat, lon = (part.strip() for part in loc.split(","))
+            float(lat)
+            float(lon)
         except ValueError:
-            logger.warning("Invalid location format: %s", loc)
-            return None, None
-        if not lat or not lon:
             logger.warning("Invalid location format: %s", loc)
             return None, None
         coords = f"{lat},{lon}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,6 +86,32 @@ async def test_get_coords_and_link_invalid_loc(
 
 
 @pytest.mark.asyncio
+async def test_get_coords_and_link_invalid_float(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    async def bad_get(self: httpx.AsyncClient, url: str, **kwargs: Any) -> Any:
+        class Resp:
+            status_code = 200
+            headers = {"Content-Type": "application/json"}
+
+            def raise_for_status(self) -> None:  # pragma: no cover - dummy
+                pass
+
+            def json(self) -> dict[str, str]:
+                return {"loc": "1,invalid"}
+
+        return Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", bad_get)
+
+    with caplog.at_level(logging.WARNING):
+        coords, link = await utils.get_coords_and_link()
+
+    assert coords is None and link is None
+    assert any("Invalid location format" in msg for msg in caplog.messages)
+
+
+@pytest.mark.asyncio
 async def test_get_coords_and_link_custom_source(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -162,9 +188,7 @@ async def test_get_coords_and_link_mixed_case_host(
     "content_type",
     ["application/json", "Application/Json", "APPLICATION/JSON"],
 )
-async def test_get_coords_and_link_content_type_case(
-    monkeypatch: pytest.MonkeyPatch, content_type: str
-) -> None:
+async def test_get_coords_and_link_content_type_case(monkeypatch: pytest.MonkeyPatch, content_type: str) -> None:
     async def fake_get(self: httpx.AsyncClient, url: str, **kwargs: Any) -> Any:
         class Resp:
             status_code = 200


### PR DESCRIPTION
## Summary
- ensure latitude and longitude strings parse as floats
- handle invalid coordinate formats in get_coords_and_link
- test invalid coordinate strings

## Testing
- `make ci` (fails: No rule to make target 'ci')
- `pytest -q --cov` (fails: 28 errors during collection)
- `mypy --strict .` (fails: Cannot find implementation or library stub for module named "redis.asyncio")
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c42bb6daec832a8f3161ad4b773f90