### PR TITLE
[services] Update OpenAI upload purpose for assistants

### DIFF
--- a/services/api/app/diabetes/services/gpt_client.py
+++ b/services/api/app/diabetes/services/gpt_client.py
@@ -464,7 +464,7 @@ async def _upload_image_file(client: OpenAI, image_path: str) -> FileObject:
 
         def _upload() -> FileObject:
             with open(safe_path, "rb") as f:
-                return client.files.create(file=f, purpose="vision")
+                return client.files.create(file=f, purpose="assistants")
 
         file = await asyncio.wait_for(asyncio.to_thread(_upload), timeout=FILE_UPLOAD_TIMEOUT)
     except asyncio.TimeoutError:
@@ -487,7 +487,9 @@ async def _upload_image_bytes(client: OpenAI, image_bytes: bytes) -> FileObject:
 
         def _upload_bytes() -> FileObject:
             with io.BytesIO(image_bytes) as buffer:
-                return client.files.create(file=("image.jpg", buffer), purpose="vision")
+                return client.files.create(
+                    file=("image.jpg", buffer), purpose="assistants"
+                )
 
         file = await asyncio.wait_for(asyncio.to_thread(_upload_bytes), timeout=FILE_UPLOAD_TIMEOUT)
     except asyncio.TimeoutError:

--- a/tests/test_gpt_client.py
+++ b/tests/test_gpt_client.py
@@ -423,7 +423,7 @@ async def test_upload_image_file(
     img.write_bytes(b"data")
 
     def fake_files_create(file: Any, purpose: str) -> SimpleNamespace:
-        assert purpose == "vision"
+        assert purpose == "assistants"
         assert file.read() == b"data"
         return SimpleNamespace(id="f1")
 
@@ -443,12 +443,17 @@ async def test_upload_image_bytes() -> None:
         name, buffer = file
         captured["name"] = name
         captured["data"] = buffer.read()
+        captured["purpose"] = purpose
         return SimpleNamespace(id="f2")
 
     fake_client = SimpleNamespace(files=SimpleNamespace(create=fake_files_create))
     file = await gpt_client._upload_image_bytes(fake_client, b"payload")
     assert file.id == "f2"
-    assert captured == {"name": "image.jpg", "data": b"payload"}
+    assert captured == {
+        "name": "image.jpg",
+        "data": b"payload",
+        "purpose": "assistants",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- update the GPT client image upload helpers to send files with the assistants purpose
- adjust the GPT client tests to expect the updated OpenAI file purpose

## Testing
- `pytest` *(fails: tests/assistant/test_integration.py::test_flow_idk_with_log_error, tests/assistant/test_lesson_answer_exceptions.py::test_lesson_answer_handler_propagates_unexpected)*

------
https://chatgpt.com/codex/tasks/task_e_68cffbbd33a8832ab2a4a97e07c2f63b