### PR TITLE
[bot] Refresh chat menu button when WebApp URL is removed

### DIFF
--- a/services/api/app/diabetes/utils/menu_setup.py
+++ b/services/api/app/diabetes/utils/menu_setup.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urljoin
 
 from telegram import Bot, MenuButtonWebApp, WebAppInfo
 
 from services.api.app import config
+
+if TYPE_CHECKING:
+    from services.api.app.config import Settings
 
 _MENU_ITEMS: tuple[tuple[str, str], ...] = (
     ("Profile", "profile"),
@@ -26,7 +29,7 @@ def _build_url(base_url: str, path: str) -> str:
     return urljoin(normalized_base, normalized_path)
 
 
-async def setup_chat_menu(bot: Bot) -> bool:
+async def setup_chat_menu(bot: Bot, *, settings: Settings | None = None) -> bool:
     """Configure the chat menu with WebApp shortcuts when available.
 
     Returns ``True`` when a custom menu button was configured, otherwise
@@ -34,8 +37,8 @@ async def setup_chat_menu(bot: Bot) -> bool:
     ``set_chat_menu_button`` (for example when using simplified stubs in tests).
     """
 
-    settings = config.get_settings()
-    base_url = settings.webapp_url
+    active_settings = settings or config.get_settings()
+    base_url = active_settings.webapp_url
     if not base_url:
         return False
 

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -193,10 +193,14 @@ async def post_init(
                 real_redis.Redis.from_url = patched_from_url
             redis = real_redis
 
+    current_settings = config.reload_settings()
+
     redis_client: Any | None = None
     should_set = True
     try:
-        redis_raw = redis.from_url(settings.redis_url)  # type: ignore[no-untyped-call]
+        redis_raw = redis.from_url(
+            current_settings.redis_url
+        )  # type: ignore[no-untyped-call]
         if redis_raw is None:
             raise ValueError("Redis client is not configured")
         redis_client = cast(Any, redis_raw)
@@ -239,7 +243,9 @@ async def post_init(
 
     menu_configured = False
     if hasattr(app.bot, "set_chat_menu_button"):
-        menu_configured = await setup_chat_menu(app.bot)
+        menu_configured = await setup_chat_menu(
+            app.bot, settings=current_settings
+        )
         if not menu_configured:
             await menu_button_post_init(app)
     else:


### PR DESCRIPTION
## Summary
- reload the bot settings before configuring the chat menu so the latest WEBAPP_URL value is used
- allow `setup_chat_menu` to accept fresh settings and fall back to the default menu button when the WebApp URL is missing
- extend chat menu tests to cover clearing `WEBAPP_URL` and assert the default helper runs

## Testing
- pytest tests/test_chat_menu_button.py tests/test_set_my_commands_retry.py tests/test_diabetes_menu_setup.py
- pytest -q --cov *(fails: `tests/assistant/test_integration.py::test_flow_idk_with_log_error`, `tests/assistant/test_lesson_answer_exceptions.py::test_lesson_answer_handler_propagates_unexpected`, `tests/test_telegram_auth.py::test_require_tg_user_after_config_reload`)*
- mypy --strict . *(fails: `services/api/app/diabetes/learning_handlers.py:589` and `:950` report `plan_id` redefinition errors)*
- ruff check .


------
https://chatgpt.com/codex/tasks/task_e_68d0cd618178832a9b1a3a84718a0f4f