### PR TITLE
[gpt_client] include user id in learning cache key

### DIFF
--- a/tests/assistant/test_e2e_learning_onboarding.py
+++ b/tests/assistant/test_e2e_learning_onboarding.py
@@ -84,11 +84,18 @@ async def test_first_run_restart_and_type_questions(
     ) -> tuple[str, bool]:
         return next(steps), False
 
-    async def fake_assistant_chat(_profile: Any, _text: str) -> str:
+    async def fake_assistant_chat(
+        _profile: Any, _text: str, *, user_id: int | None = None
+    ) -> str:
         return "feedback"
 
     async def fake_check_user_answer(
-        _profile: Any, _topic: str, _text: str, _prev: str
+        _profile: Any,
+        _topic: str,
+        _text: str,
+        _prev: str,
+        *,
+        user_id: int | None = None,
     ) -> tuple[bool, str]:
         return False, "feedback"
 

--- a/tests/assistant/test_e2e_plan_button.py
+++ b/tests/assistant/test_e2e_plan_button.py
@@ -85,7 +85,9 @@ async def test_plan_button_flow(
         learning_handlers.curriculum_engine, "next_step", fake_next_step
     )
 
-    async def fake_assistant_chat(_profile: Any, _text: str) -> str:
+    async def fake_assistant_chat(
+        _profile: Any, _text: str, *, user_id: int | None = None
+    ) -> str:
         return "feedback"
 
     monkeypatch.setattr(learning_handlers, "assistant_chat", fake_assistant_chat)

--- a/tests/assistant/test_e2e_restart.py
+++ b/tests/assistant/test_e2e_restart.py
@@ -122,12 +122,19 @@ async def test_hydrate_generates_snapshot_and_persists(
         return f"Шаг {step_idx}", False
 
     async def fake_generate_step_text(
-        _profile: Any, _topic: str, step_idx: int, _prev: str | None
+        _profile: Any,
+        _topic: str,
+        step_idx: int,
+        _prev: str | None,
+        *,
+        user_id: int | None = None,
     ) -> str:
         gen_calls.append(step_idx)
         return f"Шаг {step_idx}"
 
-    async def fake_assistant_chat(_profile: Any, _text: str) -> str:
+    async def fake_assistant_chat(
+        _profile: Any, _text: str, *, user_id: int | None = None
+    ) -> str:
         return "feedback"
 
     monkeypatch.setattr(

--- a/tests/assistant/test_integration.py
+++ b/tests/assistant/test_integration.py
@@ -56,20 +56,26 @@ async def test_flow_idk_with_log_error(monkeypatch: pytest.MonkeyPatch) -> None:
     ) -> tuple[str, bool]:
         return next(steps_iter), False
 
-    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
-    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson
+    )
+    monkeypatch.setattr(
+        learning_handlers.curriculum_engine, "next_step", fake_next_step
+    )
 
     async def fake_check_user_answer(
         profile: Mapping[str, str | None],
         topic: str,
         answer: str,
         last: str,
+        *,
+        user_id: int | None = None,
     ) -> tuple[bool, str]:
         return True, "fb"
 
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
 
-    async def fake_assistant_chat(*_: object) -> str:
+    async def fake_assistant_chat(*_: object, **__: object) -> str:
         return "fb"
 
     monkeypatch.setattr(learning_handlers, "assistant_chat", fake_assistant_chat)
@@ -83,13 +89,15 @@ async def test_flow_idk_with_log_error(monkeypatch: pytest.MonkeyPatch) -> None:
     context = SimpleNamespace(user_data={}, bot_data={}, args=["slug"])
 
     msg_start = DummyMessage()
-    update_start = SimpleNamespace(message=msg_start, effective_user=SimpleNamespace(id=1))
+    update_start = SimpleNamespace(
+        message=msg_start, effective_user=SimpleNamespace(id=1)
+    )
     await learning_handlers.lesson_command(update_start, context)
     state = get_state(context.user_data)
     assert state is not None and state.step == 1 and state.awaiting
     plan = learning_handlers.generate_learning_plan("step1?")
     assert msg_start.replies == [
-        f"\U0001F5FA План обучения\n{learning_handlers.pretty_plan(plan)}",
+        f"\U0001f5fa План обучения\n{learning_handlers.pretty_plan(plan)}",
         "step1?",
     ]
 

--- a/tests/diabetes/test_curriculum_not_found.py
+++ b/tests/diabetes/test_curriculum_not_found.py
@@ -69,7 +69,12 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(dynamic_handlers, "build_main_keyboard", lambda: None)
 
     async def fake_step_text(
-        profile: Mapping[str, str | None], slug: str, step: int, prev: str | None
+        profile: Mapping[str, str | None],
+        slug: str,
+        step: int,
+        prev: str | None,
+        *,
+        user_id: int | None = None,
     ) -> str:
         return "intro"
 
@@ -151,7 +156,12 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(dynamic_handlers, "disclaimer", lambda: "")
 
     async def fake_step_text(
-        profile: Mapping[str, str | None], slug: str, step: int, prev: str | None
+        profile: Mapping[str, str | None],
+        slug: str,
+        step: int,
+        prev: str | None,
+        *,
+        user_id: int | None = None,
     ) -> str:
         return "intro"
 

--- a/tests/learning/test_curriculum_engine.py
+++ b/tests/learning/test_curriculum_engine.py
@@ -92,9 +92,16 @@ async def test_curriculum_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert question_text.startswith(disclaimer())
 
     with db.SessionLocal() as session:
-        questions = session.query(QuizQuestion).filter_by(lesson_id=lesson_id).order_by(QuizQuestion.id).all()
+        questions = (
+            session.query(QuizQuestion)
+            .filter_by(lesson_id=lesson_id)
+            .order_by(QuizQuestion.id)
+            .all()
+        )
 
-    first_opts = "\n".join(f"{idx}. {opt}" for idx, opt in enumerate(questions[0].options, start=1))
+    first_opts = "\n".join(
+        f"{idx}. {opt}" for idx, opt in enumerate(questions[0].options, start=1)
+    )
     assert question_text.endswith(first_opts)
 
     for idx, q in enumerate(questions):
@@ -111,7 +118,11 @@ async def test_curriculum_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     assert completed is True
 
     with db.SessionLocal() as session:
-        progress = session.query(LessonProgress).filter_by(user_id=1, lesson_id=lesson_id).one()
+        progress = (
+            session.query(LessonProgress)
+            .filter_by(user_id=1, lesson_id=lesson_id)
+            .one()
+        )
         assert progress.completed is True
         assert progress.quiz_score == 100
     assert get_metric_value(lessons_completed) == base_completed + 1
@@ -156,7 +167,11 @@ async def test_lesson_without_quiz(monkeypatch: pytest.MonkeyPatch) -> None:
     assert completed is True
 
     with db.SessionLocal() as session:
-        progress = session.query(LessonProgress).filter_by(user_id=1, lesson_id=lesson_id).one()
+        progress = (
+            session.query(LessonProgress)
+            .filter_by(user_id=1, lesson_id=lesson_id)
+            .one()
+        )
         assert progress.completed is True
         assert progress.quiz_score is None
 
@@ -180,13 +195,27 @@ async def test_dynamic_mode_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
-    async def fake_generate(profile: object, slug: str, step_idx: int, prev: object) -> str:
+    async def fake_generate(
+        profile: object,
+        slug: str,
+        step_idx: int,
+        prev: object,
+        *,
+        user_id: int | None = None,
+    ) -> str:
         fake_generate.calls.append(profile)
         return f"step {step_idx}"
 
     fake_generate.calls = []  # type: ignore[attr-defined]
 
-    async def fake_check(profile: object, slug: str, answer: str, last: str) -> tuple[bool, str]:
+    async def fake_check(
+        profile: object,
+        slug: str,
+        answer: str,
+        last: str,
+        *,
+        user_id: int | None = None,
+    ) -> tuple[bool, str]:
         return True, f"fb {answer}"
 
     monkeypatch.setattr(curriculum_engine, "generate_step_text", fake_generate)
@@ -322,7 +351,14 @@ async def test_next_step_dynamic_busy_does_not_increment(
 
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
-    async def fake_generate(profile: object, slug: str, step_idx: int, prev: object) -> str:
+    async def fake_generate(
+        profile: object,
+        slug: str,
+        step_idx: int,
+        prev: object,
+        *,
+        user_id: int | None = None,
+    ) -> str:
         return BUSY_MESSAGE
 
     monkeypatch.setattr(curriculum_engine, "generate_step_text", fake_generate)
@@ -333,7 +369,11 @@ async def test_next_step_dynamic_busy_does_not_increment(
     assert completed is False
 
     with db.SessionLocal() as session:
-        progress = session.query(LessonProgress).filter_by(user_id=1, lesson_id=lesson_id).one()
+        progress = (
+            session.query(LessonProgress)
+            .filter_by(user_id=1, lesson_id=lesson_id)
+            .one()
+        )
         assert progress.current_step == 0
 
 
@@ -358,7 +398,14 @@ async def test_next_step_dynamic_db_error_propagates(
 
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
-    async def fail_generate(profile: object, slug: str, step_idx: int, prev: object) -> str:
+    async def fail_generate(
+        profile: object,
+        slug: str,
+        step_idx: int,
+        prev: object,
+        *,
+        user_id: int | None = None,
+    ) -> str:
         raise SQLAlchemyError("db fail")
 
     monkeypatch.setattr(curriculum_engine, "generate_step_text", fail_generate)
@@ -368,7 +415,11 @@ async def test_next_step_dynamic_db_error_propagates(
         await next_step(1, lesson_id, {})
 
     with db.SessionLocal() as session:
-        progress = session.query(LessonProgress).filter_by(user_id=1, lesson_id=lesson_id).one()
+        progress = (
+            session.query(LessonProgress)
+            .filter_by(user_id=1, lesson_id=lesson_id)
+            .one()
+        )
         assert progress.current_step == 0
 
 
@@ -378,7 +429,9 @@ async def test_next_step_progress_not_found(monkeypatch: pytest.MonkeyPatch) -> 
 
     async def fake_run_db(fn, *args: object, **kwargs: object) -> object:
         class DummySession:
-            def execute(self, *args: object, **kwargs: object) -> object:  # pragma: no cover - helper
+            def execute(
+                self, *args: object, **kwargs: object
+            ) -> object:  # pragma: no cover - helper
                 class DummyResult:
                     def scalar_one_or_none(self) -> None:
                         return None
@@ -404,7 +457,9 @@ async def test_next_step_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -> No
             def __init__(self) -> None:
                 self.calls = 0
 
-            def execute(self, *args: object, **kwargs: object) -> object:  # pragma: no cover - helper
+            def execute(
+                self, *args: object, **kwargs: object
+            ) -> object:  # pragma: no cover - helper
                 self.calls += 1
                 call = self.calls
 
@@ -445,7 +500,14 @@ async def test_next_step_dynamic_exception_does_not_increment(
 
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
-    async def fail_generate(profile: object, slug: str, step_idx: int, prev: object) -> str:
+    async def fail_generate(
+        profile: object,
+        slug: str,
+        step_idx: int,
+        prev: object,
+        *,
+        user_id: int | None = None,
+    ) -> str:
         raise OpenAIError("boom")
 
     monkeypatch.setattr(curriculum_engine, "generate_step_text", fail_generate)
@@ -456,5 +518,9 @@ async def test_next_step_dynamic_exception_does_not_increment(
     assert completed is False
 
     with db.SessionLocal() as session:
-        progress = session.query(LessonProgress).filter_by(user_id=1, lesson_id=lesson_id).one()
+        progress = (
+            session.query(LessonProgress)
+            .filter_by(user_id=1, lesson_id=lesson_id)
+            .one()
+        )
         assert progress.current_step == 0

--- a/tests/learning/test_handlers.py
+++ b/tests/learning/test_handlers.py
@@ -72,7 +72,12 @@ async def test_learning_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     call_count = 0
 
     async def fake_check_user_answer(
-        profile: object, topic: str, answer: str, last_step_text: str
+        profile: object,
+        topic: str,
+        answer: str,
+        last_step_text: str,
+        *,
+        user_id: int | None = None,
     ) -> tuple[bool, str]:
         return True, "<b>✅ feedback</b>"
 
@@ -272,9 +277,7 @@ async def test_static_mode_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
         "settings",
         SimpleNamespace(learning_content_mode="static", learning_mode_enabled=True),
     )
-    monkeypatch.setattr(
-        learning_handlers, "_static_learn_command", fake_learn_command
-    )
+    monkeypatch.setattr(learning_handlers, "_static_learn_command", fake_learn_command)
 
     upd = cast(Update, SimpleNamespace(message=object()))
     ctx = cast(ContextTypes.DEFAULT_TYPE, SimpleNamespace())

--- a/tests/learning/test_handlers_rate_limit.py
+++ b/tests/learning/test_handlers_rate_limit.py
@@ -38,7 +38,12 @@ async def test_lesson_callback_rate_limit(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
 
     async def fake_generate_step_text(
-        profile: object, topic: str, step_idx: int, prev: object
+        profile: object,
+        topic: str,
+        step_idx: int,
+        prev: object,
+        *,
+        user_id: int | None = None,
     ) -> str:
         return "step1"
 

--- a/tests/learning/test_on_any_text.py
+++ b/tests/learning/test_on_any_text.py
@@ -30,7 +30,12 @@ async def test_on_any_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
     called = False
 
     async def fake_check_user_answer(
-        profile: Mapping[str, str | None], topic: str, answer: str, last: str
+        profile: Mapping[str, str | None],
+        topic: str,
+        answer: str,
+        last: str,
+        *,
+        user_id: int | None = None,
     ) -> tuple[bool, str]:
         nonlocal called
         called = True
@@ -39,7 +44,12 @@ async def test_on_any_text_answer(monkeypatch: pytest.MonkeyPatch) -> None:
         return True, "fb"
 
     async def fake_generate_step_text(
-        profile: Mapping[str, str | None], topic: str, step_idx: int, prev: object
+        profile: Mapping[str, str | None],
+        topic: str,
+        step_idx: int,
+        prev: object,
+        *,
+        user_id: int | None = None,
     ) -> str:
         return "next"
 
@@ -74,14 +84,24 @@ async def test_on_any_text_idontknow(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     called = False
 
-    async def fake_assistant_chat(profile: Mapping[str, str | None], text: str) -> str:
+    async def fake_assistant_chat(
+        profile: Mapping[str, str | None],
+        text: str,
+        *,
+        user_id: int | None = None,
+    ) -> str:
         nonlocal called
         called = True
         assert "q" in text
         return "fb"
 
     async def fake_generate_step_text(
-        profile: Mapping[str, str | None], topic: str, step_idx: int, prev: object
+        profile: Mapping[str, str | None],
+        topic: str,
+        step_idx: int,
+        prev: object,
+        *,
+        user_id: int | None = None,
     ) -> str:
         assert prev == "fb"
         return "next"
@@ -118,7 +138,12 @@ async def test_on_any_text_general(monkeypatch: pytest.MonkeyPatch) -> None:
     user_data: dict[str, object] = {}
     called = False
 
-    async def fake_assistant_chat(profile: Mapping[str, str | None], text: str) -> str:
+    async def fake_assistant_chat(
+        profile: Mapping[str, str | None],
+        text: str,
+        *,
+        user_id: int | None = None,
+    ) -> str:
         nonlocal called
         called = True
         assert text == "hello"
@@ -161,14 +186,24 @@ async def test_on_any_text_within_grace(monkeypatch: pytest.MonkeyPatch) -> None
     called = False
 
     async def fake_check_user_answer(
-        profile: Mapping[str, str | None], topic: str, answer: str, last: str
+        profile: Mapping[str, str | None],
+        topic: str,
+        answer: str,
+        last: str,
+        *,
+        user_id: int | None = None,
     ) -> tuple[bool, str]:
         nonlocal called
         called = True
         return True, "fb"
 
     async def fake_generate_step_text(
-        profile: Mapping[str, str | None], topic: str, step_idx: int, prev: object
+        profile: Mapping[str, str | None],
+        topic: str,
+        step_idx: int,
+        prev: object,
+        *,
+        user_id: int | None = None,
     ) -> str:
         return "next"
 


### PR DESCRIPTION
## Summary
- include `user_id` when building learning cache keys and chat completion requests
- thread user context through dynamic tutor and handlers
- adjust tests for new user-aware API

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q --cov`


------
https://chatgpt.com/codex/tasks/task_e_68c483793ef0832a9812d7fe1454546a