### PR TITLE
[bot] Warn when redis module is missing

### DIFF
--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -82,7 +82,9 @@ async def post_init(
         try:
             import redis.asyncio as real_redis  # type: ignore[import-not-found]
         except ModuleNotFoundError:
-            pass
+            logger.warning(
+                "redis.asyncio is not installed; Redis-dependent features are disabled"
+            )
         else:
             patched_from_url = getattr(getattr(redis, "Redis", None), "from_url", None)
             if patched_from_url is not None:


### PR DESCRIPTION
## Summary
- log a warning when the optional redis.asyncio dependency is unavailable so redis features are disabled

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_e_68c94ab07328832aa20921ef6008b812