### PR TITLE
[reminders] Limit safe combine retries for nonexistent times

### DIFF
--- a/tests/test_reminders_schedule.py
+++ b/tests/test_reminders_schedule.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from datetime import datetime, time, timezone, tzinfo
+from datetime import date, datetime, time, timezone, tzinfo
 from zoneinfo import ZoneInfo
 
 import pytest
 
 from services.api.app.diabetes.services.db import Reminder
 from services.api.app.diabetes.services import reminders_schedule
-from services.api.app.diabetes.services.reminders_schedule import compute_next
+from services.api.app.diabetes.services.reminders_schedule import (
+    _safe_combine,
+    compute_next,
+)
 
 
 def _patch_now(monkeypatch: pytest.MonkeyPatch, dt: datetime) -> None:
@@ -78,4 +81,78 @@ def test_quiet_window_dst_transition(monkeypatch: pytest.MonkeyPatch) -> None:
     rem = Reminder(kind="every", interval_minutes=60)
     next_dt = compute_next(rem, tz, quiet_start="02:00", quiet_end="04:00")
     assert next_dt == datetime(2024, 3, 31, 2, 0, tzinfo=timezone.utc)
+
+
+def test_safe_combine_skips_dst_gap(monkeypatch: pytest.MonkeyPatch) -> None:
+    tz = ZoneInfo("Europe/Berlin")
+    transition_day = date(2024, 3, 31)
+    real_datetime = datetime
+
+    class GapAwareDatetime:
+        calls: list[tuple[date, time, ZoneInfo | None]] = []
+
+        @classmethod
+        def combine(
+            cls,
+            current_day: date,
+            current_time: time,
+            tzinfo: ZoneInfo | None = None,
+        ) -> datetime:
+            cls.calls.append((current_day, current_time, tzinfo))
+            if tzinfo is not None and current_time.hour == 2:
+                raise ValueError("missing time")
+            return real_datetime.combine(current_day, current_time, tzinfo=tzinfo)
+
+    GapAwareDatetime.calls = []
+    monkeypatch.setattr(reminders_schedule, "datetime", GapAwareDatetime)
+
+    result = _safe_combine(transition_day, time(2, 30), tz)
+
+    assert result == real_datetime.combine(transition_day, time(3, 30), tzinfo=tz)
+
+    tz_calls = [
+        (call_day, call_time)
+        for call_day, call_time, tzinfo in GapAwareDatetime.calls
+        if tzinfo is not None
+    ]
+    assert tz_calls == [
+        (transition_day, time(2, 30)),
+        (transition_day, time(3, 30)),
+    ]
+
+
+def test_safe_combine_raises_after_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    tz = ZoneInfo("Europe/Berlin")
+    transition_day = date(2024, 3, 31)
+    real_datetime = datetime
+
+    class BrokenDatetime:
+        attempts: int = 0
+
+        @classmethod
+        def combine(
+            cls,
+            current_day: date,
+            current_time: time,
+            tzinfo: ZoneInfo | None = None,
+        ) -> datetime:
+            if tzinfo is None:
+                return real_datetime.combine(current_day, current_time)
+            cls.attempts += 1
+            raise ValueError("still missing")
+
+    BrokenDatetime.attempts = 0
+    monkeypatch.setattr(reminders_schedule, "datetime", BrokenDatetime)
+
+    with pytest.raises(ValueError) as excinfo:
+        _safe_combine(transition_day, time(2, 30), tz)
+
+    message = str(excinfo.value)
+    assert "2024-03-31T02:30:00" in message
+    assert tz.key in message
+    assert str(reminders_schedule._MAX_NONEXISTENT_SHIFT_HOURS) in message
+    assert (
+        BrokenDatetime.attempts
+        == reminders_schedule._MAX_NONEXISTENT_SHIFT_HOURS + 1
+    )
 


### PR DESCRIPTION
## Summary
- guard `_safe_combine` against infinite retries by limiting the hourly shifts and surfacing a descriptive error once the limit is hit
- adjust the rollover logic so day changes are respected after each retry
- add reminder schedule tests that simulate DST gaps and verify the new failure path

## Testing
- pytest -q tests/test_reminders_schedule.py
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c85f09f1c4832a8fc515bb47209fcb