### PR TITLE
[learning] Handle affirmative quiz answers

### DIFF
--- a/tests/learning/test_check_user_answer.py
+++ b/tests/learning/test_check_user_answer.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from services.api.app.diabetes import dynamic_tutor
+
+
+@pytest.mark.asyncio
+async def test_affirmative_skips_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fail_call(**_: object) -> str:
+        raise AssertionError("LLM should not be called")
+
+    monkeypatch.setattr(dynamic_tutor, "create_learning_chat_completion", fail_call)
+
+    correct, feedback = await dynamic_tutor.check_user_answer({}, "t", "да", "step")
+
+    assert correct is True
+    assert feedback.startswith("✅")


### PR DESCRIPTION
## Summary
- add `is_affirmative` helper and early exit in `check_user_answer`
- skip LLM call for explicit confirmations like "да" or "yes"
- test affirmative answers advance learning step

## Testing
- `pytest tests/learning/test_check_user_answer.py tests/learning/test_dynamic_tutor.py tests/test_dynamic_tutor.py --cov=services.api.app.diabetes.dynamic_tutor --cov-report=term-missing --cov-fail-under=85 -q`
- `mypy --strict .` *(fails: Redundant cast to "str" in services/api/app/telegram_auth.py)*
- `mypy --strict services/api/app/diabetes/dynamic_tutor.py tests/learning/test_check_user_answer.py`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c50f0a782c832abe08f78fbd672781