### PR TITLE
Fix lesson logging guard and extend exception tests

### DIFF
--- a/tests/assistant/test_integration.py
+++ b/tests/assistant/test_integration.py
@@ -22,7 +22,9 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_flow_idk_with_log_error(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_flow_idk_with_log_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Simulate start→next→answer('Не знаю')→next flow with log failures."""
 
     monkeypatch.setattr(settings, "learning_mode_enabled", True)
@@ -68,6 +70,45 @@ async def test_flow_idk_with_log_error(monkeypatch: pytest.MonkeyPatch) -> None:
         return True, "fb"
 
     monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+
+    async def fake_create_plan(
+        user_id: int,
+        version: int,
+        plan_json: list[str],
+        *,
+        is_active: bool = True,
+    ) -> int:
+        return 1
+
+    async def fake_get_active_plan(user_id: int) -> None:
+        return None
+
+    async def fake_upsert_progress(*_: object, **__: object) -> None:
+        return None
+
+    async def fake_update_plan(*_: object, **__: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        learning_handlers.plans_repo,
+        "create_plan",
+        fake_create_plan,
+    )
+    monkeypatch.setattr(
+        learning_handlers.plans_repo,
+        "get_active_plan",
+        fake_get_active_plan,
+    )
+    monkeypatch.setattr(
+        learning_handlers.plans_repo,
+        "update_plan",
+        fake_update_plan,
+    )
+    monkeypatch.setattr(
+        learning_handlers.progress_repo,
+        "upsert_progress",
+        fake_upsert_progress,
+    )
 
     async def fake_assistant_chat(*_: object) -> str:
         return "fb"

--- a/tests/assistant/test_lesson_answer_exceptions.py
+++ b/tests/assistant/test_lesson_answer_exceptions.py
@@ -32,7 +32,11 @@ async def test_lesson_answer_handler_propagates_unexpected(
     async def fake_generate_step_text(*_: object, **__: object) -> str:
         return "next question"
 
+    calls = 0
+
     async def fail_safe_add_lesson_log(*_: object, **__: object) -> bool:
+        nonlocal calls
+        calls += 1
         raise ValueError("boom")
 
     async def ok_hydrate(*_: object, **__: object) -> bool:
@@ -44,6 +48,73 @@ async def test_lesson_answer_handler_propagates_unexpected(
     )
     monkeypatch.setattr(
         learning_handlers, "safe_add_lesson_log", fail_safe_add_lesson_log
+    )
+    async def noop_upsert(*_: object, **__: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        learning_handlers.progress_repo,
+        "upsert_progress",
+        noop_upsert,
+    )
+    monkeypatch.setattr(learning_handlers, "_hydrate", ok_hydrate)
+    monkeypatch.setattr(learning_handlers, "_rate_limited", lambda *_a, **_k: False)
+    monkeypatch.setattr(learning_handlers, "build_main_keyboard", lambda: None)
+    monkeypatch.setattr(learning_handlers, "sanitize_feedback", lambda s: s)
+    monkeypatch.setattr(learning_handlers, "format_reply", lambda s: s)
+    monkeypatch.setattr(learning_handlers, "ensure_single_question", lambda s: s)
+
+    user_data: dict[str, object] = {}
+    set_state(
+        user_data, LearnState(topic="t", step=0, awaiting=True, last_step_text="q")
+    )
+    user_data["learning_plan_id"] = 1
+
+    msg = DummyMessage("ans")
+    update = SimpleNamespace(message=msg, effective_user=msg.from_user)
+    context = SimpleNamespace(user_data=user_data, bot_data={})
+
+    with pytest.raises(ValueError):
+        await learning_handlers.lesson_answer_handler(update, context)
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_lesson_answer_handler_skips_logging_without_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "learning_mode_enabled", True)
+    monkeypatch.setattr(settings, "learning_content_mode", "dynamic")
+
+    async def fake_check_user_answer(*_: object, **__: object) -> tuple[bool, str]:
+        return True, "feedback"
+
+    async def fake_generate_step_text(*_: object, **__: object) -> str:
+        return "next question"
+
+    async def ok_hydrate(*_: object, **__: object) -> bool:
+        return True
+
+    called = False
+
+    async def record_safe_add(*_: object, **__: object) -> bool:
+        nonlocal called
+        called = True
+        return True
+
+    monkeypatch.setattr(learning_handlers, "check_user_answer", fake_check_user_answer)
+    monkeypatch.setattr(
+        learning_handlers, "generate_step_text", fake_generate_step_text
+    )
+    monkeypatch.setattr(learning_handlers, "safe_add_lesson_log", record_safe_add)
+    async def noop_upsert(*_: object, **__: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        learning_handlers.progress_repo,
+        "upsert_progress",
+        noop_upsert,
     )
     monkeypatch.setattr(learning_handlers, "_hydrate", ok_hydrate)
     monkeypatch.setattr(learning_handlers, "_rate_limited", lambda *_a, **_k: False)
@@ -61,5 +132,6 @@ async def test_lesson_answer_handler_propagates_unexpected(
     update = SimpleNamespace(message=msg, effective_user=msg.from_user)
     context = SimpleNamespace(user_data=user_data, bot_data={})
 
-    with pytest.raises(ValueError):
-        await learning_handlers.lesson_answer_handler(update, context)
+    await learning_handlers.lesson_answer_handler(update, context)
+
+    assert called is False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,6 +321,14 @@ def _dispose_engine_after_tests() -> Iterator[None]:
     dispose_engine()
 
 
+@pytest.fixture(autouse=True)
+def _ensure_config_module() -> Iterator[None]:
+    import services.api.app.config as config_module
+
+    sys.modules["services.api.app.config"] = config_module
+    yield
+
+
 @pytest.fixture(autouse=True, scope="module")
 def _dispose_engine_per_module() -> Iterator[None]:
     """Dispose the global database engine after each test module."""

--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -6,6 +6,8 @@ import time
 import urllib.parse
 from typing import Any
 
+import sys
+
 import pytest
 from fastapi import HTTPException
 
@@ -126,6 +128,7 @@ def test_require_tg_user_prefers_runtime_settings(
 def test_require_tg_user_after_config_reload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    sys.modules["services.api.app.config"] = config
     importlib.reload(config)
     global settings
     settings = config.get_settings()


### PR DESCRIPTION
## Summary
- streamline lesson logging to rely on `safe_add_lesson_log`, raising when no plan is active and leaving log flags unset when logging is skipped
- keep lesson log metrics intact while avoiding masking exceptions from `safe_add_lesson_log`
- strengthen lesson answer exception tests to confirm logging is skipped without a plan and that unexpected errors propagate

## Testing
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d2d8404bd8832a98549ddd1c04943c