### PR TITLE
[gpt_command_parser] Limit JSON scan length

### DIFF
--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -739,6 +739,25 @@ def test_extract_first_json_three_objects_in_row() -> None:
     }
 
 
+def test_extract_first_json_json_before_limit_in_long_text() -> None:
+    limit = gpt_command_parser.MAX_JSON_CHARS
+    json_part = '{"action":"add_entry","fields":{}}'
+    padding = "x" * (limit - len(json_part))
+    text = padding + json_part + "tail"
+    assert gpt_command_parser._extract_first_json(text) == {
+        "action": "add_entry",
+        "fields": {},
+    }
+
+
+def test_extract_first_json_returns_none_when_json_beyond_limit() -> None:
+    prefix = "x" * (gpt_command_parser.MAX_JSON_CHARS + 1)
+    text = prefix + '{"action":"add_entry","fields":{}}'
+    start = time.perf_counter()
+    assert gpt_command_parser._extract_first_json(text) is None
+    assert time.perf_counter() - start < 0.1
+
+
 @pytest.mark.asyncio
 async def test_parse_command_with_multiple_jsons(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -70,6 +70,7 @@ class DummyCallbackQuery:
 
     async def answer(self, text: str | None = None, **kwargs: Any) -> None:
         self.answers.append(text)
+        self.data = ""
 
     async def edit_message_text(self, text: str, **kwargs: Any) -> None:
         self.edited = (text, kwargs)


### PR DESCRIPTION
## Summary
- limit JSON search to 10k chars and return `None` when exceeded
- cover edge cases with long input in parser tests
- adjust reminder test helper to clear callback data after answering

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c45e6c1e70832a9d8305604478b88f