### PR TITLE
[jobs] Allow async callable objects in schedule helpers

### DIFF
--- a/services/api/app/diabetes/utils/jobs.py
+++ b/services/api/app/diabetes/utils/jobs.py
@@ -80,8 +80,11 @@ def schedule_once(
     application or scheduler.
     """
     cb = inspect.unwrap(callback)
-    if not callable(cb) or not asyncio.iscoroutinefunction(cb):
-        msg = "Job callback must be async"
+    if not callable(cb) or not (
+        asyncio.iscoroutinefunction(cb)
+        or asyncio.iscoroutinefunction(getattr(cb, "__call__", None))
+    ):
+        msg = "Job callback must be an async function or object with async __call__"
         raise TypeError(msg)
     tz = _derive_timezone(job_queue, timezone)
 
@@ -137,8 +140,11 @@ def schedule_daily(
     application or scheduler.
     """
     cb = inspect.unwrap(callback)
-    if not callable(cb) or not asyncio.iscoroutinefunction(cb):
-        msg = "Job callback must be async"
+    if not callable(cb) or not (
+        asyncio.iscoroutinefunction(cb)
+        or asyncio.iscoroutinefunction(getattr(cb, "__call__", None))
+    ):
+        msg = "Job callback must be an async function or object with async __call__"
         raise TypeError(msg)
     tz = _derive_timezone(job_queue, timezone)
 

--- a/tests/test_schedule_daily.py
+++ b/tests/test_schedule_daily.py
@@ -15,6 +15,11 @@ async def dummy_cb(context: object) -> None:  # pragma: no cover - simple callba
     return None
 
 
+class AsyncCallable:
+    async def __call__(self, context: object) -> None:  # pragma: no cover - helper
+        return None
+
+
 class Job:
     def __init__(self, tz: object | None) -> None:
         self.tz = tz
@@ -200,6 +205,13 @@ def test_schedule_daily_requires_async_callback() -> None:
 
     with pytest.raises(TypeError):
         schedule_daily(jq, sync_cb, time=dt_time(1, 0))
+
+
+def test_schedule_daily_accepts_async_callable_object() -> None:
+    jq = QueueWithTimezone()
+    cb_obj = AsyncCallable()
+    schedule_daily(jq, cb_obj, time=dt_time(1, 0))
+    assert jq.args.callback is cb_obj
 
 
 @pytest.mark.parametrize("queue_cls", [QueueWithTimezone, QueueNoTimezone])

--- a/tests/test_schedule_once.py
+++ b/tests/test_schedule_once.py
@@ -14,6 +14,11 @@ async def dummy_cb(context: object) -> None:  # pragma: no cover - simple callba
     return None
 
 
+class AsyncCallable:
+    async def __call__(self, context: object) -> None:  # pragma: no cover - helper
+        return None
+
+
 class Job:
     def __init__(self, tz: object | None) -> None:
         self.tz = tz
@@ -167,6 +172,13 @@ def test_schedule_once_requires_async_callback() -> None:
 
     with pytest.raises(TypeError):
         schedule_once(jq, sync_cb, when=timedelta(seconds=1))
+
+
+def test_schedule_once_accepts_async_callable_object() -> None:
+    jq = QueueWithTimezone()
+    cb_obj = AsyncCallable()
+    schedule_once(jq, cb_obj, when=timedelta(seconds=1))
+    assert jq.args.callback is cb_obj
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- accept objects with async `__call__` in `schedule_once` and `schedule_daily`
- clarify error when callback isn't asynchronous
- test async-callable objects for both schedule helpers

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: 'mappingproxy' object does not support item assignment in unrelated tests)*
- `pytest tests/test_schedule_once.py tests/test_schedule_daily.py -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c466abf6c4832a9b5bf3e4555b4c26