### PR TITLE
[management] Add stdout flag for onboarding aggregation

### DIFF
--- a/services/api/app/management/aggregate_onboarding.py
+++ b/services/api/app/management/aggregate_onboarding.py
@@ -84,6 +84,11 @@ def main(argv: Iterable[str] | None = None) -> int:
         default=date.today(),
         help="Target date in YYYY-MM-DD (defaults to today)",
     )
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Print aggregated metrics to stdout instead of logging",
+    )
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     try:
@@ -93,8 +98,10 @@ def main(argv: Iterable[str] | None = None) -> int:
         return 1
 
     metrics_json = json.dumps(metrics, ensure_ascii=False)
-    print(metrics_json)
-    logger.info("Aggregated metrics for %s: %s", args.date, metrics_json)
+    if args.stdout:
+        print(metrics_json)
+    else:
+        logger.info("Aggregated metrics for %s: %s", args.date, metrics_json)
     return 0
 
 

--- a/tests/management/test_aggregate_onboarding.py
+++ b/tests/management/test_aggregate_onboarding.py
@@ -78,5 +78,24 @@ def test_main_logs_json(
     assert result == 0
 
     stdout = capsys.readouterr().out.strip()
-    assert json.loads(stdout) == metrics
+    assert stdout == ""
     assert json.dumps(metrics, ensure_ascii=False) in caplog.text
+
+
+def test_main_stdout_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    metrics = [{"variant": "A", "step": "start", "count": 1}]
+    monkeypatch.setattr(
+        aggregate_onboarding, "aggregate_for_date", lambda d: metrics
+    )
+
+    caplog.set_level(logging.INFO, logger=aggregate_onboarding.logger.name)
+    result = aggregate_onboarding.main(["--date", "2024-01-02", "--stdout"])
+    assert result == 0
+
+    stdout = capsys.readouterr().out.strip()
+    assert json.loads(stdout) == metrics
+    assert caplog.text == ""


### PR DESCRIPTION
## Summary
- add a `--stdout` flag to `aggregate_onboarding` so metrics are printed only when requested and otherwise logged
- update the onboarding aggregation CLI tests to reflect the new logging behavior and cover the stdout option

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_e_68c87dea66b8832a891220d11867bd36