### PR TITLE
[bot] Support API_URL env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ curl -H 'Authorization: tg <init-data>' \
 - `TELEGRAM_TOKEN` — токен бота;
 - `PUBLIC_ORIGIN` — публичный URL API;
 - `WEBAPP_URL` — адрес WebApp для онбординга;
-- `API_URL` — базовый URL внешнего API; требует установленный пакет `diabetes_sdk`;
+- `API_URL` — базовый URL внешнего API (поддерживается устаревший `API_BASE_URL`); требует установленный пакет `diabetes_sdk`;
 - `INTERNAL_API_KEY` — ключ для внутренней аутентификации; при отсутствии нужно передавать `tg_init_data`;
 - `REDIS_URL` — адрес подключения к Redis для кеширования команд (по умолчанию `redis://localhost:6379/0`);
 - `OPENAI_API_KEY` — ключ OpenAI для распознавания фото;

--- a/docs/ops-guide.md
+++ b/docs/ops-guide.md
@@ -2,7 +2,7 @@
 
 ## Environment flags
 
-- `API_URL` — базовый URL внешнего API;
+- `API_URL` — базовый URL внешнего API (поддерживается `API_BASE_URL`);
 - `INTERNAL_API_KEY` — ключ для внутренней аутентификации бота;
 - `SUBSCRIPTION_URL` — страница подписки в WebApp;
 - `UI_BASE_URL`/`VITE_API_BASE` — базовые пути фронтенда и API;

--- a/services/api/app/bot.py
+++ b/services/api/app/bot.py
@@ -13,6 +13,22 @@ from .diabetes.bot_status_handlers import build_status_handler
 logger = logging.getLogger(__name__)
 
 
+def get_api_base_url() -> str:
+    """Return API base URL from environment.
+
+    Prefers ``API_URL`` but falls back to the deprecated ``API_BASE_URL``.
+    Defaults to ``/api`` when neither variable is set.
+    """
+
+    api_url = os.environ.get("API_URL")
+    if api_url:
+        return api_url
+    api_base_url = os.environ.get("API_BASE_URL")
+    if api_base_url:
+        return api_base_url
+    return "/api"
+
+
 def main() -> None:
     """Run the telegram bot with the /start WebApp links and status command."""
 
@@ -21,7 +37,7 @@ def main() -> None:
         logger.error("TELEGRAM_TOKEN is not set")
         raise RuntimeError("TELEGRAM_TOKEN is not configured")
     ui_base_url = os.environ.get("UI_BASE_URL", "/ui")
-    api_base_url = os.environ.get("API_BASE_URL", "/api")
+    api_base_url = get_api_base_url()
 
     persistence = build_persistence()
 

--- a/tests/bot/test_api_url_env.py
+++ b/tests/bot/test_api_url_env.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+from services.api.app.bot import get_api_base_url
+
+
+def test_uses_api_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("API_URL", "http://new.example")
+    monkeypatch.setenv("API_BASE_URL", "http://old.example")
+    assert get_api_base_url() == "http://new.example"
+
+
+def test_falls_back_to_api_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("API_URL", raising=False)
+    monkeypatch.setenv("API_BASE_URL", "http://old.example")
+    assert get_api_base_url() == "http://old.example"
+
+
+def test_default_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("API_URL", raising=False)
+    monkeypatch.delenv("API_BASE_URL", raising=False)
+    assert get_api_base_url() == "/api"


### PR DESCRIPTION
## Summary
- allow configuring bot via API_URL env variable (fallback to legacy API_BASE_URL)
- document API_URL usage and legacy alias
- test bot URL selection for env vars

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c471f8fa70832aac57cba4291048b3