### PR TITLE
[gpt_command_parser] Handle truncated JSON fragments gracefully

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -94,7 +94,6 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
     start = -1
     braces = 0
     brackets = 0
-    saw_closing = False
 
     def search_dict(obj: object) -> dict[str, object] | None:
         queue: deque[object] = deque([obj])
@@ -127,18 +126,17 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
             quote = ch
             i += 1
             continue
-        if ch == '{' or ch == '[':
+        if ch == "{" or ch == "[":
             if braces == 0 and brackets == 0:
                 start = i
-            if ch == '{':
+            if ch == "{":
                 braces += 1
             else:
                 brackets += 1
-        elif ch == '}' or ch == ']':
-            saw_closing = True
-            if ch == '}' and braces > 0:
+        elif ch == "}" or ch == "]":
+            if ch == "}" and braces > 0:
                 braces -= 1
-            elif ch == ']' and brackets > 0:
+            elif ch == "]" and brackets > 0:
                 brackets -= 1
             else:
                 start = -1
@@ -151,7 +149,6 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
                 try:
                     obj = json.loads(segment)
                 except json.JSONDecodeError:
-                    saw_closing = True
                     start += 1
                     i = start
                     braces = 0
@@ -164,7 +161,7 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
         i += 1
 
     if start != -1:
-        return {} if saw_closing else None
+        return None
     return None
 
 

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -602,7 +602,7 @@ def test_extract_first_json_multiple_objects_no_space() -> None:
 
 def test_extract_first_json_malformed_input() -> None:
     text = '{"action":"add_entry","fields":{}'
-    assert gpt_command_parser._extract_first_json(text) == {}
+    assert gpt_command_parser._extract_first_json(text) is None
 
 
 def test_extract_first_json_simple_object() -> None:
@@ -758,6 +758,11 @@ def test_extract_first_json_returns_none_when_json_beyond_limit() -> None:
     assert time.perf_counter() - start < 0.1
 
 
+def test_extract_first_json_truncated_fragment_returns_none() -> None:
+    text = '{"action":"add_entry","fields":{'
+    assert gpt_command_parser._extract_first_json(text) is None
+
+
 @pytest.mark.asyncio
 async def test_parse_command_with_multiple_jsons(
     monkeypatch: pytest.MonkeyPatch,
@@ -820,4 +825,4 @@ async def test_parse_command_with_malformed_json(
         result = await gpt_command_parser.parse_command("test")
 
     assert result is None
-    assert "Command validation failed" in caplog.text
+    assert "No JSON object found in response" in caplog.text


### PR DESCRIPTION
## Summary
- Return `None` from `_extract_first_json` when JSON is incomplete instead of `{}`
- Skip validation in `parse_command` when no JSON object is found
- Cover truncated responses with new unit tests

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check services/api/app/diabetes/gpt_command_parser.py tests/test_gpt_command_parser.py`
- `pytest -q tests/test_gpt_command_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68c50af671ac832ab39e77f4ceeb7f12