### PR TITLE
Add labs handler gate and routing regression tests

### DIFF
--- a/services/api/app/diabetes/handlers/registration.py
+++ b/services/api/app/diabetes/handlers/registration.py
@@ -24,7 +24,7 @@ from .common_handlers import help_command, smart_input_help
 from .router import callback_router
 from . import assistant_router
 from .. import learning_handlers
-from ..labs_handlers import labs_handler
+from ..labs_handlers import LabsMessageHandler, labs_handler
 from ..utils.ui import (
     PROFILE_BUTTON_TEXT,
     REMINDERS_BUTTON_TEXT,
@@ -292,9 +292,10 @@ def register_handlers(
     if learning_enabled:
         learning_handlers.register_handlers(app)
     app.add_handler(
-        MessageHandlerT(
+        LabsMessageHandler(
             (filters.TEXT | filters.PHOTO | filters.Document.ALL) & ~filters.COMMAND,
             labs_handler,
+            user_data=app.user_data,
             block=False,  # чтобы фото продолжали обрабатываться
         )
     )

--- a/tests/handlers/test_labs_routing.py
+++ b/tests/handlers/test_labs_routing.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram import Bot, Chat, Message, PhotoSize, Update, User
+from telegram.ext import Application
+
+from services.api.app.diabetes import labs_handlers
+from services.api.app.diabetes.handlers import photo_handlers, registration
+
+
+class DummyBot(Bot):
+    """Bot stub that skips network interactions."""
+
+    def __init__(self) -> None:
+        super().__init__(token="123:ABC")
+
+    async def initialize(self) -> None:  # pragma: no cover - setup helper
+        self._me = User(id=0, is_bot=True, first_name="Bot", username="bot")
+        self._bot = self
+        self._bot_user = self._me
+        self._initialized = True
+
+
+def _photo_update(bot: Bot, user_id: int, update_id: int) -> Update:
+    user = User(id=user_id, is_bot=False, first_name="User")
+    chat = Chat(id=user_id, type="private")
+    photo = PhotoSize(
+        file_id=f"photo-{update_id}",
+        file_unique_id=f"photo-{update_id}-u",
+        width=10,
+        height=10,
+        file_size=100,
+    )
+    message = Message(
+        message_id=update_id,
+        date=dt.datetime.now(dt.timezone.utc),
+        chat=chat,
+        from_user=user,
+        photo=[photo],
+    )
+    message._bot = bot
+    return Update(update_id=update_id, message=message)
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("OPENAI_ASSISTANT_ID", "asst_test")
+
+
+@pytest.fixture
+async def app_with_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Application, AsyncMock, AsyncMock]:
+    settings = SimpleNamespace(
+        learning_mode_enabled=False,
+        assistant_mode_timeout_sec=60,
+    )
+    monkeypatch.setattr("services.api.app.config.reload_settings", lambda: settings)
+    monkeypatch.setattr(registration, "register_profile_handlers", lambda app: None)
+    monkeypatch.setattr(registration, "register_reminder_handlers", lambda app: None)
+    monkeypatch.setattr(
+        "services.api.app.assistant.repositories.logs.cleanup_old_logs",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "services.api.app.assistant.services.memory_service.cleanup_old_memory",
+        AsyncMock(),
+    )
+
+    labs_mock: AsyncMock = AsyncMock(return_value=labs_handlers.END)
+    photo_mock: AsyncMock = AsyncMock(return_value=labs_handlers.END)
+    monkeypatch.setattr(labs_handlers, "labs_handler", labs_mock)
+    monkeypatch.setattr(registration, "labs_handler", labs_mock)
+    monkeypatch.setattr(photo_handlers, "photo_handler", photo_mock)
+
+    bot = DummyBot()
+    app = Application.builder().bot(bot).build()
+    registration.register_handlers(app)
+
+    async with app:
+        await app.start()
+        try:
+            yield app, labs_mock, photo_mock
+        finally:
+            await app.stop()
+
+
+@pytest.mark.asyncio
+async def test_photo_update_without_labs_flags_goes_to_photo_handler(
+    app_with_handlers: tuple[Application, AsyncMock, AsyncMock],
+) -> None:
+    app, labs_mock, photo_mock = app_with_handlers
+    update = _photo_update(app.bot, user_id=111, update_id=1)
+
+    await app.process_update(update)
+    await asyncio.sleep(0)
+
+    labs_mock.assert_not_awaited()
+    photo_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_labs_mode_photo_uses_labs_handler(
+    app_with_handlers: tuple[Application, AsyncMock, AsyncMock],
+) -> None:
+    app, labs_mock, photo_mock = app_with_handlers
+    user_id = 222
+    app._user_data[user_id]["waiting_labs"] = True
+    update = _photo_update(app.bot, user_id=user_id, update_id=2)
+
+    await app.process_update(update)
+    await asyncio.sleep(0)
+
+    labs_mock.assert_awaited_once()
+    photo_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary
- add a `LabsMessageHandler` that only accepts updates when the user is in labs mode
- wire the labs handler through the new gate so other photos reach the regular photo handler
- add regression tests covering labs-mode routing versus normal photo handling

## Testing
- pytest tests/handlers/test_labs_routing.py tests/test_labs_handlers.py -q
- ruff check services/api/app/diabetes/labs_handlers.py tests/handlers/test_labs_routing.py
- mypy --strict services/api/app/diabetes/labs_handlers.py

------
https://chatgpt.com/codex/tasks/task_e_68d30020b9f4832aaa0d44d835bfd378