### PR TITLE
[db] Close sessions before disposing engine

### DIFF
--- a/services/api/app/diabetes/services/db.py
+++ b/services/api/app/diabetes/services/db.py
@@ -552,6 +552,8 @@ def init_db() -> None:
     with engine_lock:
         if engine is None or engine.url != database_url:
             if engine is not None:
+                close_all_sessions()
+                SessionLocal.configure(bind=None)
                 engine.dispose()
             try:
                 engine = create_engine(database_url)


### PR DESCRIPTION
## Summary
- close existing SQLAlchemy sessions before disposing the previous engine in `init_db`
- reset `SessionLocal` binding prior to configuring the newly created engine

## Testing
- make ci


------
https://chatgpt.com/codex/tasks/task_e_68c91aa07abc832a876c1fa6c4ef81b3