### PR TITLE
[assistant] Restore assistant modes using public user data

### DIFF
--- a/services/api/app/diabetes/handlers/assistant_menu.py
+++ b/services/api/app/diabetes/handlers/assistant_menu.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
 from typing import TYPE_CHECKING, TypeAlias, cast
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
@@ -99,11 +98,11 @@ async def post_init(
     """Restore last assistant modes for users on startup."""
 
     records = await memory_service.get_last_modes()
-    store = cast(defaultdict[int, dict[str, object]], app._user_data)  # type: ignore[redundant-cast]
+    user_data_map = app.user_data
     for user_id, mode in records:
         if mode not in MODE_TEXTS:
             continue
-        data = store.setdefault(user_id, {})
+        data = user_data_map[user_id]
         data[AWAITING_KIND] = mode
         set_last_mode(data, mode)
         await app.bot.send_message(


### PR DESCRIPTION
## Summary
- switch the assistant post-startup restore logic to use the Application.user_data mapping instead of the private _user_data attribute
- adjust the assistant menu test to mimic the MappingProxyType-backed store and assert both awaiting kind and last mode are restored

## Testing
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c98a732218832a92313e3b2ef94f07