### PR TITLE
[handlers] implement profile timezone callback

### DIFF
--- a/tests/test_profile_timezone.py
+++ b/tests/test_profile_timezone.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from services.api.app.diabetes.handlers import router
+from services.api.app.diabetes.services.db import Profile
+
+
+class DummyQuery:
+    def __init__(self, data: str, user_id: int) -> None:
+        self.data = data
+        self.from_user = SimpleNamespace(id=user_id)
+        self.edited: list[str] = []
+
+    async def edit_message_text(self, text: str, **kwargs: Any) -> None:
+        self.edited.append(text)
+
+
+@pytest.mark.asyncio
+async def test_profile_timezone_update_success(
+    session_local: sessionmaker[Session],
+) -> None:
+    query = DummyQuery("profile_timezone:Europe/Moscow", 1)
+    update = cast(Update, SimpleNamespace(callback_query=query, effective_user=query.from_user))
+    context = cast(ContextTypes.DEFAULT_TYPE, SimpleNamespace())
+
+    await router.handle_profile_timezone(update, context, query, query.data)
+
+    assert query.edited == ["✅ Часовой пояс обновлён."]
+    with session_local() as session:
+        profile = session.get(Profile, 1)
+        assert profile is not None
+        assert profile.timezone == "Europe/Moscow"
+        assert profile.timezone_auto is False
+
+
+@pytest.mark.asyncio
+async def test_profile_timezone_invalid(session_local: sessionmaker[Session]) -> None:
+    query = DummyQuery("profile_timezone:Invalid/Zone", 1)
+    update = cast(Update, SimpleNamespace(callback_query=query, effective_user=query.from_user))
+    context = cast(ContextTypes.DEFAULT_TYPE, SimpleNamespace())
+
+    await router.handle_profile_timezone(update, context, query, query.data)
+
+    assert query.edited == ["Некорректный часовой пояс."]
+    with session_local() as session:
+        profile = session.get(Profile, 1)
+        assert profile is None


### PR DESCRIPTION
## Summary
- handle profile timezone callback by validating timezone and saving to DB
- add tests for timezone update and invalid input

## Testing
- `ruff check services/api/app/diabetes/handlers/router.py tests/test_profile_timezone.py`
- `mypy --strict services/api/app/diabetes/handlers/router.py tests/test_profile_timezone.py`
- `pytest tests/test_profile_timezone.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c45440af50832a83ac509d1d489675