### PR TITLE
fix: preserve Telegram settings cache across reloads

### DIFF
--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -31,6 +31,9 @@ def _remember_settings(candidate: object) -> None:
     _SETTINGS_CACHE.append(candidate)
 
 
+_remember_settings(config.get_settings())
+
+
 def _iter_settings_candidates() -> list[object]:
     """Return unique configuration objects to consult for the Telegram token."""
 
@@ -123,6 +126,7 @@ def get_tg_user(init_data: str) -> UserContext:
         if not value:
             continue
         token = value
+        break
     if not token:
         logger.error("telegram token not configured")
         raise HTTPException(status_code=503, detail="telegram token not configured")


### PR DESCRIPTION
## Summary
- seed the Telegram auth settings cache with the initial Settings instance at import time
- stop overriding newer Telegram tokens once a valid token is discovered

## Testing
- pytest tests/test_telegram_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68d0dd720f20832a90172588a61ca144