### PR TITLE
[auth] Remove redundant init_data check

### DIFF
--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -106,9 +106,7 @@ def require_tg_user(
             init_data = authorization[3:]
         else:
             raise HTTPException(status_code=401, detail="missing init data")
-    if init_data is None:
-        raise HTTPException(status_code=401, detail="missing init data")
-    return get_tg_user(init_data)
+    return get_tg_user(cast(str, init_data))
 
 
 def check_token(authorization: str | None = Header(None)) -> UserContext:


### PR DESCRIPTION
## Summary
- remove unnecessary init_data None check in `require_tg_user`
- cast validated init_data to str when retrieving Telegram user

## Testing
- `ruff check services/api/app/telegram_auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68c50af44554832ab8b35800ceb54807