### PR TITLE
[dose_calc] Remove redundant dose method state

### DIFF
--- a/services/api/app/diabetes/handlers/__init__.py
+++ b/services/api/app/diabetes/handlers/__init__.py
@@ -38,7 +38,6 @@ class UserData(TypedDict, total=False):
     thread_id: str
     pending_entry: EntryData
     pending_fields: list[str]
-    dose_method: str
     edit_id: int | None
     edit_entry: dict[str, object]
     edit_field: str

--- a/services/api/app/diabetes/handlers/dose_calc.py
+++ b/services/api/app/diabetes/handlers/dose_calc.py
@@ -93,7 +93,6 @@ async def dose_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
         return END
     user_data.pop("pending_entry", None)
     user_data.pop("edit_id", None)
-    user_data.pop("dose_method", None)
     await message.reply_text(
         "💉 Как рассчитать дозу? Выберите метод:",
         reply_markup=dose_keyboard,
@@ -117,11 +116,9 @@ async def dose_method_choice(update: Update, context: ContextTypes.DEFAULT_TYPE)
     if "назад" in text:
         return await dose_cancel(update, context)
     if "углев" in text:
-        user_data["dose_method"] = "carbs"
         await message.reply_text("Введите количество углеводов (г).")
         return DoseState.CARBS
     if "xe" in text or "хе" in text:
-        user_data["dose_method"] = "xe"
         await message.reply_text("Введите количество ХЕ.")
         return DoseState.XE
     await message.reply_text(
@@ -335,7 +332,6 @@ async def dose_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int
         return END
     await message.reply_text("Отменено.", reply_markup=build_main_keyboard())
     user_data.pop("pending_entry", None)
-    user_data.pop("dose_method", None)
     chat_data = getattr(context, "chat_data", None)
     if chat_data is not None:
         chat_data.pop("sugar_active", None)

--- a/tests/test_photo_fallbacks.py
+++ b/tests/test_photo_fallbacks.py
@@ -68,7 +68,7 @@ async def _exercise(
     context = cast(
         CallbackContext[Any, dict[str, Any], dict[str, Any], dict[str, Any]],
         SimpleNamespace(
-            user_data={"pending_entry": {"foo": "bar"}, "dose_method": "xe"}
+            user_data={"pending_entry": {"foo": "bar"}}
         ),
     )
     await handler.callback(update, context)


### PR DESCRIPTION
## Summary
- remove storing and clearing of `dose_method` in dose calculation handlers and user data
- update the photo fallback test to no longer depend on the removed field

## Testing
- pytest -q
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c876448000832abdb57c39b5085960