### PR TITLE
[prompts] log lessons loading errors

### DIFF
--- a/services/api/app/diabetes/prompts/__init__.py
+++ b/services/api/app/diabetes/prompts/__init__.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Mapping
 from pathlib import Path
 from textwrap import dedent
 
 # --- Meta ---------------------------------------------------------------------
+
+logger = logging.getLogger(__name__)
 
 PROMPT_VERSION = "v0.3"
 PROMPT_LANG = "ru-RU"
@@ -113,7 +116,9 @@ def build_system_prompt(p: Mapping[str, str | None], task: object | None = None)
     return _trim(prompt)
 
 
-def build_user_prompt_step(topic_slug: str, step_idx: int, prev_summary: str | None) -> str:
+def build_user_prompt_step(
+    topic_slug: str, step_idx: int, prev_summary: str | None
+) -> str:
     """Build a user-level prompt for a learning step."""
     slug = _canon_slug(topic_slug)
     goal = LESSON_GOALS_RU.get(slug, "дать понятный и безопасный шаг по теме")
@@ -174,7 +179,8 @@ try:
         LESSONS_V0_DATA = json.load(fp)
 except FileNotFoundError:
     LESSONS_V0_DATA = {}
-except Exception:
+except (OSError, json.JSONDecodeError):
+    logger.exception("Failed to load legacy lessons from %s", LESSONS_V0_PATH)
     # fail-open: не ломаем импорт, просто оставляем пустые данные
     LESSONS_V0_DATA = {}
 

--- a/tests/test_prompts_lessons_v0_load.py
+++ b/tests/test_prompts_lessons_v0_load.py
@@ -1,0 +1,33 @@
+"""Tests for legacy lessons loading."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from typing import NoReturn, TextIO
+
+import pytest
+
+
+def test_lessons_v0_load_logs_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Ensure logger captures errors during legacy lessons load."""
+
+    import services.api.app.diabetes.prompts as prompts
+
+    def bad_json_load(_fp: TextIO) -> NoReturn:
+        raise json.JSONDecodeError("bad", "", 0)
+
+    monkeypatch.setattr(json, "load", bad_json_load)
+
+    with caplog.at_level(logging.ERROR):
+        importlib.reload(prompts)
+
+    assert "Failed to load legacy lessons" in caplog.text
+    assert prompts.LESSONS_V0_DATA == {}
+
+    monkeypatch.undo()
+    importlib.reload(prompts)


### PR DESCRIPTION
## Summary
- log failures when loading legacy lesson prompts
- add unit test covering lesson file load errors

## Testing
- `pytest tests/test_prompts_lessons_v0_load.py -q`
- `make ci` *(fails: OperationalError; Database engine is not initialized)*
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c515e4ecfc832abe5255c3cc4578ef