### PR TITLE
fix: prefer cached telegram token and add tests

### DIFF
--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -118,12 +118,11 @@ def get_tg_user(init_data: str) -> UserContext:
         if candidate is None:
             continue
         value = getattr(candidate, "telegram_token", None)
-        if isinstance(value, str):
-            if value:
-                token = value
-            else:
-                token = None
-            break
+        if not isinstance(value, str):
+            continue
+        if not value:
+            continue
+        token = value
     if not token:
         logger.error("telegram token not configured")
         raise HTTPException(status_code=503, detail="telegram token not configured")

--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -136,6 +136,25 @@ def test_require_tg_user_after_config_reload(
     assert isinstance(user["id"], int)
 
 
+def test_require_tg_user_cached_token_overrides_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patched_token = "cached-token"
+    monkeypatch.setattr(config.settings, "telegram_token", patched_token)
+    init_data = build_init_data(token=patched_token)
+    # Prime cache so the patched settings instance remains available.
+    user = require_tg_user(init_data)
+    assert user["id"] == 1
+    assert isinstance(user["id"], int)
+
+    config.reload_settings()
+    monkeypatch.setattr(config.settings, "telegram_token", "")
+
+    user = require_tg_user(init_data)
+    assert user["id"] == 1
+    assert isinstance(user["id"], int)
+
+
 def test_require_tg_user_invalid_id_type(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- continue scanning cached settings until a usable Telegram token is found
- ignore empty string tokens so requests fail when no credentials are configured
- add a regression test ensuring cached monkeypatched settings survive reloads

## Testing
- pytest -q --cov *(fails: requires Telegram token and database setup in test environment)*
- mypy --strict . *(fails: pre-existing duplicate name errors in services/api/app/diabetes/learning_handlers.py)*
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d0d662398c832a9ecd97b361722d1d