### PR TITLE
[management] Return exit codes from aggregate onboarding CLI

### DIFF
--- a/services/api/app/management/aggregate_onboarding.py
+++ b/services/api/app/management/aggregate_onboarding.py
@@ -76,7 +76,7 @@ def aggregate_for_date(
     return [{"variant": variant, "step": step, "count": count} for variant, step, count in rows]
 
 
-def main(argv: Iterable[str] | None = None) -> str:
+def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Aggregate onboarding events into daily metrics")
     parser.add_argument(
         "--date",
@@ -86,11 +86,17 @@ def main(argv: Iterable[str] | None = None) -> str:
     )
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    metrics = aggregate_for_date(args.date)
+    try:
+        metrics = aggregate_for_date(args.date)
+    except Exception:  # pragma: no cover - defensive programming
+        logger.exception("Failed to aggregate onboarding metrics for %s", args.date)
+        return 1
+
     metrics_json = json.dumps(metrics, ensure_ascii=False)
+    print(metrics_json)
     logger.info("Aggregated metrics for %s: %s", args.date, metrics_json)
-    return metrics_json
+    return 0
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point
-    print(main())
+    raise SystemExit(main())

--- a/tests/management/test_aggregate_onboarding.py
+++ b/tests/management/test_aggregate_onboarding.py
@@ -64,7 +64,9 @@ def test_aggregate_onboarding(session_local: sessionmaker[SASession]) -> None:
         assert counts[("A", "start")] == 2
         assert counts[("A", "finish")] == 1
 def test_main_logs_json(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     metrics = [{"variant": "A", "step": "start", "count": 1}]
     monkeypatch.setattr(
@@ -73,5 +75,8 @@ def test_main_logs_json(
 
     caplog.set_level(logging.INFO, logger=aggregate_onboarding.logger.name)
     result = aggregate_onboarding.main(["--date", "2024-01-02"])
-    assert json.loads(result) == metrics
-    assert result in caplog.text
+    assert result == 0
+
+    stdout = capsys.readouterr().out.strip()
+    assert json.loads(stdout) == metrics
+    assert json.dumps(metrics, ensure_ascii=False) in caplog.text


### PR DESCRIPTION
## Summary
- update the aggregate onboarding CLI to handle output internally and return a process exit code
- adjust tests to validate the new CLI behaviour and captured output

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c854ab2de4832aa242b728c997948b