### PR TITLE
[diabetes] Fix chat menu button setup

### DIFF
--- a/services/api/app/diabetes/utils/menu_setup.py
+++ b/services/api/app/diabetes/utils/menu_setup.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from urllib.parse import urljoin
 
-from typing import cast
-
-from telegram import Bot, MenuButton, MenuButtonWebApp, WebAppInfo
+from telegram import Bot, MenuButtonWebApp, WebAppInfo
 
 from services.api.app import config
 
@@ -34,12 +32,13 @@ async def setup_chat_menu(bot: Bot) -> None:
     if not base_url:
         return
 
-    buttons = [
-        MenuButtonWebApp(text=label, web_app=WebAppInfo(_build_url(base_url, path)))
-        for label, path in _MENU_ITEMS
-    ]
+    label, path = _MENU_ITEMS[0]
+    menu_button = MenuButtonWebApp(
+        text=label,
+        web_app=WebAppInfo(_build_url(base_url, path)),
+    )
 
-    await bot.set_chat_menu_button(menu_button=cast(MenuButton, buttons))
+    await bot.set_chat_menu_button(menu_button=menu_button)
 
 
 __all__ = ["setup_chat_menu"]


### PR DESCRIPTION
## Summary
- replace the diabetes chat menu configuration to build a single `MenuButtonWebApp` entry point and drop the unsafe cast
- update the diabetes menu setup test to assert Telegram receives a bona fide `MenuButton`

## Testing
- pytest *(fails: tests/assistant/test_integration.py::test_flow_idk_with_log_error, tests/assistant/test_lesson_answer_exceptions.py::test_lesson_answer_handler_propagates_unexpected; both unrelated to the chat menu change)*
- pytest tests/test_diabetes_menu_setup.py


------
https://chatgpt.com/codex/tasks/task_e_68d004d09c70832ab6138f92af3407ac