### PR TITLE
fix: stabilize config reload and telegram auth

### DIFF
--- a/services/api/app/diabetes/learning_handlers.py
+++ b/services/api/app/diabetes/learning_handlers.py
@@ -430,6 +430,13 @@ async def topics_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     if message is None:
         return
     if not settings.learning_mode_enabled:
+        logger.warning(
+            "learning disabled for learn_command",
+            extra={
+                "learning_mode_enabled": settings.learning_mode_enabled,
+                "settings_id": id(settings),
+            },
+        )
         await message.reply_text("режим обучения отключён")
         return
     if settings.learning_content_mode == "static":

--- a/services/api/app/telegram_auth.py
+++ b/services/api/app/telegram_auth.py
@@ -248,7 +248,13 @@ def get_tg_user(init_data: str) -> UserContext:
 
     tokens: list[str] = [*primary_tokens, *cached_tokens]
     if not tokens:
-        logger.error("telegram token not configured")
+        module_has_token = bool(getattr(module_settings, "telegram_token", None))
+        active_has_token = bool(getattr(active_settings, "telegram_token", None))
+        logger.error(
+            "telegram token not configured (module_has_token=%s, active_has_token=%s)",
+            module_has_token,
+            active_has_token,
+        )
         raise HTTPException(status_code=503, detail="telegram token not configured")
 
     last_invalid_hash_error: HTTPException | None = None


### PR DESCRIPTION
## Summary
- reuse the existing Settings instance when services.api.app.config is reloaded so previously imported modules keep working
- add targeted logging when learning mode is disabled and when Telegram tokens are missing
- reset learning configuration between tests without reloading the full settings to avoid clearing tokens

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d30a4ed620832a83f5553151969682