### PR TITLE
[handlers] use CommandHandler directly

### DIFF
--- a/services/api/app/diabetes/bot_start_handlers.py
+++ b/services/api/app/diabetes/bot_start_handlers.py
@@ -55,4 +55,4 @@ def build_start_handler(ui_base_url: str) -> CommandHandlerT:
         if update.message:
             await update.message.reply_text(text, reply_markup=kb)
 
-    return CommandHandlerT("start", _start)
+    return CommandHandler("start", _start)

--- a/services/api/app/diabetes/bot_status_handlers.py
+++ b/services/api/app/diabetes/bot_status_handlers.py
@@ -130,4 +130,4 @@ def build_status_handler(ui_base_url: str, api_base: str = "/api") -> CommandHan
                 reply_markup=InlineKeyboardMarkup(btns),
             )
 
-    return CommandHandlerT("status", _status)
+    return CommandHandler("status", _status)

--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -111,7 +111,6 @@ if TYPE_CHECKING:
     MessageHandlerT: TypeAlias = MessageHandler[ContextTypes.DEFAULT_TYPE, object]
     CallbackQueryHandlerT: TypeAlias = CallbackQueryHandler[ContextTypes.DEFAULT_TYPE, object]
 else:
-    CommandHandlerT = CommandHandler
     MessageHandlerT = MessageHandler
     CallbackQueryHandlerT = CallbackQueryHandler
 
@@ -151,11 +150,11 @@ def register_reminder_handlers(
 
     from . import reminder_handlers
 
-    app.add_handler(CommandHandlerT("reminders", reminder_handlers.reminders_list))
-    app.add_handler(CommandHandlerT("addreminder", reminder_handlers.add_reminder))
+    app.add_handler(CommandHandler("reminders", reminder_handlers.reminders_list))
+    app.add_handler(CommandHandler("addreminder", reminder_handlers.add_reminder))
     app.add_handler(reminder_handlers.reminder_action_handler)
     app.add_handler(reminder_handlers.reminder_webapp_handler)
-    app.add_handler(CommandHandlerT("delreminder", reminder_handlers.delete_reminder))
+    app.add_handler(CommandHandler("delreminder", reminder_handlers.delete_reminder))
     app.add_handler(
         MessageHandlerT(
             filters.Regex(re.escape(REMINDERS_BUTTON_TEXT)),
@@ -220,33 +219,33 @@ def register_handlers(
     settings = reload_settings()
     learning_enabled = settings.learning_mode_enabled
 
-    app.add_handler(CommandHandlerT("menu", learning_handlers.cmd_menu))
-    app.add_handler(CommandHandlerT("assistant", assistant_menu.show_menu))
+    app.add_handler(CommandHandler("menu", learning_handlers.cmd_menu))
+    app.add_handler(CommandHandler("assistant", assistant_menu.show_menu))
     app.add_handler(
         MessageHandlerT(
             filters.TEXT & filters.Regex(ASSISTANT_BUTTON_PATTERN),
             assistant_menu.show_menu,
         )
     )
-    app.add_handler(CommandHandlerT("report", reporting_handlers.report_request))
-    app.add_handler(CommandHandlerT("history", reporting_handlers.history_view))
+    app.add_handler(CommandHandler("report", reporting_handlers.report_request))
+    app.add_handler(CommandHandler("history", reporting_handlers.history_view))
     app.add_handler(dose_calc.dose_conv)
     # Register profile conversation before sugar conversation so that numeric
     # inputs for profile aren't captured by sugar logging
     register_profile_handlers(app)
     app.add_handler(sugar_handlers.sugar_conv)
     app.add_handler(sos_handlers.sos_contact_conv)
-    app.add_handler(CommandHandlerT("cancel", cancel))
-    app.add_handler(CommandHandlerT("help", help_command))
-    app.add_handler(CommandHandlerT("reset_onboarding", bot_commands.reset_onboarding))
-    app.add_handler(CommandHandlerT("gpt", start_gpt_dialog))
-    app.add_handler(CommandHandlerT("reset", bot_commands.reset_command))
-    app.add_handler(CommandHandlerT("trial", billing_handlers.trial_command))
-    app.add_handler(CommandHandlerT("upgrade", billing_handlers.upgrade_command))
+    app.add_handler(CommandHandler("cancel", cancel))
+    app.add_handler(CommandHandler("help", help_command))
+    app.add_handler(CommandHandler("reset_onboarding", bot_commands.reset_onboarding))
+    app.add_handler(CommandHandler("gpt", start_gpt_dialog))
+    app.add_handler(CommandHandler("reset", bot_commands.reset_command))
+    app.add_handler(CommandHandler("trial", billing_handlers.trial_command))
+    app.add_handler(CommandHandler("upgrade", billing_handlers.upgrade_command))
     app.add_handler(CallbackQueryHandlerT(billing_handlers.trial_command, pattern="^trial$"))
     register_reminder_handlers(app)
-    app.add_handler(CommandHandlerT("alertstats", alert_handlers.alert_stats))
-    app.add_handler(CommandHandlerT("hypoalert", security_handlers.hypo_alert_faq))
+    app.add_handler(CommandHandler("alertstats", alert_handlers.alert_stats))
+    app.add_handler(CommandHandler("hypoalert", security_handlers.hypo_alert_faq))
     app.add_handler(
         MessageHandlerT(
             filters.Regex(re.escape(REPORT_BUTTON_TEXT)),

--- a/services/bot/handlers/start_webapp.py
+++ b/services/bot/handlers/start_webapp.py
@@ -48,7 +48,7 @@ def build_start_handler() -> CommandHandlerT:
         if update.message:
             await update.message.reply_text(text, reply_markup=kb)
 
-    return CommandHandlerT("start", _start)
+    return CommandHandler("start", _start)
 
 
 __all__ = ["build_start_handler"]

--- a/tests/test_bot_status_handler.py
+++ b/tests/test_bot_status_handler.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 import pytest
 from telegram import Update
-from telegram.ext import CallbackContext
+from telegram.ext import CallbackContext, CommandHandler
 
 from services.api.app.diabetes.bot_status_handlers import build_status_handler
 
@@ -58,6 +58,11 @@ class DummySession:
     ) -> DummyResponse:
         self.timeout = timeout
         return DummyResponse(self._data)
+
+
+def test_build_status_handler_creates_command_handler() -> None:
+    handler = build_status_handler("https://ui.example", api_base="https://api.example")
+    assert isinstance(handler, CommandHandler)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- use `CommandHandler` instead of `CommandHandlerT` when creating handlers
- keep `CommandHandlerT` only for type annotations
- test that status handler returns a `CommandHandler`

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c7da4e64e0832ab6cf406dde5a0c92