### PR TITLE
bot: always use default chat menu button

### DIFF
--- a/services/api/app/diabetes/utils/menu_setup.py
+++ b/services/api/app/diabetes/utils/menu_setup.py
@@ -4,108 +4,33 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, cast
-from urllib.parse import urljoin
 
-from telegram import Bot, MenuButtonDefault, MenuButtonWebApp, WebAppInfo
-
-from services.api.app import config
+from telegram import Bot, MenuButtonDefault
 
 if TYPE_CHECKING:
     from services.api.app.config import Settings
 
 
-_MENU_ITEMS: tuple[tuple[str, str], ...] = (
-    ("Profile", "profile"),
-    ("Reminders", "reminders"),
-    ("History", "history"),
-    ("Analytics", "analytics"),
-)
-
-_LAST_CONFIGURED_BASE_URL: str | None = None
-
-
-def _build_menu_button(base_url: str) -> MenuButtonWebApp:
-    """Return the primary WebApp menu button for ``base_url``."""
-
-    text, path = _MENU_ITEMS[0]
-    return MenuButtonWebApp(text=text, web_app=WebAppInfo(url=_build_url(base_url, path)))
-
-
-def _normalize_base_url(base_url: str) -> str:
-    """Normalize ``base_url`` to make change detection stable."""
-
-    return base_url.strip().rstrip("/")
-
-
-def _build_url(base_url: str, path: str) -> str:
-    """Join ``base_url`` with ``path`` ensuring a single slash separator."""
-
-    normalized_base = _normalize_base_url(base_url) + "/"
-    normalized_path = path.lstrip("/")
-    return urljoin(normalized_base, normalized_path)
-
-
-
 async def setup_chat_menu(bot: Bot, *, settings: Settings | None = None) -> bool:
-    """Configure Telegram's chat menu for the diabetes WebApp.
+    """Ensure Telegram's chat menu uses the default button.
 
-    When ``webapp_url`` is configured a :class:`telegram.MenuButtonWebApp`
-    pointing to the "Profile" section is installed. Otherwise the default
-    Telegram menu is restored. The function returns ``True`` if a menu button
-    was configured (either WebApp or default) and ``False`` if no action was
-    taken. Bots without ``set_chat_menu_button`` support are ignored
-    gracefully.
+    ``settings`` is accepted for API compatibility but ignored. The helper
+    returns ``True`` when the bot exposes ``set_chat_menu_button`` and the
+    default button was configured. Bots without such support are ignored
+    gracefully and result in ``False``.
     """
 
-    active_settings = settings or config.get_settings()
-    base_url = active_settings.webapp_url
+    _ = settings  # explicitly unused to keep signature stable
+
     set_chat_menu_button: Callable[..., Awaitable[Any]] | None
     set_chat_menu_button = getattr(bot, "set_chat_menu_button", None)
     if not callable(set_chat_menu_button):
-        _reset_last_configured()
-        return False
-
-    if not base_url:
-        await cast(Callable[..., Awaitable[Any]], set_chat_menu_button)(
-            menu_button=MenuButtonDefault()
-        )
-        _reset_last_configured()
-        return True
-
-    normalized_base = _normalize_base_url(base_url)
-
-    if _LAST_CONFIGURED_BASE_URL == normalized_base:
         return False
 
     await cast(Callable[..., Awaitable[Any]], set_chat_menu_button)(
-        menu_button=_build_menu_button(normalized_base)
+        menu_button=MenuButtonDefault()
     )
-    _set_last_configured(normalized_base)
     return True
 
 
-def _reset_last_configured() -> None:
-    global _LAST_CONFIGURED_BASE_URL
-    _LAST_CONFIGURED_BASE_URL = None
-
-
-def _set_last_configured(base_url: str) -> None:
-    global _LAST_CONFIGURED_BASE_URL
-    _LAST_CONFIGURED_BASE_URL = base_url
-
-
-def is_webapp_menu_active(*, settings: Settings | None = None) -> bool:
-    """Return ``True`` when the WebApp menu button matches current settings."""
-
-    if _LAST_CONFIGURED_BASE_URL is None:
-        return False
-
-    active_settings = settings or config.get_settings()
-    base_url = active_settings.webapp_url
-    if not base_url:
-        return False
-
-    return _LAST_CONFIGURED_BASE_URL == _normalize_base_url(base_url)
-
-
-__all__ = ["is_webapp_menu_active", "setup_chat_menu"]
+__all__ = ["setup_chat_menu"]

--- a/services/api/app/menu_button.py
+++ b/services/api/app/menu_button.py
@@ -1,9 +1,7 @@
 """Configure Telegram chat menu button.
 
-Whenever a WebApp URL is configured the bot installs a
-``MenuButtonWebApp`` pointing to the profile section. Otherwise the standard
-Telegram menu button is restored. The helper is idempotent and safely skips
-bots that do not expose ``set_chat_menu_button``.
+The bot always restores Telegram's default chat menu button. Bots that do not
+support ``set_chat_menu_button`` are ignored gracefully.
 """
 
 from __future__ import annotations
@@ -35,15 +33,9 @@ async def post_init(
 ) -> None:
     """Configure the chat menu, falling back to Telegram's default button."""
 
-    previous_webapp_url = config.get_settings().webapp_url
     active_settings = config.reload_settings()
 
-    if active_settings.webapp_url != previous_webapp_url:
-        menu_setup._reset_last_configured()  # noqa: SLF001
-
     if await menu_setup.setup_chat_menu(app.bot, settings=active_settings):
-        return
-    if menu_setup.is_webapp_menu_active(settings=active_settings):
         return
 
     set_chat_menu_button: Callable[..., Awaitable[Any]] | None

--- a/services/bot/main.py
+++ b/services/bot/main.py
@@ -34,10 +34,7 @@ from services.api.app.billing.jobs import schedule_subscription_expiration
 from services.api.app.config import settings
 from services.api.app.diabetes.handlers.registration import register_handlers
 from services.api.app.diabetes.services.db import init_db
-from services.api.app.diabetes.utils.menu_setup import (
-    is_webapp_menu_active,
-    setup_chat_menu,
-)
+from services.api.app.diabetes.utils.menu_setup import setup_chat_menu
 from services.api.app.menu_button import post_init as menu_button_post_init
 from services.bot.handlers.start_webapp import build_start_handler
 from services.bot.ptb_patches import apply_jobqueue_stop_workaround  # 👈 добавили
@@ -268,9 +265,7 @@ async def post_init(
     menu_configured = await setup_chat_menu(
         app.bot, settings=current_settings
     )
-    if not menu_configured and not is_webapp_menu_active(
-        settings=current_settings
-    ):
+    if not menu_configured:
         await menu_button_post_init(app)
     if not has_menu_button:
         logger.debug("Bot instance lacks set_chat_menu_button; skipping menu setup")

--- a/tests/test_diabetes_menu_setup.py
+++ b/tests/test_diabetes_menu_setup.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 import pytest
-from telegram import MenuButton, MenuButtonWebApp
+from telegram import MenuButton, MenuButtonDefault
 from telegram.ext import Application, ExtBot
 
 import services.api.app.config as config
 
 
 @pytest.mark.asyncio
-async def test_setup_chat_menu_configures_webapp_buttons(
+async def test_setup_chat_menu_configures_default_button(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Chat menu installs the configured WebApp button when ``WEBAPP_URL`` set."""
+    """Chat menu installs the default button even when ``WEBAPP_URL`` set."""
 
     monkeypatch.setenv("WEBAPP_URL", "https://web.example/app")
     config.reload_settings()
@@ -43,9 +43,7 @@ async def test_setup_chat_menu_configures_webapp_buttons(
     menu = await app.bot.get_chat_menu_button()
     assert stored_menu is not None
     assert isinstance(stored_menu, MenuButton)
-    assert isinstance(stored_menu, MenuButtonWebApp)
-    assert stored_menu.text == "Profile"
-    assert stored_menu.web_app.url == "https://web.example/app/profile"
+    assert isinstance(stored_menu, MenuButtonDefault)
     assert menu is not None
-    assert isinstance(menu, MenuButtonWebApp)
+    assert isinstance(menu, MenuButtonDefault)
     assert menu is stored_menu

--- a/tests/test_menu_button.py
+++ b/tests/test_menu_button.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 
 import pytest
-from telegram import MenuButtonDefault, MenuButtonWebApp
+from telegram import MenuButtonDefault
 from telegram.error import BadRequest
 from telegram.ext import ApplicationBuilder, ExtBot
 
@@ -15,7 +15,7 @@ def _reload_config() -> None:
 
 
 @pytest.mark.asyncio
-async def test_post_init_configures_webapp_menu(
+async def test_post_init_configures_default_menu(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("WEBAPP_URL", raising=False)
@@ -50,6 +50,4 @@ async def test_post_init_configures_webapp_menu(
 
     assert len(calls) == 2
     button = calls[-1][1]["menu_button"]
-    assert isinstance(button, MenuButtonWebApp)
-    assert button.text == "Profile"
-    assert button.web_app.url == "https://web.example/app/profile"
+    assert isinstance(button, MenuButtonDefault)


### PR DESCRIPTION
## Summary
- make the chat menu helper always install Telegram's default button
- simplify menu initialization to remove WebApp-specific branches
- update menu-related tests to assert the default button in all scenarios

## Testing
- pytest -q --cov
- mypy --strict .
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d36a7b4f94832a8a5e12afc46ba686