### PR TITLE
[tests] reload db module in profile quiet field tests

### DIFF
--- a/tests/test_profile_quiet_fields.py
+++ b/tests/test_profile_quiet_fields.py
@@ -1,9 +1,10 @@
-import pytest
+import importlib
 from datetime import time as dt_time
 
+import pytest
 from sqlalchemy.orm import Session, sessionmaker
 
-from services.api.app.diabetes.services import db
+import services.api.app.diabetes.services.db as db_module
 from services.api.app.schemas.profile import ProfileUpdateSchema
 from services.api.app.services import profile as profile_service
 
@@ -13,7 +14,11 @@ async def test_save_profile_stores_quiet_fields(
     session_local: sessionmaker[Session],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(profile_service.db, "SessionLocal", session_local, raising=False)
+    module = importlib.import_module(db_module.__name__)
+    db = importlib.reload(module)
+    monkeypatch.setattr(
+        profile_service.db, "SessionLocal", session_local, raising=False
+    )
     with session_local() as session:
         session.add(db.User(telegram_id=1, thread_id="t"))
         session.commit()
@@ -39,7 +44,11 @@ async def test_save_profile_defaults_quiet_fields(
     session_local: sessionmaker[Session],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(profile_service.db, "SessionLocal", session_local, raising=False)
+    module = importlib.import_module(db_module.__name__)
+    db = importlib.reload(module)
+    monkeypatch.setattr(
+        profile_service.db, "SessionLocal", session_local, raising=False
+    )
     with session_local() as session:
         session.add(db.User(telegram_id=2, thread_id="t"))
         session.commit()


### PR DESCRIPTION
## Summary
- reload db module in profile quiet field tests to use fixture in-memory DB

## Testing
- `ruff check .`
- `mypy --strict tests/test_profile_quiet_fields.py`
- `pytest tests/test_profile_quiet_fields.py -q --cov`
- `mypy --strict .` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68c45c9cfc60832a81565573d52b86c8