### PR TITLE
[scripts] Move diag_reminders shebang

### DIFF
--- a/scripts/diag_reminders.sh
+++ b/scripts/diag_reminders.sh
@@ -1,5 +1,5 @@
-# scripts/diag_reminders.sh
 #!/usr/bin/env bash
+# scripts/diag_reminders.sh
 set -euo pipefail
 
 # Настройки (можешь менять при запуске через аргументы)


### PR DESCRIPTION
## Summary
- Ensure `diag_reminders.sh` begins with a shebang followed by its filename comment

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c82f47f628832a9a73b4d21c75ee12