### PR TITLE
[gpt_client] Validate format_reply max_len

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -169,6 +169,9 @@ def format_reply(text: str, *, max_len: int = 800) -> str:
     str
         Formatted text with paragraphs truncated and separated by blank lines.
     """
+    if max_len <= 0:
+        raise ValueError("max_len must be positive")
+
     paragraphs = [part.strip()[:max_len] for part in re.split(r"\n\s*\n", text.strip()) if part.strip()]
     return "\n\n".join(paragraphs)
 

--- a/tests/test_format_reply.py
+++ b/tests/test_format_reply.py
@@ -1,3 +1,5 @@
+import pytest
+
 from services.api.app.diabetes.services.gpt_client import format_reply
 
 
@@ -11,3 +13,9 @@ def test_format_reply_truncates_to_default_limit() -> None:
     text = "a" * 900 + "\n\n" + "b" * 1000
     result = format_reply(text)
     assert result == "a" * 800 + "\n\n" + "b" * 800
+
+
+@pytest.mark.parametrize("max_len", [0, -1])
+def test_format_reply_raises_for_non_positive_max_len(max_len: int) -> None:
+    with pytest.raises(ValueError, match="max_len must be positive"):
+        format_reply("text", max_len=max_len)


### PR DESCRIPTION
## Summary
- raise a ValueError in `format_reply` when `max_len` is non-positive
- extend the unit tests to cover invalid `max_len` values

## Testing
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c91aa72fc8832a9acd338a8838e68a