### PR TITLE
[commands] Guard reset handler without user

### DIFF
--- a/services/api/app/diabetes/commands.py
+++ b/services/api/app/diabetes/commands.py
@@ -130,11 +130,13 @@ async def reset_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     user = getattr(update, "effective_user", None)
     if message is None or not settings.assistant_mode_enabled:
         return
+    if user is None:
+        logger.warning("Reset command invoked without effective user.")
+        return
     user_data = cast(dict[str, object], context.user_data)
     _reset_assistant(user_data)
     user_data.pop(MODE_DISCLAIMED_KEY, None)
-    if user is not None:
-        await _clear_memory(user.id)
+    await _clear_memory(user.id)
     await message.reply_text("История очищена.")
 
 


### PR DESCRIPTION
## Summary
- guard `reset_command` against missing users, logging a warning instead of clearing state
- ensure assistant reset tests cover both user-present and user-missing flows

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_e_68c91aa26878832abdf02e977e0239a6