### PR TITLE
[billing] Remove broad exception handler from trial command

### DIFF
--- a/services/api/app/diabetes/handlers/billing_handlers.py
+++ b/services/api/app/diabetes/handlers/billing_handlers.py
@@ -100,9 +100,6 @@ async def trial_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         logger.exception("invalid trial end date")
         await message.reply_text("❌ Ошибка сервера: неверный формат даты trial.")
         return
-    except Exception:  # pragma: no cover - unexpected
-        logger.exception("unexpected error parsing trial end date")
-        raise
     end_str = end_dt.strftime("%d.%m.%Y")
     await message.reply_text(f"🎉 Активирован trial до {end_str}")
     kb = subscription_keyboard(False)


### PR DESCRIPTION
## Summary
- remove the broad `except Exception` block from `trial_command` so unexpected failures bubble up

## Testing
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c86f338a74832aa038619373af11e9