### PR TITLE
[assistant] Log flush pending logs failures

### DIFF
--- a/services/api/app/assistant/repositories/logs.py
+++ b/services/api/app/assistant/repositories/logs.py
@@ -98,11 +98,12 @@ async def flush_pending_logs() -> None:
             if settings.learning_logging_required:
                 raise
             return
-    except Exception:  # pragma: no cover - logging only
+    except Exception as exc:  # pragma: no cover - logging only
         lesson_log_failures.inc(len(queued))
         async with pending_logs_lock:
             pending_logs.extend(queued)
             _trim_pending_logs()
+        logger.exception("flush_pending_logs failed", exc_info=exc)
         if settings.learning_logging_required:
             raise
         return


### PR DESCRIPTION
## Summary
- log unexpected failures in `flush_pending_logs` with a stack trace for easier troubleshooting
- update the lesson log repository tests to assert the new logging behaviour and keep shared state clean

## Testing
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c8635a73d8832a81bb88410fabf2ff