### PR TITLE
[assistant_state] Sanitize assistant history

### DIFF
--- a/services/api/app/diabetes/assistant_state.py
+++ b/services/api/app/diabetes/assistant_state.py
@@ -37,7 +37,11 @@ def add_turn(user_data: MutableMapping[str, object], text: str) -> int:
     be used by higher-level services to persist summaries in a database when
     new portions are produced.
     """
-    history = cast(list[str], user_data.setdefault(HISTORY_KEY, []))
+    history_obj = user_data.get(HISTORY_KEY)
+    if not isinstance(history_obj, list):
+        history_obj = []
+        user_data[HISTORY_KEY] = history_obj
+    history = cast(list[str], history_obj)
     history.append(text)
     summarized = 0
     if len(history) >= ASSISTANT_SUMMARY_TRIGGER:

--- a/tests/test_assistant_state.py
+++ b/tests/test_assistant_state.py
@@ -27,6 +27,17 @@ async def test_history_trim_and_summary(monkeypatch: pytest.MonkeyPatch) -> None
     assert data[assistant_state.SUMMARY_KEY] == "a1"
 
 
+def test_add_turn_replaces_non_list_history() -> None:
+    data: dict[str, Any] = {
+        assistant_state.HISTORY_KEY: "x",
+        assistant_state.SUMMARY_KEY: "y",
+    }
+    summarized = assistant_state.add_turn(data, "new")
+    assert summarized == 0
+    assert data[assistant_state.HISTORY_KEY] == ["new"]
+    assert data[assistant_state.SUMMARY_KEY] == "y"
+
+
 @pytest.mark.asyncio
 async def test_reset_command_clears(monkeypatch: pytest.MonkeyPatch) -> None:
     user_data: dict[str, Any] = {


### PR DESCRIPTION
## Summary
- ensure `assistant_history` is a list before appending turns
- add regression test for non-list history

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c82f44fae0832a9a530f79d6efcb36