### PR TITLE
[handlers] use underlying app user_data store

### DIFF
--- a/services/api/app/diabetes/handlers/assistant_menu.py
+++ b/services/api/app/diabetes/handlers/assistant_menu.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, MutableMapping, TypeAlias, cast
+from collections import defaultdict
+from typing import TYPE_CHECKING, TypeAlias, cast
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
 from telegram.ext import (
@@ -98,7 +99,7 @@ async def post_init(
     """Restore last assistant modes for users on startup."""
 
     records = await memory_service.get_last_modes()
-    store = cast(MutableMapping[int, dict[str, object]], app.user_data)
+    store = cast(defaultdict[int, dict[str, object]], app._user_data)  # type: ignore[redundant-cast]
     for user_id, mode in records:
         if mode not in MODE_TEXTS:
             continue

--- a/tests/test_assistant_menu.py
+++ b/tests/test_assistant_menu.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -119,7 +120,9 @@ async def test_assistant_callback_persists_mode(
     async def fake_set_last_mode(uid: int, mode: str | None) -> None:
         calls.append((uid, mode))
 
-    monkeypatch.setattr(assistant_menu.memory_service, "set_last_mode", fake_set_last_mode)
+    monkeypatch.setattr(
+        assistant_menu.memory_service, "set_last_mode", fake_set_last_mode
+    )
 
     await assistant_menu.assistant_callback(update, ctx)
 
@@ -148,7 +151,9 @@ async def test_assistant_callback_labs_waiting(
     async def fake_set_last_mode(uid: int, mode: str | None) -> None:
         calls.append((uid, mode))
 
-    monkeypatch.setattr(assistant_menu.memory_service, "set_last_mode", fake_set_last_mode)
+    monkeypatch.setattr(
+        assistant_menu.memory_service, "set_last_mode", fake_set_last_mode
+    )
 
     await assistant_menu.assistant_callback(update, ctx)
 
@@ -159,7 +164,9 @@ async def test_assistant_callback_labs_waiting(
 
 
 @pytest.mark.asyncio
-async def test_assistant_callback_visit_calls_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_assistant_callback_visit_calls_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     handler = AsyncMock()
     monkeypatch.setattr(visit_handlers, "send_checklist", handler)
     message = MagicMock()
@@ -179,7 +186,9 @@ async def test_assistant_callback_visit_calls_handler(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.asyncio
-async def test_assistant_callback_save_note_routes(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_assistant_callback_save_note_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     handler = AsyncMock()
     monkeypatch.setattr(visit_handlers, "save_note_callback", handler)
     query = MagicMock()
@@ -212,7 +221,9 @@ async def test_assistant_callback_unknown(
         await assistant_menu.assistant_callback(update, ctx)
     message.edit_text.assert_awaited_once()
     assert ctx.user_data == {}
-    record = next(r for r in caplog.records if r.message == "assistant_unknown_callback")
+    record = next(
+        r for r in caplog.records if r.message == "assistant_unknown_callback"
+    )
     assert record.data == "asst:unknown"
 
 
@@ -226,7 +237,8 @@ async def test_post_init_restores_modes(monkeypatch: pytest.MonkeyPatch) -> None
     )
     bot = MagicMock()
     bot.send_message = AsyncMock()
-    app = SimpleNamespace(bot=bot, user_data={})
+    store = defaultdict(dict)
+    app = SimpleNamespace(bot=bot, user_data=store, _user_data=store)
 
     await assistant_menu.post_init(app)
 
@@ -254,7 +266,9 @@ def test_assistant_menu_emoji_off(monkeypatch: pytest.MonkeyPatch) -> None:
     assert helper.render_assistant_menu(False).assistant == "Ассистент_AI"
     assert ui_keyboard.LEARN_BUTTON_TEXT == "Ассистент_AI"
     texts = [
-        btn.text for row in handler_menu.assistant_keyboard().inline_keyboard for btn in row
+        btn.text
+        for row in handler_menu.assistant_keyboard().inline_keyboard
+        for btn in row
     ]
     assert texts == ["Обучение", "Чат", "Анализы", "Визит"]
 

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -1193,7 +1193,6 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         make_context(job_queue=job_queue, user_data={"pending_entry": {}}),
     )
-    await handlers.reminder_action_cb(update, context)
     await router.callback_router(update, context)
 
     with TestSession() as session:
@@ -1207,7 +1206,7 @@ async def test_toggle_reminder_cb(monkeypatch: pytest.MonkeyPatch) -> None:
     assert not jobs_snooze
     assert not jobs_after
     assert query.answers
-    answer = query.answers[0]
+    answer = query.answers[-1]
     assert answer == "Готово ✅"
     assert context.user_data is not None
     user_data = context.user_data
@@ -1712,6 +1711,7 @@ async def test_log_callback(monkeypatch: pytest.MonkeyPatch) -> None:
     with TestSession() as session:
         log = session.query(ReminderLog).first()
         assert log is not None and log.action == "log_opened"
+
 
 @pytest.mark.asyncio
 async def test_snooze_callback_default_delay(


### PR DESCRIPTION
## Summary
- avoid mutating `Application.user_data` in assistant menu `post_init`
- adjust tests to work with `_user_data` and ensure reminder callback updates state once

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov --cov-fail-under=85`

------
https://chatgpt.com/codex/tasks/task_e_68c45cbdc49c832ab4709ab9f8b65bae