### PR TITLE
[menu] Refresh chat menu when WEBAPP_URL toggles

### DIFF
--- a/tests/test_menu_button.py
+++ b/tests/test_menu_button.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 
 import pytest
-from telegram import MenuButtonWebApp
+from telegram import MenuButtonDefault, MenuButtonWebApp
 from telegram.error import BadRequest
 from telegram.ext import ApplicationBuilder, ExtBot
 
@@ -18,8 +18,7 @@ def _reload_config() -> None:
 async def test_post_init_configures_webapp_menu(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    base_url = "https://web.example/app"
-    monkeypatch.setenv("WEBAPP_URL", base_url)
+    monkeypatch.delenv("WEBAPP_URL", raising=False)
     _reload_config()
     import services.api.app.menu_button as menu_button
 
@@ -37,11 +36,20 @@ async def test_post_init_configures_webapp_menu(
     monkeypatch.setattr(ExtBot, "set_chat_menu_button", fake_set_chat_menu_button)
 
     app = ApplicationBuilder().token("TEST").post_init(menu_button.post_init).build()
+
     await app.post_init(app)
 
     assert len(calls) == 1
-    _, kwargs = calls[0]
-    button = kwargs["menu_button"]
+    first_button = calls[0][1]["menu_button"]
+    assert isinstance(first_button, MenuButtonDefault)
+
+    base_url = "https://web.example/app"
+    monkeypatch.setenv("WEBAPP_URL", base_url)
+
+    await app.post_init(app)
+
+    assert len(calls) == 2
+    button = calls[-1][1]["menu_button"]
     assert isinstance(button, MenuButtonWebApp)
     assert button.text == "Profile"
     assert button.web_app.url == "https://web.example/app/profile"


### PR DESCRIPTION
## Summary
- reload bot settings during `menu_button.post_init` and reset the cached menu state when the WebApp URL changes
- extend the menu button test to cover toggling `WEBAPP_URL` between default and WebApp configurations
- expand the bot startup retry test to assert menu updates when the WebApp URL is added and removed

## Testing
- pytest tests/test_menu_button.py tests/test_set_my_commands_retry.py::test_post_init_reloads_settings_for_chat_menu -q
- mypy --strict .
- ruff check .
- pytest -q --cov --maxfail=1
- python - <<'PY'
import asyncio
import importlib
import os
from types import MappingProxyType, SimpleNamespace
from unittest.mock import AsyncMock

os.environ.pop("WEBAPP_URL", None)

import services.api.app.config as config
import services.api.app.diabetes.utils.menu_setup as menu_setup
import services.api.app.menu_button as menu_button
import services.bot.main as main

importlib.reload(config)
importlib.reload(menu_setup)
importlib.reload(menu_button)
importlib.reload(main)

import services.api.app.diabetes.handlers.assistant_menu as assistant_menu
assistant_menu.post_init = AsyncMock()

bot = SimpleNamespace(
    set_my_commands=AsyncMock(),
    set_chat_menu_button=AsyncMock(),
)
app = SimpleNamespace(bot=bot, job_queue=None, user_data=MappingProxyType({}))
app._user_data = {}

async def run_sequence() -> None:
    await main.post_init(app)
    first = bot.set_chat_menu_button.await_args_list[-1].kwargs["menu_button"]
    print("first", type(first).__name__)

    os.environ["WEBAPP_URL"] = "https://web.example/app"
    await main.post_init(app)
    second = bot.set_chat_menu_button.await_args_list[-1].kwargs["menu_button"]
    print("second", type(second).__name__, getattr(getattr(second, "web_app", None), "url", None))

    os.environ.pop("WEBAPP_URL", None)
    await main.post_init(app)
    third = bot.set_chat_menu_button.await_args_list[-1].kwargs["menu_button"]
    print("third", type(third).__name__)

asyncio.run(run_sequence())
PY

------
https://chatgpt.com/codex/tasks/task_e_68d2f5326fd0832a8a022daadfc2cd6c