### PR TITLE
[learning] type progress JSON and add persistence tests

### DIFF
--- a/services/api/app/assistant/services/progress_service.py
+++ b/services/api/app/assistant/services/progress_service.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
-from ...diabetes.models_learning import LearningProgress
+from ...diabetes.models_learning import LearningProgress, ProgressData
 from ...diabetes.services.db import SessionLocal, run_db
 from ...diabetes.services.repository import commit
 from ...types import SessionProtocol
@@ -30,7 +30,7 @@ async def get_progress(user_id: int, plan_id: int) -> LearningProgress | None:
 
 
 async def upsert_progress(
-    user_id: int, plan_id: int, progress_json: dict[str, Any]
+    user_id: int, plan_id: int, progress_json: ProgressData
 ) -> LearningProgress:
     """Insert or update learning progress for a user and plan."""
 
@@ -53,4 +53,3 @@ async def upsert_progress(
         return progress
 
     return await run_db(_upsert, sessionmaker=SessionLocal)
-

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Sequence
+from typing import Optional, Sequence, TypedDict
 from datetime import datetime
 
 import sqlalchemy as sa
@@ -11,9 +11,21 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from .services.db import Base, User
 
 
+class ProgressData(TypedDict):
+    """JSON structure describing learning progress."""
+
+    topic: str
+    module_idx: int
+    step_idx: int
+    snapshot: str | None
+    prev_summary: str | None
+
+
 class LearningPlan(Base):
     __tablename__ = "learning_plans"
-    __table_args__ = (sa.Index("ix_learning_plans_user_id_is_active", "user_id", "is_active"),)
+    __table_args__ = (
+        sa.Index("ix_learning_plans_user_id_is_active", "user_id", "is_active"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(
@@ -21,13 +33,19 @@ class LearningPlan(Base):
         ForeignKey("users.telegram_id", ondelete="CASCADE"),
         nullable=False,
     )
-    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.true())
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa.true()
+    )
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     plan_json: Mapped[list[str]] = mapped_column(
         sa.JSON().with_variant(JSONB, "postgresql"), nullable=False
     )
-    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False)
-    updated_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), onupdate=sa.func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False
+    )
+    updated_at: Mapped[Optional[datetime]] = mapped_column(
+        TIMESTAMP(timezone=True), onupdate=sa.func.now()
+    )
 
     user: Mapped[User] = relationship("User")
     progresses: Mapped[list["LearningProgress"]] = relationship(
@@ -43,12 +61,18 @@ class LearningProgress(Base):
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), nullable=False)
-    plan_id: Mapped[int] = mapped_column(ForeignKey("learning_plans.id"), nullable=False)
-    progress_json: Mapped[dict[str, Any]] = mapped_column(
+    user_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id"), nullable=False
+    )
+    plan_id: Mapped[int] = mapped_column(
+        ForeignKey("learning_plans.id"), nullable=False
+    )
+    progress_json: Mapped[ProgressData] = mapped_column(
         sa.JSON().with_variant(JSONB, "postgresql"), nullable=False, default=dict
     )
-    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False
+    )
     updated_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True),
         server_default=sa.func.now(),
@@ -57,7 +81,9 @@ class LearningProgress(Base):
     )
 
     user: Mapped[User] = relationship("User")
-    plan: Mapped["LearningPlan"] = relationship("LearningPlan", back_populates="progresses")
+    plan: Mapped["LearningPlan"] = relationship(
+        "LearningPlan", back_populates="progresses"
+    )
 
 
 class Lesson(Base):
@@ -67,7 +93,9 @@ class Lesson(Base):
     slug: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
     title: Mapped[str] = mapped_column(String, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
-    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default=sa.true())
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa.true()
+    )
 
     steps: Mapped[list["LessonStep"]] = relationship(
         "LessonStep",
@@ -88,9 +116,13 @@ class QuizQuestion(Base):
     __tablename__ = "quiz_questions"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)
+    lesson_id: Mapped[int] = mapped_column(
+        ForeignKey("lessons.id"), nullable=False, index=True
+    )
     question: Mapped[str] = mapped_column(Text, nullable=False)
-    options: Mapped[Sequence[str]] = mapped_column(sa.JSON().with_variant(JSONB, "postgresql"), nullable=False)
+    options: Mapped[Sequence[str]] = mapped_column(
+        sa.JSON().with_variant(JSONB, "postgresql"), nullable=False
+    )
     correct_option: Mapped[int] = mapped_column(Integer, nullable=False)
 
     lesson: Mapped[Lesson] = relationship("Lesson", back_populates="questions")
@@ -98,10 +130,16 @@ class QuizQuestion(Base):
 
 class LessonStep(Base):
     __tablename__ = "lesson_steps"
-    __table_args__ = (sa.UniqueConstraint("lesson_id", "step_order", name="lesson_steps_lesson_order_key"),)
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "lesson_id", "step_order", name="lesson_steps_lesson_order_key"
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)
+    lesson_id: Mapped[int] = mapped_column(
+        ForeignKey("lessons.id"), nullable=False, index=True
+    )
     step_order: Mapped[int] = mapped_column(Integer, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
 
@@ -110,11 +148,19 @@ class LessonStep(Base):
 
 class LessonProgress(Base):
     __tablename__ = "lesson_progress"
-    __table_args__ = (sa.UniqueConstraint("user_id", "lesson_id", name="lesson_progress_user_lesson_key"),)
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "user_id", "lesson_id", name="lesson_progress_user_lesson_key"
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True)
-    lesson_id: Mapped[int] = mapped_column(ForeignKey("lessons.id"), nullable=False, index=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.telegram_id"), nullable=False, index=True
+    )
+    lesson_id: Mapped[int] = mapped_column(
+        ForeignKey("lessons.id"), nullable=False, index=True
+    )
     completed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     current_step: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     current_question: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
@@ -122,8 +168,6 @@ class LessonProgress(Base):
 
     user: Mapped[User] = relationship("User")
     lesson: Mapped[Lesson] = relationship("Lesson", back_populates="progresses")
-
-
 
 
 class LearningUserProfile(Base):

--- a/tests/assistant/test_e2e_restart.py
+++ b/tests/assistant/test_e2e_restart.py
@@ -13,7 +13,7 @@ from services.api.app.assistant.services import progress_service as progress_rep
 from services.api.app.diabetes.services import db
 from services.api.app.diabetes import learning_handlers
 from services.api.app.diabetes.planner import generate_learning_plan, pretty_plan
-from services.api.app.diabetes.models_learning import LearningProgress
+from services.api.app.diabetes.models_learning import LearningProgress, ProgressData
 
 
 class DummyMessage:
@@ -56,7 +56,13 @@ async def test_restart_restores_step(
     await progress_repo.upsert_progress(
         1,
         plan_id,
-        {"topic": "intro", "module_idx": 0, "step_idx": 2, "snapshot": "Шаг 2"},
+        {
+            "topic": "intro",
+            "module_idx": 0,
+            "step_idx": 2,
+            "snapshot": "Шаг 2",
+            "prev_summary": None,
+        },
     )
 
     update = SimpleNamespace(
@@ -66,6 +72,11 @@ async def test_restart_restores_step(
     monkeypatch.setattr(learning_handlers, "build_main_keyboard", lambda: None)
     monkeypatch.setattr(learning_handlers.settings, "learning_mode_enabled", True)
     monkeypatch.setattr(learning_handlers.settings, "learning_content_mode", "dynamic")
+
+    async def fake_get_profile(_uid: int) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers, "get_learning_profile", fake_get_profile)
 
     await learning_handlers.plan_command(update, context)
     state = learning_handlers.get_state(context.user_data)
@@ -150,7 +161,7 @@ async def test_hydrate_generates_snapshot_and_persists(
     orig_upsert = progress_repo.upsert_progress
 
     async def spy_upsert(
-        user_id: int, plan_id: int, progress_json: dict[str, Any]
+        user_id: int, plan_id: int, progress_json: ProgressData
     ) -> Any:
         calls.append(progress_json.copy())
         return await orig_upsert(user_id, plan_id, progress_json)

--- a/tests/assistant/test_hydration.py
+++ b/tests/assistant/test_hydration.py
@@ -14,6 +14,7 @@ from services.api.app.assistant.repositories import plans as plans_repo
 from services.api.app.assistant.services import progress_service as progress_repo
 from services.api.app.diabetes import learning_handlers
 from services.api.app.diabetes.services import db
+from services.api.app.diabetes.models_learning import ProgressData
 
 
 class DummyBot(Bot):
@@ -66,7 +67,15 @@ async def test_hydration_restores_state(monkeypatch: pytest.MonkeyPatch) -> None
         session.commit()
     plan_id = await plans_repo.create_plan(1, version=1, plan_json=["p1"])
     await progress_repo.upsert_progress(
-        1, plan_id, {"topic": "t1", "module_idx": 2, "step_idx": 3}
+        1,
+        plan_id,
+        {
+            "topic": "t1",
+            "module_idx": 2,
+            "step_idx": 3,
+            "snapshot": None,
+            "prev_summary": None,
+        },
     )
 
     bot = DummyBot()
@@ -139,7 +148,15 @@ async def test_hydration_busy_message(monkeypatch: pytest.MonkeyPatch) -> None:
         session.commit()
     plan_id = await plans_repo.create_plan(1, version=1, plan_json=["p1"])
     await progress_repo.upsert_progress(
-        1, plan_id, {"topic": "t1", "module_idx": 2, "step_idx": 3}
+        1,
+        plan_id,
+        {
+            "topic": "t1",
+            "module_idx": 2,
+            "step_idx": 3,
+            "snapshot": None,
+            "prev_summary": None,
+        },
     )
 
     bot = DummyBot()
@@ -187,7 +204,9 @@ async def test_hydration_busy_message(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "upsert" not in called
     assert "lesson" not in called
     assert learning_handlers.get_state(app.user_data[1]) is None
-    progress_map = cast(dict[int, Any], app.bot_data[learning_handlers.PROGRESS_KEY])
-    assert "snapshot" not in progress_map[1]
+    progress_map = cast(
+        dict[int, ProgressData], app.bot_data[learning_handlers.PROGRESS_KEY]
+    )
+    assert progress_map[1]["snapshot"] is None
 
     await app.shutdown()

--- a/tests/assistant/test_progress_repo.py
+++ b/tests/assistant/test_progress_repo.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from services.api.app.assistant.services import progress_service as progress
-from services.api.app.diabetes.models_learning import LearningPlan
+from services.api.app.diabetes.models_learning import LearningPlan, ProgressData
 from services.api.app.diabetes.services import db
 
 
@@ -41,15 +41,29 @@ async def test_get_and_upsert(session_local: sessionmaker[Session]) -> None:
 
     assert await progress.get_progress(1, plan_id) is None
 
-    prog = await progress.upsert_progress(1, plan_id, {"step": 1})
-    assert prog.progress_json == {"step": 1}
+    data1: ProgressData = {
+        "topic": "t",
+        "module_idx": 0,
+        "step_idx": 1,
+        "snapshot": None,
+        "prev_summary": None,
+    }
+    prog = await progress.upsert_progress(1, plan_id, data1)
+    assert prog.progress_json == data1
 
     fetched = await progress.get_progress(1, plan_id)
     assert fetched is not None
-    assert fetched.progress_json == {"step": 1}
+    assert fetched.progress_json == data1
 
-    prog2 = await progress.upsert_progress(1, plan_id, {"step": 2})
-    assert prog2.progress_json == {"step": 2}
+    data2: ProgressData = {
+        "topic": "t",
+        "module_idx": 0,
+        "step_idx": 2,
+        "snapshot": None,
+        "prev_summary": None,
+    }
+    prog2 = await progress.upsert_progress(1, plan_id, data2)
+    assert prog2.progress_json == data2
     fetched2 = await progress.get_progress(1, plan_id)
     assert fetched2 is not None
-    assert fetched2.progress_json == {"step": 2}
+    assert fetched2.progress_json == data2

--- a/tests/diabetes/test_curriculum_not_found.py
+++ b/tests/diabetes/test_curriculum_not_found.py
@@ -14,6 +14,7 @@ from services.api.app.diabetes.curriculum_engine import (
 import services.api.app.diabetes.learning_handlers as handlers
 from services.api.app.diabetes.learning_state import get_state
 from tests.utils.telegram import make_context, make_update
+from services.api.app.diabetes.models_learning import ProgressData
 
 dynamic_handlers = handlers
 
@@ -112,7 +113,7 @@ async def test_learn_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) -
         return None
 
     async def fake_upsert_progress(
-        user_id: int, plan_id: int, data: Mapping[str, Any]
+        user_id: int, plan_id: int, data: ProgressData
     ) -> None:
         return None
 
@@ -194,7 +195,7 @@ async def test_lesson_command_lesson_not_found(monkeypatch: pytest.MonkeyPatch) 
         return None
 
     async def fake_upsert_progress(
-        user_id: int, plan_id: int, data: Mapping[str, Any]
+        user_id: int, plan_id: int, data: ProgressData
     ) -> None:
         return None
 

--- a/tests/learning/test_progress_persistence.py
+++ b/tests/learning/test_progress_persistence.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from services.api.app.diabetes import learning_handlers
+from services.api.app.diabetes.learning_state import LearnState, set_state
+from services.api.app.diabetes.models_learning import ProgressData
+
+
+@pytest.mark.asyncio
+async def test_persist_saves_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    user_data: dict[str, Any] = {
+        "learning_plan": ["a"],
+        "learning_plan_id": 1,
+        "learning_module_idx": 3,
+    }
+    state = LearnState(topic="intro", step=2, last_step_text="s", prev_summary="p")
+    set_state(user_data, state)
+    bot_data: dict[str, object] = {}
+
+    calls: list[tuple[int, int, ProgressData]] = []
+
+    async def fake_update_plan(plan_id: int, plan_json: list[str]) -> None:
+        return None
+
+    async def fake_upsert(uid: int, pid: int, data: ProgressData) -> None:
+        calls.append((uid, pid, data))
+
+    monkeypatch.setattr(learning_handlers.plans_repo, "update_plan", fake_update_plan)
+    monkeypatch.setattr(learning_handlers.progress_repo, "upsert_progress", fake_upsert)
+
+    await learning_handlers._persist(1, user_data, bot_data)
+
+    expected: ProgressData = {
+        "topic": "intro",
+        "module_idx": 3,
+        "step_idx": 2,
+        "snapshot": "s",
+        "prev_summary": "p",
+    }
+    progress_map = bot_data[learning_handlers.PROGRESS_KEY]
+    assert progress_map == {1: expected}
+    assert calls == [(1, 1, expected)]
+
+
+@pytest.mark.asyncio
+async def test_hydrate_loads_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = ["a", "b"]
+    progress: ProgressData = {
+        "topic": "intro",
+        "module_idx": 1,
+        "step_idx": 1,
+        "snapshot": "snap",
+        "prev_summary": None,
+    }
+
+    async def fake_get_active_plan(user_id: int) -> Any:
+        return SimpleNamespace(id=1, plan_json=plan)
+
+    async def fake_get_progress(user_id: int, plan_id: int) -> Any:
+        return SimpleNamespace(progress_json=progress)
+
+    async def fake_get_profile(user_id: int) -> None:
+        return None
+
+    monkeypatch.setattr(
+        learning_handlers.plans_repo, "get_active_plan", fake_get_active_plan
+    )
+    monkeypatch.setattr(
+        learning_handlers.progress_repo, "get_progress", fake_get_progress
+    )
+    monkeypatch.setattr(learning_handlers, "get_learning_profile", fake_get_profile)
+
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1), effective_message=None
+    )
+    context = SimpleNamespace(user_data={}, bot_data={})
+
+    ok = await learning_handlers._hydrate(update, context)
+    assert ok is True
+
+    state = learning_handlers.get_state(context.user_data)
+    assert state is not None
+    assert state.topic == "intro"
+    assert state.step == 1
+    assert state.last_step_text == "snap"
+    assert context.user_data["learning_plan"] == plan
+    assert context.user_data["learning_plan_index"] == 0
+    assert context.user_data["learning_plan_id"] == 1


### PR DESCRIPTION
## Summary
- introduce `ProgressData` typed dict for learning progress and use it in models and services
- adjust learning handlers to work with typed progress data
- add tests for saving and hydrating progress

## Testing
- `ruff check services/api/app/assistant/services/progress_service.py services/api/app/diabetes/learning_handlers.py services/api/app/diabetes/models_learning.py tests/assistant/test_e2e_restart.py tests/assistant/test_hydration.py tests/assistant/test_progress_repo.py tests/assistant/test_progress_service.py tests/diabetes/test_curriculum_not_found.py tests/learning/test_progress_persistence.py`
- `mypy --strict services/api/app/assistant/services/progress_service.py`
- `mypy --strict services/api/app/diabetes/learning_handlers.py`
- `mypy --strict services/api/app/diabetes/models_learning.py`
- `mypy --strict tests/assistant/test_e2e_restart.py`
- `mypy --strict tests/assistant/test_hydration.py`
- `mypy --strict tests/assistant/test_progress_repo.py`
- `mypy --strict tests/assistant/test_progress_service.py`
- `mypy --strict tests/diabetes/test_curriculum_not_found.py`
- `mypy --strict tests/learning/test_progress_persistence.py`
- `pytest tests/learning/test_progress_persistence.py tests/assistant/test_progress_repo.py tests/assistant/test_progress_service.py tests/assistant/test_e2e_restart.py tests/assistant/test_hydration.py tests/diabetes/test_curriculum_not_found.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4fbb46eb4832a9d45802f49517d01