### PR TITLE
[utils] Ensure calc_bolus rejects invalid carb units

### DIFF
--- a/services/api/app/diabetes/utils/calc_bolus.py
+++ b/services/api/app/diabetes/utils/calc_bolus.py
@@ -83,12 +83,10 @@ def calc_bolus(
     if bolus_round_step <= 0:
         raise ValueError("bolus_round_step must be positive")
 
-    if carb_units == "xe":
-        carbs_g = carbs * XE_GRAMS
-    elif carb_units == "g":
-        carbs_g = carbs
-    else:  # pragma: no cover - invalid unit branch
+    if carb_units not in {"g", "xe"}:
         raise ValueError("carb_units must be 'g' or 'xe'")
+
+    carbs_g = carbs * XE_GRAMS if carb_units == "xe" else carbs
 
     with localcontext() as ctx:
         ctx.prec = 6

--- a/tests/test_calc_bolus.py
+++ b/tests/test_calc_bolus.py
@@ -93,3 +93,14 @@ def test_calc_bolus_negative_max_bolus() -> None:
             profile=profile,
             max_bolus=-1.0,
         )
+
+
+def test_calc_bolus_invalid_carb_units() -> None:
+    profile = PatientProfile(icr=10, cf=2, target_bg=6)
+    with pytest.raises(ValueError, match="carb_units must be 'g' or 'xe'"):
+        calc_bolus(
+            carbs=10,
+            current_bg=7,
+            profile=profile,
+            carb_units="kg",
+        )


### PR DESCRIPTION
## Summary
- validate carb_units argument before conversion so only "g" and "xe" are accepted
- add regression test covering invalid carb unit handling

## Testing
- pytest tests/test_calc_bolus.py

------
https://chatgpt.com/codex/tasks/task_e_68c8634e3b64832a93d9436e6575f3e5