### PR TITLE
fix: ensure telegram auth uses runtime settings

### DIFF
--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -109,11 +109,25 @@ def test_require_tg_user_prefers_runtime_settings(
     assert user["id"] == 1
     assert isinstance(user["id"], int)
 
+    monkeypatch.setattr(config.settings, "telegram_token", "")
+    with pytest.raises(HTTPException) as exc:
+        require_tg_user(init_data)
+    assert exc.value.status_code == 503
+
+    patched_token = "patched-token-2"
+    monkeypatch.setattr(config.settings, "telegram_token", patched_token)
+    init_data = build_init_data(token=patched_token)
+    user = require_tg_user(init_data)
+    assert user["id"] == 1
+    assert isinstance(user["id"], int)
+
 
 def test_require_tg_user_after_config_reload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     importlib.reload(config)
+    global settings
+    settings = config.get_settings()
     patched_token = "reloaded-token"
     monkeypatch.setattr(settings, "telegram_token", patched_token)
     init_data = build_init_data(token=patched_token)


### PR DESCRIPTION
## Summary
- update the Telegram auth helper to keep track of current settings objects instead of the import-time snapshot and stop when an explicit empty token is configured
- treat an empty token as misconfiguration and surface the 503 instead of falling back to stale state
- extend the Telegram auth tests to cover clearing the runtime token, reloading settings, and re-accepting a patched token

## Testing
- pytest tests/test_telegram_auth.py -q


------
https://chatgpt.com/codex/tasks/task_e_68d0cd604d00832a9e77e9c5b45495e0