### PR TITLE
[utils] refine job exception handling

### DIFF
--- a/tests/utils/test_jobs_safe_remove.py
+++ b/tests/utils/test_jobs_safe_remove.py
@@ -1,0 +1,21 @@
+import logging
+
+import pytest
+
+from services.api.app.diabetes.utils.jobs import _safe_remove
+
+
+class _FailingJob:
+    id = "1"
+    name = "bad"
+
+    def remove(self) -> None:  # pragma: no cover - simple mock
+        raise ValueError("boom")
+
+
+def test_safe_remove_unknown_exception(caplog: pytest.LogCaptureFixture) -> None:
+    job = _FailingJob()
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError):
+            _safe_remove(job)
+    assert "remove() raised unexpected error" in caplog.text


### PR DESCRIPTION
## Summary
- narrow job removal exception catching to RuntimeError and APScheduler-specific errors
- log and re-raise unexpected removal errors
- add regression test for `_safe_remove` handling of unknown exceptions

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c477ae573c832abbaac74cf6cc667d