### PR TITLE
[tests] Remove unused sys import from telegram auth tests

### DIFF
--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -6,8 +6,6 @@ import time
 import urllib.parse
 from typing import Any
 
-import sys
-
 import pytest
 from fastapi import HTTPException
 


### PR DESCRIPTION
## Summary
- drop the unused `sys` import from `tests/test_telegram_auth.py` to satisfy Ruff

## Testing
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d2eccbca80832a885278cb3969d892