### PR TITLE
[handlers] ensure user_data mutable

### DIFF
--- a/tests/test_handlers_doc.py
+++ b/tests/test_handlers_doc.py
@@ -68,7 +68,7 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=dummy_bot, user_data=MappingProxyType({})),
     )
-    context._user_data = {}
+    photo_handlers._get_mutable_user_data(context)
 
     monkeypatch.setattr(photo_handlers, "photo_handler", fake_photo_handler)
     monkeypatch.setattr(
@@ -82,7 +82,7 @@ async def test_doc_handler_calls_photo_handler(monkeypatch: pytest.MonkeyPatch) 
     assert result == 200
     assert called.flag
     assert called.path == f"{settings.photos_dir}/1_uid.png"
-    assert context._user_data == {}
+    assert photo_handlers._get_mutable_user_data(context) == {}
     assert update.message is not None
     msg = update.message
     assert getattr(msg, "photo", None) is None
@@ -113,7 +113,7 @@ async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> 
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data=MappingProxyType({})),
     )
-    context._user_data = {}
+    photo_handlers._get_mutable_user_data(context)
 
     monkeypatch.setattr(photo_handlers, "photo_handler", fake_photo_handler)
 
@@ -121,8 +121,8 @@ async def test_doc_handler_skips_non_images(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert result == photo_handlers.END
     assert not called.flag
-    assert context._user_data is not None
-    assert "__file_path" not in context._user_data
+    assert photo_handlers._get_mutable_user_data(context) is not None
+    assert "__file_path" not in photo_handlers._get_mutable_user_data(context)
 
 
 @pytest.mark.asyncio
@@ -142,7 +142,7 @@ async def test_doc_handler_get_file_error(monkeypatch: pytest.MonkeyPatch) -> No
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=bot, user_data=MappingProxyType({})),
     )
-    context._user_data = {}
+    photo_handlers._get_mutable_user_data(context)
     monkeypatch.setattr(
         photo_handlers.os,
         "makedirs",
@@ -153,7 +153,7 @@ async def test_doc_handler_get_file_error(monkeypatch: pytest.MonkeyPatch) -> No
 
     assert result == photo_handlers.END
     message.reply_text.assert_awaited_once()
-    assert not context._user_data
+    assert not photo_handlers._get_mutable_user_data(context)
 
 
 @pytest.mark.asyncio
@@ -177,7 +177,7 @@ async def test_doc_handler_download_error(monkeypatch: pytest.MonkeyPatch) -> No
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=bot, user_data=MappingProxyType({})),
     )
-    context._user_data = {}
+    photo_handlers._get_mutable_user_data(context)
     monkeypatch.setattr(
         photo_handlers.os,
         "makedirs",
@@ -188,7 +188,7 @@ async def test_doc_handler_download_error(monkeypatch: pytest.MonkeyPatch) -> No
 
     assert result == photo_handlers.END
     message.reply_text.assert_awaited_once()
-    assert not context._user_data
+    assert not photo_handlers._get_mutable_user_data(context)
 
 
 @pytest.mark.asyncio
@@ -208,7 +208,7 @@ async def test_photo_handler_non_writable_dir(monkeypatch: pytest.MonkeyPatch) -
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=bot, user_data=MappingProxyType({})),
     )
-    context._user_data = {}
+    photo_handlers._get_mutable_user_data(context)
 
     def raise_os_error(*args: Any, **kwargs: Any) -> None:
         raise OSError("no perm")
@@ -219,7 +219,7 @@ async def test_photo_handler_non_writable_dir(monkeypatch: pytest.MonkeyPatch) -
 
     assert result == photo_handlers.END
     message.reply_text.assert_awaited_once()
-    assert photo_handlers.WAITING_GPT_FLAG not in context._user_data
+    assert photo_handlers.WAITING_GPT_FLAG not in photo_handlers._get_mutable_user_data(context)
 
 
 @pytest.mark.asyncio
@@ -251,7 +251,7 @@ async def test_doc_handler_non_writable_dir(monkeypatch: pytest.MonkeyPatch) -> 
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=bot, user_data=MappingProxyType({})),
     )
-    context._user_data = {}
+    photo_handlers._get_mutable_user_data(context)
 
     result = await photo_handlers.doc_handler(update, context)
 
@@ -269,14 +269,14 @@ async def test_photo_handler_handles_typeerror() -> None:
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(user_data=MappingProxyType({})),
     )
-    context._user_data = {}
+    photo_handlers._get_mutable_user_data(context)
 
     result = await photo_handlers.photo_handler(update, context)
 
     assert message.texts == ["❗ Файл не распознан как изображение."]
     assert result == photo_handlers.END
-    assert context._user_data is not None
-    assert photo_handlers.WAITING_GPT_FLAG not in context._user_data
+    assert photo_handlers._get_mutable_user_data(context) is not None
+    assert photo_handlers.WAITING_GPT_FLAG not in photo_handlers._get_mutable_user_data(context)
 
 
 @pytest.mark.asyncio
@@ -310,7 +310,7 @@ async def test_photo_handler_sends_bytes(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=dummy_bot, user_data=MappingProxyType(user_data)),
     )
-    context._user_data = user_data
+    photo_handlers._get_mutable_user_data(context).update(user_data)
 
     call = {}
 
@@ -412,7 +412,7 @@ async def test_photo_then_freeform_calculates_dose(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(bot=dummy_bot, user_data=MappingProxyType(user_data)),
     )
-    context._user_data = user_data
+    photo_handlers._get_mutable_user_data(context).update(user_data)
 
     await photo_handlers.photo_handler(update_photo, context)
 
@@ -451,6 +451,6 @@ async def test_photo_then_freeform_calculates_dose(
 
     reply = sugar_msg.texts[0]
     assert reply == "💉\u202fРасчёт дозы: 1.0\u202fЕд.\nСахар: 5.0\u202fммоль/л"
-    assert context._user_data is not None
-    user_data = context._user_data
+    assert photo_handlers._get_mutable_user_data(context) is not None
+    user_data = photo_handlers._get_mutable_user_data(context)
     assert "dose" in user_data["pending_entry"]

--- a/tests/test_photo_handler_errors.py
+++ b/tests/test_photo_handler_errors.py
@@ -71,10 +71,10 @@ async def test_photo_handler_not_image(
     calls = 0
     orig = photo_handlers._clear_waiting_gpt
 
-    def wrapped(user_data: dict[str, Any]) -> None:
+    def wrapped(context: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]) -> None:
         nonlocal calls
         calls += 1
-        orig(user_data)
+        orig(context)
 
     monkeypatch.setattr(photo_handlers, "_clear_waiting_gpt", wrapped)
     message = NoPhotoMessage()
@@ -131,10 +131,10 @@ async def test_photo_handler_timeout(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     calls = 0
     orig = photo_handlers._clear_waiting_gpt
 
-    def wrapped(user_data: dict[str, Any]) -> None:
+    def wrapped(context: CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]]) -> None:
         nonlocal calls
         calls += 1
-        orig(user_data)
+        orig(context)
 
     monkeypatch.setattr(photo_handlers, "_clear_waiting_gpt", wrapped)
     result = await photo_handlers.photo_handler(update, context)

--- a/tests/test_photo_handlers.py
+++ b/tests/test_photo_handlers.py
@@ -185,7 +185,7 @@ async def test_photo_handler_mapping_proxy_mutable_user_data(
     result = await photo_handlers.photo_handler(update, context, file_bytes=b"img")
 
     assert result == photo_handlers.END
-    user_data = context._user_data
+    user_data = photo_handlers._get_mutable_user_data(context)
     assert isinstance(user_data, dict)
     assert photo_handlers.WAITING_GPT_FLAG not in user_data
     assert photo_handlers.WAITING_GPT_TIMESTAMP not in user_data
@@ -258,7 +258,7 @@ async def test_photo_handler_pending_entry_mapping_proxy(
     result = await photo_handlers.photo_handler(update, context, file_bytes=b"img")
 
     assert result == photo_handlers.PHOTO_SUGAR
-    user_data = context._user_data
+    user_data = photo_handlers._get_mutable_user_data(context)
     assert isinstance(user_data, dict)
     pending = user_data.get("pending_entry")
     assert pending is not None


### PR DESCRIPTION
## Summary
- ensure user_data is always mutable via helper and context-based clearing
- update handlers to use helper and share mutable user data
- refactor tests to rely on mutable user data helper

## Testing
- `pytest -q --disable-warnings --maxfail=1`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c471de8f00832aab507926e0408d92