### PR TITLE
[diabetes] respect overall timeout in command parser

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -196,8 +196,9 @@ async def parse_command(
     api_timeout:
         Timeout passed to the OpenAI client.
     overall_timeout:
-        Maximum time in seconds to wait for the entire operation. If ``None``,
-        ``api_timeout + 1`` seconds are used.
+        Maximum time in seconds to wait for the entire operation. When
+        provided, this value is used directly. If ``None``, ``api_timeout + 1``
+        seconds are used.
 
     Returns
     -------
@@ -206,9 +207,7 @@ async def parse_command(
         optional ``fields`` describing the command, or ``None`` if parsing fails.
     """
 
-    wait_timeout = (
-        overall_timeout + 1 if overall_timeout is not None else api_timeout + 1
-    )
+    wait_timeout = overall_timeout if overall_timeout is not None else api_timeout + 1
     try:
         resp: ChatCompletion | Awaitable[ChatCompletion] = create_chat_completion(
             model=config.get_settings().openai_command_model,

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -51,11 +51,28 @@ async def test_parse_command_timeout_non_blocking(
     elapsed = time.perf_counter() - start
 
     assert isinstance(results[0], gpt_command_parser.ParserTimeoutError)
-    assert elapsed < overall_timeout + 1.5
+    assert elapsed < overall_timeout + 0.2
     assert started.is_set()
     await asyncio.sleep(0.2)
     assert cancelled.is_set()
     assert captured.get("timeout") == api_timeout
+
+
+@pytest.mark.asyncio
+async def test_parse_command_respects_overall_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def slow_create(*args: Any, **kwargs: Any) -> Any:
+        await asyncio.sleep(2)
+
+    monkeypatch.setattr(gpt_command_parser, "create_chat_completion", slow_create)
+
+    overall_timeout = 0.1
+    start = time.perf_counter()
+    with pytest.raises(gpt_command_parser.ParserTimeoutError):
+        await gpt_command_parser.parse_command("test", overall_timeout=overall_timeout)
+    elapsed = time.perf_counter() - start
+    assert elapsed < overall_timeout + 0.2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- respect provided overall timeout in GPT command parser
- document overall timeout behavior and add regression test

## Testing
- `pytest -q --cov --cov-fail-under=85`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c7da547c74832aa7f6c85876caac5d