### PR TITLE
[handlers] Remove duplicate reminder handler export

### DIFF
--- a/services/api/app/diabetes/handlers/reminder_handlers.py
+++ b/services/api/app/diabetes/handlers/reminder_handlers.py
@@ -1346,5 +1346,4 @@ __all__ = [
     "reminder_webapp_handler",
     "SessionLocal",
     "commit",
-    "create_reminder_from_preset",
 ]


### PR DESCRIPTION
## Summary
- remove duplicate `create_reminder_from_preset` from `reminder_handlers.__all__`

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c7153ec834832a8348ee258b45d121