### PR TITLE
[scripts] Add learning progress check script

### DIFF
--- a/docs/learn_mode.md
+++ b/docs/learn_mode.md
@@ -48,6 +48,14 @@ python services/api/app/bot.py
 python scripts/probe_learn.py --user 123 --lesson xe_basics
 ```
 
+Для просмотра состояния обучения конкретного пользователя воспользуйтесь
+скриптом `scripts/check_learning_progress.sh`. Он требует переменные
+`DATABASE_URL` и `UID`:
+
+```bash
+DATABASE_URL=postgresql://… UID=<user_id> scripts/check_learning_progress.sh
+```
+
 В Telegram отправьте команду `/learn` и убедитесь, что бот показывает кнопки с уроками.
 
 ## Схема базы данных

--- a/scripts/check_learning_progress.sh
+++ b/scripts/check_learning_progress.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# scripts/check_learning_progress.sh
+set -euo pipefail
+
+: "${DATABASE_URL:?DATABASE_URL environment variable is required}"
+: "${UID:?UID environment variable is required}"
+
+psql "$DATABASE_URL" -c "
+  SELECT *
+  FROM learning_user_profile
+  WHERE user_id = ${UID};
+"
+
+psql "$DATABASE_URL" -c "
+  SELECT l.slug, lp.completed, lp.current_step, lp.current_question, lp.quiz_score
+  FROM lesson_progress lp
+  JOIN lessons l ON l.id = lp.lesson_id
+  WHERE lp.user_id = ${UID}
+  ORDER BY l.id;
+"
+
+psql "$DATABASE_URL" -c "
+  SELECT l.slug, q.id AS question_id, q.question, q.correct_option
+  FROM lesson_progress lp
+  JOIN lessons l ON l.id = lp.lesson_id
+  JOIN quiz_questions q ON q.lesson_id = l.id
+  WHERE lp.user_id = ${UID}
+  ORDER BY l.id, q.id;
+"


### PR DESCRIPTION
## Summary
- add script to check learning progress via psql
- document how to run the new script

## Testing
- `pytest tests/test_progress_command.py -q --cov`
- `mypy --strict .` *(fails: timed out/interrupted)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c57ab3ca94832aa35ca571ab4e9b12