### PR TITLE
handlers: enforce run_db requirement

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -44,6 +44,12 @@ class Settings(BaseSettings):
     app_name: str = "diabetes-bot"
     debug: bool = False
 
+    allow_sync_db_fallback: bool = Field(
+        default=True,
+        alias="ALLOW_SYNC_DB_FALLBACK",
+        description="Allow synchronous DB operations when async runner is missing",
+    )
+
     photos_dir: str = Field(default="/var/lib/diabetes-bot/photos", alias="PHOTOS_DIR")
 
     # Database configuration

--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -91,6 +91,19 @@ SessionLocal: sessionmaker[Session] = _SessionLocal
 commit: Callable[[Session], None] = _commit
 
 
+async def _run_db_or_sync(
+    fn: Callable[Concatenate[Session, P], T],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> T:
+    if run_db is None:
+        if not config.settings.allow_sync_db_fallback:
+            raise RuntimeError("run_db is required")
+        with SessionLocal() as session:
+            return fn(session, *args, **kwargs)
+    return await run_db(fn, *args, sessionmaker=SessionLocal, **kwargs)
+
+
 class DbActionStatus(Enum):
     NOT_FOUND = "not_found"
     UNKNOWN = "unknown"
@@ -411,11 +424,7 @@ async def create_reminder_from_preset(user_id: int, code: str, job_queue: Defaul
             reminder.user = user
         return reminder, user
 
-    if run_db is None:
-        with SessionLocal() as session:
-            saved, db_user = db_save(session)
-    else:
-        saved, db_user = await run_db(db_save, sessionmaker=SessionLocal)
+    saved, db_user = await _run_db_or_sync(db_save)
 
     if saved is None:
         logger.info("Preset reminder %s not created for user %s", code, user_id)
@@ -458,14 +467,7 @@ async def reminders_list(
         _render_reminders,
     )
     try:
-        if run_db is None:
-            with SessionLocal() as session:
-                text, keyboard = render_fn(session, user_id)
-        else:
-            text, keyboard = cast(
-                tuple[str, InlineKeyboardMarkup | None],
-                await run_db(render_fn, user_id, sessionmaker=SessionLocal),
-            )
+        text, keyboard = await _run_db_or_sync(render_fn, user_id)
     except SQLAlchemyError:
         logger.exception("Failed to render reminders")
         await message.reply_text("Не удалось получить напоминания, попробуйте позже.")
@@ -503,11 +505,7 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             settings = session.get(Profile, user_id)
             return getattr(settings, "postmeal_check_min", None)
 
-        if run_db is None:
-            with SessionLocal() as session:
-                default_minutes = load_default(session)
-        else:
-            default_minutes = await run_db(load_default, sessionmaker=SessionLocal)
+        default_minutes = await _run_db_or_sync(load_default)
         if default_minutes is None:
             await message.reply_text(
                 "Использование: /addreminder <type> <value>"  # noqa: RUF001
@@ -600,11 +598,7 @@ async def add_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             return "error", db_user, limit, count
         return "ok", db_user, limit, reminder.id
 
-    if run_db is None:
-        with SessionLocal() as session:
-            status, db_user, limit, rid_or_count = db_add(session)
-    else:
-        status, db_user, limit, rid_or_count = await run_db(db_add, sessionmaker=SessionLocal)
+    status, db_user, limit, rid_or_count = await _run_db_or_sync(db_add)
 
     if status == "limit":
         count = rid_or_count
@@ -694,14 +688,7 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
                 return "error"
             return "ok"
 
-        if run_db is None:
-            with SessionLocal() as session:
-                status = save_sugar(session)
-        else:
-            status = cast(
-                Literal["ok"] | Literal["error"],
-                await run_db(save_sugar, sessionmaker=SessionLocal),
-            )
+        status = await _run_db_or_sync(save_sugar)
         if status == "ok":
             await msg.reply_text(f"Записано {sugar_val} ммоль/л")
             await check_alert(update, context, sugar_val)
@@ -728,14 +715,7 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
                 return "error"
             return "ok"
 
-        if run_db is None:
-            with SessionLocal() as session:
-                status = log_snooze(session)
-        else:
-            status = cast(
-                Literal["ok"] | Literal["error"],
-                await run_db(log_snooze, sessionmaker=SessionLocal),
-            )
+        status = await _run_db_or_sync(log_snooze)
         if status == "ok":
             job_queue: DefaultJobQueue | None = cast(DefaultJobQueue | None, context.job_queue)
             if job_queue is not None:
@@ -775,11 +755,7 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
             settings = session.get(Profile, user_id)
             return getattr(settings, "postmeal_check_min", None)
 
-        if run_db is None:
-            with SessionLocal() as session:
-                default_minutes = load_default(session)
-        else:
-            default_minutes = await run_db(load_default, sessionmaker=SessionLocal)
+        default_minutes = await _run_db_or_sync(load_default)
         if default_minutes is not None:
             minutes_after_raw = default_minutes
 
@@ -958,11 +934,7 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
         session.refresh(rem)
         return "ok", rem, None, None
 
-    if run_db is None:
-        with SessionLocal() as session:
-            status, rem, plan, limit = db_save(session)
-    else:
-        status, rem, plan, limit = await run_db(db_save, sessionmaker=SessionLocal)
+    status, rem, plan, limit = await _run_db_or_sync(db_save)
     if status == "not_found":
         await msg.reply_text("Не найдено")
         return
@@ -995,11 +967,7 @@ async def reminder_webapp_save(update: Update, context: ContextTypes.DEFAULT_TYP
         Callable[[Session, int], tuple[str, InlineKeyboardMarkup | None]],
         _render_reminders,
     )
-    if run_db is None:
-        with SessionLocal() as session:
-            text, keyboard = render_fn(session, user_id)
-    else:
-        text, keyboard = await run_db(render_fn, user_id, sessionmaker=SessionLocal)
+    text, keyboard = await _run_db_or_sync(render_fn, user_id)
     if keyboard is not None:
         await msg.reply_text(text, parse_mode="HTML", reply_markup=keyboard)
     else:
@@ -1238,14 +1206,7 @@ async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE)
             return DbActionResult(DbActionStatus.TOGGLE, rem)
         return DbActionResult(DbActionStatus.DELETE)
 
-    if run_db is None:
-        with SessionLocal() as session:
-            result = db_action(session)
-    else:
-        result = cast(
-            DbActionResult,
-            await run_db(db_action, sessionmaker=SessionLocal),
-        )
+    result = await _run_db_or_sync(db_action)
     if result.status is DbActionStatus.NOT_FOUND:
         await query.answer("Не найдено", show_alert=True)
         return
@@ -1305,14 +1266,7 @@ async def reminder_action_cb(update: Update, context: ContextTypes.DEFAULT_TYPE)
         Callable[[Session, int], tuple[str, InlineKeyboardMarkup | None]],
         _render_reminders,
     )
-    if run_db is None:
-        with SessionLocal() as session:
-            text, keyboard = render_fn(session, user_id)
-    else:
-        text, keyboard = cast(
-            tuple[str, InlineKeyboardMarkup | None],
-            await run_db(render_fn, user_id, sessionmaker=SessionLocal),
-        )
+    text, keyboard = await _run_db_or_sync(render_fn, user_id)
     try:
         if keyboard is not None:
             await query.edit_message_text(text, parse_mode="HTML", reply_markup=keyboard)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,8 +271,12 @@ def session_local(monkeypatch: pytest.MonkeyPatch) -> Iterator[sessionmaker[Sess
     # Import models with additional tables to register them in Base metadata.
     import services.api.app.diabetes.models_learning as ml_models
     import services.api.app.assistant.models as as_models
+    import services.api.app.services.onboarding_state as onboarding_state_module
+    import services.api.app.models.onboarding_metrics as onboarding_metrics_module
     importlib.reload(ml_models)
     importlib.reload(as_models)
+    importlib.reload(onboarding_state_module)
+    importlib.reload(onboarding_metrics_module)
 
     # Ensure the database URL points to an in-memory SQLite instance. Use a
     # ``StaticPool`` so that the in-memory database persists across multiple

--- a/tests/test_assistant_menu.py
+++ b/tests/test_assistant_menu.py
@@ -59,7 +59,7 @@ async def test_assistant_callback_mode_has_back_button() -> None:
 
 @pytest.mark.asyncio
 async def test_assistant_callback_logs_selection(
-    caplog: pytest.LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     user_data: dict[str, object] = {}
     message = MagicMock()
@@ -73,6 +73,12 @@ async def test_assistant_callback_logs_selection(
     update.effective_user = MagicMock(id=42)
     ctx = MagicMock()
     ctx.user_data = user_data
+    from services.api.app.assistant.services import memory_service
+
+    async def _noop(*args: object, **kwargs: object) -> None:  # pragma: no cover - trivial
+        return None
+
+    monkeypatch.setattr(memory_service, "run_db", _noop)
     with caplog.at_level(logging.INFO):
         await assistant_menu.assistant_callback(update, ctx)
     record = next(r for r in caplog.records if r.message == "assistant_mode_selected")

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -92,10 +92,17 @@ async def test_sugar_conv_photo_fallback() -> None:
 
 
 @pytest.mark.asyncio
-async def test_onboarding_conv_photo_fallback() -> None:
+async def test_onboarding_conv_photo_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     handler = _find_handler(
         onboarding_handlers.onboarding_conv.fallbacks, PHOTO_BUTTON_PATTERN.pattern
     )
+
+    async def _run_db(*args: object, **kwargs: object) -> None:  # pragma: no cover
+        return None
+
+    monkeypatch.setattr(onboarding_handlers, "run_db", _run_db, raising=False)
     await _exercise(handler)
 
 

--- a/tests/test_reminders.py
+++ b/tests/test_reminders.py
@@ -2078,3 +2078,14 @@ def test_patch_reminder_forbidden(
     assert resp.status_code == 403
     assert resp.json() == {"detail": "forbidden"}
     fastapi_app.dependency_overrides[check_token] = lambda: {"id": 1}
+
+
+@pytest.mark.asyncio
+async def test_preset_requires_run_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    from services.api.app import config
+    from services.api.app.diabetes.handlers import reminder_handlers as handlers
+
+    monkeypatch.setattr(config.settings, "allow_sync_db_fallback", False, raising=False)
+    monkeypatch.setattr(handlers, "run_db", None)
+    with pytest.raises(RuntimeError):
+        await handlers.create_reminder_from_preset(1, "sugar_08", None)


### PR DESCRIPTION
## Summary
- add configurable `allow_sync_db_fallback` flag
- guard reminder handlers with `_run_db_or_sync` helper
- test error when run_db is missing in production

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c5286f2614832a884f169b8b4e4f53