### PR TITLE
[handlers] Make labs handler non-blocking

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -322,6 +322,7 @@ def register_handlers(
         MessageHandlerT(
             (filters.TEXT | filters.PHOTO | filters.Document.ALL) & ~filters.COMMAND,
             labs_handler,
+            block=False,  # чтобы фото продолжали обрабатываться
         )
     )
     app.add_handler(


### PR DESCRIPTION
## Summary
- Allow lab handler to run without blocking so photo processing continues

## Testing
- `make ci` *(fails: TypeError: 'mappingproxy' object does not support item deletion in tests/handlers/test_photo_handler_recognition.py)*
- `mypy --strict .`
- `ruff check .`
- `python services/api/app/bot.py` *(fails: ImportError: cannot import name 'GenericAlias' from partially initialized module 'types')*

------
https://chatgpt.com/codex/tasks/task_e_68c466fb5224832aa9b66c0f2b53a4f6