### PR TITLE
[helpers] Allow spaced interval units

### DIFF
--- a/services/api/app/diabetes/utils/helpers.py
+++ b/services/api/app/diabetes/utils/helpers.py
@@ -11,11 +11,11 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-INVALID_TIME_MSG = "❌ Неверный формат. Примеры: 22:30 | 6:00 | 5h | 3d"
+INVALID_TIME_MSG = "❌ Неверный формат. Примеры: 22:30 | 6:00 | 5h | 3d | 3 h | 5 d"
 
 
 def parse_time_interval(value: str) -> time | timedelta:
-    """Convert strings like 'HH:MM', 'H:MM', 'Nh' or 'Nd' to time or timedelta."""
+    """Convert strings like 'HH:MM', 'H:MM', 'Nh', 'Nd', 'N h' or 'N d' to time or timedelta."""
 
     value = value.strip()
     # Normalize times like `9:30` -> `09:30` before parsing
@@ -24,7 +24,7 @@ def parse_time_interval(value: str) -> time | timedelta:
     try:
         return datetime.strptime(value, "%H:%M").time()
     except ValueError:
-        match = re.fullmatch(r"(\d+)([hd])", value, re.IGNORECASE)
+        match = re.fullmatch(r"(\d+)\s*([hd])", value, re.IGNORECASE)
         if match:
             num, unit = match.groups()
             unit = unit.lower()

--- a/tests/test_parse_time_interval.py
+++ b/tests/test_parse_time_interval.py
@@ -1,5 +1,4 @@
 from typing import Any
-
 from datetime import time, timedelta
 
 import pytest
@@ -34,6 +33,8 @@ def test_parse_time_success(text: Any, expected: Any) -> None:
     [
         ("5h", timedelta(hours=5)),
         ("3d", timedelta(days=3)),
+        ("3 h", timedelta(hours=3)),
+        ("5 d", timedelta(days=5)),
     ],
 )
 def test_parse_interval_success(text: Any, expected: Any) -> None:
@@ -42,7 +43,7 @@ def test_parse_interval_success(text: Any, expected: Any) -> None:
 
 @pytest.mark.parametrize(
     "value",
-    ["", "25:00", "5x", "1:60", "2h30", "3 d", "0h", "0d"],
+    ["", "25:00", "5x", "1:60", "2h30", "0h", "0d"],
 )
 def test_parse_time_invalid(value: Any) -> None:
     with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
## Summary
- allow `parse_time_interval` to handle optional spaces between number and unit
- document supported formats and update error message
- add tests for spaced hour/day intervals

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c471fee6d8832a92d8185ea70838e7