### PR TITLE
[auth] handle missing init data

### DIFF
--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -106,12 +106,14 @@ def require_tg_user(
     Accepts Telegram init data from ``X-Telegram-Init-Data`` or
     ``Authorization: tg <init_data>`` header.
     """
+    if (
+        not init_data
+        and isinstance(authorization, str)
+        and authorization.startswith("tg ")
+    ):
+        init_data = authorization[3:]
     if not init_data:
-        if isinstance(authorization, str) and authorization.startswith("tg "):
-            init_data = authorization[3:]
-        else:
-            raise HTTPException(status_code=401, detail="missing init data")
-    assert init_data is not None
+        raise HTTPException(status_code=401, detail="missing init data")
     return get_tg_user(init_data)
 
 

--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -129,6 +129,14 @@ def test_require_tg_user_authorization_header(
     assert user["id"] == 1
 
 
+def test_require_tg_user_empty_authorization() -> None:
+    header = "tg "
+    with pytest.raises(HTTPException) as exc:
+        require_tg_user(None, header)
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "missing init data"
+
+
 def test_require_tg_user_missing_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """Requests fail with a clear error if the bot token is not configured."""
     monkeypatch.setattr(settings, "telegram_token", "")


### PR DESCRIPTION
## Summary
- raise HTTP 401 when Telegram init data is missing after header fallbacks
- cover empty authorization header with a unit test

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest tests/test_telegram_auth.py -q --cov=services.api.app.telegram_auth --cov-fail-under=85`
- `pytest -q --cov --cov-fail-under=85` *(fails: Database engine is not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_68c515dee234832aad2eaf931a64c4b5