### PR TITLE
[handlers] delegate rem_ callbacks to reminder handlers

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -1307,6 +1307,17 @@ async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE)
         await query.answer("Готово ✅")
 
 
+async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Route reminder-related callbacks."""
+    query = update.callback_query
+    if query is None or query.data is None:
+        return
+    if query.data.startswith("remind_"):
+        await reminder_callback(update, context)
+    else:
+        await reminder_action_cb(update, context)
+
+
 def schedule_after_meal(user_id: int, job_queue: DefaultJobQueue | None) -> None:
     if job_queue is None:
         logger.warning("schedule_after_meal called without job_queue")
@@ -1349,6 +1360,7 @@ __all__ = [
     "reminder_job",
     "reminder_callback",
     "reminder_action_cb",
+    "callback_router",
     "schedule_after_meal",
     "reminder_action_handler",
     "reminder_webapp_handler",

--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -256,6 +256,9 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     data = query.data or ""
 
     if data.startswith("rem_"):
+        from . import reminder_handlers
+
+        await reminder_handlers.callback_router(update, context)
         return
 
     handler = callback_handlers.get(data)

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -142,12 +142,28 @@ async def test_callback_router_unknown_data(
 
 
 @pytest.mark.asyncio
-async def test_callback_router_ignores_reminder_action(
+async def test_callback_router_delegates_reminder_action(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
     import services.api.app.diabetes.handlers.router as router
+    from services.api.app.diabetes.handlers import reminder_handlers
+
+    calls: list[
+        tuple[
+            Update,
+            CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        ]
+    ] = []
+
+    async def fake_router(
+        update: Update,
+        context: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+    ) -> None:
+        calls.append((update, context))
+
+    monkeypatch.setattr(reminder_handlers, "callback_router", fake_router)
 
     query = DummyQuery(DummyMessage(), "rem_toggle:1")
     update = cast(Update, SimpleNamespace(callback_query=query))
@@ -158,7 +174,6 @@ async def test_callback_router_ignores_reminder_action(
 
     await router.callback_router(update, context)
 
-    assert query.edited == []
+    assert calls and calls[0][0] is update and calls[0][1] is context
     assert context.user_data is not None
-    user_data = context.user_data
-    assert "pending_entry" in user_data
+    assert "pending_entry" in context.user_data


### PR DESCRIPTION
## Summary
- delegate rem_* callbacks from main router to reminder handler router
- expose reminder callback router and cover via regression test

## Testing
- `ruff check services/api/app/diabetes/handlers/router.py services/api/app/diabetes/handlers/reminder_handlers.py tests`
- `mypy --strict --hide-error-context services/api/app/diabetes/handlers/router.py services/api/app/diabetes/handlers/reminder_handlers.py tests`
- `pytest tests/test_handlers_cancel_entry.py::test_callback_router_delegates_reminder_action -q`
- `pytest -q --cov --cov-fail-under=85` *(fails: OperationalError no such table: users; test_toggle_reminder_cb assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68c456ae1f98832a90b508224e08e4c9