### PR TITLE
[handlers] Handle send_message runtime errors

### DIFF
--- a/services/api/app/diabetes/handlers/photo_handlers.py
+++ b/services/api/app/diabetes/handlers/photo_handlers.py
@@ -6,7 +6,6 @@ import html
 import io
 import logging
 from collections.abc import MutableMapping
-from types import MappingProxyType
 from typing import cast
 
 from openai import OpenAIError
@@ -62,17 +61,13 @@ def _get_mutable_user_data(context: ContextTypes.DEFAULT_TYPE) -> UserData:
     return data
 
 
-async def _delete_status_message(
-    status_message: Message | None, tag: str
-) -> None:
+async def _delete_status_message(status_message: Message | None, tag: str) -> None:
     if not status_message or not hasattr(status_message, "delete"):
         return
     try:
         await status_message.delete()
     except TelegramError as exc:
-        logger.warning(
-            "[PHOTO][%s] Failed to delete status message: %s", tag, exc
-        )
+        logger.warning("[PHOTO][%s] Failed to delete status message: %s", tag, exc)
     except OSError as exc:
         logger.exception("[PHOTO][%s] OS error: %s", tag, exc)
         raise
@@ -83,9 +78,7 @@ async def photo_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     message = update.message
     if message is None:
         return
-    await message.reply_text(
-        "📸 Пришлите фото блюда для анализа.", reply_markup=build_main_keyboard()
-    )
+    await message.reply_text("📸 Пришлите фото блюда для анализа.", reply_markup=build_main_keyboard())
 
 
 async def photo_handler(
@@ -110,10 +103,7 @@ async def photo_handler(
     flag_ts = user_data.get(WAITING_GPT_TIMESTAMP)
     now = datetime.datetime.now(datetime.timezone.utc)
     if user_data.get(WAITING_GPT_FLAG):
-        if (
-            isinstance(flag_ts, datetime.datetime)
-            and now - flag_ts > WAITING_GPT_TIMEOUT
-        ):
+        if isinstance(flag_ts, datetime.datetime) and now - flag_ts > WAITING_GPT_TIMEOUT:
             _clear_waiting_gpt(context)
         else:
             await message.reply_text("⏳ Уже обрабатываю фото, подождите…")
@@ -170,22 +160,20 @@ async def photo_handler(
             )
         except asyncio.TimeoutError:
             logger.warning("[PHOTO] GPT request timed out")
-            await message.reply_text(
-                "⚠️ Превышено время ожидания ответа. Попробуйте ещё раз."
-            )
+            await message.reply_text("⚠️ Превышено время ожидания ответа. Попробуйте ещё раз.")
             return END
-        status_message = await message.reply_text(
-            "🔍 Анализирую фото (это займёт 5‑10 с)…"
-        )
+        except (RuntimeError, httpx.HTTPError) as exc:
+            logger.exception("[PHOTO] Failed to send message: %s", exc)
+            await message.reply_text("⚠️ Vision не смог обработать фото. Попробуйте ещё раз.")
+            return END
+        status_message = await message.reply_text("🔍 Анализирую фото (это займёт 5‑10 с)…")
         chat_id = getattr(message, "chat_id", None)
 
         async def send_typing_action() -> None:
             if not chat_id:
                 return
             try:
-                await context.bot.send_chat_action(
-                    chat_id=chat_id, action=ChatAction.TYPING
-                )
+                await context.bot.send_chat_action(chat_id=chat_id, action=ChatAction.TYPING)
             except TelegramError as exc:
                 logger.warning(
                     "[PHOTO][TYPING_ACTION] Failed to send typing action: %s",
@@ -218,35 +206,25 @@ async def photo_handler(
             except asyncio.TimeoutError:
                 logger.warning("[PHOTO][RUN_RETRIEVE] Timed out retrieving run")
                 await _delete_status_message(status_message, "RUN_RETRIEVE_DELETE")
-                await message.reply_text(
-                    "⚠️ Превышено время ожидания Vision. Попробуйте ещё раз."
-                )
+                await message.reply_text("⚠️ Превышено время ожидания Vision. Попробуйте ещё раз.")
                 return END
             except (OpenAIError, httpx.HTTPError) as exc:
-                logger.exception(
-                    "[PHOTO][RUN_RETRIEVE] Failed to retrieve run: %s", exc
-                )
+                logger.exception("[PHOTO][RUN_RETRIEVE] Failed to retrieve run: %s", exc)
                 await _delete_status_message(status_message, "RUN_RETRIEVE_DELETE")
-                await message.reply_text(
-                    "⚠️ Vision не смог обработать фото. Попробуйте ещё раз."
-                )
+                await message.reply_text("⚠️ Vision не смог обработать фото. Попробуйте ещё раз.")
                 return END
             if attempt == warn_after:
                 await send_typing_action()
         else:
             await _delete_status_message(status_message, "TIMEOUT_DELETE")
-            await message.reply_text(
-                "⚠️ Время ожидания Vision истекло. Попробуйте позже."
-            )
+            await message.reply_text("⚠️ Время ожидания Vision истекло. Попробуйте позже.")
             return END
 
         if run.status != "completed":
             logger.error("[VISION][RUN_FAILED] run.status=%s", run.status)
             if status_message and hasattr(status_message, "edit_text"):
                 try:
-                    await status_message.edit_text(
-                        "⚠️ Vision не смог обработать фото. Попробуйте ещё раз."
-                    )
+                    await status_message.edit_text("⚠️ Vision не смог обработать фото. Попробуйте ещё раз.")
                 except TelegramError as exc:
                     logger.warning(
                         "[PHOTO][RUN_FAILED_EDIT] Failed to send Vision failure notice: %s",
@@ -259,9 +237,7 @@ async def photo_handler(
                     )
                     raise
             else:
-                await message.reply_text(
-                    "⚠️ Vision не смог обработать фото. Попробуйте ещё раз."
-                )
+                await message.reply_text("⚠️ Vision не смог обработать фото. Попробуйте ещё раз.")
             return END
 
         try:
@@ -351,13 +327,7 @@ async def photo_handler(
             notice = "⚠️ Ответ Vision слишком длинный, полный текст во вложении."
             max_len = max(
                 0,
-                MessageLimit.MAX_TEXT_LENGTH
-                - len(prefix)
-                - len("\n\n")
-                - len(notice)
-                - len("\n\n")
-                - len(suffix)
-                - 3,
+                MessageLimit.MAX_TEXT_LENGTH - len(prefix) - len("\n\n") - len(notice) - len("\n\n") - len(suffix) - 3,
             )
             truncated = vision_text[:max_len] + "..."
             await message.reply_document(
@@ -370,15 +340,11 @@ async def photo_handler(
 
     except OSError as exc:
         logger.exception("[PHOTO] File processing error: %s", exc)
-        await message.reply_text(
-            "⚠️ Ошибка при обработке файла изображения. Попробуйте ещё раз."
-        )
+        await message.reply_text("⚠️ Ошибка при обработке файла изображения. Попробуйте ещё раз.")
         return END
     except OpenAIError as exc:
         logger.exception("[PHOTO] Vision API error: %s", exc)
-        await message.reply_text(
-            "⚠️ Vision не смог обработать фото. Попробуйте ещё раз."
-        )
+        await message.reply_text("⚠️ Vision не смог обработать фото. Попробуйте ещё раз.")
         return END
     except ValueError as exc:
         logger.exception("[PHOTO] Parsing error: %s", exc)

--- a/tests/test_photo_handler_send_message_errors.py
+++ b/tests/test_photo_handler_send_message_errors.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from typing import Any, Type, cast
+
+import httpx
+import pytest
+from telegram import Update
+from telegram.ext import CallbackContext
+
+import services.api.app.diabetes.handlers.photo_handlers as photo_handlers
+
+
+class DummyPhoto:
+    file_id = "fid"
+    file_unique_id = "uid"
+
+
+class DummyMessage:
+    def __init__(self) -> None:
+        self.photo = (DummyPhoto(),)
+        self.texts: list[str] = []
+
+    async def reply_text(self, text: str, **kwargs: Any) -> None:
+        self.texts.append(text)
+
+
+async def fake_get_file(file_id: str) -> Any:
+    class File:
+        async def download_as_bytearray(self) -> bytearray:
+            return bytearray(b"img")
+
+    return File()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc_cls", [RuntimeError, httpx.HTTPError])
+async def test_photo_handler_send_message_errors(monkeypatch: pytest.MonkeyPatch, exc_cls: Type[Exception]) -> None:
+    message = DummyMessage()
+    update = cast(Update, SimpleNamespace(message=message, effective_user=SimpleNamespace(id=1)))
+    dummy_bot = SimpleNamespace(get_file=fake_get_file)
+    context = cast(
+        CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
+        SimpleNamespace(bot=dummy_bot, user_data={"thread_id": "tid"}),
+    )
+
+    async def fake_send_message(**kwargs: Any) -> Any:
+        raise exc_cls("boom")
+
+    monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
+
+    result = await photo_handlers.photo_handler(update, context)
+
+    assert result == photo_handlers.END
+    assert message.texts == ["⚠️ Vision не смог обработать фото. Попробуйте ещё раз."]
+    assert context.user_data is not None
+    assert photo_handlers.WAITING_GPT_FLAG not in context.user_data
+    assert photo_handlers.WAITING_GPT_TIMESTAMP not in context.user_data


### PR DESCRIPTION
## Summary
- handle `RuntimeError` and `httpx.HTTPError` when sending photos to GPT
- test send_message errors clear waiting flag and warn user

## Testing
- `pytest --cov -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c50abfc458832aae82bc8785397af9