### PR TITLE
[config] Fix reload_settings proxy usage

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -261,7 +261,7 @@ def reload_settings() -> Settings:
     with _settings_lock:
 
         fresh_settings = Settings()
-        current = settings
+        current = get_settings()
 
         if type(current) is not type(fresh_settings):
             try:
@@ -284,7 +284,7 @@ def reload_settings() -> Settings:
         object.__setattr__(
             current,
             "__pydantic_fields_set__",
-            getattr(fresh_settings, "__pydantic_fields_set__", set()),
+            getattr(fresh_settings, "__pydantic_fields_set__", set()).copy(),
         )
 
         return current


### PR DESCRIPTION
## Summary
- update `reload_settings` to operate on the concrete `Settings` instance returned by `get_settings`
- refresh `__pydantic_fields_set__` on the real settings object while preserving thread safety and identity

## Testing
- pytest tests/test_config_reload.py tests/test_config_thread_safe.py tests/test_reminders_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d308a534a8832a83e6fb92b504b568