### PR TITLE
[dose] Skip calculations for unsupported diabetes types

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -267,6 +267,15 @@ async def dose_sugar(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         user_data.pop("pending_entry", None)
         return END
 
+    diabetes_type = getattr(profile, "diabetes_type", "")
+    if diabetes_type in {"unknown", "t2_no"}:
+        await message.reply_text(
+            "Для указанного типа диабета расчёт дозы недоступен.",
+            reply_markup=build_main_keyboard(),
+        )
+        user_data.pop("pending_entry", None)
+        return END
+
     patient = PatientProfile(
         icr=profile.icr,
         cf=profile.cf,

--- a/services/api/app/diabetes/prompts/__init__.py
+++ b/services/api/app/diabetes/prompts/__init__.py
@@ -22,6 +22,7 @@ def _trim(text: str, limit: int = MAX_PROMPT_LEN) -> str:
 
 # --- Common helpers / disclaimers ---------------------------------------------
 
+
 def disclaimer() -> str:
     """Standard medical warning used across prompts."""
     # Коротко, единообразно: выводим в системном промпте, не дублируем в каждом шаге.
@@ -79,6 +80,7 @@ def _canon_slug(slug: str | None) -> str:
 
 # --- Dynamic prompts -----------------------------------------------------------
 
+
 def build_system_prompt(p: Mapping[str, str | None], task: object | None = None) -> str:
     """Build a system prompt tailored to the user *p* profile."""
     age = (p.get("age_group") or "").strip()
@@ -100,8 +102,11 @@ def build_system_prompt(p: Mapping[str, str | None], task: object | None = None)
         """
     ).strip()
 
-    if diabetes_type == "unknown":
-        prompt += " Тип диабета не определён — избегай тип-специфичных рекомендаций."
+    if diabetes_type in {"unknown", "t2_no"}:
+        prompt += (
+            " Тип диабета не определён или СД2 без инсулина — "
+            "не рассчитывай дозы и избегай тип-специфичных рекомендаций."
+        )
 
     # Единый дисклеймер в системном сообщении
     prompt += f" Предупреждение: {disclaimer()}"

--- a/tests/test_learning_prompts.py
+++ b/tests/test_learning_prompts.py
@@ -80,11 +80,13 @@ def test_build_user_prompt_step_trims_and_ends_with_instruction() -> None:
     assert prompt.endswith("Ответ не показывай.")
 
 
-def test_build_system_prompt_warns_on_unknown_type() -> None:
-    """Include warning when diabetes type is unknown."""
+@pytest.mark.parametrize("dtype", ["unknown", "t2_no"])
+def test_build_system_prompt_warns_on_unknown_or_t2(dtype: str) -> None:
+    """Include warning when diabetes type is unknown or T2 without insulin."""
 
-    prompt = build_system_prompt({"diabetes_type": "unknown"})
-    assert "Тип диабета не определён — избегай тип-специфичных рекомендаций." in prompt
+    prompt = build_system_prompt({"diabetes_type": dtype})
+    assert "не рассчитывай дозы" in prompt
+
 
 def test_system_prompt_avoids_type_specific_mentions_when_unknown() -> None:
     """When diabetes type is unknown no T1/T2 hints appear."""


### PR DESCRIPTION
## Summary
- avoid calculating insulin doses for "unknown" and non-insulin T2 profiles
- warn in system prompts when diabetes type is unknown or T2 without insulin
- cover unsupported diabetes type scenarios with tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c4838c24f0832a8319679aa72dd81f