### PR TITLE
[tests] Set deterministic learning model in router test

### DIFF
--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -38,6 +38,8 @@ async def test_create_learning_chat_completion_uses_router(
     monkeypatch.setattr(
         gpt_client, "create_chat_completion", fake_create_chat_completion
     )
+    settings = config.get_settings()
+    monkeypatch.setattr(settings, "learning_model_default", "gpt-4o-mini")
     monkeypatch.setattr(gpt_client, "_learning_router", LLMRouter())
 
     await gpt_client.create_learning_chat_completion(


### PR DESCRIPTION
## Summary
- ensure `learning_model_default` is set before constructing `LLMRouter` in tests for deterministic model selection

## Testing
- `pytest tests/test_llm_router.py -q`
- `ruff check .`
- `mypy --strict .` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c45c95f18c832a8d92aa8bd1c89607