### PR TITLE
[utils] Keep chat menu button default

### DIFF
--- a/services/api/app/diabetes/utils/menu_setup.py
+++ b/services/api/app/diabetes/utils/menu_setup.py
@@ -1,40 +1,23 @@
-"""Chat menu configuration for diabetes WebApp shortcuts."""
+"""Chat menu configuration helpers for the diabetes bot."""
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, cast
-from urllib.parse import urljoin
-
-from telegram import Bot, MenuButtonWebApp, WebAppInfo
+from telegram import Bot, MenuButtonDefault
 
 from services.api.app import config
 
 if TYPE_CHECKING:
     from services.api.app.config import Settings
 
-_MENU_ITEMS: tuple[tuple[str, str], ...] = (
-    ("Profile", "profile"),
-    ("Reminders", "reminders"),
-    ("History", "history"),
-    ("Analytics", "analytics"),
-)
-
-
-def _build_url(base_url: str, path: str) -> str:
-    """Join ``base_url`` with ``path`` ensuring a single slash separator."""
-
-    normalized_base = base_url.rstrip("/") + "/"
-    normalized_path = path.lstrip("/")
-    return urljoin(normalized_base, normalized_path)
-
-
 async def setup_chat_menu(bot: Bot, *, settings: Settings | None = None) -> bool:
-    """Configure the chat menu with WebApp shortcuts when available.
+    """Keep Telegram's default menu button when a WebApp URL is configured.
 
-    Returns ``True`` when a custom menu button was configured, otherwise
-    ``False``. The function safely exits if the bot instance does not expose
-    ``set_chat_menu_button`` (for example when using simplified stubs in tests).
+    Returns ``True`` when a menu button was configured, otherwise ``False``.
+    The function safely exits if the bot instance does not expose
+    ``set_chat_menu_button`` (for example when using simplified stubs in
+    tests).
     """
 
     active_settings = settings or config.get_settings()
@@ -47,14 +30,8 @@ async def setup_chat_menu(bot: Bot, *, settings: Settings | None = None) -> bool
     if not callable(set_chat_menu_button):
         return False
 
-    label, path = _MENU_ITEMS[0]
-    menu_button = MenuButtonWebApp(
-        text=label,
-        web_app=WebAppInfo(_build_url(base_url, path)),
-    )
-
     await cast(Callable[..., Awaitable[Any]], set_chat_menu_button)(
-        menu_button=menu_button
+        menu_button=MenuButtonDefault()
     )
     return True
 

--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -8,7 +8,7 @@ from types import MappingProxyType, ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from telegram import MenuButtonDefault, MenuButtonWebApp
+from telegram import MenuButtonDefault
 from telegram.error import NetworkError, RetryAfter
 
 from services.api.app.assistant.services import memory_service
@@ -128,10 +128,10 @@ async def test_post_init_warns_when_retry_fails(
 
 
 @pytest.mark.asyncio
-async def test_post_init_configures_webapp_menu_once(
+async def test_post_init_configures_menu_button_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Custom WebApp button is applied once when WEBAPP_URL is set."""
+    """Default menu button is applied once when ``WEBAPP_URL`` is set."""
 
     monkeypatch.setenv("WEBAPP_URL", "https://web.example/app")
     main = _reload_main()
@@ -152,9 +152,7 @@ async def test_post_init_configures_webapp_menu_once(
     bot.set_my_commands.assert_awaited_once_with(main.commands)
     assert bot.set_chat_menu_button.await_count == 1
     button = bot.set_chat_menu_button.call_args.kwargs["menu_button"]
-    assert isinstance(button, MenuButtonWebApp)
-    assert button.text == "Profile"
-    assert button.web_app.url == "https://web.example/app/profile"
+    assert isinstance(button, MenuButtonDefault)
     main.menu_button_post_init.assert_not_awaited()
 
 
@@ -186,7 +184,7 @@ async def test_post_init_restores_default_when_webapp_url_removed(
 
     assert bot.set_chat_menu_button.await_count == 1
     first_button = bot.set_chat_menu_button.await_args_list[0].kwargs["menu_button"]
-    assert isinstance(first_button, MenuButtonWebApp)
+    assert isinstance(first_button, MenuButtonDefault)
     assert fallback_mock.await_count == 0
 
     monkeypatch.delenv("WEBAPP_URL", raising=False)

--- a/tests/test_diabetes_menu_setup.py
+++ b/tests/test_diabetes_menu_setup.py
@@ -1,9 +1,9 @@
-"""Tests for configuring chat menu WebApp shortcuts."""
+"""Tests for configuring chat menu buttons."""
 
 from __future__ import annotations
 
 import pytest
-from telegram import MenuButton, MenuButtonWebApp
+from telegram import MenuButton, MenuButtonDefault
 from telegram.ext import Application, ExtBot
 
 import services.api.app.config as config
@@ -13,7 +13,7 @@ import services.api.app.config as config
 async def test_setup_chat_menu_configures_webapp_buttons(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Chat menu exposes a single WebApp shortcut derived from ``WEBAPP_URL``."""
+    """Chat menu falls back to Telegram's default button even with ``WEBAPP_URL``."""
 
     monkeypatch.setenv("WEBAPP_URL", "https://web.example/app")
     config.reload_settings()
@@ -43,9 +43,7 @@ async def test_setup_chat_menu_configures_webapp_buttons(
     menu = await app.bot.get_chat_menu_button()
     assert stored_menu is not None
     assert isinstance(stored_menu, MenuButton)
-    assert isinstance(stored_menu, MenuButtonWebApp)
+    assert isinstance(stored_menu, MenuButtonDefault)
     assert menu is not None
-    assert isinstance(menu, MenuButtonWebApp)
+    assert isinstance(menu, MenuButtonDefault)
     assert menu is stored_menu
-    assert menu.text == "Profile"
-    assert menu.web_app.url == "https://web.example/app/profile"


### PR DESCRIPTION
## Summary
- update the diabetes chat menu setup helper to set the default Telegram menu button instead of creating a WebApp shortcut
- adjust chat menu related tests to assert the default button is used and the fallback post-init hook is skipped when the WebApp URL is configured

## Testing
- `pytest -q` *(fails: tests/assistant/test_integration.py::test_flow_idk_with_log_error, tests/assistant/test_lesson_answer_exceptions.py::test_lesson_answer_handler_propagates_unexpected, tests/test_telegram_auth.py::test_require_tg_user_after_config_reload)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d76e6c78832a85005b950e4aed15