### PR TITLE
[handlers] Ensure mutable user data

### DIFF
--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -266,8 +266,9 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     query = update.callback_query
     if query is None:
         return
-    await query.answer()
     data = query.data or ""
+    await query.answer()
+    query.data = data
 
     if data.startswith("rem_"):
         from . import reminder_handlers

--- a/tests/test_mutable_user_data.py
+++ b/tests/test_mutable_user_data.py
@@ -1,0 +1,22 @@
+from types import MappingProxyType, SimpleNamespace
+
+import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
+
+
+def test_get_mutable_user_data_from_mapping_proxy() -> None:
+    proxy = MappingProxyType(
+        {
+            photo_handlers.WAITING_GPT_FLAG: True,
+            photo_handlers.WAITING_GPT_TIMESTAMP: 1,
+        }
+    )
+    context = SimpleNamespace(user_data=proxy)
+    user_data = photo_handlers._get_mutable_user_data(context)
+    assert not isinstance(user_data, MappingProxyType)
+    user_data["pending_entry"] = {"value": 1}
+    photo_handlers._clear_waiting_gpt(context)
+    assert photo_handlers.WAITING_GPT_FLAG not in context._user_data
+    assert photo_handlers.WAITING_GPT_TIMESTAMP not in context._user_data
+    assert context._user_data["pending_entry"] == {"value": 1}
+    assert photo_handlers._get_mutable_user_data(context) is user_data
+    assert context.user_data is proxy


### PR DESCRIPTION
## Summary
- add `_get_mutable_user_data` helper and use it in photo handling
- ensure callback router preserves query data when answering
- test mutable user data with MappingProxyType

## Testing
- `ruff check services/api/app/diabetes/handlers/photo_handlers.py services/api/app/diabetes/handlers/router.py tests/test_mutable_user_data.py`
- `mypy --strict services/api/app/diabetes/handlers/router.py services/api/app/diabetes/handlers/photo_handlers.py tests/test_mutable_user_data.py`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68c463d3cd40832a8f9c8402484df96e