### PR TITLE
[gpt_command_parser] Return None for truncated JSON

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -94,7 +94,6 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
     start = -1
     braces = 0
     brackets = 0
-    saw_closing = False
 
     def search_dict(obj: object) -> dict[str, object] | None:
         queue: deque[object] = deque([obj])
@@ -127,18 +126,17 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
             quote = ch
             i += 1
             continue
-        if ch == '{' or ch == '[':
+        if ch == "{" or ch == "[":
             if braces == 0 and brackets == 0:
                 start = i
-            if ch == '{':
+            if ch == "{":
                 braces += 1
             else:
                 brackets += 1
-        elif ch == '}' or ch == ']':
-            saw_closing = True
-            if ch == '}' and braces > 0:
+        elif ch == "}" or ch == "]":
+            if ch == "}" and braces > 0:
                 braces -= 1
-            elif ch == ']' and brackets > 0:
+            elif ch == "]" and brackets > 0:
                 brackets -= 1
             else:
                 start = -1
@@ -151,7 +149,6 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
                 try:
                     obj = json.loads(segment)
                 except json.JSONDecodeError:
-                    saw_closing = True
                     start += 1
                     i = start
                     braces = 0
@@ -164,7 +161,7 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
         i += 1
 
     if start != -1:
-        return {} if saw_closing else None
+        return None
     return None
 
 
@@ -197,9 +194,7 @@ async def parse_command(text: str, timeout: float = 10) -> dict[str, object] | N
             timeout=timeout,
         )
         try:
-            response: ChatCompletion = await asyncio.wait_for(
-                cast(Awaitable[ChatCompletion], resp), timeout
-            )
+            response: ChatCompletion = await asyncio.wait_for(cast(Awaitable[ChatCompletion], resp), timeout)
         except TypeError:
             if isinstance(resp, Awaitable):
                 raise

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -30,9 +30,7 @@ async def test_parse_command_timeout_non_blocking(
             raise
 
         class FakeResponse:
-            choices = [
-                type("Choice", (), {"message": type("Msg", (), {"content": "{}"})()})
-            ]
+            choices = [type("Choice", (), {"message": type("Msg", (), {"content": "{}"})()})]
 
         return FakeResponse()
 
@@ -68,9 +66,7 @@ async def test_parse_command_with_explanatory_text(
                         (),
                         {
                             "content": (
-                                'Вот ответ: {"action":"add_entry",'
-                                '"time":"09:00","fields":{}}'
-                                " Дополнительный текст"
+                                'Вот ответ: {"action":"add_entry","time":"09:00","fields":{}} Дополнительный текст'
                             )
                         },
                     )()
@@ -131,11 +127,7 @@ async def test_parse_command_uses_config_model(
             type(
                 "Choice",
                 (),
-                {
-                    "message": type(
-                        "Msg", (), {"content": '{"action":"get_day_summary"}'}
-                    )()
-                },
+                {"message": type("Msg", (), {"content": '{"action":"get_day_summary"}'})()},
             )
         ]
 
@@ -170,12 +162,7 @@ async def test_parse_command_with_array_multiple_objects(
                     "message": type(
                         "Msg",
                         (),
-                        {
-                            "content": (
-                                '[{"action":"add_entry","fields":{}},'
-                                '{"action":"delete_entry","fields":{}}]'
-                            )
-                        },
+                        {"content": ('[{"action":"add_entry","fields":{}},{"action":"delete_entry","fields":{}}]')},
                     )()
                 },
             )
@@ -202,11 +189,7 @@ async def test_parse_command_without_fields(
             type(
                 "Choice",
                 (),
-                {
-                    "message": type(
-                        "Msg", (), {"content": '{"action":"get_day_summary"}'}
-                    )()
-                },
+                {"message": type("Msg", (), {"content": '{"action":"get_day_summary"}'})()},
             )
         ]
 
@@ -252,11 +235,7 @@ async def test_parse_command_delete_entry_without_fields(
             type(
                 "Choice",
                 (),
-                {
-                    "message": type(
-                        "Msg", (), {"content": '{"action":"delete_entry"}'}
-                    )()
-                },
+                {"message": type("Msg", (), {"content": '{"action":"delete_entry"}'})()},
             )
         ]
 
@@ -356,13 +335,7 @@ async def test_parse_command_with_braces_in_explanatory_text(
                     "message": type(
                         "Msg",
                         (),
-                        {
-                            "content": (
-                                '"пример {текста}" '
-                                '{"action":"add_entry","fields":{}}'
-                                " trailing"
-                            )
-                        },
+                        {"content": ('"пример {текста}" {"action":"add_entry","fields":{}} trailing')},
                     )()
                 },
             )
@@ -499,9 +472,7 @@ async def test_parse_command_propagates_unexpected_exception(
 )
 def test_sanitize_masks_api_like_tokens(token: Any) -> None:
     text = f"before {token} after"
-    assert (
-        gpt_command_parser._sanitize_sensitive_data(text) == "before [REDACTED] after"
-    )
+    assert gpt_command_parser._sanitize_sensitive_data(text) == "before [REDACTED] after"
 
 
 def test_sanitize_leaves_numeric_strings() -> None:
@@ -514,10 +485,7 @@ def test_sanitize_masks_multiple_tokens() -> None:
     token1 = "sk-" + "A1b2_" * 8 + "Z9"
     token2 = "ghp_" + "A1b2" * 9 + "Cd"
     text = f"{token1} middle {token2}"
-    assert (
-        gpt_command_parser._sanitize_sensitive_data(text)
-        == "[REDACTED] middle [REDACTED]"
-    )
+    assert gpt_command_parser._sanitize_sensitive_data(text) == "[REDACTED] middle [REDACTED]"
 
 
 def test_sanitize_leaves_short_api_like_token() -> None:
@@ -535,9 +503,7 @@ def test_extract_first_json_array_single_object() -> None:
 
 
 def test_extract_first_json_multi_object_array() -> None:
-    text = (
-        '[{"action":"add_entry","fields":{}},' '{"action":"delete_entry","fields":{}}]'
-    )
+    text = '[{"action":"add_entry","fields":{}},{"action":"delete_entry","fields":{}}]'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {},
@@ -561,7 +527,7 @@ def test_extract_first_json_nested_array_wrapper() -> None:
 
 
 def test_extract_first_json_multiple_objects() -> None:
-    text = '{"action":"add_entry","fields":{}} ' '{"action":"delete_entry","fields":{}}'
+    text = '{"action":"add_entry","fields":{}} {"action":"delete_entry","fields":{}}'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {},
@@ -577,7 +543,7 @@ def test_extract_first_json_braces_in_string_before_object() -> None:
 
 
 def test_extract_first_json_braces_in_single_quotes_before_object() -> None:
-    text = "prefix 'not json { [ ] }' " '{"action":"add_entry","fields":{}}'
+    text = 'prefix \'not json { [ ] }\' {"action":"add_entry","fields":{}}'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {},
@@ -585,7 +551,7 @@ def test_extract_first_json_braces_in_single_quotes_before_object() -> None:
 
 
 def test_extract_first_json_explanatory_braces_before_object() -> None:
-    text = "text with {not valid json} " '{"action":"add_entry","fields":{}}'
+    text = 'text with {not valid json} {"action":"add_entry","fields":{}}'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {},
@@ -593,7 +559,7 @@ def test_extract_first_json_explanatory_braces_before_object() -> None:
 
 
 def test_extract_first_json_multiple_objects_no_space() -> None:
-    text = '{"action":"add_entry","fields":{}}' '{"action":"delete_entry","fields":{}}'
+    text = '{"action":"add_entry","fields":{}}{"action":"delete_entry","fields":{}}'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {},
@@ -602,7 +568,12 @@ def test_extract_first_json_multiple_objects_no_space() -> None:
 
 def test_extract_first_json_malformed_input() -> None:
     text = '{"action":"add_entry","fields":{}'
-    assert gpt_command_parser._extract_first_json(text) == {}
+    assert gpt_command_parser._extract_first_json(text) is None
+
+
+def test_extract_first_json_truncated_array() -> None:
+    text = '[{"action":"add_entry"}'
+    assert gpt_command_parser._extract_first_json(text) is None
 
 
 def test_extract_first_json_simple_object() -> None:
@@ -618,10 +589,7 @@ def test_extract_first_json_no_object() -> None:
 
 
 def test_extract_first_json_with_escaped_quotes() -> None:
-    text = (
-        'prefix "escaped \\"quote\\"" '
-        '{"action":"add_entry","fields":{"note":"He said \\"hi\\""}}'
-    )
+    text = 'prefix "escaped \\"quote\\"" {"action":"add_entry","fields":{"note":"He said \\"hi\\""}}'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {"note": 'He said "hi"'},
@@ -629,9 +597,7 @@ def test_extract_first_json_with_escaped_quotes() -> None:
 
 
 def test_extract_first_json_array_with_many_objects() -> None:
-    text = (
-        '[{"action":"add_entry","fields":{}},' ' {"action":"delete_entry","fields":{}}]'
-    )
+    text = '[{"action":"add_entry","fields":{}}, {"action":"delete_entry","fields":{}}]'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {},
@@ -649,16 +615,12 @@ def test_extract_first_json_malformed_then_valid() -> None:
 def test_extract_first_json_non_dict_reset(monkeypatch: pytest.MonkeyPatch) -> None:
     orig_raw_decode = gpt_command_parser.json.JSONDecoder.raw_decode
 
-    def fake_raw_decode(
-        self: gpt_command_parser.json.JSONDecoder, s: str, idx: int = 0
-    ) -> tuple[object, int]:
+    def fake_raw_decode(self: gpt_command_parser.json.JSONDecoder, s: str, idx: int = 0) -> tuple[object, int]:
         if s[idx:].startswith('{"skip":1}'):
             return 1, idx + len('{"skip":1}')
         return orig_raw_decode(self, s, idx)
 
-    monkeypatch.setattr(
-        gpt_command_parser.json.JSONDecoder, "raw_decode", fake_raw_decode
-    )
+    monkeypatch.setattr(gpt_command_parser.json.JSONDecoder, "raw_decode", fake_raw_decode)
     text = '{"skip":1} {"action":"add_entry","fields":{}}'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
@@ -667,7 +629,7 @@ def test_extract_first_json_non_dict_reset(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_extract_first_json_nested_object() -> None:
-    text = 'prefix {"action":"add_entry","fields":{"nested":{"level":1}}}' " suffix"
+    text = 'prefix {"action":"add_entry","fields":{"nested":{"level":1}}} suffix'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {"nested": {"level": 1}},
@@ -675,7 +637,7 @@ def test_extract_first_json_nested_object() -> None:
 
 
 def test_extract_first_json_nested_array() -> None:
-    text = 'prefix {"action":"add_entry","fields":{"list":[{"x":1},{"x":2}]}}' " suffix"
+    text = 'prefix {"action":"add_entry","fields":{"list":[{"x":1},{"x":2}]}} suffix'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {"list": [{"x": 1}, {"x": 2}]},
@@ -691,9 +653,7 @@ def test_extract_first_json_with_escaped_chars() -> None:
 
 
 def test_extract_first_json_braces_inside_string_field() -> None:
-    text = (
-        'prefix {"action":"add_entry","fields":{"note":"use {curly} braces"}} ' "suffix"
-    )
+    text = 'prefix {"action":"add_entry","fields":{"note":"use {curly} braces"}} suffix'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {"note": "use {curly} braces"},
@@ -709,10 +669,7 @@ def test_extract_first_json_braces_and_quotes_inside_string_field() -> None:
 
 
 def test_extract_first_json_deep_nested_arrays() -> None:
-    text = (
-        'start {"action":"add_entry","fields":{"matrix":[[1,2],[3,{"v":[4,5]}]]}}'
-        " end"
-    )
+    text = 'start {"action":"add_entry","fields":{"matrix":[[1,2],[3,{"v":[4,5]}]]}} end'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "fields": {"matrix": [[1, 2], [3, {"v": [4, 5]}]]},
@@ -729,9 +686,7 @@ def test_extract_first_json_quotes_inside_value() -> None:
 
 def test_extract_first_json_three_objects_in_row() -> None:
     text = (
-        '{"action":"add_entry","fields":{}}'
-        '{"action":"delete_entry","fields":{}}'
-        '{"action":"update_entry","fields":{}}'
+        '{"action":"add_entry","fields":{}}{"action":"delete_entry","fields":{}}{"action":"update_entry","fields":{}}'
     )
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
@@ -771,12 +726,7 @@ async def test_parse_command_with_multiple_jsons(
                     "message": type(
                         "Msg",
                         (),
-                        {
-                            "content": (
-                                '{"action":"add_entry","fields":{}} '
-                                '{"action":"delete_entry","fields":{}}'
-                            )
-                        },
+                        {"content": ('{"action":"add_entry","fields":{}} {"action":"delete_entry","fields":{}}')},
                     )()
                 },
             )
@@ -820,4 +770,4 @@ async def test_parse_command_with_malformed_json(
         result = await gpt_command_parser.parse_command("test")
 
     assert result is None
-    assert "Command validation failed" in caplog.text
+    assert "No JSON object found in response" in caplog.text


### PR DESCRIPTION
## Summary
- treat truncated JSON snippets as absent
- test partial JSON parsing returns `None`

## Testing
- `pytest -q tests/test_gpt_command_parser.py tests/test_gpt_command_parser_errors.py tests/diabetes/test_gpt_command_parser.py --cov=services.api.app.diabetes.gpt_command_parser --cov-fail-under=85`
- `mypy --strict services/api/app/diabetes/gpt_command_parser.py tests/test_gpt_command_parser.py tests/test_gpt_command_parser_errors.py tests/diabetes/test_gpt_command_parser.py`
- `ruff check .`
- `pytest -q --cov --cov-fail-under=85` *(fails: sqlite3.OperationalError: no such table: onboarding_states)*

------
https://chatgpt.com/codex/tasks/task_e_68c515e39510832a962ba12bb503fcc4