### PR TITLE
[config] Normalize UI URL paths

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,3 +40,96 @@ def test_get_db_role_passwords(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DB_WRITE_PASSWORD", "wpass")
     assert config.get_db_read_password() == "rpass"
     assert config.get_db_write_password() == "wpass"
+
+
+@pytest.mark.parametrize(
+    ("origin", "ui_base", "path", "expected"),
+    [
+        (
+            "https://example.com",
+            "/ui",
+            "/reminders/new",
+            "https://example.com/ui/reminders/new",
+        ),
+        (
+            "https://example.com/",
+            "ui/",
+            "reminders/new",
+            "https://example.com/ui/reminders/new",
+        ),
+        (
+            "https://example.com",
+            "/ui",
+            "reminders//new",
+            "https://example.com/ui/reminders/new",
+        ),
+        (
+            "https://example.com",
+            "/ui",
+            "reminders/new/",
+            "https://example.com/ui/reminders/new/",
+        ),
+        (
+            "https://example.com",
+            "/ui",
+            "",
+            "https://example.com/ui/",
+        ),
+        (
+            "https://example.com/base",
+            "",
+            "section?foo=1#top",
+            "https://example.com/base/section?foo=1#top",
+        ),
+    ],
+)
+def test_build_ui_url_normalizes_path(
+    monkeypatch: pytest.MonkeyPatch,
+    origin: str,
+    ui_base: str,
+    path: str,
+    expected: str,
+) -> None:
+    monkeypatch.setenv("PUBLIC_ORIGIN", origin)
+    monkeypatch.setenv("UI_BASE_URL", ui_base)
+    config = cast(Any, _reload("services.api.app.config"))
+    try:
+        url = config.build_ui_url(path)
+        assert url == expected
+        assert url.startswith(origin.rstrip("/"))
+    finally:
+        sys.modules.pop("services.api.app.config", None)
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["../admin", "/../admin", "reminders/../admin"],
+)
+def test_build_ui_url_rejects_parent_segments(
+    monkeypatch: pytest.MonkeyPatch, path: str
+) -> None:
+    monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.com")
+    monkeypatch.setenv("UI_BASE_URL", "/ui")
+    config = cast(Any, _reload("services.api.app.config"))
+    try:
+        with pytest.raises(ValueError, match=r"\.\."):
+            config.build_ui_url(path)
+    finally:
+        sys.modules.pop("services.api.app.config", None)
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["https://evil.com", "//evil.com", "http://evil.com/path"],
+)
+def test_build_ui_url_rejects_absolute_urls(
+    monkeypatch: pytest.MonkeyPatch, path: str
+) -> None:
+    monkeypatch.setenv("PUBLIC_ORIGIN", "https://example.com")
+    monkeypatch.setenv("UI_BASE_URL", "/ui")
+    config = cast(Any, _reload("services.api.app.config"))
+    try:
+        with pytest.raises(ValueError, match="relative"):
+            config.build_ui_url(path)
+    finally:
+        sys.modules.pop("services.api.app.config", None)


### PR DESCRIPTION
## Summary
- normalize UI URLs to reject parent directory traversal and absolute targets while preserving query and fragment components
- ensure generated paths stay within the configured UI base path
- add regression tests covering normalization, traversal rejection, and absolute URL handling

## Testing
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c98aabffd0832a95ad4abb4f242959