### PR TITLE
[assistant] Centralize assistant menu emoji toggle

### DIFF
--- a/services/api/app/assistant/assistant_menu.py
+++ b/services/api/app/assistant/assistant_menu.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AssistantMenu:
+    """Texts for assistant-related buttons."""
+
+    assistant: str
+    learn: str
+    chat: str
+    labs: str
+    visit: str
+
+
+def render_assistant_menu(emoji: bool) -> AssistantMenu:
+    """Return assistant menu button texts.
+
+    Args:
+        emoji: Whether to include emoji in button labels.
+    """
+
+    if emoji:
+        return AssistantMenu(
+            assistant="🤖 Ассистент_AI",
+            learn="🎓 Обучение",
+            chat="💬 Чат",
+            labs="🧪 Анализы",
+            visit="🩺 Визит",
+        )
+    return AssistantMenu(
+        assistant="Ассистент_AI",
+        learn="Обучение",
+        chat="Чат",
+        labs="Анализы",
+        visit="Визит",
+    )
+
+
+__all__ = ["AssistantMenu", "render_assistant_menu"]

--- a/services/api/app/diabetes/handlers/assistant_menu.py
+++ b/services/api/app/diabetes/handlers/assistant_menu.py
@@ -14,6 +14,9 @@ from telegram.ext import (
     JobQueue,
 )
 
+from services.api.app.assistant.assistant_menu import render_assistant_menu
+from services.api.app.config import get_settings
+
 from services.api.app.assistant.services import memory_service
 from services.api.app.diabetes.utils.ui import BACK_BUTTON_TEXT
 from services.api.app.diabetes.assistant_state import AWAITING_KIND, set_last_mode
@@ -30,11 +33,14 @@ __all__ = [
     "ASSISTANT_HANDLER",
 ]
 
+_settings = get_settings()
+_menu_texts = render_assistant_menu(_settings.assistant_menu_emoji)
+
 MENU_LAYOUT: tuple[tuple[InlineKeyboardButton, ...], ...] = (
-    (InlineKeyboardButton("🎓 Обучение", callback_data="asst:learn"),),
-    (InlineKeyboardButton("💬 Чат", callback_data="asst:chat"),),
-    (InlineKeyboardButton("🧪 Анализы", callback_data="asst:labs"),),
-    (InlineKeyboardButton("🩺 Визит", callback_data="asst:visit"),),
+    (InlineKeyboardButton(_menu_texts.learn, callback_data="asst:learn"),),
+    (InlineKeyboardButton(_menu_texts.chat, callback_data="asst:chat"),),
+    (InlineKeyboardButton(_menu_texts.labs, callback_data="asst:labs"),),
+    (InlineKeyboardButton(_menu_texts.visit, callback_data="asst:visit"),),
 )
 
 MODE_TEXTS: dict[str, str] = {

--- a/services/api/app/ui/keyboard.py
+++ b/services/api/app/ui/keyboard.py
@@ -2,11 +2,11 @@ from telegram import ReplyKeyboardMarkup, KeyboardButton
 
 from services.api.app.diabetes.utils.ui import menu_keyboard
 from services.api.app.config import get_settings
+from services.api.app.assistant.assistant_menu import render_assistant_menu
 
 _settings = get_settings()
-LEARN_BUTTON_TEXT = (
-    "🤖 Ассистент_AI" if _settings.assistant_menu_emoji else "Ассистент_AI"
-)
+_texts = render_assistant_menu(_settings.assistant_menu_emoji)
+LEARN_BUTTON_TEXT = _texts.assistant
 
 
 def build_main_keyboard() -> ReplyKeyboardMarkup:

--- a/tests/test_assistant_menu.py
+++ b/tests/test_assistant_menu.py
@@ -233,3 +233,34 @@ async def test_post_init_restores_modes(monkeypatch: pytest.MonkeyPatch) -> None
     assert app.user_data[1][assistant_state.LAST_MODE_KEY] == "chat"
     assert app.user_data[2][assistant_state.LAST_MODE_KEY] == "learn"
     assert bot.send_message.await_count == 2
+
+
+def test_assistant_menu_emoji_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ASSISTANT_MENU_EMOJI", "false")
+    from importlib import reload
+
+    from services.api.app import config
+
+    reload(config)
+    config.reload_settings()
+    import services.api.app.assistant.assistant_menu as helper
+    import services.api.app.ui.keyboard as ui_keyboard
+    import services.api.app.diabetes.handlers.assistant_menu as handler_menu
+
+    reload(helper)
+    reload(ui_keyboard)
+    reload(handler_menu)
+
+    assert helper.render_assistant_menu(False).assistant == "Ассистент_AI"
+    assert ui_keyboard.LEARN_BUTTON_TEXT == "Ассистент_AI"
+    texts = [
+        btn.text for row in handler_menu.assistant_keyboard().inline_keyboard for btn in row
+    ]
+    assert texts == ["Обучение", "Чат", "Анализы", "Визит"]
+
+    monkeypatch.delenv("ASSISTANT_MENU_EMOJI", raising=False)
+    reload(config)
+    config.reload_settings()
+    reload(helper)
+    reload(ui_keyboard)
+    reload(handler_menu)


### PR DESCRIPTION
## Summary
- centralize assistant menu button texts in `render_assistant_menu`
- respect `ASSISTANT_MENU_EMOJI` setting for inline and main menus
- add regression test for emoji-off configuration

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c43b535718832aa616f95cc215ec4b