### PR TITLE
[scripts] Allow overriding dev server port

### DIFF
--- a/run_dev.sh
+++ b/run_dev.sh
@@ -2,6 +2,8 @@
 # file: run_dev.sh
 set -e
 
+DEV_PORT="${DEV_PORT:-8000}"
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$REPO_ROOT"
 
@@ -39,8 +41,13 @@ if [[ ! -w "$STATE_DIRECTORY" ]]; then
 fi
 
 # Запускаем API с авто-reload (1 процесс)
+if lsof -iTCP:"$DEV_PORT" -sTCP:LISTEN >/dev/null; then
+  echo "Port $DEV_PORT is already in use. Set DEV_PORT to use a different port." >&2
+  exit 1
+fi
+
 uvicorn services.api.app.main:app \
-        --reload --host 0.0.0.0 --port 8000 &
+        --reload --host 0.0.0.0 --port "$DEV_PORT" &
 API_PID=$!
 
 # Запускаем Telegram-бота


### PR DESCRIPTION
## Summary
- allow overriding the development server port via the DEV_PORT environment variable
- detect when the chosen port is already in use before spawning uvicorn
- pass the selected port through to the uvicorn command

## Testing
- `make ci` *(fails: existing test failures in test_flow_idk_with_log_error, test_lesson_answer_handler_propagates_unexpected, and test_require_tg_user_after_config_reload)*

------
https://chatgpt.com/codex/tasks/task_e_68d267c8a36c832aa1044369f99750b9