### PR TITLE
[utils] Close OpenAI clients

### DIFF
--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -125,6 +125,11 @@ async def openai_client_ctx() -> AsyncIterator[OpenAI]:
         yield client
     finally:
         try:
+            client.close()
+        except Exception:  # pragma: no cover - best effort on shutdown
+            logger.exception("[OpenAI] Failed to close client")
+
+        try:
             loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
         except RuntimeError:
             loop = None
@@ -146,6 +151,11 @@ async def async_openai_client_ctx() -> AsyncIterator[AsyncOpenAI]:
     try:
         yield client
     finally:
+        try:
+            await client.close()
+        except Exception:  # pragma: no cover - best effort on shutdown
+            logger.exception("[OpenAI] Failed to close client")
+
         try:
             await dispose_http_client()
         except Exception:  # pragma: no cover - best effort on shutdown

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -16,12 +16,16 @@ _original_get_async_openai_client = openai_utils.get_async_openai_client
 @pytest.fixture(autouse=True)
 def _restore_openai_utils(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(openai_utils, "get_openai_client", _original_get_openai_client)
-    monkeypatch.setattr(openai_utils, "get_async_openai_client", _original_get_async_openai_client)
+    monkeypatch.setattr(
+        openai_utils, "get_async_openai_client", _original_get_async_openai_client
+    )
 
 
 def test_get_openai_client_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(openai_utils, "_http_client", {})
-    fake_settings = SimpleNamespace(openai_api_key="", openai_proxy=None, openai_assistant_id=None)
+    fake_settings = SimpleNamespace(
+        openai_api_key="", openai_proxy=None, openai_assistant_id=None
+    )
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     with pytest.raises(RuntimeError):
         openai_utils.get_openai_client()
@@ -35,7 +39,9 @@ async def test_get_openai_client_uses_proxy(
     http_client_mock = Mock(return_value=fake_http_client)
     openai_mock = Mock()
 
-    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None)
+    fake_settings = SimpleNamespace(
+        openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None
+    )
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_http_client", {})
     monkeypatch.setattr(httpx, "Client", http_client_mock)
@@ -52,9 +58,13 @@ async def test_get_openai_client_uses_proxy(
     fake_http_client.close.assert_called_once()
 
 
-def test_get_openai_client_logs_assistant(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+def test_get_openai_client_logs_assistant(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     openai_mock = Mock()
-    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy=None, openai_assistant_id="assistant")
+    fake_settings = SimpleNamespace(
+        openai_api_key="key", openai_proxy=None, openai_assistant_id="assistant"
+    )
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_http_client", {})
     monkeypatch.setattr(openai_utils, "OpenAI", openai_mock)
@@ -69,7 +79,9 @@ def test_get_openai_client_without_proxy(monkeypatch: pytest.MonkeyPatch) -> Non
     openai_mock = Mock()
     http_client_mock = Mock()
 
-    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy=None, openai_assistant_id=None)
+    fake_settings = SimpleNamespace(
+        openai_api_key="key", openai_proxy=None, openai_assistant_id=None
+    )
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_http_client", {})
     monkeypatch.setattr(openai_utils, "OpenAI", openai_mock)
@@ -97,7 +109,9 @@ async def test_http_client_lock_used(monkeypatch: pytest.MonkeyPatch) -> None:
 
     dummy_lock = DummyLock()
     fake_http_client = Mock()
-    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None)
+    fake_settings = SimpleNamespace(
+        openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None
+    )
 
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_http_client_lock", dummy_lock)
@@ -119,7 +133,9 @@ def test_get_async_openai_client_requires_api_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(openai_utils, "_async_http_client", {})
-    fake_settings = SimpleNamespace(openai_api_key="", openai_proxy=None, openai_assistant_id=None)
+    fake_settings = SimpleNamespace(
+        openai_api_key="", openai_proxy=None, openai_assistant_id=None
+    )
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     with pytest.raises(RuntimeError):
         openai_utils.get_async_openai_client()
@@ -135,7 +151,9 @@ async def test_get_async_openai_client_uses_proxy(
 
     openai_mock = Mock()
 
-    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None)
+    fake_settings = SimpleNamespace(
+        openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None
+    )
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_async_http_client", {})
 
@@ -177,18 +195,22 @@ async def test_dispose_http_client_resets_all(
 async def test_openai_client_ctx_disposes(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_http_client = Mock()
     http_client_mock = Mock(return_value=fake_http_client)
-    openai_mock = Mock()
+    fake_openai_client = Mock()
+    openai_mock = Mock(return_value=fake_openai_client)
 
-    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None)
+    fake_settings = SimpleNamespace(
+        openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None
+    )
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_http_client", {})
     monkeypatch.setattr(httpx, "Client", http_client_mock)
     monkeypatch.setattr(openai_utils, "OpenAI", openai_mock)
 
     async with openai_utils.openai_client_ctx() as client:
-        assert client is openai_mock.return_value
+        assert client is fake_openai_client
 
     fake_http_client.close.assert_called_once()
+    fake_openai_client.close.assert_called_once()
     assert openai_utils._http_client == {}
 
 
@@ -198,7 +220,9 @@ async def test_openai_client_ctx_disposes_with_running_loop(
 ) -> None:
     dispose_mock = AsyncMock()
     monkeypatch.setattr(openai_utils, "dispose_http_client", dispose_mock)
-    monkeypatch.setattr(openai_utils, "get_openai_client", Mock())
+    fake_openai_client = Mock()
+    get_client_mock = Mock(return_value=fake_openai_client)
+    monkeypatch.setattr(openai_utils, "get_openai_client", get_client_mock)
 
     run_mock = Mock(side_effect=RuntimeError("asyncio.run should not be called"))
     monkeypatch.setattr(asyncio, "run", run_mock)
@@ -208,18 +232,23 @@ async def test_openai_client_ctx_disposes_with_running_loop(
 
     dispose_mock.assert_awaited_once()
     run_mock.assert_not_called()
+    fake_openai_client.close.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_async_openai_client_ctx_disposes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    fake_async_client = Mock()
-    fake_async_client.aclose = AsyncMock()
-    async_client_mock = Mock(return_value=fake_async_client)
-    openai_mock = Mock()
+    fake_async_http_client = Mock()
+    fake_async_http_client.aclose = AsyncMock()
+    async_client_mock = Mock(return_value=fake_async_http_client)
+    fake_async_openai_client = Mock()
+    fake_async_openai_client.close = AsyncMock()
+    openai_mock = Mock(return_value=fake_async_openai_client)
 
-    fake_settings = SimpleNamespace(openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None)
+    fake_settings = SimpleNamespace(
+        openai_api_key="key", openai_proxy="http://proxy", openai_assistant_id=None
+    )
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(openai_utils, "_async_http_client", {})
     monkeypatch.setattr(openai_utils, "_http_client", {})
@@ -227,9 +256,10 @@ async def test_async_openai_client_ctx_disposes(
     monkeypatch.setattr(openai_utils, "AsyncOpenAI", openai_mock)
 
     async with openai_utils.async_openai_client_ctx() as client:
-        assert client is openai_mock.return_value
+        assert client is fake_async_openai_client
 
-    fake_async_client.aclose.assert_awaited_once()
+    fake_async_openai_client.close.assert_awaited_once()
+    fake_async_http_client.aclose.assert_awaited_once()
     assert openai_utils._async_http_client == {}
 
 
@@ -237,8 +267,11 @@ async def test_async_openai_client_ctx_disposes(
 async def test_async_openai_client_ctx_logs_dispose_error(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    fake_client = object()
-    monkeypatch.setattr(openai_utils, "get_async_openai_client", Mock(return_value=fake_client))
+    fake_client = Mock()
+    fake_client.close = AsyncMock()
+    monkeypatch.setattr(
+        openai_utils, "get_async_openai_client", Mock(return_value=fake_client)
+    )
     dispose_mock = AsyncMock(side_effect=RuntimeError("boom"))
     monkeypatch.setattr(openai_utils, "dispose_http_client", dispose_mock)
 
@@ -246,8 +279,11 @@ async def test_async_openai_client_ctx_logs_dispose_error(
         async with openai_utils.async_openai_client_ctx() as client:
             assert client is fake_client
 
+    fake_client.close.assert_awaited_once()
     dispose_mock.assert_awaited_once()
-    assert any("Failed to dispose HTTP client" in record.message for record in caplog.records)
+    assert any(
+        "Failed to dispose HTTP client" in record.message for record in caplog.records
+    )
 
 
 def test_dispose_http_client_sync(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- close OpenAI sync client in `openai_client_ctx`
- close async OpenAI client in `async_openai_client_ctx`
- extend tests for client closure

## Testing
- `pytest -q --cov` *(fails: TypeError: 'mappingproxy' object does not support item assignment)*
- `pytest tests/test_openai_utils.py -q`
- `mypy --strict services/api/app/diabetes/utils/openai_utils.py tests/test_openai_utils.py`
- `ruff check services/api/app/diabetes/utils/openai_utils.py tests/test_openai_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c466a9e2a0832ab7457c5d2ced4c20