### PR TITLE
[gpt] Make create_thread_sync safe across event loops

### DIFF
--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -351,6 +351,14 @@ def test_create_thread_sync_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_thread_sync_running_loop_error() -> None:
+    message = r"create_thread_sync\(\) cannot be used when the event loop is running"
+
+    with pytest.raises(RuntimeError, match=message):
+        gpt_client.create_thread_sync()
+
+
+@pytest.mark.asyncio
 async def test_send_message_timeout(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
## Summary
- guard `create_thread_sync` against running event loops while keeping `asyncio.run` for synchronous callers
- add regression tests covering both execution contexts

## Testing
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c85f07e760832a81e0b9353743cca4