### PR TITLE
[tests] Annotate run_db in billing status test

### DIFF
--- a/tests/test_billing_status.py
+++ b/tests/test_billing_status.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime
 
 import pytest
@@ -31,7 +32,12 @@ def setup_db() -> sessionmaker[Session]:
 def make_client(monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]) -> TestClient:
     from services.api.app.billing.config import BillingSettings
 
-    async def run_db(fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs):
+    async def run_db(
+        fn: Callable[..., object],
+        *args: object,
+        sessionmaker: sessionmaker[Session] = session_local,
+        **kwargs: object,
+    ) -> object:
         with sessionmaker() as session:
             return fn(session, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
- add explicit Callable and return type for run_db stub in billing status test

## Testing
- `pytest -q --cov`
- `mypy --strict . | tail -n 20`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c47f32aa70832a99732c7625d5df41