### PR TITLE
[handlers] route assistant button to menu

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -10,7 +10,7 @@ from telegram.ext import ContextTypes
 
 from .learning_handlers import learn_command, topics_command
 from .handlers.onboarding_handlers import reset_onboarding as _reset_onboarding
-from ..ui.keyboard import LEARN_BUTTON_TEXT
+from ..ui.keyboard import ASSISTANT_BUTTON_TEXT
 from .assistant_state import reset as _reset_assistant
 from .handlers.registration import MODE_DISCLAIMED_KEY
 from ..assistant.services.memory_service import clear_memory as _clear_memory
@@ -23,7 +23,7 @@ HELP_TEXT = "\n".join(
         "Доступные команды:",
         "/start - начать работу с ботом",
         "/help - краткая справка",
-        f"нажмите кнопку {LEARN_BUTTON_TEXT} или команду /learn - режим обучения",
+        f"нажмите кнопку {ASSISTANT_BUTTON_TEXT} или команду /learn - режим обучения",
         "/topics - список тем",
         "/reset_onboarding - сбросить мастер настройки",
         "/trial - Включить trial",

--- a/services/api/app/diabetes/handlers/assistant_router.py
+++ b/services/api/app/diabetes/handlers/assistant_router.py
@@ -25,7 +25,7 @@ from services.api.app.diabetes.utils.ui import (
     SOS_BUTTON_TEXT,
     SUBSCRIPTION_BUTTON_TEXT,
 )
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import ASSISTANT_BUTTON_TEXT
 from services.api.app.diabetes.metrics import assistant_mode_total
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ BOTTOM_BUTTON_PATTERNS: Sequence[re.Pattern[str]] = (
     re.compile(re.escape(HELP_BUTTON_TEXT)),
     re.compile(re.escape(SOS_BUTTON_TEXT)),
     re.compile(re.escape(SUBSCRIPTION_BUTTON_TEXT)),
-    re.compile(re.escape(LEARN_BUTTON_TEXT)),
+    re.compile(re.escape(ASSISTANT_BUTTON_TEXT)),
 )
 
 
@@ -80,9 +80,7 @@ async def on_any_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         raise ApplicationHandlerStop
     if mode == "visit":
         user_data[AWAITING_KIND] = "visit"
-        await message.reply_text(
-            "Чек-лист визита: измерения, вопросы врачу, назначения."
-        )
+        await message.reply_text("Чек-лист визита: измерения, вопросы врачу, назначения.")
         set_last_mode(user_data, None)
         raise ApplicationHandlerStop
 

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -36,15 +36,15 @@ from ..utils.ui import (
     SOS_BUTTON_TEXT,
     SUBSCRIPTION_BUTTON_TEXT,
 )
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import ASSISTANT_BUTTON_TEXT
 
-OLD_LEARN_BUTTON_TEXT = "🎓 Обучение"
-LEARN_BUTTON_ALIASES: tuple[str, ...] = (
-    LEARN_BUTTON_TEXT,
-    OLD_LEARN_BUTTON_TEXT,
+OLD_ASSISTANT_BUTTON_TEXT = "🎓 Обучение"
+ASSISTANT_BUTTON_ALIASES: tuple[str, ...] = (
+    ASSISTANT_BUTTON_TEXT,
+    OLD_ASSISTANT_BUTTON_TEXT,
 )
-LEARN_BUTTON_PATTERN: re.Pattern[str] = re.compile(
-    r"^(?:" + "|".join(re.escape(text) for text in LEARN_BUTTON_ALIASES) + r")$"
+ASSISTANT_BUTTON_PATTERN: re.Pattern[str] = re.compile(
+    r"^(?:" + "|".join(re.escape(text) for text in ASSISTANT_BUTTON_ALIASES) + r")$"
 )
 
 logger = logging.getLogger(__name__)
@@ -87,9 +87,7 @@ async def start_gpt_dialog(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             name=job_name,
             data=user.id,
         )
-    await message.reply_text(
-        "💬 GPT режим активирован. Напишите сообщение или /cancel для выхода."
-    )
+    await message.reply_text("💬 GPT режим активирован. Напишите сообщение или /cancel для выхода.")
 
 
 async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -111,9 +109,7 @@ async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 if TYPE_CHECKING:
     CommandHandlerT: TypeAlias = CommandHandler[ContextTypes.DEFAULT_TYPE, object]
     MessageHandlerT: TypeAlias = MessageHandler[ContextTypes.DEFAULT_TYPE, object]
-    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[
-        ContextTypes.DEFAULT_TYPE, object
-    ]
+    CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, object]
 else:
     CommandHandlerT = CommandHandler
     MessageHandlerT = MessageHandler
@@ -136,17 +132,9 @@ def register_profile_handlers(
 
     app.add_handler(profile.profile_conv)
     app.add_handler(profile.profile_webapp_handler)
-    app.add_handler(
-        MessageHandlerT(
-            filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandlerT(profile.profile_security, pattern="^profile_security")
-    )
-    app.add_handler(
-        CallbackQueryHandlerT(profile.profile_back, pattern="^profile_back$")
-    )
+    app.add_handler(MessageHandlerT(filters.Regex(re.escape(PROFILE_BUTTON_TEXT)), profile.profile_view))
+    app.add_handler(CallbackQueryHandlerT(profile.profile_security, pattern="^profile_security"))
+    app.add_handler(CallbackQueryHandlerT(profile.profile_back, pattern="^profile_back$"))
 
 
 def register_reminder_handlers(
@@ -174,9 +162,7 @@ def register_reminder_handlers(
             reminder_handlers.reminders_list,
         )
     )
-    app.add_handler(
-        CallbackQueryHandlerT(reminder_handlers.reminder_callback, pattern="^remind_")
-    )
+    app.add_handler(CallbackQueryHandlerT(reminder_handlers.reminder_callback, pattern="^remind_"))
 
     # --- DEBUG HANDLERS ---
     try:
@@ -238,8 +224,8 @@ def register_handlers(
     app.add_handler(CommandHandlerT("assistant", assistant_menu.show_menu))
     app.add_handler(
         MessageHandlerT(
-            filters.TEXT & filters.Regex(LEARN_BUTTON_PATTERN),
-            learning_handlers.learn_command,
+            filters.TEXT & filters.Regex(ASSISTANT_BUTTON_PATTERN),
+            assistant_menu.show_menu,
         )
     )
     app.add_handler(CommandHandlerT("report", reporting_handlers.report_request))
@@ -257,9 +243,7 @@ def register_handlers(
     app.add_handler(CommandHandlerT("reset", bot_commands.reset_command))
     app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
     app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))
-    app.add_handler(
-        CallbackQueryHandlerT(billing_handlers.trial_command, pattern="^trial$")
-    )
+    app.add_handler(CallbackQueryHandlerT(billing_handlers.trial_command, pattern="^trial$"))
     register_reminder_handlers(app)
     app.add_handler(CommandHandlerT("alertstats", alert_handlers.alert_stats))
     app.add_handler(CommandHandlerT("hypoalert", security_handlers.hypo_alert_faq))
@@ -275,19 +259,9 @@ def register_handlers(
             reporting_handlers.history_view,
         )
     )
-    app.add_handler(
-        MessageHandlerT(
-            filters.Regex(PHOTO_BUTTON_PATTERN), photo_handlers.photo_prompt
-        )
-    )
-    app.add_handler(
-        MessageHandlerT(
-            filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help
-        )
-    )
-    app.add_handler(
-        MessageHandlerT(filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command)
-    )
+    app.add_handler(MessageHandlerT(filters.Regex(PHOTO_BUTTON_PATTERN), photo_handlers.photo_prompt))
+    app.add_handler(MessageHandlerT(filters.Regex(re.escape(QUICK_INPUT_BUTTON_TEXT)), smart_input_help))
+    app.add_handler(MessageHandlerT(filters.Regex(re.escape(HELP_BUTTON_TEXT)), help_command))
     app.add_handler(
         MessageHandlerT(
             filters.Regex(re.escape(SUBSCRIPTION_BUTTON_TEXT)),
@@ -324,24 +298,12 @@ def register_handlers(
             labs_handler,
         )
     )
-    app.add_handler(
-        MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler)
-    )
+    app.add_handler(MessageHandlerT(filters.TEXT & ~filters.COMMAND, gpt_handlers.freeform_handler))
     app.add_handler(MessageHandlerT(filters.PHOTO, photo_handlers.photo_handler))
     app.add_handler(MessageHandlerT(filters.Document.IMAGE, photo_handlers.doc_handler))
-    app.add_handler(
-        CallbackQueryHandlerT(assistant_menu.assistant_callback, pattern="^asst:")
-    )
-    app.add_handler(
-        CallbackQueryHandlerT(
-            reporting_handlers.report_period_callback, pattern="^report_back$"
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandlerT(
-            reporting_handlers.report_period_callback, pattern="^report_period:"
-        )
-    )
+    app.add_handler(CallbackQueryHandlerT(assistant_menu.assistant_callback, pattern="^asst:"))
+    app.add_handler(CallbackQueryHandlerT(reporting_handlers.report_period_callback, pattern="^report_back$"))
+    app.add_handler(CallbackQueryHandlerT(reporting_handlers.report_period_callback, pattern="^report_period:"))
     app.add_handler(CallbackQueryHandlerT(callback_router))
 
     async def _clear_waiting_flags(context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -36,7 +36,7 @@ from .dynamic_tutor import (
     sanitize_feedback,
     ensure_single_question,
 )
-from ..ui.keyboard import LEARN_BUTTON_TEXT
+from ..ui.keyboard import ASSISTANT_BUTTON_TEXT
 from .learning_onboarding import ensure_overrides, needs_age, needs_level
 from .learning_state import LearnState, clear_state, get_state, set_state
 from .learning_utils import choose_initial_topic
@@ -301,7 +301,7 @@ async def _static_learn_command(update: Update, context: ContextTypes.DEFAULT_TY
     if message is None:
         return
     if not settings.learning_mode_enabled:
-        await message.reply_text(f"🚫 {LEARN_BUTTON_TEXT} недоступен.")
+        await message.reply_text(f"🚫 {ASSISTANT_BUTTON_TEXT} недоступен.")
         return
     if not await ensure_overrides(update, context):
         return
@@ -322,7 +322,7 @@ async def _static_learn_command(update: Update, context: ContextTypes.DEFAULT_TY
 
     titles = "\n".join(f"/lesson {slug} — {title}" for title, slug in lessons)
     await message.reply_text(
-        f"{LEARN_BUTTON_TEXT} активирован. Модель: {model}\n\nДоступные уроки:\n{titles}",
+        f"{ASSISTANT_BUTTON_TEXT} активирован. Модель: {model}\n\nДоступные уроки:\n{titles}",
         reply_markup=build_main_keyboard(),
     )
 
@@ -551,7 +551,7 @@ async def _static_lesson_command(update: Update, context: ContextTypes.DEFAULT_T
     if message is None or user is None:
         return
     if not settings.learning_mode_enabled:
-        await message.reply_text(f"🚫 {LEARN_BUTTON_TEXT} недоступен.")
+        await message.reply_text(f"🚫 {ASSISTANT_BUTTON_TEXT} недоступен.")
         return
     if not await ensure_overrides(update, context):
         return
@@ -569,7 +569,9 @@ async def _static_lesson_command(update: Update, context: ContextTypes.DEFAULT_T
     lesson_id = cast(int | None, user_data.get("lesson_id"))
     if lesson_id is None:
         if lesson_slug is None:
-            await message.reply_text(f"Сначала выберите урок — нажмите кнопку {LEARN_BUTTON_TEXT} или команду /learn")
+            await message.reply_text(
+                f"Сначала выберите урок — нажмите кнопку {ASSISTANT_BUTTON_TEXT} или команду /learn"
+            )
             return
         progress = await curriculum_engine.start_lesson(user.id, lesson_slug)
         lesson_id = progress.lesson_id
@@ -624,7 +626,7 @@ async def lesson_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         return
     topic_slug = context.args[0] if context.args else None
     if topic_slug is None:
-        await message.reply_text(f"Сначала выберите тему — нажмите кнопку {LEARN_BUTTON_TEXT} или команду /learn")
+        await message.reply_text(f"Сначала выберите тему — нажмите кнопку {ASSISTANT_BUTTON_TEXT} или команду /learn")
         return
     if topic_slug not in TOPICS_RU:
         await message.reply_text("Неизвестная тема")
@@ -840,7 +842,7 @@ async def quiz_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     if message is None or user is None:
         return
     if not settings.learning_mode_enabled:
-        await message.reply_text(f"🚫 {LEARN_BUTTON_TEXT} недоступен.")
+        await message.reply_text(f"🚫 {ASSISTANT_BUTTON_TEXT} недоступен.")
         return
     user_data = cast(MutableMapping[str, Any], context.user_data)
     if _rate_limited(user_data, "_quiz_ts"):
@@ -989,7 +991,7 @@ async def progress_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     result = await run_db(_load_progress, user_id, sessionmaker=SessionLocal)
     if result is None:
         await message.reply_text(
-            f"Вы ещё не начали обучение. Нажмите кнопку {LEARN_BUTTON_TEXT} или команду /learn, чтобы начать."
+            f"Вы ещё не начали обучение. Нажмите кнопку {ASSISTANT_BUTTON_TEXT} или команду /learn, чтобы начать."
         )
         return
     title, current_step, completed, quiz_score = result
@@ -1073,7 +1075,7 @@ async def _static_exit_command(update: Update, context: ContextTypes.DEFAULT_TYP
         await run_db(_complete, user.id, lesson_id, sessionmaker=SessionLocal)
 
     await message.reply_text(
-        f"Сессия {LEARN_BUTTON_TEXT} завершена.",
+        f"Сессия {ASSISTANT_BUTTON_TEXT} завершена.",
         reply_markup=build_main_keyboard(),
     )
     logger.info(
@@ -1101,7 +1103,7 @@ async def exit_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     user = update.effective_user
     if user is not None:
         await _persist(user.id, user_data, context.bot_data)
-    await message.reply_text(f"Сессия {LEARN_BUTTON_TEXT} завершена.", reply_markup=build_main_keyboard())
+    await message.reply_text(f"Сессия {ASSISTANT_BUTTON_TEXT} завершена.", reply_markup=build_main_keyboard())
 
 
 async def plan_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -1116,7 +1118,7 @@ async def plan_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     plan = cast(list[str] | None, user_data.get("learning_plan"))
     if not plan:
         await message.reply_text(
-            f"План не найден. Нажмите кнопку {LEARN_BUTTON_TEXT} или команду /learn, чтобы начать.",
+            f"План не найден. Нажмите кнопку {ASSISTANT_BUTTON_TEXT} или команду /learn, чтобы начать.",
             reply_markup=build_main_keyboard(),
         )
         return
@@ -1135,7 +1137,7 @@ async def skip_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     plan = cast(list[str] | None, user_data.get("learning_plan"))
     if not plan:
         await message.reply_text(
-            f"План не найден. Нажмите кнопку {LEARN_BUTTON_TEXT} или команду /learn, чтобы начать.",
+            f"План не найден. Нажмите кнопку {ASSISTANT_BUTTON_TEXT} или команду /learn, чтобы начать.",
             reply_markup=build_main_keyboard(),
         )
         return

--- a/services/api/app/ui/keyboard.py
+++ b/services/api/app/ui/keyboard.py
@@ -6,14 +6,14 @@ from services.api.app.assistant.assistant_menu import render_assistant_menu
 
 _settings = get_settings()
 _texts = render_assistant_menu(_settings.assistant_menu_emoji)
-LEARN_BUTTON_TEXT = _texts.assistant
+ASSISTANT_BUTTON_TEXT = _texts.assistant
 
 
 def build_main_keyboard() -> ReplyKeyboardMarkup:
     """Build main menu keyboard with extra assistant button."""
     menu = menu_keyboard()
     layout = [row[:] for row in menu.keyboard]
-    layout.append((KeyboardButton(LEARN_BUTTON_TEXT),))
+    layout.append((KeyboardButton(ASSISTANT_BUTTON_TEXT),))
     return ReplyKeyboardMarkup(
         keyboard=layout,
         resize_keyboard=True,
@@ -24,6 +24,6 @@ def build_main_keyboard() -> ReplyKeyboardMarkup:
 
 
 __all__ = [
-    "LEARN_BUTTON_TEXT",
+    "ASSISTANT_BUTTON_TEXT",
     "build_main_keyboard",
 ]

--- a/services/api/tests/test_learning_mode_toggle.py
+++ b/services/api/tests/test_learning_mode_toggle.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from services.api.app import config
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import ASSISTANT_BUTTON_TEXT
 from services.api.app.diabetes.learning_fixtures import load_lessons
 import services.api.app.diabetes.learning_handlers as learning_handlers
 from services.api.app.diabetes.services import db
@@ -98,7 +98,7 @@ async def test_learning_mode_enabled_lists_lessons(
 
     await learning_handlers.learn_command(update, context)
 
-    assert message.replies[0].startswith(f"{LEARN_BUTTON_TEXT} активирован.")
+    assert message.replies[0].startswith(f"{ASSISTANT_BUTTON_TEXT} активирован.")
     keyboard = message.kwargs[0].get("reply_markup")
     assert keyboard is not None
     assert keyboard.keyboard
@@ -131,10 +131,8 @@ async def test_learning_mode_disabled_denies_access(
         ),
     )
 
-    with caplog.at_level(
-        logging.INFO, logger="services.api.app.diabetes.learning_fixtures"
-    ):
+    with caplog.at_level(logging.INFO, logger="services.api.app.diabetes.learning_fixtures"):
         await learning_handlers.learn_command(update, context)
 
-    assert message.replies == [f"🚫 {LEARN_BUTTON_TEXT} недоступен."]
+    assert message.replies == [f"🚫 {ASSISTANT_BUTTON_TEXT} недоступен."]
     assert "OK: lessons loaded" not in caplog.text

--- a/tests/diabetes/test_learning_chat_handlers.py
+++ b/tests/diabetes/test_learning_chat_handlers.py
@@ -11,7 +11,7 @@ from services.api.app.config import settings
 from services.api.app.diabetes import dynamic_tutor, learning_handlers
 from services.api.app.diabetes.prompts import disclaimer
 from services.api.app.diabetes.learning_state import LearnState, get_state, set_state
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import ASSISTANT_BUTTON_TEXT
 from services.api.app.diabetes.planner import generate_learning_plan, pretty_plan
 
 
@@ -22,13 +22,9 @@ class DummyMessage:
         self.replies: list[str] = []
         self.markups: list[InlineKeyboardMarkup | None] = []
 
-    async def reply_text(
-        self, text: str, **kwargs: Any
-    ) -> None:  # pragma: no cover - helper
+    async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - helper
         self.replies.append(text)
-        self.markups.append(
-            cast(InlineKeyboardMarkup | None, kwargs.get("reply_markup"))
-        )
+        self.markups.append(cast(InlineKeyboardMarkup | None, kwargs.get("reply_markup")))
 
 
 class DummyCallback:
@@ -100,12 +96,8 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
 
-    monkeypatch.setattr(
-        learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
-    )
-    monkeypatch.setattr(
-        learning_handlers.curriculum_engine, "next_step", fake_next_step
-    )
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
     monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
 
     msg = DummyMessage()
@@ -138,9 +130,7 @@ async def test_learn_command_and_callback(monkeypatch: pytest.MonkeyPatch) -> No
 async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
-    async def fake_check_user_answer(
-        profile: object, topic: str, answer: str, last: str
-    ) -> tuple[bool, str]:
+    async def fake_check_user_answer(profile: object, topic: str, answer: str, last: str) -> tuple[bool, str]:
         return True, "feedback"
 
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
@@ -172,12 +162,8 @@ async def test_lesson_flow(monkeypatch: pytest.MonkeyPatch) -> None:
             return f"{disclaimer()}\n\n{text}", False
         return text, False
 
-    monkeypatch.setattr(
-        learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
-    )
-    monkeypatch.setattr(
-        learning_handlers.curriculum_engine, "next_step", fake_next_step
-    )
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
 
     msg = DummyMessage()
     update = make_update(message=msg)
@@ -265,7 +251,7 @@ async def test_exit_command_clears_state(
     context = make_context(user_data=user_data)
 
     await learning_handlers.exit_command(update, context)
-    assert msg.replies == [f"Сессия {LEARN_BUTTON_TEXT} завершена."]
+    assert msg.replies == [f"Сессия {ASSISTANT_BUTTON_TEXT} завершена."]
     assert isinstance(msg.markups[0], ReplyKeyboardMarkup)
     assert get_state(user_data) is None
 
@@ -281,9 +267,7 @@ async def test_learn_command_autostarts_when_topics_hidden(
         return True
 
     monkeypatch.setattr(learning_handlers, "ensure_overrides", fake_ensure_overrides)
-    monkeypatch.setattr(
-        learning_handlers, "choose_initial_topic", lambda _: ("slug", "t")
-    )
+    monkeypatch.setattr(learning_handlers, "choose_initial_topic", lambda _: ("slug", "t"))
 
     progress = SimpleNamespace(lesson_id=1)
 
@@ -303,12 +287,8 @@ async def test_learn_command_autostarts_when_topics_hidden(
         return "first", False
 
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
-    monkeypatch.setattr(
-        learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
-    )
-    monkeypatch.setattr(
-        learning_handlers.curriculum_engine, "next_step", fake_next_step
-    )
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -351,21 +331,15 @@ async def test_lesson_answer_ignores_busy(monkeypatch: pytest.MonkeyPatch) -> No
 async def test_lesson_answer_double_click(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
-    async def slow_check_user_answer(
-        profile: object, topic: str, answer: str, last: str
-    ) -> tuple[bool, str]:
+    async def slow_check_user_answer(profile: object, topic: str, answer: str, last: str) -> tuple[bool, str]:
         await asyncio.sleep(0)
         return True, "fb"
 
-    async def fake_generate_step_text(
-        profile: object, topic: str, step_idx: int, prev: object
-    ) -> str:
+    async def fake_generate_step_text(profile: object, topic: str, step_idx: int, prev: object) -> str:
         return "next"
 
     monkeypatch.setattr(learning_handlers, "check_user_answer", slow_check_user_answer)
-    monkeypatch.setattr(
-        learning_handlers, "generate_step_text", fake_generate_step_text
-    )
+    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -383,9 +357,7 @@ async def test_lesson_answer_double_click(monkeypatch: pytest.MonkeyPatch) -> No
     update1 = make_update(message=msg1)
     context1 = make_context(user_data=user_data)
 
-    task = asyncio.create_task(
-        learning_handlers.lesson_answer_handler(update1, context1)
-    )
+    task = asyncio.create_task(learning_handlers.lesson_answer_handler(update1, context1))
     await asyncio.sleep(0)
 
     msg2 = DummyMessage("ans")
@@ -404,18 +376,14 @@ async def test_lesson_answer_handler_error_keeps_state(
 ) -> None:
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
-    async def fake_check_user_answer(
-        *args: object, **kwargs: object
-    ) -> tuple[bool, str]:
+    async def fake_check_user_answer(*args: object, **kwargs: object) -> tuple[bool, str]:
         return False, dynamic_tutor.BUSY_MESSAGE
 
     async def fail_generate_step_text(*args: object, **kwargs: object) -> str:
         raise AssertionError("should not be called")
 
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
-    monkeypatch.setattr(
-        learning_handlers, "generate_step_text", fail_generate_step_text
-    )
+    monkeypatch.setattr(learning_handlers, "generate_step_text", fail_generate_step_text)
 
     async def fake_add_log(*args: object, **kwargs: object) -> None:
         return None
@@ -452,9 +420,7 @@ async def test_lesson_answer_handler_add_log_failure(
 
     calls: list[tuple[object, ...]] = []
 
-    async def fake_check_user_answer(
-        *args: object, **kwargs: object
-    ) -> tuple[bool, str]:
+    async def fake_check_user_answer(*args: object, **kwargs: object) -> tuple[bool, str]:
         calls.append(args)
         return True, "feedback"
 
@@ -464,9 +430,7 @@ async def test_lesson_answer_handler_add_log_failure(
     async def fake_generate_step_text(*_a: object, **_k: object) -> str:
         return "step2"
 
-    monkeypatch.setattr(
-        learning_handlers, "generate_step_text", fake_generate_step_text
-    )
+    monkeypatch.setattr(learning_handlers, "generate_step_text", fake_generate_step_text)
 
     async def fake_next_step(
         user_id: int,
@@ -476,9 +440,7 @@ async def test_lesson_answer_handler_add_log_failure(
     ) -> tuple[str, bool]:
         return "step2", False
 
-    monkeypatch.setattr(
-        learning_handlers.curriculum_engine, "next_step", fake_next_step
-    )
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
     monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
     monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
 

--- a/tests/diabetes/test_learning_handlers.py
+++ b/tests/diabetes/test_learning_handlers.py
@@ -15,7 +15,7 @@ from services.api.app.diabetes import learning_handlers as dynamic_handlers
 from services.api.app.diabetes import learning_onboarding as onboarding_utils
 from services.api.app.diabetes.learning_fixtures import load_lessons
 from services.api.app.diabetes.services import db
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import ASSISTANT_BUTTON_TEXT
 
 legacy_handlers = dynamic_handlers
 
@@ -25,9 +25,7 @@ class DummyMessage:
         self.text = text
         self.replies: list[str] = []
 
-    async def reply_text(
-        self, text: str, **kwargs: Any
-    ) -> None:  # pragma: no cover - helper
+    async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - helper
         self.replies.append(text)
 
 
@@ -52,7 +50,7 @@ async def test_learn_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
         SimpleNamespace(user_data={}),
     )
     await legacy_handlers.learn_command(update, context)
-    assert message.replies == [f"🚫 {LEARN_BUTTON_TEXT} недоступен."]
+    assert message.replies == [f"🚫 {ASSISTANT_BUTTON_TEXT} недоступен."]
 
 
 def setup_db() -> sessionmaker[Session]:
@@ -221,9 +219,7 @@ async def test_plan_precedes_step(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(dynamic_handlers, "_persist", fake_persist)
 
     message = DummyMessage()
-    update = cast(
-        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    )
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(
@@ -322,9 +318,7 @@ async def test_reenter_after_onboarding(monkeypatch: pytest.MonkeyPatch) -> None
     )
 
     msg1 = DummyMessage()
-    upd1 = cast(
-        Update, SimpleNamespace(message=msg1, effective_user=SimpleNamespace(id=1))
-    )
+    upd1 = cast(Update, SimpleNamespace(message=msg1, effective_user=SimpleNamespace(id=1)))
     await dynamic_handlers.learn_command(upd1, context)
     assert msg1.replies == [
         "\U0001f5fa План обучения\nfirst|second",
@@ -332,9 +326,7 @@ async def test_reenter_after_onboarding(monkeypatch: pytest.MonkeyPatch) -> None
     ]
 
     msg2 = DummyMessage()
-    upd2 = cast(
-        Update, SimpleNamespace(message=msg2, effective_user=SimpleNamespace(id=1))
-    )
+    upd2 = cast(Update, SimpleNamespace(message=msg2, effective_user=SimpleNamespace(id=1)))
     await dynamic_handlers.learn_command(upd2, context)
     assert msg2.replies == ["first"]
     assert counts == {"start": 1, "next": 1}

--- a/tests/diabetes/test_learning_onboarding.py
+++ b/tests/diabetes/test_learning_onboarding.py
@@ -23,7 +23,7 @@ from services.api.app.diabetes.handlers import learning_onboarding
 from services.api.app.diabetes.learning_fixtures import load_lessons
 from services.api.app.diabetes.services import db
 from services.api.app.assistant.repositories import plans
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import ASSISTANT_BUTTON_TEXT
 
 
 class DummyMessage:
@@ -33,9 +33,7 @@ class DummyMessage:
         self.markups: list[Any] = []
         self.from_user = SimpleNamespace(id=0)
 
-    async def reply_text(
-        self, text: str, **kwargs: Any
-    ) -> None:  # pragma: no cover - helper
+    async def reply_text(self, text: str, **kwargs: Any) -> None:  # pragma: no cover - helper
         self.replies.append(text)
         self.markups.append(kwargs.get("reply_markup"))
 
@@ -49,9 +47,7 @@ class DummyCallbackQuery:
         self.message = message
         self.answers: list[str | None] = []
 
-    async def answer(
-        self, text: str | None = None, **kwargs: Any
-    ) -> None:  # pragma: no cover - helper
+    async def answer(self, text: str | None = None, **kwargs: Any) -> None:  # pragma: no cover - helper
         self.answers.append(text)
 
 
@@ -67,9 +63,7 @@ def setup_db() -> tuple[sessionmaker[Session], Engine]:
 
 
 @pytest.mark.asyncio
-async def test_learning_onboarding_flow(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_learning_onboarding_flow(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(settings, "learning_mode_enabled", True)
     monkeypatch.setattr(settings, "learning_command_model", "test-model")
     monkeypatch.setattr(settings, "learning_content_mode", "static")
@@ -77,9 +71,7 @@ async def test_learning_onboarding_flow(
     async def fake_get_profile(_: int, __: object) -> dict[str, object]:
         return {}
 
-    monkeypatch.setattr(
-        onboarding_utils.profiles, "get_profile_for_user", fake_get_profile
-    )
+    monkeypatch.setattr(onboarding_utils.profiles, "get_profile_for_user", fake_get_profile)
 
     sample = [{"title": "Sample", "steps": ["s1"], "quiz": []}]
     path = tmp_path / "lessons.json"
@@ -115,9 +107,7 @@ async def test_learning_onboarding_flow(
         message3 = DummyMessage("новичок")
         update3 = cast(Update, SimpleNamespace(message=message3, effective_user=None))
         await learning_onboarding.onboarding_reply(update3, context)
-        assert any(
-            LEARN_BUTTON_TEXT in text or "Урок" in text for text in message3.replies
-        )
+        assert any(ASSISTANT_BUTTON_TEXT in text or "Урок" in text for text in message3.replies)
         assert context.user_data["learn_profile_overrides"] == {
             "age_group": "adult",
             "learning_level": "novice",
@@ -126,14 +116,10 @@ async def test_learning_onboarding_flow(
         message5 = DummyMessage()
         update5 = cast(Update, SimpleNamespace(message=message5, effective_user=None))
         await learning_handlers.learn_command(update5, context)
-        assert any(
-            LEARN_BUTTON_TEXT in text or "Урок" in text for text in message5.replies
-        )
+        assert any(ASSISTANT_BUTTON_TEXT in text or "Урок" in text for text in message5.replies)
 
         message_reset = DummyMessage()
-        update_reset = cast(
-            Update, SimpleNamespace(message=message_reset, effective_user=None)
-        )
+        update_reset = cast(Update, SimpleNamespace(message=message_reset, effective_user=None))
         context.user_data["learn_profile_overrides"] = {"a": 1}
         context.user_data["learn_onboarding_stage"] = "stage"
         await learning_onboarding.learn_reset(update_reset, context)
@@ -149,9 +135,7 @@ async def test_learning_onboarding_flow(
 
 
 @pytest.mark.asyncio
-async def test_learning_onboarding_callback_flow(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_learning_onboarding_callback_flow(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(settings, "learning_mode_enabled", True)
     monkeypatch.setattr(settings, "learning_command_model", "test-model")
     monkeypatch.setattr(settings, "learning_content_mode", "static")
@@ -159,9 +143,7 @@ async def test_learning_onboarding_callback_flow(
     async def fake_get_profile(_: int, __: object) -> dict[str, object]:
         return {}
 
-    monkeypatch.setattr(
-        onboarding_utils.profiles, "get_profile_for_user", fake_get_profile
-    )
+    monkeypatch.setattr(onboarding_utils.profiles, "get_profile_for_user", fake_get_profile)
 
     sample = [{"title": "Sample", "steps": ["s1"], "quiz": []}]
     path = tmp_path / "lessons.json"
@@ -205,9 +187,7 @@ async def test_learning_onboarding_callback_flow(
             SimpleNamespace(callback_query=q2, message=None, effective_user=None),
         )
         await learning_onboarding.onboarding_callback(upd_cb2, ctx)
-        assert any(
-            LEARN_BUTTON_TEXT in text or "Урок" in text for text in q2_msg.replies
-        )
+        assert any(ASSISTANT_BUTTON_TEXT in text or "Урок" in text for text in q2_msg.replies)
         assert ctx.user_data["learn_profile_overrides"] == {
             "age_group": "adult",
             "learning_level": "novice",
@@ -216,7 +196,7 @@ async def test_learning_onboarding_callback_flow(
         msg2 = DummyMessage()
         upd2 = cast(Update, SimpleNamespace(message=msg2, effective_user=None))
         await learning_handlers.learn_command(upd2, ctx)
-        assert any(LEARN_BUTTON_TEXT in text or "Урок" in text for text in msg2.replies)
+        assert any(ASSISTANT_BUTTON_TEXT in text or "Урок" in text for text in msg2.replies)
     finally:
         engine.dispose()
 
@@ -247,72 +227,48 @@ async def test_ensure_overrides_normalizes_level() -> None:
             }
         ),
     )
-    update = cast(
-        Update, SimpleNamespace(message=None, callback_query=None, effective_user=None)
-    )
+    update = cast(Update, SimpleNamespace(message=None, callback_query=None, effective_user=None))
     assert await onboarding_utils.ensure_overrides(update, context)
     assert context.user_data["learn_profile_overrides"]["learning_level"] == "expert"
     assert context.user_data.get("learning_onboarded") is True
 
 
 @pytest.mark.asyncio
-async def test_ensure_overrides_logs_age(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_ensure_overrides_logs_age(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     async def fake_get_profile(_: int, __: object) -> dict[str, object]:
         return {}
 
-    monkeypatch.setattr(
-        onboarding_utils.profiles, "get_profile_for_user", fake_get_profile
-    )
+    monkeypatch.setattr(onboarding_utils.profiles, "get_profile_for_user", fake_get_profile)
     user = SimpleNamespace(id=1)
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
     msg = DummyMessage()
-    upd = cast(
-        Update, SimpleNamespace(message=msg, callback_query=None, effective_user=user)
-    )
+    upd = cast(Update, SimpleNamespace(message=msg, callback_query=None, effective_user=user))
     with caplog.at_level(logging.INFO):
         assert not await onboarding_utils.ensure_overrides(upd, context)
-    assert any(
-        r.message == "ensure_overrides" and r.asked == "age" for r in caplog.records
-    )
-    assert any(
-        r.message == "onboarding_question" and r.reason == "needs_age"
-        for r in caplog.records
-    )
+    assert any(r.message == "ensure_overrides" and r.asked == "age" for r in caplog.records)
+    assert any(r.message == "onboarding_question" and r.reason == "needs_age" for r in caplog.records)
 
 
 @pytest.mark.asyncio
-async def test_ensure_overrides_logs_level(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_ensure_overrides_logs_level(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     async def fake_get_profile(_: int, __: object) -> dict[str, object]:
         return {"age_group": "adult"}
 
-    monkeypatch.setattr(
-        onboarding_utils.profiles, "get_profile_for_user", fake_get_profile
-    )
+    monkeypatch.setattr(onboarding_utils.profiles, "get_profile_for_user", fake_get_profile)
     user = SimpleNamespace(id=1)
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}),
     )
     msg = DummyMessage()
-    upd = cast(
-        Update, SimpleNamespace(message=msg, callback_query=None, effective_user=user)
-    )
+    upd = cast(Update, SimpleNamespace(message=msg, callback_query=None, effective_user=user))
     with caplog.at_level(logging.INFO):
         assert not await onboarding_utils.ensure_overrides(upd, context)
-    assert any(
-        r.message == "ensure_overrides" and r.asked == "level" for r in caplog.records
-    )
-    assert any(
-        r.message == "onboarding_question" and r.reason == "needs_level"
-        for r in caplog.records
-    )
+    assert any(r.message == "ensure_overrides" and r.asked == "level" for r in caplog.records)
+    assert any(r.message == "onboarding_question" and r.reason == "needs_level" for r in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -330,9 +286,7 @@ async def test_lesson_command_requires_onboarding(
         fake_get_profile,
     )
     message = DummyMessage()
-    update = cast(
-        Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1))
-    )
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data={}, args=["l1"]),
@@ -375,9 +329,7 @@ async def test_ensure_overrides_logs_http_error(
     async def fake_get_profile(_: int, __: object) -> dict[str, object]:
         raise httpx.HTTPError("boom")
 
-    monkeypatch.setattr(
-        onboarding_utils.profiles, "get_profile_for_user", fake_get_profile
-    )
+    monkeypatch.setattr(onboarding_utils.profiles, "get_profile_for_user", fake_get_profile)
     user = SimpleNamespace(id=1)
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -402,9 +354,7 @@ async def test_ensure_overrides_propagates_unexpected(
     async def fake_get_profile(_: int, __: object) -> dict[str, object]:
         raise ValueError("bad")
 
-    monkeypatch.setattr(
-        onboarding_utils.profiles, "get_profile_for_user", fake_get_profile
-    )
+    monkeypatch.setattr(onboarding_utils.profiles, "get_profile_for_user", fake_get_profile)
     user = SimpleNamespace(id=1)
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],

--- a/tests/learning/test_handlers_e2e.py
+++ b/tests/learning/test_handlers_e2e.py
@@ -17,7 +17,7 @@ from telegram.ext import Application, CommandHandler, MessageHandler, filters
 from services.api.app.config import settings
 from services.api.app.diabetes import learning_handlers
 from services.api.app.diabetes.handlers import registration
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import ASSISTANT_BUTTON_TEXT
 
 
 class DummyBot(Bot):
@@ -101,11 +101,7 @@ async def test_keyboard_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
 
     first_markup = bot.markups[0]
     assert isinstance(first_markup, ReplyKeyboardMarkup)
-    assert any(
-        LEARN_BUTTON_TEXT == button.text
-        for row in first_markup.keyboard
-        for button in row
-    )
+    assert any(ASSISTANT_BUTTON_TEXT == button.text for row in first_markup.keyboard for button in row)
     assert isinstance(bot.markups[-1], ReplyKeyboardMarkup)
 
     await app.shutdown()
@@ -125,7 +121,7 @@ async def test_old_learn_button_triggers_handler(
 
     app.add_handler(
         MessageHandler(
-            filters.TEXT & filters.Regex(registration.LEARN_BUTTON_PATTERN),
+            filters.TEXT & filters.Regex(registration.ASSISTANT_BUTTON_PATTERN),
             learning_handlers.learn_command,
         )
     )
@@ -138,7 +134,7 @@ async def test_old_learn_button_triggers_handler(
         date=datetime.now(),
         chat=chat,
         from_user=user,
-        text=registration.OLD_LEARN_BUTTON_TEXT,
+        text=registration.OLD_ASSISTANT_BUTTON_TEXT,
     )
     msg._bot = bot
     await app.process_update(Update(update_id=1, message=msg))
@@ -162,7 +158,7 @@ async def test_new_learn_button_triggers_handler(
 
     app.add_handler(
         MessageHandler(
-            filters.TEXT & filters.Regex(registration.LEARN_BUTTON_PATTERN),
+            filters.TEXT & filters.Regex(registration.ASSISTANT_BUTTON_PATTERN),
             learning_handlers.learn_command,
         )
     )
@@ -175,7 +171,7 @@ async def test_new_learn_button_triggers_handler(
         date=datetime.now(),
         chat=chat,
         from_user=user,
-        text=LEARN_BUTTON_TEXT,
+        text=ASSISTANT_BUTTON_TEXT,
     )
     msg._bot = bot
     await app.process_update(Update(update_id=1, message=msg))

--- a/tests/test_learn_command.py
+++ b/tests/test_learn_command.py
@@ -18,7 +18,7 @@ from services.api.app.config import Settings
 from services.api.app.diabetes.learning_fixtures import load_lessons
 from services.api.app.diabetes.services import db
 from services.api.app.diabetes.utils.ui import menu_keyboard
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import ASSISTANT_BUTTON_TEXT
 
 
 class DummyMessage:
@@ -58,9 +58,7 @@ async def test_learn_command_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     message = DummyMessage()
     update = cast(
         Update,
-        SimpleNamespace(
-            message=message, effective_message=message, effective_user=None
-        ),
+        SimpleNamespace(message=message, effective_message=message, effective_user=None),
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -69,7 +67,7 @@ async def test_learn_command_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await handlers.learn_command(update, context)
 
-    assert message.replies == [f"🚫 {LEARN_BUTTON_TEXT} недоступен."]
+    assert message.replies == [f"🚫 {ASSISTANT_BUTTON_TEXT} недоступен."]
 
 
 @pytest.mark.asyncio
@@ -123,9 +121,7 @@ async def test_learn_command_no_lessons(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 @pytest.mark.asyncio
-async def test_learn_command_lists_lessons(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_learn_command_lists_lessons(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """After loading fixtures /learn should show at least one button."""
 
     sample = [
@@ -174,7 +170,7 @@ async def test_learn_command_lists_lessons(
 
     await handlers.learn_command(update, context)
 
-    assert message.replies[0].startswith(f"{LEARN_BUTTON_TEXT} активирован.")
+    assert message.replies[0].startswith(f"{ASSISTANT_BUTTON_TEXT} активирован.")
     keyboard = message.kwargs[0].get("reply_markup")
     assert keyboard is not None
     assert keyboard.keyboard
@@ -185,9 +181,7 @@ async def test_cmd_menu_shows_keyboard() -> None:
     message = DummyMessage()
     update = cast(
         Update,
-        SimpleNamespace(
-            message=message, effective_message=message, effective_user=None
-        ),
+        SimpleNamespace(message=message, effective_message=message, effective_user=None),
     )
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
@@ -200,13 +194,9 @@ async def test_cmd_menu_shows_keyboard() -> None:
     keyboard = message.kwargs[0].get("reply_markup")
     assert keyboard is not None
     expected_layout = list(menu_keyboard().keyboard)
-    expected_layout.append((KeyboardButton(LEARN_BUTTON_TEXT),))
+    expected_layout.append((KeyboardButton(ASSISTANT_BUTTON_TEXT),))
     assert list(keyboard.keyboard) == expected_layout
-    assert not any(
-        button.text == registration.OLD_LEARN_BUTTON_TEXT
-        for row in keyboard.keyboard
-        for button in row
-    )
+    assert not any(button.text == registration.OLD_ASSISTANT_BUTTON_TEXT for row in keyboard.keyboard for button in row)
 
 
 @pytest.mark.asyncio
@@ -232,7 +222,5 @@ async def test_on_learn_button_calls_learn(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_learn_button_texts_match_pattern() -> None:
-    assert registration.LEARN_BUTTON_PATTERN.fullmatch(LEARN_BUTTON_TEXT)
-    assert registration.LEARN_BUTTON_PATTERN.fullmatch(
-        registration.OLD_LEARN_BUTTON_TEXT
-    )
+    assert registration.ASSISTANT_BUTTON_PATTERN.fullmatch(ASSISTANT_BUTTON_TEXT)
+    assert registration.ASSISTANT_BUTTON_PATTERN.fullmatch(registration.OLD_ASSISTANT_BUTTON_TEXT)

--- a/tests/test_menu_keyboard.py
+++ b/tests/test_menu_keyboard.py
@@ -3,13 +3,11 @@ import services.api.app.ui.keyboard as kb
 
 
 def test_menu_keyboard_layout() -> None:
-    keyboard_texts = [
-        [btn.text for btn in row] for row in kb.build_main_keyboard().keyboard
-    ]
+    keyboard_texts = [[btn.text for btn in row] for row in kb.build_main_keyboard().keyboard]
     assert keyboard_texts == [
         [ui.PHOTO_BUTTON_TEXT, ui.SUGAR_BUTTON_TEXT],
         [ui.DOSE_BUTTON_TEXT, ui.REPORT_BUTTON_TEXT],
         [ui.QUICK_INPUT_BUTTON_TEXT, ui.HELP_BUTTON_TEXT],
         [ui.SOS_BUTTON_TEXT],
-        [kb.LEARN_BUTTON_TEXT],
+        [kb.ASSISTANT_BUTTON_TEXT],
     ]

--- a/tests/test_menu_keyboard_webapp.py
+++ b/tests/test_menu_keyboard_webapp.py
@@ -3,13 +3,11 @@ import services.api.app.ui.keyboard as kb
 
 
 def test_menu_keyboard_webapp_layout() -> None:
-    keyboard_texts = [
-        [btn.text for btn in row] for row in kb.build_main_keyboard().keyboard
-    ]
+    keyboard_texts = [[btn.text for btn in row] for row in kb.build_main_keyboard().keyboard]
     assert keyboard_texts == [
         [ui.PHOTO_BUTTON_TEXT, ui.SUGAR_BUTTON_TEXT],
         [ui.DOSE_BUTTON_TEXT, ui.REPORT_BUTTON_TEXT],
         [ui.QUICK_INPUT_BUTTON_TEXT, ui.HELP_BUTTON_TEXT],
         [ui.SOS_BUTTON_TEXT],
-        [kb.LEARN_BUTTON_TEXT],
+        [kb.ASSISTANT_BUTTON_TEXT],
     ]

--- a/tests/test_progress_command.py
+++ b/tests/test_progress_command.py
@@ -11,7 +11,7 @@ import services.api.app.diabetes.learning_handlers as handlers
 from services.api.app.config import settings
 from services.api.app.diabetes.services import db
 from services.api.app.diabetes.models_learning import Lesson, LessonProgress
-from services.api.app.ui.keyboard import LEARN_BUTTON_TEXT
+from services.api.app.ui.keyboard import ASSISTANT_BUTTON_TEXT
 
 
 class DummyMessage:
@@ -56,7 +56,7 @@ async def test_progress_command_no_progress(monkeypatch: pytest.MonkeyPatch) -> 
     await handlers.progress_command(update, context)
 
     assert message.replies == [
-        f"Вы ещё не начали обучение. Нажмите кнопку {LEARN_BUTTON_TEXT} или команду /learn, чтобы начать."
+        f"Вы ещё не начали обучение. Нажмите кнопку {ASSISTANT_BUTTON_TEXT} или команду /learn, чтобы начать."
     ]
 
 

--- a/tests/test_register_handlers.py
+++ b/tests/test_register_handlers.py
@@ -102,7 +102,14 @@ def test_register_handlers_attaches_expected_handlers(
     )
     assert any(
         isinstance(h, MessageHandler)
-        and h.callback is dynamic_learning_handlers.learn_command
+        and h.callback is assistant_menu.show_menu
+        for h in handlers
+    )
+    assert all(
+        not (
+            isinstance(h, MessageHandler)
+            and h.callback is dynamic_learning_handlers.learn_command
+        )
         for h in handlers
     )
     assert any(

--- a/tests/test_ui_keyboard.py
+++ b/tests/test_ui_keyboard.py
@@ -12,7 +12,7 @@ def _reload_keyboard():
 def test_learn_button_text_has_emoji() -> None:
     keyboard = _reload_keyboard()
 
-    assert keyboard.LEARN_BUTTON_TEXT == "🤖 Ассистент_AI"
+    assert keyboard.ASSISTANT_BUTTON_TEXT == "🤖 Ассистент_AI"
 
 
 def test_learn_button_text_without_emoji(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -25,7 +25,7 @@ def test_learn_button_text_without_emoji(monkeypatch: pytest.MonkeyPatch) -> Non
     importlib.reload(app_config)
     keyboard = _reload_keyboard()
 
-    assert keyboard.LEARN_BUTTON_TEXT == "Ассистент_AI"
+    assert keyboard.ASSISTANT_BUTTON_TEXT == "Ассистент_AI"
 
     monkeypatch.setenv("ASSISTANT_MENU_EMOJI", "true")
     monkeypatch.delenv("TELEGRAM_TOKEN")

--- a/tests/ui/test_keyboard_regression.py
+++ b/tests/ui/test_keyboard_regression.py
@@ -3,15 +3,13 @@ import services.api.app.ui.keyboard as kb
 
 
 def test_main_keyboard_preserves_buttons() -> None:
-    keyboard_layout = [
-        [btn.text for btn in row] for row in kb.build_main_keyboard().keyboard
-    ]
+    keyboard_layout = [[btn.text for btn in row] for row in kb.build_main_keyboard().keyboard]
     assert keyboard_layout == [
         [ui.PHOTO_BUTTON_TEXT, ui.SUGAR_BUTTON_TEXT],
         [ui.DOSE_BUTTON_TEXT, ui.REPORT_BUTTON_TEXT],
         [ui.QUICK_INPUT_BUTTON_TEXT, ui.HELP_BUTTON_TEXT],
         [ui.SOS_BUTTON_TEXT],
-        [kb.LEARN_BUTTON_TEXT],
+        [kb.ASSISTANT_BUTTON_TEXT],
     ]
 
 


### PR DESCRIPTION
## Summary
- rename learn button constant to ASSISTANT_BUTTON_TEXT
- show assistant menu when pressing the assistant button
- add tests for assistant button routing and update registration handler tests

## Testing
- `mypy --strict services/api/app/ui/keyboard.py services/api/app/diabetes/handlers/registration.py services/api/app/diabetes/learning_handlers.py services/api/app/diabetes/handlers/assistant_router.py services/api/app/diabetes/commands.py tests/test_assistant_menu.py tests/test_register_handlers.py`
- `ruff check .`
- `pytest tests/test_assistant_menu.py::test_assistant_button_shows_menu -q`
- `pytest -q --cov` *(fails: TypeError 'mappingproxy' object does not support item assignment; assert 0 == 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c465acf5bc832ab6f07109b832e389