### PR TITLE
[diabetes] Make LocalProfileAPI sessionmaker optional

### DIFF
--- a/services/api/app/diabetes/handlers/profile/api.py
+++ b/services/api/app/diabetes/handlers/profile/api.py
@@ -82,8 +82,10 @@ class LocalProfileAPI:
     calls used by the bot are provided.
     """
 
-    def __init__(self, sessionmaker: Callable[[], Session] = SessionLocal) -> None:
-        self._sessionmaker = sessionmaker
+    def __init__(
+        self, sessionmaker: Callable[[], Session] | None = None
+    ) -> None:
+        self._sessionmaker = sessionmaker or SessionLocal
 
     def profiles_post(self, profile: LocalProfile) -> None:
         """Persist ``profile`` to the database."""

--- a/tests/handlers/profile/test_api.py
+++ b/tests/handlers/profile/test_api.py
@@ -178,14 +178,18 @@ def test_save_profile_creates_missing_user(
 def test_local_profiles_post_failure(
     monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker[Session]
 ) -> None:
-    api = profile_api.LocalProfileAPI(session_factory)
+    monkeypatch.setattr(profile_api, "SessionLocal", session_factory)
+    api = profile_api.LocalProfileAPI()
     monkeypatch.setattr(profile_api, "save_profile", lambda *a, **k: False)
     with pytest.raises(profile_api.ProfileSaveError):
         api.profiles_post(profile_api.LocalProfile(telegram_id=1))
 
 
-def test_local_profiles_roundtrip(session_factory: sessionmaker[Session]) -> None:
-    api = profile_api.LocalProfileAPI(session_factory)
+def test_local_profiles_roundtrip(
+    monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker[Session]
+) -> None:
+    monkeypatch.setattr(profile_api, "SessionLocal", session_factory)
+    api = profile_api.LocalProfileAPI()
 
     with session_factory() as session:
         session.add(User(telegram_id=1, thread_id="t"))
@@ -209,9 +213,10 @@ def test_local_profiles_roundtrip(session_factory: sessionmaker[Session]) -> Non
 
 
 def test_local_profiles_partial_update_keeps_existing(
-    session_factory: sessionmaker[Session],
+    monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker[Session]
 ) -> None:
-    api = profile_api.LocalProfileAPI(session_factory)
+    monkeypatch.setattr(profile_api, "SessionLocal", session_factory)
+    api = profile_api.LocalProfileAPI()
 
     initial = profile_api.LocalProfile(
         telegram_id=1,
@@ -237,9 +242,10 @@ def test_local_profiles_partial_update_keeps_existing(
 
 
 def test_local_profiles_missing_required_raises(
-    session_factory: sessionmaker[Session],
+    monkeypatch: pytest.MonkeyPatch, session_factory: sessionmaker[Session]
 ) -> None:
-    api = profile_api.LocalProfileAPI(session_factory)
+    monkeypatch.setattr(profile_api, "SessionLocal", session_factory)
+    api = profile_api.LocalProfileAPI()
 
     with pytest.raises(profile_api.ProfileSaveError):
         api.profiles_post(


### PR DESCRIPTION
## Summary
- allow `LocalProfileAPI` to accept an optional session factory and fall back to `SessionLocal`
- adjust profile API tests to rely on patched `SessionLocal`

## Testing
- `pytest -q --cov` *(fails: database engine is not initialized in unrelated onboarding tests)*
- `pytest tests/handlers/profile/test_api.py::test_local_profiles_roundtrip tests/handlers/profile/test_api.py::test_local_profiles_partial_update_keeps_existing tests/handlers/profile/test_api.py::test_local_profiles_post_failure tests/handlers/profile/test_api.py::test_local_profiles_missing_required_raises -q`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c52864726c832abd3256ac3b54e032