### PR TITLE
[scripts] Add type hints to diag reminders script

### DIFF
--- a/scripts/diag_reminders.sh
+++ b/scripts/diag_reminders.sh
@@ -121,7 +121,7 @@ except Exception as e:
 
 token=os.environ.get("BOT_TOKEN") or os.environ.get("TELEGRAM_BOT_TOKEN")
 chat_id=int("${TG_ID}")
-async def main():
+async def main() -> None:
     bot=Bot(token=token)
     txt=f"Диагностика: бот доступен ✅ (UTC={datetime.now(UTC):%Y-%m-%d %H:%M:%S})"
     await bot.send_message(chat_id=chat_id, text=txt)


### PR DESCRIPTION
## Summary
- annotate the async `main` helper in `scripts/diag_reminders.sh` with an explicit `-> None` return type for clarity

## Testing
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68c998394650832a872fa717ada94fc8