### PR TITLE
[utils] Import urljoin for menu setup

### DIFF
--- a/services/api/app/diabetes/utils/menu_setup.py
+++ b/services/api/app/diabetes/utils/menu_setup.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urljoin
+
 from telegram import Bot, MenuButtonDefault
 
 from services.api.app import config


### PR DESCRIPTION
## Summary
- add the missing urllib.parse import required by menu_setup

## Testing
- ruff check services/api/app/diabetes/utils/menu_setup.py

------
https://chatgpt.com/codex/tasks/task_e_68d2e9cb9bd8832a9f38d8ca20a27449