### PR TITLE
[learning] Use public gpt client helpers for logging

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -56,6 +56,37 @@ _learning_router = LLMRouter()
 
 CacheKey = tuple[str, str, str, str, str, str, str, str]
 
+
+def choose_model(task: LLMTask) -> str:
+    """Return the model name configured for the given learning task."""
+
+    return _learning_router.choose_model(task)
+
+
+def make_cache_key(
+    model: str,
+    system: str,
+    user: str,
+    user_id: str | None,
+    plan_id: str | None,
+    topic_slug: str | None,
+    step_idx: int | None,
+    last_reply_hash: str,
+) -> CacheKey:
+    """Create a cache key for learning prompt completions."""
+
+    return _make_cache_key(
+        model,
+        system,
+        user,
+        user_id,
+        plan_id,
+        topic_slug,
+        step_idx,
+        last_reply_hash,
+    )
+
+
 _learning_cache: OrderedDict[CacheKey, tuple[str, float]] = OrderedDict()
 _learning_cache_lock = threading.Lock()
 
@@ -241,7 +272,7 @@ async def create_learning_chat_completion(
     last_reply: str | None = None,
 ) -> str:
     """Create and format a chat completion for learning tasks."""
-    model = _learning_router.choose_model(task)
+    model = choose_model(task)
     msg_list = list(messages)
     system = ""
     user = ""
@@ -279,7 +310,7 @@ async def create_learning_chat_completion(
         else ""
     )
     settings = config.get_settings()
-    cache_key = _make_cache_key(
+    cache_key = make_cache_key(
         model, system, user, user_id, plan_id, topic_slug, step_idx, last_hash
     )
     if settings.learning_prompt_cache:

--- a/tests/learning/test_learning_debug_logging.py
+++ b/tests/learning/test_learning_debug_logging.py
@@ -29,7 +29,7 @@ async def test_generate_step_text_logged(
         learning_handlers, "generate_step_text", fake_generate_step_text
     )
     monkeypatch.setattr(
-        learning_handlers.gpt_client._learning_router,
+        learning_handlers,
         "choose_model",
         lambda task: "m",
     )
@@ -61,10 +61,8 @@ async def test_generate_step_text_logged(
     assert rec.sys_h == learning_handlers._sha1("sys")[:12]
     assert rec.usr_h == learning_handlers._sha1("usr")[:12]
 
-    old_key = learning_handlers.gpt_client._make_cache_key(
-        "m", "sys", "usr", "", "", "", None, ""
-    )
-    new_key = learning_handlers.gpt_client._make_cache_key(
+    old_key = learning_handlers.make_cache_key("m", "sys", "usr", "", "", "", None, "")
+    new_key = learning_handlers.make_cache_key(
         "m", "sys", "usr", "1", "42", "topic", 2, ""
     )
     assert rec.cache_key_old_preview == learning_handlers._sha1("|".join(old_key))[:12]

--- a/tests/test_learning_prompt_cache.py
+++ b/tests/test_learning_prompt_cache.py
@@ -39,12 +39,7 @@ async def test_learning_cache_reuses_response(monkeypatch: pytest.MonkeyPatch) -
             learning_prompt_cache_ttl_sec=1000,
         ),
     )
-    monkeypatch.setattr(
-        gpt_client,
-        "_learning_router",
-        gpt_client.LLMRouter("gpt-4o-mini"),
-        raising=False,
-    )
+    monkeypatch.setattr(gpt_client, "choose_model", lambda task: "gpt-4o-mini")
     monkeypatch.setattr(gpt_client, "_learning_cache", OrderedDict())
 
     messages = [
@@ -82,12 +77,7 @@ async def test_learning_cache_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
             learning_prompt_cache_ttl_sec=1000,
         ),
     )
-    monkeypatch.setattr(
-        gpt_client,
-        "_learning_router",
-        gpt_client.LLMRouter("gpt-4o-mini"),
-        raising=False,
-    )
+    monkeypatch.setattr(gpt_client, "choose_model", lambda task: "gpt-4o-mini")
     monkeypatch.setattr(gpt_client, "_learning_cache", OrderedDict())
 
     messages = [
@@ -120,12 +110,12 @@ async def test_learning_cache_key_components(monkeypatch: pytest.MonkeyPatch) ->
             learning_prompt_cache_ttl_sec=1000,
         ),
     )
-    monkeypatch.setattr(
-        gpt_client,
-        "_learning_router",
-        gpt_client.LLMRouter("m1"),
-        raising=False,
-    )
+    model_name = {"value": "m1"}
+
+    def choose(task: LLMTask) -> str:
+        return model_name["value"]
+
+    monkeypatch.setattr(gpt_client, "choose_model", choose)
     monkeypatch.setattr(gpt_client, "_learning_cache", OrderedDict())
 
     msg_base = [
@@ -185,12 +175,7 @@ async def test_learning_cache_key_components(monkeypatch: pytest.MonkeyPatch) ->
     assert call_count == 3
 
     # different model => miss
-    monkeypatch.setattr(
-        gpt_client,
-        "_learning_router",
-        gpt_client.LLMRouter("m2"),
-        raising=False,
-    )
+    model_name["value"] = "m2"
     await gpt_client.create_learning_chat_completion(
         task=LLMTask.EXPLAIN_STEP, messages=msg_base
     )
@@ -281,12 +266,7 @@ async def test_learning_cache_respects_size(monkeypatch: pytest.MonkeyPatch) -> 
             learning_prompt_cache_ttl_sec=1000,
         ),
     )
-    monkeypatch.setattr(
-        gpt_client,
-        "_learning_router",
-        gpt_client.LLMRouter("m1"),
-        raising=False,
-    )
+    monkeypatch.setattr(gpt_client, "choose_model", lambda task: "m1")
     monkeypatch.setattr(gpt_client, "_learning_cache", OrderedDict())
 
     def make_msgs(i: int) -> list[dict[str, str]]:
@@ -321,12 +301,7 @@ async def test_learning_cache_respects_ttl(monkeypatch: pytest.MonkeyPatch) -> N
             learning_prompt_cache_ttl_sec=1,
         ),
     )
-    monkeypatch.setattr(
-        gpt_client,
-        "_learning_router",
-        gpt_client.LLMRouter("m1"),
-        raising=False,
-    )
+    monkeypatch.setattr(gpt_client, "choose_model", lambda task: "m1")
     monkeypatch.setattr(gpt_client, "_learning_cache", OrderedDict())
 
     start = 100.0


### PR DESCRIPTION
## Summary
- add public helpers to choose the learning model and build cache keys inside gpt_client
- update the learning debug logger to rely on the new helpers and simplify its guard
- adjust unit tests to patch the new helpers instead of private attributes

## Testing
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c854a9e75c832aa0f9018053d1e977