### PR TITLE
tests: stabilize profile quiet field tests

### DIFF
--- a/tests/test_profile_quiet_fields.py
+++ b/tests/test_profile_quiet_fields.py
@@ -11,7 +11,9 @@ from services.api.app.services import profile as profile_service
 @pytest.mark.asyncio
 async def test_save_profile_stores_quiet_fields(
     session_local: sessionmaker[Session],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(profile_service.db, "SessionLocal", session_local, raising=False)
     with session_local() as session:
         session.add(db.User(telegram_id=1, thread_id="t"))
         session.commit()
@@ -35,7 +37,9 @@ async def test_save_profile_stores_quiet_fields(
 @pytest.mark.asyncio
 async def test_save_profile_defaults_quiet_fields(
     session_local: sessionmaker[Session],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(profile_service.db, "SessionLocal", session_local, raising=False)
     with session_local() as session:
         session.add(db.User(telegram_id=2, thread_id="t"))
         session.commit()


### PR DESCRIPTION
## Summary
- access `User` and `Profile` via the db module to avoid stale ORM classes
- make quiet-hours profile tests patch `SessionLocal` for isolation

## Testing
- `pytest -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c457273b38832a88f7aaf0af5c2ca8