### PR TITLE
[tests] Add return annotations for run_db stubs

### DIFF
--- a/tests/billing/test_admin_mock_webhook.py
+++ b/tests/billing/test_admin_mock_webhook.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -38,7 +39,12 @@ def make_client(
     session_local: sessionmaker[Session],
     settings: BillingSettings,
 ) -> TestClient:
-    async def run_db(fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs):
+    async def run_db(
+        fn,
+        *args,
+        sessionmaker: sessionmaker[Session] = session_local,
+        **kwargs,
+    ) -> Any:
         with sessionmaker() as session:
             return fn(session, *args, **kwargs)
 

--- a/tests/billing/test_billing_subscribe.py
+++ b/tests/billing/test_billing_subscribe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
 
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, select
@@ -36,7 +37,12 @@ def setup_db() -> sessionmaker[Session]:
 
 
 def make_client(monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]) -> TestClient:
-    async def run_db(fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs):
+    async def run_db(
+        fn,
+        *args,
+        sessionmaker: sessionmaker[Session] = session_local,
+        **kwargs,
+    ) -> Any:
         with sessionmaker() as session:
             return fn(session, *args, **kwargs)
 

--- a/tests/billing/test_billing_webhook.py
+++ b/tests/billing/test_billing_webhook.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 import hmac
 import logging
+from typing import Any
+
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -36,7 +38,12 @@ def make_client(
     session_local: sessionmaker[Session],
     **settings_kwargs: object,
 ) -> TestClient:
-    async def run_db(fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs):
+    async def run_db(
+        fn,
+        *args,
+        sessionmaker: sessionmaker[Session] = session_local,
+        **kwargs,
+    ) -> Any:
         with sessionmaker() as session:
             return fn(session, *args, **kwargs)
 

--- a/tests/handlers/profile/test_api.py
+++ b/tests/handlers/profile/test_api.py
@@ -1,5 +1,6 @@
 import importlib
 from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -338,7 +339,7 @@ def _build_app(
 
     monkeypatch.setattr(db, "SessionLocal", session_factory, raising=False)
 
-    async def _run_db(fn, *args, **kwargs):
+    async def _run_db(fn, *args, **kwargs) -> Any:
         return await db.run_db(fn, *args, sessionmaker=session_factory, **kwargs)
 
     monkeypatch.setattr(main, "run_db", _run_db)

--- a/tests/handlers/test_photo_handler_recognition.py
+++ b/tests/handlers/test_photo_handler_recognition.py
@@ -113,7 +113,7 @@ async def test_photo_handler_recognition_success_db_save(
     monkeypatch.setattr(photo_handlers, "send_message", fake_send_message)
     monkeypatch.setattr(photo_handlers, "_get_client", lambda: DummyClient())
 
-    async def run_db_stub(fn, *args, sessionmaker, **kwargs):
+    async def run_db_stub(fn, *args, sessionmaker, **kwargs) -> Any:
         def wrapper() -> Any:
             with sessionmaker() as sess:
                 return fn(sess, *args, **kwargs)

--- a/tests/test_billing_trial.py
+++ b/tests/test_billing_trial.py
@@ -45,7 +45,12 @@ def setup_db() -> sessionmaker[Session]:
 def make_client(monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]) -> TestClient:
     from services.api.app.billing.config import BillingSettings
 
-    async def run_db(fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs):
+    async def run_db(
+        fn,
+        *args,
+        sessionmaker: sessionmaker[Session] = session_local,
+        **kwargs,
+    ) -> Any:
         with sessionmaker() as session:
             return fn(session, *args, **kwargs)
 

--- a/tests/test_learning_profile_router.py
+++ b/tests/test_learning_profile_router.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -24,7 +26,12 @@ def setup_db() -> sessionmaker[Session]:
 def make_client(
     monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]
 ) -> TestClient:
-    async def run_db(fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs):
+    async def run_db(
+        fn,
+        *args,
+        sessionmaker: sessionmaker[Session] = session_local,
+        **kwargs,
+    ) -> Any:
         with sessionmaker() as session:
             return fn(session, *args, **kwargs)
 

--- a/tests/test_onboarding_router.py
+++ b/tests/test_onboarding_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -28,7 +29,12 @@ def setup_db() -> sessionmaker[Session]:
 
 
 def make_client(monkeypatch: pytest.MonkeyPatch, session_local: sessionmaker[Session]) -> TestClient:
-    async def run_db(fn, *args, sessionmaker: sessionmaker[Session] = session_local, **kwargs):
+    async def run_db(
+        fn,
+        *args,
+        sessionmaker: sessionmaker[Session] = session_local,
+        **kwargs,
+    ) -> Any:
         with sessionmaker() as session:
             return fn(session, *args, **kwargs)
 

--- a/tests/test_photo_handlers_additional.py
+++ b/tests/test_photo_handlers_additional.py
@@ -70,7 +70,7 @@ async def test_photo_handler_commit_failure(
     monkeypatch.setattr(photo_handlers, "commit", fail_commit)
     monkeypatch.setattr(photo_handlers, "send_message", send_message_mock)
 
-    async def run_db_stub(fn, *args, sessionmaker, **kwargs):
+    async def run_db_stub(fn, *args, sessionmaker, **kwargs) -> Any:
         def wrapper() -> Any:
             with sessionmaker() as sess:
                 return fn(sess, *args, **kwargs)
@@ -152,7 +152,7 @@ async def test_photo_handler_commit_failure_resets_waiting_flag(
     monkeypatch.setattr(photo_handlers, "commit", fail_commit)
     monkeypatch.setattr(photo_handlers, "send_message", send_message_mock)
 
-    async def run_db_stub(fn, *args, sessionmaker, **kwargs):
+    async def run_db_stub(fn, *args, sessionmaker, **kwargs) -> Any:
         def wrapper() -> Any:
             with sessionmaker() as sess:
                 return fn(sess, *args, **kwargs)
@@ -594,7 +594,7 @@ async def test_photo_handler_long_vision_text(
     )
     monkeypatch.setattr(photo_handlers, "build_main_keyboard", lambda: None)
 
-    async def run_db_stub(fn, *args, sessionmaker, **kwargs):
+    async def run_db_stub(fn, *args, sessionmaker, **kwargs) -> Any:
         def wrapper() -> Any:
             with sessionmaker() as sess:
                 return fn(sess, *args, **kwargs)
@@ -706,7 +706,7 @@ async def test_photo_handler_long_vision_text_parse_fail(
     )
     monkeypatch.setattr(photo_handlers, "build_main_keyboard", lambda: None)
 
-    async def run_db_stub(fn, *args, sessionmaker, **kwargs):
+    async def run_db_stub(fn, *args, sessionmaker, **kwargs) -> Any:
         def wrapper() -> Any:
             with sessionmaker() as sess:
                 return fn(sess, *args, **kwargs)

--- a/tests/test_profile_service_get_or_create.py
+++ b/tests/test_profile_service_get_or_create.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine
@@ -19,7 +21,12 @@ async def test_get_profile_settings_creates_profile(
         bind=engine, autoflush=False, autocommit=False, class_=Session
     )
 
-    async def run_db(func, *args, sessionmaker: sessionmaker[Session], **kwargs):
+    async def run_db(
+        func,
+        *args,
+        sessionmaker: sessionmaker[Session],
+        **kwargs,
+    ) -> Any:
         with sessionmaker() as session:
             return func(session, *args, **kwargs)
 
@@ -50,7 +57,12 @@ async def test_get_profile_settings_negative_id(
         bind=engine, autoflush=False, autocommit=False, class_=Session
     )
 
-    async def run_db(func, *args, sessionmaker: sessionmaker[Session], **kwargs):
+    async def run_db(
+        func,
+        *args,
+        sessionmaker: sessionmaker[Session],
+        **kwargs,
+    ) -> Any:
         with sessionmaker() as session:
             return func(session, *args, **kwargs)
 

--- a/tests/test_profile_timezone_save_flow.py
+++ b/tests/test_profile_timezone_save_flow.py
@@ -71,7 +71,7 @@ async def test_profile_timezone_save_success(
     reminder_user = SimpleNamespace(id=1)
     reminder = SimpleNamespace(id=5, user=reminder_user)
 
-    async def run_db(fn, *, sessionmaker):
+    async def run_db(fn, *, sessionmaker) -> Any:
         run_db.calls += 1
         if run_db.calls == 1:
             return True, True


### PR DESCRIPTION
## Summary
- add explicit return annotations to run_db/run_db_stub helpers in the affected test modules
- import Any where required and wrap function definitions for readability

## Testing
- ruff check tests/billing/test_admin_mock_webhook.py tests/billing/test_billing_subscribe.py tests/billing/test_billing_webhook.py tests/handlers/profile/test_api.py tests/handlers/test_photo_handler_recognition.py tests/test_billing_trial.py tests/test_learning_profile_router.py tests/test_onboarding_router.py tests/test_photo_handlers_additional.py tests/test_profile_service_get_or_create.py tests/test_profile_timezone_save_flow.py
- mypy --strict tests/test_profile_service_get_or_create.py
- mypy --strict tests/test_learning_profile_router.py
- mypy --strict tests/test_onboarding_router.py
- mypy --strict tests/test_billing_trial.py
- mypy --strict tests/billing/test_admin_mock_webhook.py
- mypy --strict tests/billing/test_billing_subscribe.py
- mypy --strict tests/billing/test_billing_webhook.py
- mypy --strict tests/handlers/profile/test_api.py
- mypy --strict tests/handlers/test_photo_handler_recognition.py
- mypy --strict tests/test_photo_handlers_additional.py
- mypy --strict tests/test_profile_timezone_save_flow.py
- pytest tests/test_profile_timezone_save_flow.py tests/test_photo_handlers_additional.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c99844b56c832aba226b7464d18743