### PR TITLE
[alerts] Extract db_eval helper and add coverage

### DIFF
--- a/tests/test_alert_handlers.py
+++ b/tests/test_alert_handlers.py
@@ -7,11 +7,17 @@ from typing import Any, Callable, cast
 from unittest.mock import AsyncMock
 
 import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine
 from telegram.error import TelegramError
 from telegram.ext import ContextTypes, JobQueue
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
 
 from .context_stub import AlertContext, ContextStub
 import services.api.app.diabetes.handlers.alert_handlers as handlers
+from services.api.app.diabetes.services.db import Alert, Base, Profile, User
+from services.api.app.diabetes.services.repository import commit as repo_commit
 
 
 async def fake_get_coords_and_link() -> tuple[str | None, str | None]:
@@ -263,3 +269,84 @@ def test_schedule_alert_without_timezone_kwarg() -> None:
         profile=profile,
     )
     assert len(job_queue.jobs) == 1
+
+
+def _setup_db() -> tuple[Engine, sessionmaker[Session]]:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    return engine, session_factory
+
+
+def _prepare_profile(session_factory: sessionmaker[Session]) -> None:
+    with session_factory() as session:
+        session.add(User(telegram_id=1, thread_id="thread-1"))
+        session.add(
+            Profile(
+                telegram_id=1,
+                low_threshold=4.0,
+                high_threshold=8.0,
+                sos_contact="@alice",
+                sos_alerts_enabled=True,
+            )
+        )
+        session.commit()
+
+
+def test_db_eval_creates_alert(monkeypatch: pytest.MonkeyPatch) -> None:
+    """db_eval creates an alert and requests scheduling."""
+
+    monkeypatch.setattr(handlers, "commit", repo_commit)
+    engine, session_factory = _setup_db()
+    try:
+        _prepare_profile(session_factory)
+
+        with session_factory() as session:
+            ok, result = handlers.db_eval(session, 1, 9.5)
+
+        assert ok is True
+        assert result is not None
+        assert result["action"] == "schedule"
+        assert result["notify"] is False
+        profile_info = cast(dict[str, object], result["profile"])
+        assert profile_info["sos_contact"] == "@alice"
+        assert profile_info["sos_alerts_enabled"] is True
+
+        with session_factory() as session:
+            alert = session.scalars(sa.select(Alert).filter_by(user_id=1)).one()
+            assert alert.type == "hyper"
+            assert alert.resolved is False
+    finally:
+        engine.dispose()
+
+
+def test_db_eval_resolves_alert(monkeypatch: pytest.MonkeyPatch) -> None:
+    """db_eval resolves active alerts when sugar normalises."""
+
+    monkeypatch.setattr(handlers, "commit", repo_commit)
+    engine, session_factory = _setup_db()
+    try:
+        _prepare_profile(session_factory)
+
+        with session_factory() as session:
+            ok, _ = handlers.db_eval(session, 1, 3.0)
+
+        assert ok is True
+
+        with session_factory() as session:
+            active = session.scalars(sa.select(Alert).filter_by(user_id=1)).one()
+            assert active.resolved is False
+
+        with session_factory() as session:
+            ok, result = handlers.db_eval(session, 1, 5.0)
+
+        assert ok is True
+        assert result is not None
+        assert result["action"] == "remove"
+        assert result["notify"] is False
+
+        with session_factory() as session:
+            resolved = session.scalars(sa.select(Alert).filter_by(user_id=1)).one()
+            assert resolved.resolved is True
+    finally:
+        engine.dispose()


### PR DESCRIPTION
## Summary
- extract the database evaluation logic from `evaluate_sugar` into a dedicated `db_eval` helper
- call the helper from `evaluate_sugar` so the coroutine focuses on scheduling and notifications
- add unit tests that cover alert creation and resolution flows

## Testing
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c98a9bca8c832aade4626a278fce45