### PR TITLE
[dynamic_tutor] allow quotes in sanitize feedback

### DIFF
--- a/services/api/app/diabetes/dynamic_tutor.py
+++ b/services/api/app/diabetes/dynamic_tutor.py
@@ -18,7 +18,7 @@ BUSY_MESSAGE = "сервер занят, попробуйте позже"
 
 
 _TAGS_RE = re.compile(r"<[^>]+>")
-_SAFE_RE = re.compile(r"[^0-9A-Za-zА-Яа-яёЁ.,!?;:()\-\s✅⚠️❌]")
+_SAFE_RE = re.compile(r"[^0-9A-Za-zА-Яа-яёЁ.,!?;:()\-\s✅⚠️❌'\"]")
 
 _MAX_FEEDBACK_CHARS = 400
 _MAX_FEEDBACK_SENTENCES = 2

--- a/tests/test_dynamic_tutor.py
+++ b/tests/test_dynamic_tutor.py
@@ -77,6 +77,11 @@ def test_sanitize_feedback() -> None:
     assert dynamic_tutor.sanitize_feedback(text) == "привет ✅ мир"
 
 
+def test_sanitize_feedback_keeps_quotes() -> None:
+    text = '<b>цитата</b> "привет" и \'пока\''
+    assert dynamic_tutor.sanitize_feedback(text) == 'цитата "привет" и \'пока\''
+
+
 @pytest.mark.asyncio
 async def test_check_user_answer_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
     async def raise_error(**kwargs: object) -> str:


### PR DESCRIPTION
## Summary
- include ' and " in sanitize_feedback safe character regex
- test sanitize_feedback preserves quotes

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c47796e908832aa521aadf5497e6d4