### PR TITLE
[handlers] ensure mutable user_data

### DIFF
--- a/services/api/app/diabetes/handlers/router.py
+++ b/services/api/app/diabetes/handlers/router.py
@@ -271,7 +271,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
     if data.startswith("rem_"):
         from . import reminder_handlers
-
+        query.data = data
         await reminder_handlers.callback_router(update, context)
         return
 


### PR DESCRIPTION
## Summary
- add `_get_mutable_user_data` helper to safely mutate `context.user_data`
- use helper in photo/doc handlers and keep callback data in router
- cover MappingProxyType mutations with tests

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68c467493bbc832a84d0d34ec7277e2b