### PR TITLE
feat: honor configured chat menu webapp

### DIFF
--- a/tests/test_chat_menu_button.py
+++ b/tests/test_chat_menu_button.py
@@ -192,8 +192,7 @@ async def test_post_init_restores_default_when_webapp_url_removed(
 
     monkeypatch.setattr(assistant_menu, "post_init", AsyncMock())
 
-    real_menu_post_init = main.menu_button_post_init
-    fallback_mock = AsyncMock(side_effect=real_menu_post_init)
+    fallback_mock = AsyncMock()
     monkeypatch.setattr(main, "menu_button_post_init", fallback_mock)
 
     app = SimpleNamespace(bot=bot, job_queue=None, user_data=MappingProxyType({}))
@@ -203,14 +202,14 @@ async def test_post_init_restores_default_when_webapp_url_removed(
 
     assert bot.set_chat_menu_button.await_count == 1
     first_button = bot.set_chat_menu_button.await_args_list[0].kwargs["menu_button"]
-    assert isinstance(first_button, MenuButtonDefault)
+    assert isinstance(first_button, MenuButtonWebApp)
     assert fallback_mock.await_count == 0
 
     monkeypatch.delenv("WEBAPP_URL", raising=False)
 
     await main.post_init(app)
 
-    assert fallback_mock.await_count == 1
+    assert fallback_mock.await_count == 0
     assert bot.set_chat_menu_button.await_count == 2
     last_button = bot.set_chat_menu_button.await_args_list[-1].kwargs["menu_button"]
     assert isinstance(last_button, MenuButtonDefault)

--- a/tests/test_diabetes_menu_setup.py
+++ b/tests/test_diabetes_menu_setup.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from telegram import MenuButton, MenuButtonDefault
+from telegram import MenuButton, MenuButtonWebApp
 from telegram.ext import Application, ExtBot
 
 import services.api.app.config as config
@@ -13,7 +13,7 @@ import services.api.app.config as config
 async def test_setup_chat_menu_configures_webapp_buttons(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Chat menu falls back to Telegram's default button even with ``WEBAPP_URL``."""
+    """Chat menu installs the configured WebApp button when ``WEBAPP_URL`` set."""
 
     monkeypatch.setenv("WEBAPP_URL", "https://web.example/app")
     config.reload_settings()
@@ -43,7 +43,9 @@ async def test_setup_chat_menu_configures_webapp_buttons(
     menu = await app.bot.get_chat_menu_button()
     assert stored_menu is not None
     assert isinstance(stored_menu, MenuButton)
-    assert isinstance(stored_menu, MenuButtonDefault)
+    assert isinstance(stored_menu, MenuButtonWebApp)
+    assert stored_menu.text == "Profile"
+    assert stored_menu.web_app.url == "https://web.example/app/profile"
     assert menu is not None
-    assert isinstance(menu, MenuButtonDefault)
+    assert isinstance(menu, MenuButtonWebApp)
     assert menu is stored_menu

--- a/tests/test_menu_button.py
+++ b/tests/test_menu_button.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import importlib
+
 import pytest
-from telegram import MenuButtonDefault
+from telegram import MenuButtonWebApp
 from telegram.error import BadRequest
 from telegram.ext import ApplicationBuilder, ExtBot
 
@@ -12,10 +15,11 @@ def _reload_config() -> None:
 
 
 @pytest.mark.asyncio
-async def test_post_init_sets_default_menu(monkeypatch: pytest.MonkeyPatch) -> None:
-    base_url = "https://example.com"
-    monkeypatch.setenv("PUBLIC_ORIGIN", base_url)
-    monkeypatch.setenv("UI_BASE_URL", "/ui")
+async def test_post_init_configures_webapp_menu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_url = "https://web.example/app"
+    monkeypatch.setenv("WEBAPP_URL", base_url)
     _reload_config()
     import services.api.app.menu_button as menu_button
 
@@ -38,4 +42,6 @@ async def test_post_init_sets_default_menu(monkeypatch: pytest.MonkeyPatch) -> N
     assert len(calls) == 1
     _, kwargs = calls[0]
     button = kwargs["menu_button"]
-    assert isinstance(button, MenuButtonDefault)
+    assert isinstance(button, MenuButtonWebApp)
+    assert button.text == "Profile"
+    assert button.web_app.url == "https://web.example/app/profile"


### PR DESCRIPTION
## Summary
- build and cache MenuButtonWebApp instances in the menu setup helper while falling back to the default button only when necessary
- wire the Application post-init hook to reuse the helper so configured WebApp buttons persist
- update chat menu and command retry tests to validate the initial install, caching, and default fallback behaviour

## Testing
- `pytest tests/test_chat_menu_button.py tests/test_set_my_commands_retry.py tests/test_diabetes_menu_setup.py -q`
- `pytest tests/test_menu_button.py -q`
- `pytest tests/assistant/test_lesson_logs_plan_id.py::test_logs_are_stored_with_plan_id -q` *(fails: IntegrityError UNIQUE constraint)*
- `mypy --strict .`
- `ruff check .` *(fails: unused sys import in tests/test_telegram_auth.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ec4b8094832a95e467930226bdfa