### PR TITLE
[telegram] Preserve patched settings after reload

### DIFF
--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -1,3 +1,4 @@
+import importlib
 import hashlib
 import hmac
 import json
@@ -103,6 +104,18 @@ def test_require_tg_user_prefers_runtime_settings(
     monkeypatch.setattr(config, "get_settings", lambda: stub)
     patched_token = "patched-token"
     monkeypatch.setattr(config.settings, "telegram_token", patched_token)
+    init_data = build_init_data(token=patched_token)
+    user = require_tg_user(init_data)
+    assert user["id"] == 1
+    assert isinstance(user["id"], int)
+
+
+def test_require_tg_user_after_config_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    importlib.reload(config)
+    patched_token = "reloaded-token"
+    monkeypatch.setattr(settings, "telegram_token", patched_token)
     init_data = build_init_data(token=patched_token)
     user = require_tg_user(init_data)
     assert user["id"] == 1


### PR DESCRIPTION
## Summary
- keep a reference to the original settings object so Telegram auth falls back to patched tokens after config reloads
- add a regression test that reloads the config module and verifies require_tg_user still accepts init data built with the patched token

## Testing
- pytest tests/test_telegram_auth.py
- pytest tests/test_webapp_init_data_auth.py tests/test_webapp_reminders_auth.py tests/test_webapp_user.py tests/test_webapp_history.py tests/test_webapp_timezone.py tests/test_metrics_api.py tests/test_users_api.py tests/test_auth_middleware.py tests/api/test_onboarding_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68d06f89893c832a842712bc9c5961a3