### PR TITLE
[openai] Split http client builders into sync and async

### DIFF
--- a/services/api/app/diabetes/utils/openai_utils.py
+++ b/services/api/app/diabetes/utils/openai_utils.py
@@ -4,7 +4,6 @@ import logging
 import threading
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Literal, overload
 
 import httpx
 from openai import AsyncOpenAI, OpenAI
@@ -20,42 +19,34 @@ _async_http_client: dict[str, httpx.AsyncClient] = {}
 _async_http_client_lock = threading.Lock()
 
 
-@overload
-def _build_http_client(
-    proxy: str | None, async_: Literal[False]
-) -> httpx.Client | None: ...
-
-
-@overload
-def _build_http_client(
-    proxy: str | None, async_: Literal[True]
-) -> httpx.AsyncClient | None: ...
-
-
-def _build_http_client(
-    proxy: str | None, async_: bool
-) -> httpx.Client | httpx.AsyncClient | None:
-    """Return an httpx client configured with optional proxy."""
+def build_http_client(proxy: str | None) -> httpx.Client | None:
+    """Return a synchronous httpx client configured with optional proxy."""
 
     if proxy is None:
         return None
 
-    if async_:
-        global _async_http_client
-        with _async_http_client_lock:
-            async_client = _async_http_client.get(proxy)
-            if async_client is None:
-                async_client = httpx.AsyncClient(proxy=proxy)
-                _async_http_client[proxy] = async_client
-            return async_client
-
     global _http_client
     with _http_client_lock:
-        sync_client = _http_client.get(proxy)
-        if sync_client is None:
-            sync_client = httpx.Client(proxy=proxy)
-            _http_client[proxy] = sync_client
-        return sync_client
+        client = _http_client.get(proxy)
+        if client is None:
+            client = httpx.Client(proxy=proxy)
+            _http_client[proxy] = client
+        return client
+
+
+def build_async_http_client(proxy: str | None) -> httpx.AsyncClient | None:
+    """Return an asynchronous httpx client configured with optional proxy."""
+
+    if proxy is None:
+        return None
+
+    global _async_http_client
+    with _async_http_client_lock:
+        client = _async_http_client.get(proxy)
+        if client is None:
+            client = httpx.AsyncClient(proxy=proxy)
+            _async_http_client[proxy] = client
+        return client
 
 
 def get_openai_client() -> OpenAI:
@@ -72,7 +63,7 @@ def get_openai_client() -> OpenAI:
         logger.error("[OpenAI] %s", message)
         raise RuntimeError(message)
 
-    http_client = _build_http_client(settings.openai_proxy, False)
+    http_client = build_http_client(settings.openai_proxy)
     client = OpenAI(api_key=settings.openai_api_key, http_client=http_client)
 
     if settings.openai_assistant_id:
@@ -89,7 +80,7 @@ def get_async_openai_client() -> AsyncOpenAI:
         logger.error("[OpenAI] %s", message)
         raise RuntimeError(message)
 
-    http_client = _build_http_client(settings.openai_proxy, True)
+    http_client = build_async_http_client(settings.openai_proxy)
     client = AsyncOpenAI(api_key=settings.openai_api_key, http_client=http_client)
 
     if settings.openai_assistant_id:

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -345,12 +345,12 @@ async def test_build_http_client_returns_separate_clients_for_each_proxy(
     monkeypatch.setattr(httpx, "Client", client_mock)
     monkeypatch.setattr(openai_utils, "_http_client", {})
 
-    client_a = openai_utils._build_http_client("http://proxy1", False)
-    client_b = openai_utils._build_http_client("http://proxy2", False)
+    client_a = openai_utils.build_http_client("http://proxy1")
+    client_b = openai_utils.build_http_client("http://proxy2")
 
     assert client_a is fake_client1
     assert client_b is fake_client2
-    assert openai_utils._build_http_client("http://proxy1", False) is client_a
+    assert openai_utils.build_http_client("http://proxy1") is client_a
 
     await openai_utils.dispose_http_client()
     fake_client1.close.assert_called_once()
@@ -371,12 +371,12 @@ async def test_build_async_http_client_returns_separate_clients_for_each_proxy(
     monkeypatch.setattr(openai_utils, "_async_http_client", {})
     monkeypatch.setattr(openai_utils, "_http_client", {})
 
-    client_a = openai_utils._build_http_client("http://proxy1", True)
-    client_b = openai_utils._build_http_client("http://proxy2", True)
+    client_a = openai_utils.build_async_http_client("http://proxy1")
+    client_b = openai_utils.build_async_http_client("http://proxy2")
 
     assert client_a is fake_async_client1
     assert client_b is fake_async_client2
-    assert openai_utils._build_http_client("http://proxy1", True) is client_a
+    assert openai_utils.build_async_http_client("http://proxy1") is client_a
 
     await openai_utils.dispose_http_client()
     fake_async_client1.aclose.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Separate HTTP client builders for sync and async OpenAI clients
- Update OpenAI client factories to use new builders
- Adjust OpenAI utility tests for the split builders

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c47bb29584832a821470cfba4ec417