### PR TITLE
[tests] simulate application user data mapping

### DIFF
--- a/tests/test_assistant_menu.py
+++ b/tests/test_assistant_menu.py
@@ -1,5 +1,5 @@
 import logging
-from types import SimpleNamespace
+from types import MappingProxyType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -226,12 +226,13 @@ async def test_post_init_restores_modes(monkeypatch: pytest.MonkeyPatch) -> None
     )
     bot = MagicMock()
     bot.send_message = AsyncMock()
-    app = SimpleNamespace(bot=bot, user_data={})
+    app = SimpleNamespace(bot=bot, user_data=MappingProxyType({}))
+    app._user_data = {}
 
     await assistant_menu.post_init(app)
 
-    assert app.user_data[1][assistant_state.LAST_MODE_KEY] == "chat"
-    assert app.user_data[2][assistant_state.LAST_MODE_KEY] == "learn"
+    assert app._user_data[1][assistant_state.LAST_MODE_KEY] == "chat"
+    assert app._user_data[2][assistant_state.LAST_MODE_KEY] == "learn"
     assert bot.send_message.await_count == 2
 
 

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib
 import logging
-from types import ModuleType, SimpleNamespace
+from types import MappingProxyType, ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -39,7 +39,8 @@ async def test_post_init_sets_chat_menu_button(
         set_chat_menu_button=AsyncMock(),
     )
     monkeypatch.setattr(memory_service, "get_last_modes", AsyncMock(return_value=[]))
-    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data=MappingProxyType({}))
+    app._user_data = {}
     await main.post_init(app)
     bot.set_my_commands.assert_awaited_once_with(main.commands)
     bot.set_chat_menu_button.assert_awaited_once()
@@ -62,7 +63,8 @@ async def test_post_init_skips_chat_menu_button_without_url(
         set_chat_menu_button=AsyncMock(),
     )
     monkeypatch.setattr(memory_service, "get_last_modes", AsyncMock(return_value=[]))
-    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data=MappingProxyType({}))
+    app._user_data = {}
     await main.post_init(app)
     bot.set_my_commands.assert_awaited_once_with(main.commands)
     bot.set_chat_menu_button.assert_awaited_once()
@@ -80,7 +82,8 @@ async def test_post_init_warns_and_retries_on_retry_after(
     bot = SimpleNamespace(
         set_my_commands=AsyncMock(side_effect=[RetryAfter(1), None]),
     )
-    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data=MappingProxyType({}))
+    app._user_data = {}
     monkeypatch.setattr(main, "menu_button_post_init", AsyncMock())
     import services.api.app.diabetes.handlers.assistant_menu as assistant_menu
 
@@ -108,7 +111,8 @@ async def test_post_init_warns_when_retry_fails(
             side_effect=[RetryAfter(1), NetworkError("boom")]
         ),
     )
-    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data=MappingProxyType({}))
+    app._user_data = {}
     monkeypatch.setattr(main, "menu_button_post_init", AsyncMock())
     import services.api.app.diabetes.handlers.assistant_menu as assistant_menu
 

--- a/tests/test_set_my_commands_retry.py
+++ b/tests/test_set_my_commands_retry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib
 from datetime import datetime, timedelta, timezone
-from types import ModuleType, SimpleNamespace
+from types import MappingProxyType, ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -26,7 +26,8 @@ async def test_post_init_retries_on_retry_after(
     bot = SimpleNamespace(
         set_my_commands=AsyncMock(side_effect=[RetryAfter(1), None]),
     )
-    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data=MappingProxyType({}))
+    app._user_data = {}
     monkeypatch.setattr(main, "menu_button_post_init", AsyncMock())
     import services.api.app.diabetes.handlers.assistant_menu as assistant_menu
 
@@ -49,7 +50,8 @@ async def test_post_init_handles_retry_after_and_network_error(
     bot = SimpleNamespace(
         set_my_commands=AsyncMock(side_effect=[RetryAfter(1), NetworkError("boom")]),
     )
-    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data=MappingProxyType({}))
+    app._user_data = {}
     monkeypatch.setattr(main, "menu_button_post_init", AsyncMock())
     import services.api.app.diabetes.handlers.assistant_menu as assistant_menu
 
@@ -85,7 +87,8 @@ async def test_post_init_skips_recent_commands(monkeypatch: pytest.MonkeyPatch) 
     redis_client = DummyRedis(now.isoformat().encode())
     monkeypatch.setattr(main.redis.Redis, "from_url", lambda url: redis_client)
     bot = SimpleNamespace(set_my_commands=AsyncMock())
-    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data=MappingProxyType({}))
+    app._user_data = {}
     monkeypatch.setattr(main, "menu_button_post_init", AsyncMock())
     import services.api.app.diabetes.handlers.assistant_menu as assistant_menu
 
@@ -104,7 +107,8 @@ async def test_post_init_sets_and_caches(monkeypatch: pytest.MonkeyPatch) -> Non
     redis_client = DummyRedis(past.isoformat().encode())
     monkeypatch.setattr(main.redis.Redis, "from_url", lambda url: redis_client)
     bot = SimpleNamespace(set_my_commands=AsyncMock())
-    app = SimpleNamespace(bot=bot, job_queue=None, user_data={})
+    app = SimpleNamespace(bot=bot, job_queue=None, user_data=MappingProxyType({}))
+    app._user_data = {}
     monkeypatch.setattr(main, "menu_button_post_init", AsyncMock())
     import services.api.app.diabetes.handlers.assistant_menu as assistant_menu
 


### PR DESCRIPTION
## Summary
- mimic python-telegram-bot's runtime user_data structure in tests using MappingProxyType and backing _user_data
- adjust assertions to track mutations via _user_data
- cover assistant menu and photo handler tests for mapping proxy mismatch

## Testing
- `pytest tests/test_assistant_menu.py tests/test_photo_handlers_additional.py tests/test_handlers_doc.py tests/handlers/test_photo_handler_recognition.py tests/test_set_my_commands_retry.py tests/test_chat_menu_button.py -q --cov` *(fails: AttributeError/TypeError as expected)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c45cc1f700832aabeb7007a4d30966