### PR TITLE
[labs] Reset state on lab upload failures

### DIFF
--- a/services/api/app/diabetes/labs_handlers.py
+++ b/services/api/app/diabetes/labs_handlers.py
@@ -201,6 +201,8 @@ async def labs_handler(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> int:
         if mime and not (mime.lower().startswith(("image/", "text/")) or "pdf" in mime.lower()):
             logger.warning("Unsupported MIME type: %s", mime)
             await message.reply_text("⚠️ Неподдерживаемый тип файла.")
+            user_data.pop("waiting_labs", None)
+            user_data.pop("assistant_last_mode", None)
             return END
         kind = KIND_FILE
         text = _extract_text_from_file(file_bytes, mime)

--- a/tests/test_labs_handlers.py
+++ b/tests/test_labs_handlers.py
@@ -26,12 +26,13 @@ async def test_labs_handler_text() -> None:
     message.reply_text = AsyncMock()
     update.effective_message = message
     ctx = MagicMock()
-    ctx.user_data = {"waiting_labs": True}
+    ctx.user_data = {"waiting_labs": True, "assistant_last_mode": "labs"}
 
     result = await labs_handlers.labs_handler(update, ctx)
 
     assert result == labs_handlers.END
     assert ctx.user_data.get("waiting_labs") is None
+    assert ctx.user_data.get("assistant_last_mode") is None
     message.reply_text.assert_awaited_once()
 
 
@@ -45,7 +46,7 @@ async def test_labs_handler_unsupported_mime(
     message.reply_text = AsyncMock()
     update.effective_message = message
     ctx = MagicMock()
-    ctx.user_data = {"waiting_labs": True}
+    ctx.user_data = {"waiting_labs": True, "assistant_last_mode": "labs"}
     monkeypatch.setattr(
         labs_handlers,
         "_download_file",
@@ -54,5 +55,29 @@ async def test_labs_handler_unsupported_mime(
     result = await labs_handlers.labs_handler(update, ctx)
     assert result == labs_handlers.END
     message.reply_text.assert_awaited_once()
-    assert ctx.user_data.get("waiting_labs") is True
+    assert ctx.user_data.get("waiting_labs") is None
+    assert ctx.user_data.get("assistant_last_mode") is None
     assert labs_handlers.AWAITING_KIND not in ctx.user_data
+
+
+@pytest.mark.asyncio
+async def test_labs_handler_download_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    update = MagicMock()
+    message = MagicMock()
+    message.text = None
+    message.reply_text = AsyncMock()
+    update.effective_message = message
+    ctx = MagicMock()
+    ctx.user_data = {"waiting_labs": True, "assistant_last_mode": "labs"}
+    monkeypatch.setattr(
+        labs_handlers,
+        "_download_file",
+        AsyncMock(return_value=None),
+    )
+
+    result = await labs_handlers.labs_handler(update, ctx)
+
+    assert result == labs_handlers.END
+    message.reply_text.assert_awaited_once_with("⚠️ Не удалось получить файл.")
+    assert ctx.user_data.get("waiting_labs") is None
+    assert ctx.user_data.get("assistant_last_mode") is None


### PR DESCRIPTION
## Summary
- clear the labs conversation state when an unsupported file type is uploaded
- extend labs handler tests to cover state reset for success and failure paths

## Testing
- pytest --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c94d9e1484832abab9f71321b32ff9