### PR TITLE
tests: add SessionLocal fixture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,9 @@
 ### Тест-утилиты
 - Для проверки «нет предупреждения» используйте `tests/utils/warn_ctx.py::warn_or_not(None)` вместо `pytest.warns`.
 - Временный `xfail` допускается только с причиной и TODO-сроком.
+- Для тестов, требующих БД, добавляйте фикстуру `session_local` из `tests/conftest.py`.
+  Она настраивает `SessionLocal` на in-memory SQLite, вызывает `init_db()` и
+  подменяет его во всех уже импортированных модулях.
 
 ### Локальный чек перед коммитом
 - `make ci` или `pytest -q --cov && mypy --strict . && ruff check .`.


### PR DESCRIPTION
## Summary
- add `session_local` fixture configuring `SessionLocal` with in-memory SQLite
- document fixture in AGENTS.md
- refactor profile quiet field tests to use fixture

## Testing
- `pytest tests/test_profile_quiet_fields.py -q`
- `mypy --strict tests/conftest.py tests/test_profile_quiet_fields.py` *(fails: Call to untyped function "from_url" in typed context)*
- `ruff check tests/conftest.py tests/test_profile_quiet_fields.py`


------
https://chatgpt.com/codex/tasks/task_e_68c44032a9bc832ab8febc92d675e214