### PR TITLE
[migrations] Log missing lesson_logs table via Alembic logger

### DIFF
--- a/services/api/alembic/versions/20251009_lesson_logs_user_ondelete_cascade.py
+++ b/services/api/alembic/versions/20251009_lesson_logs_user_ondelete_cascade.py
@@ -20,7 +20,7 @@ def upgrade() -> None:
     inspector = inspect(bind)
 
     if "lesson_logs" not in inspector.get_table_names():
-        print("⚠️ Skipping: lesson_logs table does not exist yet")
+        op.get_context().log.warning("⚠️ Skipping: lesson_logs table does not exist yet")
         return
 
     # пробуем дропнуть FK, если он есть


### PR DESCRIPTION
## Summary
- log the missing `lesson_logs` table warning through Alembic instead of printing directly

## Testing
- make ci

------
https://chatgpt.com/codex/tasks/task_e_68c94aba5504832abafcf32097dd8870