### PR TITLE
[tests] Import MenuButtonWebApp in chat menu tests

### DIFF
--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -8,7 +8,7 @@ from types import MappingProxyType, ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from telegram import MenuButtonDefault
+from telegram import MenuButtonDefault, MenuButtonWebApp
 from telegram.error import NetworkError, RetryAfter
 
 from services.api.app.assistant.services import memory_service


### PR DESCRIPTION
## Summary
- update chat menu button tests to import MenuButtonWebApp from telegram

## Testing
- ruff check tests/test_chat_menu_button.py

------
https://chatgpt.com/codex/tasks/task_e_68d2e9cdd200832aa92b379810157257