### PR TITLE
[handlers] preserve callback data for reminder routing

### DIFF
--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -266,8 +266,8 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     query = update.callback_query
     if query is None:
         return
-    await query.answer()
     data = query.data or ""
+    await query.answer()
 
     if data.startswith("rem_"):
         from . import reminder_handlers

--- a/tests/test_handlers_cancel_entry.py
+++ b/tests/test_handlers_cancel_entry.py
@@ -157,13 +157,13 @@ async def test_callback_router_delegates_reminder_action(
         ]
     ] = []
 
-    async def fake_router(
+    async def fake_action_cb(
         update: Update,
         context: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
     ) -> None:
         calls.append((update, context))
 
-    monkeypatch.setattr(reminder_handlers, "callback_router", fake_router)
+    monkeypatch.setattr(reminder_handlers, "reminder_action_cb", fake_action_cb)
 
     query = DummyQuery(DummyMessage(), "rem_toggle:1")
     update = cast(Update, SimpleNamespace(callback_query=query))


### PR DESCRIPTION
## Summary
- preserve callback query data before answering
- verify reminder callbacks dispatch to `reminder_action_cb`

## Testing
- `pytest -q --cov` *(fails: mappingproxy object does not support item assignment)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c463d4bde8832a92ce3448aeffbdbb