### PR TITLE
[diabetes] handle trailing JSON segment

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -172,7 +172,12 @@ def _extract_first_json(text: str) -> dict[str, object] | None:
         i += 1
 
     if start != -1:
-        return None
+        segment = text[start:length]
+        try:
+            obj = json.loads(segment)
+        except json.JSONDecodeError:
+            return None
+        return search_dict(obj)
     return None
 
 
@@ -205,7 +210,9 @@ async def parse_command(text: str, timeout: float = 10) -> dict[str, object] | N
             timeout=timeout,
         )
         try:
-            response: ChatCompletion = await asyncio.wait_for(cast(Awaitable[ChatCompletion], resp), timeout)
+            response: ChatCompletion = await asyncio.wait_for(
+                cast(Awaitable[ChatCompletion], resp), timeout
+            )
         except TypeError:
             if isinstance(resp, Awaitable):
                 raise

--- a/tests/diabetes/test_gpt_command_parser.py
+++ b/tests/diabetes/test_gpt_command_parser.py
@@ -39,10 +39,13 @@ def test_extract_first_json_deeply_nested_arrays() -> None:
     assert gpt_command_parser._extract_first_json(text) == {"action": "get_stats"}
 
 
+def test_extract_first_json_at_line_end() -> None:
+    text = 'prefix {"action":"get_stats"}'
+    assert gpt_command_parser._extract_first_json(text) == {"action": "get_stats"}
+
+
 def test_extract_first_json_with_escaped_braces() -> None:
-    text = (
-        '{"action":"add_entry","note":"escaped {\\"inner\\": [1,2]} text"}'
-    )
+    text = '{"action":"add_entry","note":"escaped {\\"inner\\": [1,2]} text"}'
     assert gpt_command_parser._extract_first_json(text) == {
         "action": "add_entry",
         "note": 'escaped {"inner": [1,2]} text',


### PR DESCRIPTION
## Summary
- Parse final JSON segment when search loop ends
- Remove redundant `return None`
- Test for JSON located at end of string

## Testing
- `pytest -q --cov --cov-fail-under=85` *(fails: no such table: onboarding_states)*
- `pytest tests/diabetes/test_gpt_command_parser.py tests/test_gpt_command_parser.py -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c528531850832a844bbf0a5db95992