### PR TITLE
[utils] separate HTTP client builders

### DIFF
--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -339,12 +339,12 @@ async def test_build_http_client_returns_separate_clients_for_each_proxy(
     monkeypatch.setattr(httpx, "Client", client_mock)
     monkeypatch.setattr(openai_utils, "_http_client", {})
 
-    client_a = openai_utils._build_http_client("http://proxy1", False)
-    client_b = openai_utils._build_http_client("http://proxy2", False)
+    client_a = openai_utils.build_http_client("http://proxy1")
+    client_b = openai_utils.build_http_client("http://proxy2")
 
     assert client_a is fake_client1
     assert client_b is fake_client2
-    assert openai_utils._build_http_client("http://proxy1", False) is client_a
+    assert openai_utils.build_http_client("http://proxy1") is client_a
 
     await openai_utils.dispose_http_client()
     fake_client1.close.assert_called_once()
@@ -365,12 +365,12 @@ async def test_build_async_http_client_returns_separate_clients_for_each_proxy(
     monkeypatch.setattr(openai_utils, "_async_http_client", {})
     monkeypatch.setattr(openai_utils, "_http_client", {})
 
-    client_a = openai_utils._build_http_client("http://proxy1", True)
-    client_b = openai_utils._build_http_client("http://proxy2", True)
+    client_a = openai_utils.build_async_http_client("http://proxy1")
+    client_b = openai_utils.build_async_http_client("http://proxy2")
 
     assert client_a is fake_async_client1
     assert client_b is fake_async_client2
-    assert openai_utils._build_http_client("http://proxy1", True) is client_a
+    assert openai_utils.build_async_http_client("http://proxy1") is client_a
 
     await openai_utils.dispose_http_client()
     fake_async_client1.aclose.assert_awaited_once()


### PR DESCRIPTION
## Summary
- split `_build_http_client` into `build_http_client` and `build_async_http_client`
- adjust OpenAI client factories to use the new builders
- update tests for the new HTTP client helpers

## Testing
- `make ci`

------
https://chatgpt.com/codex/tasks/task_e_68c477f0f16c832a97f2bd220341660e