### PR TITLE
[helpers] reuse async geo client

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -30,6 +30,7 @@ from .diabetes.handlers.reminder_jobs import DefaultJobQueue
 from .diabetes.models_learning import Lesson
 from .diabetes.services.db import init_db, run_db
 from services.api.app.diabetes.services.gpt_client import dispose_openai_clients
+from services.api.app.diabetes.utils.helpers import dispose_geo_client
 from services.api.app.diabetes.utils.openai_utils import dispose_http_client
 from .telegram_auth import require_tg_user  # noqa: F401
 from .legacy import router as legacy_router
@@ -82,6 +83,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         yield
     finally:
         reminder_events.register_job_queue(None)
+        await dispose_geo_client()
         await dispose_http_client()
         await dispose_openai_clients()
         await stop_flush_task()

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -13,7 +13,7 @@ import asyncio
 import logging
 import sys
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias, cast
 from zoneinfo import ZoneInfo
 
 import redis.asyncio as redis
@@ -74,7 +74,9 @@ async def post_init(
     redis_client: redis.Redis | None = None
     should_set = True
     try:
-        redis_client = redis.Redis.from_url(settings.redis_url)
+        redis_client = cast(
+            redis.Redis, redis.from_url(settings.redis_url)  # type: ignore[no-untyped-call]
+        )
         raw_ts = await redis_client.get("bot:commands_set_at")
         if raw_ts:
             last_set = datetime.fromisoformat(raw_ts.decode())

--- a/tests/test_shutdown_clients.py
+++ b/tests/test_shutdown_clients.py
@@ -5,8 +5,11 @@ from fastapi.testclient import TestClient
 from services.api.app.main import app
 
 
-def test_shutdown_openai_client_disposes() -> None:
+def test_shutdown_clients_dispose() -> None:
     with patch(
+        "services.api.app.main.dispose_geo_client",
+        new_callable=AsyncMock,
+    ) as dispose_geo, patch(
         "services.api.app.main.dispose_http_client",
         new_callable=AsyncMock,
     ) as dispose_http, patch(
@@ -15,5 +18,6 @@ def test_shutdown_openai_client_disposes() -> None:
     ) as dispose_clients:
         with TestClient(app):
             pass
+        dispose_geo.assert_awaited_once()
         dispose_http.assert_awaited_once()
         dispose_clients.assert_awaited_once()


### PR DESCRIPTION
## Summary
- reuse singleton `httpx.AsyncClient` in helpers and close it on shutdown
- dispose geo client during FastAPI lifespan and cover behavior with tests
- patch bot startup to use `redis.from_url` with typing fix

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c42bbca9d8832aa4eb636f18588d51