### PR TITLE
[tests] Add return annotations to helper mocks

### DIFF
--- a/tests/services/bot/test_main.py
+++ b/tests/services/bot/test_main.py
@@ -11,7 +11,7 @@ from services.bot import main
 async def test_post_init_without_redis(monkeypatch) -> None:
     original_import = builtins.__import__
 
-    def fake_import(name: str, *args: object, **kwargs: object):
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
         if name == "redis.asyncio":
             raise ModuleNotFoundError
         return original_import(name, *args, **kwargs)
@@ -43,7 +43,7 @@ async def test_post_init_handles_none_redis_client(
 ) -> None:
     original_import = builtins.__import__
 
-    def fake_import(name: str, *args: object, **kwargs: object):
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
         if name == "redis.asyncio":
             raise ModuleNotFoundError
         return original_import(name, *args, **kwargs)

--- a/tests/test_handlers_profile_webapp.py
+++ b/tests/test_handlers_profile_webapp.py
@@ -1,7 +1,7 @@
 import json
 import importlib
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Callable, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -152,7 +152,10 @@ async def test_webapp_save_success(monkeypatch: pytest.MonkeyPatch) -> None:
     post_mock = MagicMock(return_value=(True, None))
     save_mock = MagicMock(return_value=True)
 
-    async def run_db(func, sessionmaker):
+    async def run_db(
+        func: Callable[..., object],
+        sessionmaker: object,
+    ) -> object:
         session = MagicMock()
         return func(session)
 
@@ -190,7 +193,10 @@ async def test_webapp_save_success(monkeypatch: pytest.MonkeyPatch) -> None:
 async def test_webapp_save_db_error(monkeypatch: pytest.MonkeyPatch) -> None:
     post_mock = MagicMock(return_value=(True, None))
 
-    async def run_db(func, sessionmaker):
+    async def run_db(
+        func: Callable[..., object],
+        sessionmaker: object,
+    ) -> object:
         session = MagicMock()
         return func(session)
 
@@ -249,7 +255,10 @@ async def test_webapp_save_settings_patch_error(
     post_mock = MagicMock(return_value=(True, None))
     save_mock = MagicMock(return_value=True)
 
-    async def run_db(func, sessionmaker):
+    async def run_db(
+        func: Callable[..., object],
+        sessionmaker: object,
+    ) -> object:
         session = MagicMock()
         return func(session)
 


### PR DESCRIPTION
## Summary
- add explicit return types to helper imports in bot main tests
- annotate temporary run_db overrides in profile webapp tests

## Testing
- `mypy --strict .`


------
https://chatgpt.com/codex/tasks/task_e_68c86f3a13d0832a903957f38dc42b7b