### PR TITLE
[scripts] Prevent duplicate bot instance in run_dev

### DIFF
--- a/run_dev.sh
+++ b/run_dev.sh
@@ -38,6 +38,12 @@ if [[ ! -w "$STATE_DIRECTORY" ]]; then
   exit 1
 fi
 
+# Проверяем, не запущен ли уже Telegram-бот
+if pgrep -f 'services\.bot\.main' > /dev/null; then
+  echo "Another Telegram-bot instance is already running. Abort." >&2
+  exit 1
+fi
+
 # Запускаем API с авто-reload (1 процесс)
 uvicorn services.api.app.main:app \
         --reload --host 0.0.0.0 --port 8000 &


### PR DESCRIPTION
## Summary
- add a guard in `run_dev.sh` that checks for an existing bot process before launching another instance

## Testing
- make ci *(fails: existing failures in assistant integration tests and telegram auth import)*

------
https://chatgpt.com/codex/tasks/task_e_68d267d02090832a905b96d2c07893f2