### PR TITLE
assistant: requeue pending logs on flush errors

### DIFF
--- a/tests/assistant/test_lesson_logs.py
+++ b/tests/assistant/test_lesson_logs.py
@@ -149,4 +149,5 @@ async def test_reflush_does_not_duplicate(
 
     with session_factory() as session:
         assert session.query(LessonLog).count() == 1
-    assert not logs.pending_logs
+    assert len(logs.pending_logs) == 1
+    assert logs.pending_logs[0] is dup


### PR DESCRIPTION
## Summary
- always restore the queued lessons when `flush_pending_logs` aborts with a CommitError and reuse `_restore_queued_logs` for reinserting missing entries
- extend the logging repository tests to cover CommitError with an IntegrityError cause and adjust duplicate-flush expectations

## Testing
- `pytest -q --cov`
- `mypy --strict .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68d2d83cd5f8832a81676390627f92c0