### PR TITLE
[deps] Include pytest dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 -r services/api/app/requirements.txt
+pytest
+pytest-asyncio
 pytest-cov
 # Optional local Python SDK (generated from OpenAPI)
 # To use it, generate `libs/py-sdk` and install its dependencies manually:


### PR DESCRIPTION
## Summary
- ensure tests are installable by adding pytest and pytest-asyncio to project requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q --cov --cov-fail-under=85` *(fails: KeyboardInterrupt)*
- `mypy --strict .` *(fails: Interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c45e5f2218832aa296c9dfe004064e