### PR TITLE
[gpt_client] expand learning cache key with context

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -1,6 +1,7 @@
 # gpt_client.py
 
 import asyncio
+import hashlib
 import io
 import logging
 import os
@@ -53,15 +54,33 @@ _async_client_locks: WeakKeyDictionary[AbstractEventLoop, asyncio.Lock] = WeakKe
 
 _learning_router = LLMRouter()
 
-CacheKey = tuple[str, str, str]
+CacheKey = tuple[str, str, str, str, str, str, str, str]
 
 _learning_cache: OrderedDict[CacheKey, tuple[str, float]] = OrderedDict()
 _learning_cache_lock = threading.Lock()
 
 
-def _make_cache_key(model: str, system: str, user: str) -> CacheKey:
-    """Create a hashable cache key from model and prompts."""
-    return model, system, user
+def _make_cache_key(
+    model: str,
+    system: str,
+    user: str,
+    user_id: str | None,
+    plan_id: str | None,
+    topic_slug: str | None,
+    step_idx: int | None,
+    last_reply_hash: str,
+) -> CacheKey:
+    """Create a hashable cache key from model, prompts and context."""
+    return (
+        model,
+        system,
+        user,
+        user_id or "",
+        plan_id or "",
+        topic_slug or "",
+        str(step_idx) if step_idx is not None else "",
+        last_reply_hash,
+    )
 
 
 def _get_client() -> OpenAI:
@@ -215,12 +234,18 @@ async def create_learning_chat_completion(
     temperature: float | None = None,
     max_tokens: int | None = None,
     timeout: float | httpx.Timeout | None = None,
+    user_id: str | None = None,
+    plan_id: str | None = None,
+    topic_slug: str | None = None,
+    step_idx: int | None = None,
+    last_reply: str | None = None,
 ) -> str:
     """Create and format a chat completion for learning tasks."""
     model = _learning_router.choose_model(task)
     msg_list = list(messages)
     system = ""
     user = ""
+    assistant_text = last_reply or ""
     for msg in msg_list:
         mapping = cast(Mapping[str, object], msg)
         role = mapping.get("role")
@@ -228,11 +253,42 @@ async def create_learning_chat_completion(
             system = str(mapping.get("content", ""))
         elif role == "user" and not user:
             user = str(mapping.get("content", ""))
+        elif role == "assistant":
+            assistant_text = str(mapping.get("content", ""))
+        if user_id is None:
+            uid = mapping.get("user_id")
+            if isinstance(uid, str):
+                user_id = uid
+        if plan_id is None:
+            pid = mapping.get("plan_id")
+            if isinstance(pid, str):
+                plan_id = pid
+        if topic_slug is None:
+            ts = mapping.get("topic_slug")
+            if isinstance(ts, str):
+                topic_slug = ts
+        if step_idx is None:
+            si = mapping.get("step_idx")
+            if isinstance(si, int):
+                step_idx = si
+            elif isinstance(si, str) and si.isdigit():
+                step_idx = int(si)
+    last_hash = (
+        hashlib.sha256(assistant_text.encode("utf-8")).hexdigest()
+        if assistant_text
+        else ""
+    )
     settings = config.get_settings()
-    cache_key = _make_cache_key(model, system, user)
+    cache_key = _make_cache_key(
+        model, system, user, user_id, plan_id, topic_slug, step_idx, last_hash
+    )
     if settings.learning_prompt_cache:
         now = time.time()
         with _learning_cache_lock:
+            if _learning_cache:
+                first_key = next(iter(_learning_cache))
+                if len(first_key) < len(cache_key):
+                    _learning_cache.clear()
             cached = _learning_cache.get(cache_key)
             if cached is not None:
                 reply, ts = cached

--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -111,7 +111,8 @@ def require_tg_user(
             init_data = authorization[3:]
         else:
             raise HTTPException(status_code=401, detail="missing init data")
-    return get_tg_user(cast(str, init_data))
+    assert init_data is not None
+    return get_tg_user(init_data)
 
 
 def check_token(authorization: str | None = Header(None)) -> UserContext:

--- a/tests/test_learning_prompt_cache.py
+++ b/tests/test_learning_prompt_cache.py
@@ -129,30 +129,59 @@ async def test_learning_cache_key_components(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(gpt_client, "_learning_cache", OrderedDict())
 
     msg_base = [
-        {"role": "system", "content": "sys1"},
+        {
+            "role": "system",
+            "content": "sys1",
+            "user_id": "u1",
+            "plan_id": "p1",
+            "topic_slug": "t1",
+            "step_idx": 1,
+        },
         {"role": "user", "content": "u1"},
     ]
 
     # initial call populates cache
-    await gpt_client.create_learning_chat_completion(task=LLMTask.EXPLAIN_STEP, messages=msg_base)
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_base
+    )
     # same prompts => hit
-    await gpt_client.create_learning_chat_completion(task=LLMTask.EXPLAIN_STEP, messages=msg_base)
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_base
+    )
     assert call_count == 1
 
     # different system prompt => miss
     msg_system = [
-        {"role": "system", "content": "sys2"},
+        {
+            "role": "system",
+            "content": "sys2",
+            "user_id": "u1",
+            "plan_id": "p1",
+            "topic_slug": "t1",
+            "step_idx": 1,
+        },
         {"role": "user", "content": "u1"},
     ]
-    await gpt_client.create_learning_chat_completion(task=LLMTask.EXPLAIN_STEP, messages=msg_system)
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_system
+    )
     assert call_count == 2
 
     # different user prompt => miss
     msg_user = [
-        {"role": "system", "content": "sys1"},
+        {
+            "role": "system",
+            "content": "sys1",
+            "user_id": "u1",
+            "plan_id": "p1",
+            "topic_slug": "t1",
+            "step_idx": 1,
+        },
         {"role": "user", "content": "u2"},
     ]
-    await gpt_client.create_learning_chat_completion(task=LLMTask.EXPLAIN_STEP, messages=msg_user)
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_user
+    )
     assert call_count == 3
 
     # different model => miss
@@ -162,9 +191,75 @@ async def test_learning_cache_key_components(monkeypatch: pytest.MonkeyPatch) ->
         gpt_client.LLMRouter("m2"),
         raising=False,
     )
-    await gpt_client.create_learning_chat_completion(task=LLMTask.EXPLAIN_STEP, messages=msg_base)
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_base
+    )
 
-    assert call_count == 4
+    # different user_id => miss
+    msg_uid = [
+        {
+            "role": "system",
+            "content": "sys1",
+            "user_id": "u2",
+            "plan_id": "p1",
+            "topic_slug": "t1",
+            "step_idx": 1,
+        },
+        {"role": "user", "content": "u1"},
+    ]
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_uid
+    )
+
+    # different plan_id => miss
+    msg_plan = [
+        {
+            "role": "system",
+            "content": "sys1",
+            "user_id": "u1",
+            "plan_id": "p2",
+            "topic_slug": "t1",
+            "step_idx": 1,
+        },
+        {"role": "user", "content": "u1"},
+    ]
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_plan
+    )
+
+    # different topic_slug => miss
+    msg_topic = [
+        {
+            "role": "system",
+            "content": "sys1",
+            "user_id": "u1",
+            "plan_id": "p1",
+            "topic_slug": "t2",
+            "step_idx": 1,
+        },
+        {"role": "user", "content": "u1"},
+    ]
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_topic
+    )
+
+    # different step_idx => miss
+    msg_step = [
+        {
+            "role": "system",
+            "content": "sys1",
+            "user_id": "u1",
+            "plan_id": "p1",
+            "topic_slug": "t1",
+            "step_idx": 2,
+        },
+        {"role": "user", "content": "u1"},
+    ]
+    await gpt_client.create_learning_chat_completion(
+        task=LLMTask.EXPLAIN_STEP, messages=msg_step
+    )
+
+    assert call_count == 8
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- extend learning cache key with user, plan, topic, step and last reply hash
- derive context in `create_learning_chat_completion` and clear old cache entries
- expand tests to ensure cache differentiates user, plan and step
- remove redundant cast in `telegram_auth.py` flagged by mypy

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c50ef68ec0832a878120802cca3df8