### PR TITLE
[alert_handlers] Remove run_db guard

### DIFF
--- a/services/api/app/diabetes/handlers/alert_handlers.py
+++ b/services/api/app/diabetes/handlers/alert_handlers.py
@@ -196,7 +196,9 @@ async def evaluate_sugar(
         low = profile.low_threshold
         high = profile.high_threshold
 
-        active = session.scalars(sa.select(Alert).filter_by(user_id=user_id, resolved=False)).all()
+        active = session.scalars(
+            sa.select(Alert).filter_by(user_id=user_id, resolved=False)
+        ).all()
 
         if (low is not None and sugar < low) or (high is not None and sugar > high):
             atype = "hypo" if low is not None and sugar < low else "hyper"
@@ -208,7 +210,10 @@ async def evaluate_sugar(
                 logger.error("Failed to commit new alert for user %s", user_id)
                 return False, None
             alerts = session.scalars(
-                sa.select(Alert).filter_by(user_id=user_id, resolved=False).order_by(Alert.ts.desc()).limit(3)
+                sa.select(Alert)
+                .filter_by(user_id=user_id, resolved=False)
+                .order_by(Alert.ts.desc())
+                .limit(3)
             ).all()
             notify = len(alerts) == 3 and all(a.type == atype for a in alerts)
             if notify:
@@ -217,7 +222,9 @@ async def evaluate_sugar(
                 try:
                     commit(session)
                 except CommitError:
-                    logger.error("Failed to commit resolved alerts for user %s", user_id)
+                    logger.error(
+                        "Failed to commit resolved alerts for user %s", user_id
+                    )
                     return False, None
             return True, {
                 "action": "schedule",
@@ -237,8 +244,6 @@ async def evaluate_sugar(
                 return False, None
             return True, {"action": "remove", "notify": False}
 
-    if run_db is None:  # pragma: no cover - guard for tests
-        raise RuntimeError("run_db is unavailable")
     ok, result = cast(
         tuple[bool, dict[str, object] | None],
         await run_db(db_eval, sessionmaker=SessionLocal),
@@ -269,9 +274,13 @@ async def evaluate_sugar(
         )
 
 
-async def check_alert(update: Update, context: ContextTypes.DEFAULT_TYPE, sugar: float) -> None:
+async def check_alert(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, sugar: float
+) -> None:
     """Wrapper to evaluate sugar using :func:`evaluate_sugar`."""
-    job_queue: DefaultJobQueue | None = cast(DefaultJobQueue | None, getattr(context, "job_queue", None))
+    job_queue: DefaultJobQueue | None = cast(
+        DefaultJobQueue | None, getattr(context, "job_queue", None)
+    )
     if job_queue is None:
         job_queue = cast(
             DefaultJobQueue | None,
@@ -319,7 +328,12 @@ async def alert_job(context: ContextTypes.DEFAULT_TYPE) -> None:
     first_name = data.get("first_name", "")
 
     def has_active_alert(session: Session) -> bool:
-        return session.scalars(sa.select(Alert).filter_by(user_id=user_id, resolved=False)).first() is not None
+        return (
+            session.scalars(
+                sa.select(Alert).filter_by(user_id=user_id, resolved=False)
+            ).first()
+            is not None
+        )
 
     active = cast(
         bool,
@@ -332,7 +346,9 @@ async def alert_job(context: ContextTypes.DEFAULT_TYPE) -> None:
     if count >= MAX_REPEATS:
 
         def resolve_alerts(session: Session) -> None:
-            alerts = session.scalars(sa.select(Alert).filter_by(user_id=user_id, resolved=False)).all()
+            alerts = session.scalars(
+                sa.select(Alert).filter_by(user_id=user_id, resolved=False)
+            ).all()
             for a in alerts:
                 a.resolved = True
             try:
@@ -367,7 +383,9 @@ async def alert_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     week_ago = now - datetime.timedelta(days=7)
 
     def fetch_alerts(session: Session) -> Sequence[Alert]:
-        return session.scalars(sa.select(Alert).where(Alert.user_id == user_id, Alert.ts >= week_ago)).all()
+        return session.scalars(
+            sa.select(Alert).where(Alert.user_id == user_id, Alert.ts >= week_ago)
+        ).all()
 
     alerts = list(
         cast(

--- a/tests/test_alert_handlers.py
+++ b/tests/test_alert_handlers.py
@@ -88,7 +88,10 @@ async def test_send_alert_message_invalid_contact(
         )
 
     assert expected in caplog.text
-    assert "SOS contact 'bad_contact' is not a Telegram username, chat id, or phone number; skipping" in caplog.text
+    assert (
+        "SOS contact 'bad_contact' is not a Telegram username, chat id, or phone number; skipping"
+        in caplog.text
+    )
     assert bot.send_message.await_count == 1
 
 
@@ -191,15 +194,3 @@ def test_schedule_alert_without_timezone_kwarg() -> None:
         profile=profile,
     )
     assert len(job_queue.jobs) == 1
-
-
-@pytest.mark.asyncio
-async def test_evaluate_sugar_requires_run_db(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """evaluate_sugar raises when run_db is missing."""
-
-    monkeypatch.setattr(handlers, "run_db", None)
-
-    with pytest.raises(RuntimeError, match="run_db"):
-        await handlers.evaluate_sugar(1, 5.5)


### PR DESCRIPTION
## Summary
- call `run_db` in alert handlers without `None` guard
- drop obsolete unit test expecting missing `run_db`

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68c477a2054c832aba352114b8b4166a