### PR TITLE
[gpt] Validate parse_command timeouts

### DIFF
--- a/services/api/app/diabetes/gpt_command_parser.py
+++ b/services/api/app/diabetes/gpt_command_parser.py
@@ -207,6 +207,11 @@ async def parse_command(
         optional ``fields`` describing the command, or ``None`` if parsing fails.
     """
 
+    if api_timeout <= 0:
+        raise ValueError("api_timeout must be greater than 0")
+    if overall_timeout is not None and overall_timeout <= 0:
+        raise ValueError("overall_timeout must be greater than 0 when provided")
+
     wait_timeout = overall_timeout if overall_timeout is not None else api_timeout + 1
     try:
         resp: ChatCompletion | Awaitable[ChatCompletion] = create_chat_completion(

--- a/tests/test_gpt_command_parser.py
+++ b/tests/test_gpt_command_parser.py
@@ -59,6 +59,18 @@ async def test_parse_command_timeout_non_blocking(
 
 
 @pytest.mark.asyncio
+async def test_parse_command_rejects_non_positive_api_timeout() -> None:
+    with pytest.raises(ValueError, match="api_timeout must be greater than 0"):
+        await gpt_command_parser.parse_command("test", api_timeout=0)
+
+
+@pytest.mark.asyncio
+async def test_parse_command_rejects_non_positive_overall_timeout() -> None:
+    with pytest.raises(ValueError, match="overall_timeout must be greater than 0 when provided"):
+        await gpt_command_parser.parse_command("test", overall_timeout=0)
+
+
+@pytest.mark.asyncio
 async def test_parse_command_respects_overall_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- validate `parse_command` rejects non-positive API and overall timeouts with clear `ValueError`s
- add unit tests covering the new timeout validation paths

## Testing
- pytest tests/test_gpt_command_parser.py
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c86f383660832a8577ba54e7c36331