### PR TITLE
[learning] Handle lesson log errors explicitly

### DIFF
--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -950,7 +950,7 @@ async def lesson_answer_handler(
                         role,
                         "",
                     )
-                except Exception as exc:  # pragma: no cover - logging only
+                except (httpx.HTTPError, SQLAlchemyError) as exc:
                     logger.exception("lesson log failed: %s", exc)
                     pending_logs.append(
                         _PendingLog(
@@ -963,6 +963,9 @@ async def lesson_answer_handler(
                         )
                     )
                     pending_logs_size.set(len(pending_logs))
+                except Exception as exc:  # pragma: no cover - unexpected
+                    logger.exception("unexpected lesson log error: %s", exc)
+                    raise
                 return ok
 
             log_user_ok = await _record(prev_step, "user")

--- a/tests/assistant/test_lesson_answer_exceptions.py
+++ b/tests/assistant/test_lesson_answer_exceptions.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from services.api.app.config import settings
+from services.api.app.diabetes import learning_handlers
+from services.api.app.diabetes.learning_state import LearnState, set_state
+
+
+class DummyMessage:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.from_user = SimpleNamespace(id=1)
+
+    async def reply_text(
+        self, text: str, **_: Any
+    ) -> None:  # pragma: no cover - helper
+        return None
+
+
+@pytest.mark.asyncio
+async def test_lesson_answer_handler_propagates_unexpected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+    monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+
+    async def fake_check_user_answer(*_: object, **__: object) -> tuple[bool, str]:
+        return True, "feedback"
+
+    async def fake_generate_step_text(*_: object, **__: object) -> str:
+        return "next question"
+
+    async def fail_safe_add_lesson_log(*_: object, **__: object) -> bool:
+        raise ValueError("boom")
+
+    async def ok_hydrate(*_: object, **__: object) -> bool:
+        return True
+
+    monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fake_generate_step_text
+    )
+    monkeypatch.setattr(
+        learning_handlers, "safe_add_lesson_log", fail_safe_add_lesson_log
+    )
+    monkeypatch.setattr(learning_handlers, "_hydrate", ok_hydrate)
+    monkeypatch.setattr(learning_handlers, "_rate_limited", lambda *_a, **_k: False)
+    monkeypatch.setattr(learning_handlers, "build_main_keyboard", lambda: None)
+    monkeypatch.setattr(learning_handlers, "sanitize_feedback", lambda s: s)
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda s: s)
+    monkeypatch.setattr(learning_handlers, "ensure_single_question", lambda s: s)
+
+    user_data: dict[str, object] = {}
+    set_state(
+        user_data, LearnState(topic="t", step=0, awaiting=True, last_step_text="q")
+    )
+
+    msg = DummyMessage("ans")
+    update = SimpleNamespace(message=msg, effective_user=msg.from_user)
+    context = SimpleNamespace(user_data=user_data, bot_data={})
+
+    with pytest.raises(ValueError):
+        await learning_handlers.lesson_answer_handler(update, context)


### PR DESCRIPTION
## Summary
- narrow lesson log error handling to HTTP and database failures
- re-raise unexpected lesson log errors
- test that unexpected logging errors propagate

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c82f44391c832abada0a11d8fb7b23