### PR TITLE
[handlers] use application user store directly

### DIFF
--- a/services/api/app/diabetes/handlers/assistant_menu.py
+++ b/services/api/app/diabetes/handlers/assistant_menu.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, MutableMapping, TypeAlias, cast
+from collections import defaultdict
+from typing import TYPE_CHECKING, TypeAlias, cast
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
 from telegram.ext import (
@@ -98,7 +99,7 @@ async def post_init(
     """Restore last assistant modes for users on startup."""
 
     records = await memory_service.get_last_modes()
-    store = cast(MutableMapping[int, dict[str, object]], app.user_data)
+    store = cast(defaultdict[int, dict[str, object]], app._user_data)  # type: ignore[redundant-cast]
     for user_id, mode in records:
         if mode not in MODE_TEXTS:
             continue


### PR DESCRIPTION
## Summary
- access the application's underlying `_user_data` mapping when restoring assistant modes

## Testing
- `pytest -q --cov` *(fails: mappingproxy object does not support item assignment)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c4601a5420832aab0a531760cb3b62