### PR TITLE
[learning] Track last sent step

### DIFF
--- a/services/api/alembic/versions/20251018_add_last_sent_step_id.py
+++ b/services/api/alembic/versions/20251018_add_last_sent_step_id.py
@@ -1,0 +1,52 @@
+"""add last_sent_step_id to learning_progress"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "20251018_add_last_sent_step_id"
+down_revision: Union[str, None] = "20251017_add_assistant_memory_last_mode"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    progress = sa.table(
+        "learning_progress",
+        sa.column("id", sa.Integer),
+        sa.column("progress_json", sa.JSON()),
+    )
+    rows = bind.execute(sa.select(progress.c.id, progress.c.progress_json)).fetchall()
+    for row in rows:
+        data = dict(row.progress_json or {})
+        if "last_sent_step_id" not in data:
+            data["last_sent_step_id"] = None
+            bind.execute(
+                sa.update(progress)
+                .where(progress.c.id == row.id)
+                .values(progress_json=data)
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    progress = sa.table(
+        "learning_progress",
+        sa.column("id", sa.Integer),
+        sa.column("progress_json", sa.JSON()),
+    )
+    rows = bind.execute(sa.select(progress.c.id, progress.c.progress_json)).fetchall()
+    for row in rows:
+        data = dict(row.progress_json or {})
+        if "last_sent_step_id" in data:
+            data.pop("last_sent_step_id", None)
+            bind.execute(
+                sa.update(progress)
+                .where(progress.c.id == row.id)
+                .values(progress_json=data)
+            )

--- a/services/api/app/diabetes/learning_state.py
+++ b/services/api/app/diabetes/learning_state.py
@@ -14,6 +14,7 @@ class LearnState:
     step: int
     last_step_text: str | None = None
     prev_summary: str | None = None
+    last_sent_step_id: int | None = None
     awaiting: bool = True
     last_step_at: float = 0.0
 

--- a/services/api/app/diabetes/models_learning.py
+++ b/services/api/app/diabetes/models_learning.py
@@ -19,6 +19,7 @@ class ProgressData(TypedDict):
     step_idx: int
     snapshot: str | None
     prev_summary: str | None
+    last_sent_step_id: int | None
 
 
 class LearningPlan(Base):

--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -111,7 +111,8 @@ def require_tg_user(
             init_data = authorization[3:]
         else:
             raise HTTPException(status_code=401, detail="missing init data")
-    return get_tg_user(cast(str, init_data))
+    assert init_data is not None
+    return get_tg_user(init_data)
 
 
 def check_token(authorization: str | None = Header(None)) -> UserContext:

--- a/tests/assistant/test_e2e_restart.py
+++ b/tests/assistant/test_e2e_restart.py
@@ -62,6 +62,7 @@ async def test_restart_restores_step(
             "step_idx": 2,
             "snapshot": "Шаг 2",
             "prev_summary": None,
+            "last_sent_step_id": None,
         },
     )
 

--- a/tests/assistant/test_hydration.py
+++ b/tests/assistant/test_hydration.py
@@ -75,6 +75,7 @@ async def test_hydration_restores_state(monkeypatch: pytest.MonkeyPatch) -> None
             "step_idx": 3,
             "snapshot": None,
             "prev_summary": None,
+            "last_sent_step_id": None,
         },
     )
 
@@ -156,6 +157,7 @@ async def test_hydration_busy_message(monkeypatch: pytest.MonkeyPatch) -> None:
             "step_idx": 3,
             "snapshot": None,
             "prev_summary": None,
+            "last_sent_step_id": None,
         },
     )
 

--- a/tests/assistant/test_progress_repo.py
+++ b/tests/assistant/test_progress_repo.py
@@ -47,6 +47,7 @@ async def test_get_and_upsert(session_local: sessionmaker[Session]) -> None:
         "step_idx": 1,
         "snapshot": None,
         "prev_summary": None,
+        "last_sent_step_id": None,
     }
     prog = await progress.upsert_progress(1, plan_id, data1)
     assert prog.progress_json == data1
@@ -61,6 +62,7 @@ async def test_get_and_upsert(session_local: sessionmaker[Session]) -> None:
         "step_idx": 2,
         "snapshot": None,
         "prev_summary": None,
+        "last_sent_step_id": None,
     }
     prog2 = await progress.upsert_progress(1, plan_id, data2)
     assert prog2.progress_json == data2

--- a/tests/assistant/test_progress_service.py
+++ b/tests/assistant/test_progress_service.py
@@ -61,6 +61,7 @@ async def test_upsert_updates_timestamp(session_local: sessionmaker[Session]) ->
         "step_idx": 1,
         "snapshot": None,
         "prev_summary": None,
+        "last_sent_step_id": None,
     }
     await progress_service.upsert_progress(1, plan_id, data1)
     progress = await progress_service.get_progress(1, plan_id)
@@ -79,6 +80,7 @@ async def test_upsert_updates_timestamp(session_local: sessionmaker[Session]) ->
         "step_idx": 2,
         "snapshot": None,
         "prev_summary": None,
+        "last_sent_step_id": None,
     }
     await progress_service.upsert_progress(1, plan_id, data2)
     progress2 = await progress_service.get_progress(1, plan_id)
@@ -105,6 +107,7 @@ async def test_upsert_progress_concurrent(session_local: sessionmaker[Session]) 
             "step_idx": step,
             "snapshot": None,
             "prev_summary": None,
+            "last_sent_step_id": None,
         }
         await progress_service.upsert_progress(1, plan_id, data)
 
@@ -117,5 +120,6 @@ async def test_upsert_progress_concurrent(session_local: sessionmaker[Session]) 
         "step_idx": 2,
         "snapshot": None,
         "prev_summary": None,
+        "last_sent_step_id": None,
     }
     assert progress.progress_json == expected

--- a/tests/learning/test_last_sent_step_id.py
+++ b/tests/learning/test_last_sent_step_id.py
@@ -1,0 +1,98 @@
+import pytest
+from types import SimpleNamespace
+from typing import Any
+
+from services.api.app.diabetes import learning_handlers
+from services.api.app.diabetes.models_learning import ProgressData
+
+
+class DummyMessage:
+    """Minimal Telegram-like message collecting replies and IDs."""
+
+    counter = 0
+
+    def __init__(self, text: str = "", user_id: int = 1) -> None:
+        self.text = text
+        self.from_user = SimpleNamespace(id=user_id)
+        self.sent: list[str] = []
+
+    async def reply_text(self, text: str, **_kwargs: Any) -> SimpleNamespace:
+        DummyMessage.counter += 1
+        self.sent.append(text)
+        return SimpleNamespace(message_id=DummyMessage.counter)
+
+
+@pytest.mark.asyncio
+async def test_last_sent_step_id_updates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ID of the last sent step is stored and updated on new step."""
+
+    monkeypatch.setattr(learning_handlers.settings, "learning_mode_enabled", True)
+    monkeypatch.setattr(learning_handlers.settings, "learning_content_mode", "dynamic")
+    monkeypatch.setattr(learning_handlers, "build_main_keyboard", lambda: None)
+    monkeypatch.setattr(learning_handlers, "disclaimer", lambda: "")
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda t: t)
+    monkeypatch.setattr(learning_handlers, "ensure_single_question", lambda t: t)
+    monkeypatch.setattr(learning_handlers, "sanitize_feedback", lambda t: t)
+    async def fake_get_profile(_uid: int) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers, "get_learning_profile", fake_get_profile)
+    monkeypatch.setattr(learning_handlers, "assistant_chat", lambda *_a, **_k: "fb")
+
+    async def fake_start_lesson(user_id: int, slug: str) -> SimpleNamespace:
+        return SimpleNamespace(lesson_id=1)
+
+    async def fake_next_step(
+        user_id: int, lesson_id: int, profile: Any, prev: str | None = None
+    ) -> tuple[str, bool]:
+        fake_next_step.calls += 1
+        return f"step {fake_next_step.calls}", False
+
+    fake_next_step.calls = 0
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "start_lesson", fake_start_lesson)
+    monkeypatch.setattr(learning_handlers.curriculum_engine, "next_step", fake_next_step)
+    monkeypatch.setattr(learning_handlers, "generate_learning_plan", lambda text: [text])
+    monkeypatch.setattr(learning_handlers, "pretty_plan", lambda plan: "1. " + plan[0])
+
+    async def fake_add_log(*_a: object, **_k: object) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", fake_add_log)
+
+    async def fake_get_active_plan(_uid: int) -> None:
+        return None
+
+    async def fake_create_plan(_uid: int, _version: int, _plan: list[str]) -> int:
+        return 1
+
+    async def fake_update_plan(plan_id: int, plan_json: list[str]) -> None:
+        return None
+
+    monkeypatch.setattr(learning_handlers.plans_repo, "get_active_plan", fake_get_active_plan)
+    monkeypatch.setattr(learning_handlers.plans_repo, "create_plan", fake_create_plan)
+    monkeypatch.setattr(learning_handlers.plans_repo, "update_plan", fake_update_plan)
+
+    calls: list[ProgressData] = []
+
+    async def spy_upsert(uid: int, pid: int, data: ProgressData) -> None:
+        calls.append(data.copy())
+
+    monkeypatch.setattr(learning_handlers.progress_repo, "upsert_progress", spy_upsert)
+
+    user_data: dict[str, Any] = {}
+    bot_data: dict[str, object] = {}
+
+    msg1 = DummyMessage()
+    await learning_handlers._start_lesson(msg1, user_data, bot_data, {}, "intro")
+
+    assert calls[0]["last_sent_step_id"] == 2
+    progress_map = bot_data[learning_handlers.PROGRESS_KEY]
+    assert progress_map[1]["last_sent_step_id"] == 2
+
+    context = SimpleNamespace(user_data=user_data, bot_data=bot_data)
+    msg2 = DummyMessage(text="answer")
+    update = SimpleNamespace(message=msg2, effective_user=msg2.from_user)
+    await learning_handlers.lesson_answer_handler(update, context)
+
+    assert calls[-1]["last_sent_step_id"] == 3
+    assert progress_map[1]["last_sent_step_id"] == 3

--- a/tests/learning/test_progress_persistence.py
+++ b/tests/learning/test_progress_persistence.py
@@ -40,6 +40,7 @@ async def test_persist_saves_progress(monkeypatch: pytest.MonkeyPatch) -> None:
         "step_idx": 2,
         "snapshot": "s",
         "prev_summary": "p",
+        "last_sent_step_id": None,
     }
     progress_map = bot_data[learning_handlers.PROGRESS_KEY]
     assert progress_map == {1: expected}
@@ -55,6 +56,7 @@ async def test_hydrate_loads_progress(monkeypatch: pytest.MonkeyPatch) -> None:
         "step_idx": 1,
         "snapshot": "snap",
         "prev_summary": None,
+        "last_sent_step_id": None,
     }
 
     async def fake_get_active_plan(user_id: int) -> Any:


### PR DESCRIPTION
## Summary
- store `last_sent_step_id` in learning progress and state
- persist last sent step after sending and add migration
- test progress tracking for last sent step transitions

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c50f11222c832abc1df582f92761ef