### PR TITLE
[handlers] Allow negative dose inputs

### DIFF
--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -402,16 +402,18 @@ dose_conv = ConversationHandler(
         DoseState.METHOD: [
             MessageHandler(filters.TEXT & ~filters.COMMAND, dose_method_choice)
         ],
-        DoseState.XE: [MessageHandler(filters.Regex(r"^\d+(?:[.,]\d+)?$"), dose_xe)],
+        DoseState.XE: [
+            MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), dose_xe)
+        ],
         DoseState.CARBS: [
-            MessageHandler(filters.Regex(r"^\d+(?:[.,]\d+)?$"), dose_carbs)
+            MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), dose_carbs)
         ],
         DoseState.SUGAR: [
-            MessageHandler(filters.Regex(r"^\d+(?:[.,]\d+)?$"), dose_sugar)
+            MessageHandler(filters.Regex(r"^-?\d+(?:[.,]\d+)?$"), dose_sugar)
         ],
         PHOTO_SUGAR: [
             MessageHandler(
-                filters.Regex(r"^\d+(?:[.,]\d+)?$"),
+                filters.Regex(r"^-?\d+(?:[.,]\d+)?$"),
                 dose_sugar,
             )
         ],


### PR DESCRIPTION
## Summary
- allow negative numeric entries through dose calculation regex filters so the handlers can validate them explicitly
- ensure dose calculation handlers respond with warnings on negative values via new unit tests
- update regex-focused tests to assert that conversation states accept negative values

## Testing
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c8492e01c4832a8c4f1427291ddefa