### PR TITLE
[scripts] annotate callback ctx and return types

### DIFF
--- a/scripts/probe_reminder_30s.py
+++ b/scripts/probe_reminder_30s.py
@@ -1,17 +1,21 @@
 # scripts/probe_reminder_30s.py
 # Фикс: читаем токен ещё и из TELEGRAM_TOKEN. Реально шлёт сообщение через 30 секунд.
-import os, asyncio
+import asyncio
+import os
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
+
 from telegram.ext import ApplicationBuilder, ContextTypes
 
 CHAT_ID = int(os.environ.get("CHAT_ID", "448794918"))
 
-async def send_msg(ctx: ContextTypes.DEFAULT_TYPE):
+
+async def send_msg(ctx: ContextTypes.DEFAULT_TYPE) -> None:
     now = datetime.now(tz=timezone.utc)
     await ctx.bot.send_message(CHAT_ID, f"Пробный джоб ✅ (UTC {now:%H:%M:%S})")
 
-async def main():
+
+async def main() -> None:
     token = (
         os.environ.get("BOT_TOKEN")
         or os.environ.get("TELEGRAM_BOT_TOKEN")
@@ -21,10 +25,15 @@ async def main():
         raise SystemExit("Нет токена: установи BOT_TOKEN/TELEGRAM_BOT_TOKEN/TELEGRAM_TOKEN в окружении или .env")
 
     app = ApplicationBuilder().token(token).build()
+    assert app.job_queue is not None
     app.job_queue.scheduler.configure(timezone=ZoneInfo("Europe/Moscow"))
     print("JobQueue TZ:", app.job_queue.scheduler.timezone)
 
-    app.job_queue.run_once(send_msg, when=datetime.now(tz=timezone.utc)+timedelta(seconds=30), name="probe_30s")
+    app.job_queue.run_once(
+        send_msg,
+        when=datetime.now(tz=timezone.utc) + timedelta(seconds=30),
+        name="probe_30s",
+    )
     async with app:
         await asyncio.sleep(40)
 

--- a/scripts/ptb_selftest_offline.py
+++ b/scripts/ptb_selftest_offline.py
@@ -3,13 +3,16 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
-from telegram.ext import ApplicationBuilder
+from telegram.ext import ApplicationBuilder, ContextTypes
 
-async def probe(_ctx):
+
+async def probe(_ctx: ContextTypes.DEFAULT_TYPE) -> None:
     print(f"[{datetime.now(tz=timezone.utc):%H:%M:%S} UTC] PROBE JOB fired ok")
 
-async def main():
+
+async def main() -> None:
     app = ApplicationBuilder().token("TEST:TOKEN").build()
+    assert app.job_queue is not None
     app.job_queue.scheduler.configure(timezone=ZoneInfo("Europe/Moscow"))
     print("APScheduler timezone:", app.job_queue.scheduler.timezone)
     app.job_queue.scheduler.start(paused=False)


### PR DESCRIPTION
## Summary
- add explicit return type hints and context annotations to PTB helper scripts
- assert JobQueue presence before scheduling tasks

## Testing
- `ruff check scripts/`
- `mypy --strict scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4543b57cc832a8c28e57c4deaa67c