### PR TITLE
[assistant] Deduplicate lesson log flushes

### DIFF
--- a/tests/assistant/test_integration.py
+++ b/tests/assistant/test_integration.py
@@ -161,4 +161,17 @@ async def test_flow_idk_with_log_error(
     assert state is not None and state.step == 4 and state.awaiting
     assert msg_next2.replies == ["fb\n\n—\n\nstep4?"]
 
-    assert len(lesson_log.pending_logs) == 10
+    expected_keys = {
+        (0, 1, "assistant"),
+        (0, 1, "user"),
+        (0, 2, "assistant"),
+        (0, 2, "user"),
+        (0, 3, "assistant"),
+        (0, 3, "user"),
+        (0, 4, "assistant"),
+    }
+    actual_keys = {
+        (log.module_idx, log.step_idx, log.role) for log in lesson_log.pending_logs
+    }
+    assert actual_keys == expected_keys
+    assert len(lesson_log.pending_logs) == len(expected_keys)

--- a/tests/assistant/test_lesson_logs.py
+++ b/tests/assistant/test_lesson_logs.py
@@ -149,5 +149,4 @@ async def test_reflush_does_not_duplicate(
 
     with session_factory() as session:
         assert session.query(LessonLog).count() == 1
-    assert len(logs.pending_logs) == 1
-    assert logs.pending_logs[0] is dup
+    assert not logs.pending_logs

--- a/tests/test_telegram_auth.py
+++ b/tests/test_telegram_auth.py
@@ -6,8 +6,6 @@ import time
 import urllib.parse
 from typing import Any
 
-import sys
-
 import pytest
 from fastapi import HTTPException
 


### PR DESCRIPTION
## Summary
- deduplicate restored pending logs and skip duplicates when flushing lesson logs to the database
- add regression coverage to ensure duplicate safe_add calls keep plan logs unique and queue-free
- update log repository tests to emulate Session.query usage and remove an unused import flagged by linting

## Testing
- pytest tests/assistant/test_lesson_logs_plan_id.py
- pytest tests/assistant/test_logs.py
- pytest tests/assistant/test_integration.py::test_flow_idk_with_log_error -q
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d2ec5b0520832aab82d018080e15b5