### PR TITLE
[openai_utils] handle client close errors

### DIFF
--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -106,14 +106,20 @@ async def dispose_http_client() -> None:
         sync_clients = list(_http_client.values())
         _http_client.clear()
     for sync_client in sync_clients:
-        sync_client.close()
+        try:
+            sync_client.close()
+        except Exception:  # pragma: no cover - best effort
+            logger.exception("[OpenAI] Failed to close HTTP client")
 
     # Gather and clear asynchronous clients under lock, then close outside the lock
     with _async_http_client_lock:
         async_clients = list(_async_http_client.values())
         _async_http_client.clear()
     for async_client in async_clients:
-        await async_client.aclose()
+        try:
+            await async_client.aclose()
+        except Exception:  # pragma: no cover - best effort
+            logger.exception("[OpenAI] Failed to close HTTP client")
 
 
 @asynccontextmanager


### PR DESCRIPTION
## Summary
- avoid short-circuiting `dispose_http_client` by logging and ignoring individual close errors
- test that `dispose_http_client` continues closing all clients

## Testing
- `ruff check services/api/app/diabetes/utils/openai_utils.py tests/test_openai_utils.py`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68c47a5d9bf0832aa1c05d64c07be869